### PR TITLE
chore:(release) prepare 0.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 <p align="center">
   <a href="https://code.memorax.net/"><img src="https://img.shields.io/badge/website-code.memorax.net-2563eb" alt="MemoraX Code website"></a>
   <a href="https://www.npmjs.com/package/@memorax/memorax-code"><img src="https://img.shields.io/npm/v/@memorax/memorax-code.svg" alt="npm version"></a>
-  <img src="https://img.shields.io/badge/version-0.1.0-f59e0b" alt="Version 0.1.0">
+  <img src="https://img.shields.io/badge/version-0.1.1-f59e0b" alt="Version 0.1.1">
   <img src="https://img.shields.io/badge/node-%3E%3D24-339933?logo=node.js&logoColor=white" alt="Node.js 24 or newer">
 </p>
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -17,7 +17,7 @@
 <p align="center">
   <a href="https://code.memorax.net/"><img src="https://img.shields.io/badge/website-code.memorax.net-2563eb" alt="MemoraX Code 产品网站"></a>
   <a href="https://www.npmjs.com/package/@memorax/memorax-code"><img src="https://img.shields.io/npm/v/@memorax/memorax-code.svg" alt="npm 版本"></a>
-  <img src="https://img.shields.io/badge/version-0.1.0-f59e0b" alt="版本 0.1.0">
+  <img src="https://img.shields.io/badge/version-0.1.1-f59e0b" alt="版本 0.1.1">
   <img src="https://img.shields.io/badge/node-%3E%3D24-339933?logo=node.js&logoColor=white" alt="Node.js 24 或更高版本">
 </p>
 

--- a/packages/npm/memorax-code/package.json
+++ b/packages/npm/memorax-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax/memorax-code",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "MemoraX Code CLI, local memory backend, Codex and Claude Code adapters, skills, and Memory Viewer.",
   "license": "MIT",
   "type": "module",

--- a/packages/ts/memorax-code-backend/package-lock.json
+++ b/packages/ts/memorax-code-backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@memorax-code/backend",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@memorax-code/backend",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "smol-toml": "^1.7.0"
       },

--- a/packages/ts/memorax-code-backend/package.json
+++ b/packages/ts/memorax-code-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/backend",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "description": "Local memory integration, lifecycle, trace, and diagnostics for MemoraX Code.",

--- a/packages/ts/memorax-code-claude-adapter/.claude-plugin/plugin.json
+++ b/packages/ts/memorax-code-claude-adapter/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorax-code-claude-adapter",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Memory skill and local hooks for MemoraX Code in Claude Code.",
   "author": {
     "name": "MemoraX Code Maintainers"

--- a/packages/ts/memorax-code-claude-adapter/hooks/runtime-shell.json
+++ b/packages/ts/memorax-code-claude-adapter/hooks/runtime-shell.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
-  "shellVersion": "0.1.0",
+  "shellVersion": "0.1.1",
   "runtimeAbi": 1
 }

--- a/packages/ts/memorax-code-claude-adapter/package.json
+++ b/packages/ts/memorax-code-claude-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/claude-adapter",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "description": "Claude Code Hook adapter for MemoraX Code memory services.",

--- a/packages/ts/memorax-code-codex-adapter/.codex-plugin/plugin.json
+++ b/packages/ts/memorax-code-codex-adapter/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorax-code-codex-adapter",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Codex adapter, memory skill, and local hooks for MemoraX Code.",
   "author": {
     "name": "MemoraX AI"

--- a/packages/ts/memorax-code-codex-adapter/hooks/runtime-shell.json
+++ b/packages/ts/memorax-code-codex-adapter/hooks/runtime-shell.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
-  "shellVersion": "0.1.0",
+  "shellVersion": "0.1.1",
   "runtimeAbi": 1
 }

--- a/packages/ts/memorax-code-codex-adapter/package.json
+++ b/packages/ts/memorax-code-codex-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/codex-adapter",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "description": "Codex Hook and memory integration for MemoraX Code.",


### PR DESCRIPTION
## Summary

Prepare the public MemoraX Code 0.1.1 release after the Codex repeated-session-metadata fix was merged. All shipped runtime and plugin version authorities now advance together.

## Changes

- Set the public npm package version to 0.1.1.
- Align Backend, Codex, Claude Code, plugin manifest, and runtime shell versions.
- Update the English and Chinese README version badges.

## Validation

- `make test` — Backend 489 passed / 2 platform skips; Codex 200/200; Claude Code 64/64; npm/package 149/149.
- `make docs-check` — passed.
- `make npm-package-check` — passed; 282-file tarball allowlist and isolated install/update gate passed.
- `make npm-publish-dry-run` — passed for `@memorax/memorax-code@0.1.1` with the `latest` tag.

## Risk and compatibility

Low. This commit changes release metadata only. The included runtime fix was reviewed and merged separately in #1; no configuration, data-handling, or protocol contract changes are introduced by this version bump.