### PR TITLE
fix:(memory) accept repeated Codex session metadata

### DIFF
--- a/packages/ts/memorax-code-backend/src/codex-rollout-turn.ts
+++ b/packages/ts/memorax-code-backend/src/codex-rollout-turn.ts
@@ -209,11 +209,10 @@ function scanCodexRolloutTurn(transcript: string, targetTurnId: string): CodexRo
         authoritySessionId = nonBlankString(payload.id);
         authoritySource = stringValue(payload.source)?.toLowerCase();
       } else {
-        composite = true;
         const importedSessionId = nonBlankString(payload.id);
-        if (targetBoundarySeen
-          || !importedSessionId
-          || importedSessionId === authoritySessionId) {
+        if (importedSessionId && importedSessionId === authoritySessionId) continue;
+        composite = true;
+        if (targetBoundarySeen || !importedSessionId) {
           ambiguousSessionMetadata = true;
         }
       }

--- a/packages/ts/memorax-code-backend/test/codex-rollout-turn.test.mjs
+++ b/packages/ts/memorax-code-backend/test/codex-rollout-turn.test.mjs
@@ -217,6 +217,41 @@ test("Codex rollout reader uses the file header authority across imported histor
   assert.deepEqual(execResult.turn.activities, []);
 });
 
+test("Codex rollout reader treats repeated authority session metadata as idempotent", () => {
+  const usage = tokenUsage({
+    input_tokens: 30,
+    cached_input_tokens: 12,
+    cache_write_input_tokens: 0,
+    output_tokens: 6,
+    reasoning_output_tokens: 2,
+  });
+  const transcript = jsonLines([
+    sessionMeta("session-1", "vscode"),
+    sessionMeta("session-1", "vscode"),
+    taskStarted("turn-1"),
+    turnContext("turn-1"),
+    userMessage("Prompt from a resumed session."),
+    tokenCount(usage),
+    sessionMeta("session-1", "vscode"),
+    agentMessage("Reply from a resumed session.", "final_answer"),
+  ]);
+
+  assert.deepEqual(codexRolloutTurnFromJsonLines(transcript, {
+    sessionId: "session-1",
+    turnId: "turn-1",
+  }), {
+    ok: true,
+    turn: {
+      sessionId: "session-1",
+      turnId: "turn-1",
+      userPrompt: "Prompt from a resumed session.",
+      assistantReply: "Reply from a resumed session.",
+      activities: [],
+      usage,
+    },
+  });
+});
+
 test("Codex interrupted rollout reader preserves visible partial output, usage, and activities", () => {
   const baseline = tokenUsage({
     input_tokens: 100,
@@ -498,24 +533,18 @@ test("Codex rollout reader fails closed for session, turn, and content mismatche
     sessionId: "session-1",
     turnId: "turn-1",
   }), { ok: false, reason: "transcript_session_mismatch" });
-  for (const ambiguousImportedSessionMeta of [
+  assert.deepEqual(codexRolloutTurnFromJsonLines(jsonLines([
     sessionMeta("session-1"),
     { type: "session_meta", payload: {} },
-  ]) {
-    assert.deepEqual(codexRolloutTurnFromJsonLines(jsonLines([
-      sessionMeta("session-1"),
-      ambiguousImportedSessionMeta,
-      taskStarted("turn-1"),
-      userMessage("Prompt."),
-      agentMessage("Reply.", "final_answer"),
-    ]), {
-      sessionId: "session-1",
-      turnId: "turn-1",
-    }), { ok: false, reason: "transcript_session_mismatch" });
-  }
+    taskStarted("turn-1"),
+    userMessage("Prompt."),
+    agentMessage("Reply.", "final_answer"),
+  ]), {
+    sessionId: "session-1",
+    turnId: "turn-1",
+  }), { ok: false, reason: "transcript_session_mismatch" });
   for (const trailingSessionMeta of [
     sessionMeta("other-session"),
-    sessionMeta("session-1"),
     { type: "session_meta", payload: {} },
   ]) {
     assert.deepEqual(codexRolloutTurnFromJsonLines(jsonLines([

--- a/packages/ts/memorax-code-backend/test/server-memory-hook.test.mjs
+++ b/packages/ts/memorax-code-backend/test/server-memory-hook.test.mjs
@@ -94,7 +94,7 @@ test("Codex Hook retrieves automatic memory once per exact turn", async () => {
   }
 });
 
-test("memory hook writeback reads prompt and reply from the exact Codex rollout turn", async () => {
+test("memory hook writeback accepts repeated authority metadata in the exact Codex rollout turn", async () => {
   const root = await mkdtemp(join(tmpdir(), "memorax-code-hook-rollout-source-"));
   const workspace = join(root, "memorax-code");
   await mkdir(workspace, { recursive: true });
@@ -102,7 +102,13 @@ test("memory hook writeback reads prompt and reply from the exact Codex rollout 
     turnId: "turn-1",
     prompt: "Remember this persisted Codex turn.\n",
     reply: "Stored persisted Codex answer.\n",
-  }]);
+  }], {
+    prefixRecords: [{
+      timestamp: "2026-07-16T00:00:00.500Z",
+      type: "session_meta",
+      payload: { id: "session-hook" },
+    }],
+  });
   const { fetchImpl, requests } = memoraxAddFetch();
   const events = [];
   const controller = createCodexMemoryHookRuntime({


### PR DESCRIPTION
## Summary

Fix automatic writeback for long-lived or resumed Codex sessions whose rollout contains repeated `session_meta` records with the same authority session ID.

Codex may legitimately repeat identical session metadata throughout one rollout. The parser previously treated those idempotent records as ambiguous and rejected the exact turn with `transcript_session_mismatch`, preventing automatic writeback. Repeated same-ID metadata is now accepted while malformed or conflicting session metadata continues to fail closed.

## Changes

- Treat repeated metadata matching the rollout authority session ID as idempotent.
- Preserve fail-closed handling for missing IDs and cross-session metadata after the target turn boundary.
- Add a parser regression covering repeated metadata before and inside the target turn.
- Exercise the same behavior through the Codex Hook automatic-writeback path.

## Validation

- `node --test --test-timeout=5000 --test-force-exit packages/ts/memorax-code-backend/test/codex-rollout-turn.test.mjs packages/ts/memorax-code-backend/test/server-memory-hook.test.mjs` — 46 passed.
- `npm run typecheck --prefix packages/ts/memorax-code-backend` — passed.
- `npm test --prefix packages/ts/memorax-code-backend` — 489 passed, 2 platform skips, 0 failures.
- Real-client check in a long-lived Codex session — automatic writeback reached normal provider processing instead of `transcript_session_mismatch`.

## Risk and compatibility

Affects Codex rollout parsing and automatic writeback only. Claude Code behavior, installation and update flows, persisted state, public protocols, configuration, and data-handling boundaries are unchanged. Missing or foreign session metadata remains rejected.
