### PR TITLE
feat:(repo-memory) 缺少 Repo Memory 时自动构建

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,10 +122,14 @@ the current repository.
 | **Background memory writeback** | Extracts reusable knowledge from completed turns and writes it to Coding Memory in the background. |
 | **Preference continuity** | Records User Profile preferences and injects them into future tasks on a configured cadence. |
 | **Procedure reuse** | Records reusable task procedures and reminds future agents to apply them. |
-| **Background Repo Memory maintenance** | Automatically organizes repository structure, entry points, and history evidence in the background, then updates them according to policy to reduce repeated searching and summarization. |
+| **Background Repo Memory maintenance** | On a Git worktree's first eligible prompt, starts a background build when `.repo_memory/PROFILE.md` is missing. Later relevant Repo Memory reads validate and update the bundle according to policy. |
 | **Active memory control** | Lets you search and add memory through the bundled MemoraX Code skill (`$memorax-code` in Codex or `/memorax-code` in Claude Code) or the CLI. |
 | **Hook integration** | Uses Codex and Claude Code Hooks to trigger memory retrieval, reminders, and writeback. |
 | **Local visualization** | Uses the local Memory Viewer to summarize activity counts, retrieval, and writeback status. |
+
+The missing-profile check is local and does not block the prompt. It skips
+non-Git and Codex projectless workspaces, and an active Repo Memory job is
+reused instead of launching another build.
 
 ## Your Memory, Your Control
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -107,10 +107,13 @@ cd test-repo
 | **后台写入记忆** | 任务完成后，在后台提取可复用知识并写入 Coding Memory。 |
 | **用户偏好延续** | 在 User Profile 中记录用户偏好，并按设定周期将其带入后续任务。 |
 | **Procedure 自动复用** | 记录可复用的任务流程，并在后续任务中自动提醒 Agent 按流程执行。 |
-| **Repo Memory 后台整理** | 在后台整理仓库结构、代码入口和历史证据，并按策略自动更新，避免反复搜索和总结。 |
+| **Repo Memory 后台整理** | Git 工作树首次收到符合条件的请求时，如果缺少 `.repo_memory/PROFILE.md`，就启动后台构建；之后在相关 Repo Memory 读取中按策略校验和更新。 |
 | **主动记忆控制** | 使用内置的 MemoraX Code Skill（Codex 中为 `$memorax-code`，Claude Code 中为 `/memorax-code`）或 CLI，主动查找和添加记忆。 |
 | **Hook 集成** | 借助 Codex 和 Claude Code 的 Hook 触发记忆检索、提醒和写入。 |
 | **本地可视化** | 通过本地 Memory Viewer 查看活动统计、召回与写入状态。 |
+
+缺失检查只在本地进行，不会阻塞当前请求。非 Git 工作区和 Codex 无项目工作区会跳过；如果已有
+Repo Memory 后台任务，则复用现有任务，不会重复启动。
 
 ## 你的记忆，由你控制
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -97,6 +97,13 @@ Generated `.repo_memory/` content, personal procedures, and profile preferences
 remain local and are Git-ignored by the supported workflow. Review and redact
 all diagnostic artifacts before sharing them.
 
+On an eligible prompt in a Git worktree, a missing `.repo_memory/PROFILE.md`
+starts a background Repo Memory build through the active Codex or Claude Code
+client. That worker uses the client's existing model and provider boundary to
+inspect the repository and may use authenticated `gh` or `glab` commands for
+PR, MR, and issue evidence. The generated bundle remains local; provider CLI
+traffic and model-provider traffic are separate from MemoraX memory traffic.
+
 ## Uninstall and Retention
 
 Use:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -167,6 +167,13 @@ Supported policies are `every-commit`, `commit-count`, `daily`,
 `pull-request`, `pull-request-or-daily`, and `adaptive`. Invalid policy values
 fall back to `adaptive`.
 
+These settings control incremental maintenance of an existing Repo Memory
+bundle. On an eligible `UserPromptSubmit`, the client Hook independently checks
+the selected Git worktree for `.repo_memory/PROFILE.md`; when it is missing,
+the Hook silently starts the initial background build. The check skips non-Git
+and Codex projectless workspaces, does not wait for the build, and does not use
+the policy fields above to decide whether an existing profile is stale.
+
 ## Local traces
 
 `[trace.codex]` and `[trace.claude]` support the same fields:

--- a/packages/npm/memorax-code/README.md
+++ b/packages/npm/memorax-code/README.md
@@ -34,6 +34,11 @@ After the first installation, restart or refresh the detected clients before
 opening a new session. In Codex, enable **MemoraX Code Codex Adapter** from
 Plugins or `/plugins` if it is not already enabled.
 
+On the first eligible prompt in a Git worktree, the client Hook checks for
+`.repo_memory/PROFILE.md`. If it is missing, MemoraX Code starts the initial
+Repo Memory build in the background without blocking the prompt. Non-Git and
+Codex projectless workspaces are skipped, and active jobs are deduplicated.
+
 ## Verify
 
 ```bash

--- a/packages/ts/memorax-code-adapter-common/src/repo-memory/repo-memory-auto-build.mjs
+++ b/packages/ts/memorax-code-adapter-common/src/repo-memory/repo-memory-auto-build.mjs
@@ -1,0 +1,272 @@
+import { spawn } from "node:child_process";
+import {
+  lstatSync,
+  readFileSync,
+  realpathSync,
+  statSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { readJsonFile, stringOption } from "../config-utils.mjs";
+import { readActiveRepoMemoryJobMarker } from "./repo-memory-job-marker.mjs";
+
+const MAX_GIT_POINTER_BYTES = 64 * 1024;
+
+export function scheduleMissingRepoMemoryBuild(input, options = {}) {
+  try {
+    if (hookEvent(input) !== "UserPromptSubmit") return skipped("inapplicable_event");
+    if (workspaceKind(input) === "projectless") return skipped("projectless_workspace");
+
+    const cwd = resolveHookCwd(input, options);
+    if (!cwd) return skipped("workspace_unavailable");
+    const repo = resolveGitWorktreeRoot(cwd);
+    if (!repo) return skipped("git_worktree_unavailable");
+    if (repoMemoryProfileExists(repo)) return skipped("profile_present", { repo });
+
+    const jobHookPath = resolveJobHookPath(options.pluginRoot);
+    if (!jobHookPath) return skipped("job_hook_unavailable", { repo });
+
+    const memoraxCodeHome = process.env.MEMORAX_CODE_HOME || join(homedir(), ".memorax-code");
+    const active = readActiveRepoMemoryJobMarker({
+      memoraxCodeHome,
+      repoRealpath: repo,
+    });
+    if (active.active) return skipped("active_job", { repo });
+
+    const child = spawn(process.execPath, [jobHookPath, "maintain", "--repo", repo], {
+      cwd: repo,
+      detached: true,
+      env: process.env,
+      stdio: "ignore",
+      windowsHide: true,
+    });
+    child.once("error", (error) => debug(options, error));
+    child.unref();
+    return {
+      ok: true,
+      scheduled: true,
+      reason: "profile_missing",
+      repo,
+    };
+  } catch (error) {
+    debug(options, error);
+    return skipped("check_failed");
+  }
+}
+
+export function resolveGitWorktreeRoot(cwd) {
+  let current = canonicalDirectory(cwd);
+  if (!current) return undefined;
+
+  while (true) {
+    const marker = join(current, ".git");
+    const state = gitMarkerState(marker);
+    if (state === "valid") return current;
+    if (state === "invalid") return undefined;
+    const parent = dirname(current);
+    if (parent === current) return undefined;
+    current = parent;
+  }
+}
+
+function gitMarkerState(marker) {
+  let metadata;
+  try {
+    metadata = lstatSync(marker);
+  } catch (error) {
+    return error?.code === "ENOENT" ? "missing" : "invalid";
+  }
+  if (metadata.isSymbolicLink()) return "invalid";
+  try {
+    const gitDir = metadata.isDirectory()
+      ? canonicalDirectory(marker)
+      : metadata.isFile()
+        ? resolveGitPointer(marker)
+        : undefined;
+    if (!gitDir) return "invalid";
+    validateGitDirectory(gitDir);
+    return "valid";
+  } catch {
+    return "invalid";
+  }
+}
+
+function resolveGitPointer(marker) {
+  const line = readSingleLine(marker, MAX_GIT_POINTER_BYTES);
+  const match = /^gitdir:[ \t]*(.+)$/i.exec(line);
+  const value = match?.[1]?.trim();
+  if (!value || value.includes("\0")) return undefined;
+  return canonicalDirectory(isAbsolute(value) ? value : resolve(dirname(marker), value));
+}
+
+function validateGitDirectory(gitDir) {
+  const head = readSingleLine(join(gitDir, "HEAD"), MAX_GIT_POINTER_BYTES).trim();
+  if (!/^ref: refs\/[^\0\r\n]+$/.test(head) && !/^(?:[a-fA-F0-9]{40}|[a-fA-F0-9]{64})$/.test(head)) {
+    throw new Error("invalid Git HEAD");
+  }
+
+  const commonDirPath = join(gitDir, "commondir");
+  let commonDir = gitDir;
+  try {
+    const metadata = lstatSync(commonDirPath);
+    if (metadata.isSymbolicLink() || !metadata.isFile()) throw new Error("invalid Git common directory pointer");
+    const value = readSingleLine(commonDirPath, MAX_GIT_POINTER_BYTES).trim();
+    if (!value || value.includes("\0")) throw new Error("invalid Git common directory pointer");
+    commonDir = canonicalDirectory(isAbsolute(value) ? value : resolve(gitDir, value));
+  } catch (error) {
+    if (error?.code !== "ENOENT") throw error;
+  }
+  if (!commonDir || !statSync(join(commonDir, "objects")).isDirectory()) {
+    throw new Error("invalid Git objects directory");
+  }
+  const hasRefs = directoryExists(join(commonDir, "refs"));
+  const hasReftable = directoryExists(join(commonDir, "reftable"));
+  if (!hasRefs && !hasReftable) throw new Error("invalid Git refs directory");
+}
+
+function repoMemoryProfileExists(repo) {
+  try {
+    lstatSync(join(repo, ".repo_memory", "PROFILE.md"));
+    return true;
+  } catch (error) {
+    if (error?.code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+function resolveJobHookPath(pluginRoot) {
+  const rootValue = stringOption(pluginRoot);
+  if (!rootValue) return undefined;
+  const root = canonicalDirectory(rootValue);
+  if (!root) return undefined;
+  const target = join(root, "hooks", "repo-memory-job.mjs");
+  return isContainedRegularFile(root, target) ? target : undefined;
+}
+
+function resolveHookCwd(input, options) {
+  const direct = safeRealpath(stringOption(input?.cwd));
+  if (direct) return direct;
+  const sessionId = stringOption(input?.session_id) ?? stringOption(input?.sessionId);
+  const transcriptPath = stringOption(input?.transcript_path) ?? stringOption(input?.transcriptPath);
+  const pluginWorkspace = process.env.PLUGIN_DATA
+    ? workspaceCwdFromState(join(process.env.PLUGIN_DATA, "workspaces.json"), options.sessionKeyPrefix, sessionId, transcriptPath)
+    : undefined;
+  if (pluginWorkspace) return pluginWorkspace;
+  const memoraxCodeHome = process.env.MEMORAX_CODE_HOME || join(homedir(), ".memorax-code");
+  return workspaceCwdFromState(
+    join(memoraxCodeHome, "adapters", options.adapterDir, "workspaces.json"),
+    options.sessionKeyPrefix,
+    sessionId,
+    transcriptPath,
+  );
+}
+
+function workspaceCwdFromState(path, sessionKeyPrefix, sessionId, transcriptPath) {
+  const state = readJsonFile(path);
+  if (state?.unreadable) return undefined;
+  const sessions = state?.value?.sessions && typeof state.value.sessions === "object" && !Array.isArray(state.value.sessions)
+    ? state.value.sessions
+    : {};
+  for (const key of registryKeys(sessionKeyPrefix, sessionId, transcriptPath)) {
+    const record = sessions[key];
+    const cwd = safeRealpath(stringOption(record?.cwd) ?? stringOption(record?.workspace));
+    if (cwd) return cwd;
+  }
+  return undefined;
+}
+
+function registryKeys(sessionKeyPrefix, ...values) {
+  const keys = new Set();
+  for (const value of values) {
+    const string = stringOption(value);
+    if (!string) continue;
+    keys.add(string);
+    const base = string.split(/[\\/]/).pop()?.replace(/\.[^.]+$/, "") ?? string;
+    keys.add(base);
+    if (string.startsWith(`${sessionKeyPrefix}_`)) keys.add(string.slice(sessionKeyPrefix.length + 1));
+    else keys.add(`${sessionKeyPrefix}_${string}`);
+    if (base.startsWith(`${sessionKeyPrefix}_`)) keys.add(base.slice(sessionKeyPrefix.length + 1));
+    else keys.add(`${sessionKeyPrefix}_${base}`);
+  }
+  return keys;
+}
+
+function hookEvent(input) {
+  return stringOption(input?.hook_event_name)
+    ?? stringOption(input?.hookEventName)
+    ?? stringOption(input?.event)
+    ?? stringOption(input?.type);
+}
+
+function workspaceKind(input) {
+  return (stringOption(input?.workspace_kind) ?? stringOption(input?.workspaceKind))?.toLowerCase();
+}
+
+function canonicalDirectory(path) {
+  const value = stringOption(path);
+  if (!value) return undefined;
+  try {
+    const canonical = realpathSync(resolve(value));
+    return statSync(canonical).isDirectory() ? canonical : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function safeRealpath(path) {
+  const value = stringOption(path);
+  if (!value) return undefined;
+  try {
+    return realpathSync(resolve(value));
+  } catch {
+    return undefined;
+  }
+}
+
+function readSingleLine(path, maxBytes) {
+  const metadata = lstatSync(path);
+  if (metadata.isSymbolicLink() || !metadata.isFile() || metadata.size > maxBytes) {
+    throw new Error("invalid Git metadata file");
+  }
+  const text = readFileSync(path, "utf8");
+  if (Buffer.byteLength(text, "utf8") > maxBytes || text.includes("\0")) {
+    throw new Error("invalid Git metadata file");
+  }
+  const lines = text.split(/\r?\n/);
+  if (lines.length > 2 || (lines.length === 2 && lines[1] !== "")) {
+    throw new Error("invalid Git metadata line");
+  }
+  return lines[0];
+}
+
+function directoryExists(path) {
+  try {
+    const metadata = lstatSync(path);
+    return !metadata.isSymbolicLink() && metadata.isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function isContainedRegularFile(boundary, path) {
+  try {
+    const root = realpathSync(boundary);
+    const target = realpathSync(path);
+    const child = relative(root, target);
+    if (child === ".." || child.startsWith(`..${sep}`) || isAbsolute(child)) return false;
+    const metadata = lstatSync(path);
+    return !metadata.isSymbolicLink() && metadata.isFile();
+  } catch {
+    return false;
+  }
+}
+
+function skipped(reason, details = {}) {
+  return { ok: true, scheduled: false, reason, ...details };
+}
+
+function debug(options, error) {
+  if (process.env[options.debugEnv] === "1") {
+    console.error(error instanceof Error ? error.message : String(error));
+  }
+}

--- a/packages/ts/memorax-code-claude-adapter/runtime-hooks/memory-skill-reminder.mjs
+++ b/packages/ts/memorax-code-claude-adapter/runtime-hooks/memory-skill-reminder.mjs
@@ -4,6 +4,8 @@ import {
   runMemorySkillReminderHook,
 } from "../../memorax-code-adapter-common/src/hooks/memory-skill-reminder-hook.mjs";
 import { resolveBackendConnection } from "../../memorax-code-adapter-common/src/backend-connection.mjs";
+import { readStdinJson } from "../../memorax-code-adapter-common/src/config-utils.mjs";
+import { scheduleMissingRepoMemoryBuild } from "../../memorax-code-adapter-common/src/repo-memory/repo-memory-auto-build.mjs";
 import { isRepoMemoryJobWorker } from "../../memorax-code-adapter-common/src/repo-memory/repo-memory-job-context.mjs";
 import { buildRepoProcedureMemoryContext } from "../../memorax-code-adapter-common/src/repo-memory/repo-procedure-memory-context.mjs";
 import { buildRepoUserProfilePreferencesContext } from "../../memorax-code-adapter-common/src/repo-memory/repo-user-profile-context.mjs";
@@ -19,6 +21,14 @@ const personalMemoryContextOptions = {
   sessionKeyPrefix: "claude",
 };
 
+const input = await readStdinJson();
+scheduleMissingRepoMemoryBuild(input, {
+  adapterDir: "claude-code",
+  debugEnv: "MEMORAX_CODE_CLAUDE_HOOK_DEBUG",
+  pluginRoot: process.env.CLAUDE_PLUGIN_ROOT,
+  sessionKeyPrefix: "claude",
+});
+
 await runMemorySkillReminderHook({
   additionalReminderContext: personalMemoryReminderContext(MEMORY_SKILL_INVOCATION),
   adapterDir: "claude-code",
@@ -30,7 +40,7 @@ await runMemorySkillReminderHook({
   remindOnFirstTurn: true,
   runtime: "claude-code",
   supplementalReminderAfterCompact: true,
-});
+}, input);
 
 async function recordReminder(reminder) {
   const promptId = reminder.turnId;

--- a/packages/ts/memorax-code-claude-adapter/test/memory-skill-reminder-hook.test.mjs
+++ b/packages/ts/memorax-code-claude-adapter/test/memory-skill-reminder-hook.test.mjs
@@ -23,6 +23,7 @@ test("Claude memory skill metadata uses the plugin-namespaced invocation", async
 
 test("UserPromptSubmit manifest declares the Claude memory reminder hook", async () => {
   const manifest = JSON.parse(await readFile(join(packageRoot, "hooks", "hooks.json"), "utf8"));
+  const runtime = await readFile(hookPath, "utf8");
   const commands = manifest.hooks.UserPromptSubmit[0].hooks.map((hook) => hook.command);
 
   assert.deepEqual(commands, [
@@ -31,6 +32,8 @@ test("UserPromptSubmit manifest declares the Claude memory reminder hook", async
     "node \"${CLAUDE_PLUGIN_ROOT}/hooks/runtime-hook.mjs\" memory-skill-reminder",
   ]);
   assert.equal(manifest.hooks.UserPromptSubmit[0].hooks[2].timeout, undefined);
+  assert.match(runtime, /scheduleMissingRepoMemoryBuild\(input/);
+  assert.match(runtime, /pluginRoot: process\.env\.CLAUDE_PLUGIN_ROOT/);
 });
 
 test("Claude memory skill reminder mirrors due context to the Backend trace contract", async () => {

--- a/packages/ts/memorax-code-codex-adapter/runtime-hooks/memory-skill-reminder.mjs
+++ b/packages/ts/memorax-code-codex-adapter/runtime-hooks/memory-skill-reminder.mjs
@@ -5,6 +5,7 @@ import {
 } from "../../memorax-code-adapter-common/src/hooks/memory-skill-reminder-hook.mjs";
 import { resolveBackendConnection } from "../../memorax-code-adapter-common/src/backend-connection.mjs";
 import { readStdinJson, stringOption } from "../../memorax-code-adapter-common/src/config-utils.mjs";
+import { scheduleMissingRepoMemoryBuild } from "../../memorax-code-adapter-common/src/repo-memory/repo-memory-auto-build.mjs";
 import { isRepoMemoryJobWorker } from "../../memorax-code-adapter-common/src/repo-memory/repo-memory-job-context.mjs";
 import { buildRepoProcedureMemoryContext } from "../../memorax-code-adapter-common/src/repo-memory/repo-procedure-memory-context.mjs";
 import { buildRepoUserProfilePreferencesContext } from "../../memorax-code-adapter-common/src/repo-memory/repo-user-profile-context.mjs";
@@ -22,12 +23,19 @@ const DEFAULT_BACKEND_TIMEOUT_MS = 5_000;
 
 try {
   const input = await readStdinJson();
-  const turnStart = turnStartBody(input);
+  const resolvedWorkspaceKind = resolveCodexWorkspaceKind(input);
+  const normalizedInput = resolvedWorkspaceKind
+    ? { ...input, workspaceKind: resolvedWorkspaceKind }
+    : input;
+  scheduleMissingRepoMemoryBuild(normalizedInput, {
+    adapterDir: "codex",
+    debugEnv: "MEMORAX_CODE_CODEX_HOOK_DEBUG",
+    pluginRoot: process.env.PLUGIN_ROOT,
+    sessionKeyPrefix: "codex",
+  });
+  const turnStart = turnStartBody(normalizedInput);
   if (turnStart) {
     const turnStartResult = await recordTurnStart(turnStart);
-    const normalizedInput = turnStart.workspaceKind
-      ? { ...input, workspaceKind: turnStart.workspaceKind }
-      : input;
     await runMemorySkillReminderHook({
       additionalReminderContext: PERSONAL_MEMORY_REMINDER_CONTEXT,
       adapterDir: "codex",

--- a/packages/ts/memorax-code-codex-adapter/skills/memorax-code/references/repo-build.md
+++ b/packages/ts/memorax-code-codex-adapter/skills/memorax-code/references/repo-build.md
@@ -46,6 +46,12 @@ If the directory is not a git repository, do not create `.repo_memory/` and do n
 - If you only want file inspection, continue by inspecting files without repo memory.
 ```
 
+## Automatic First Build
+
+On each eligible `UserPromptSubmit`, the supported client Hook checks the selected Git worktree for `.repo_memory/PROFILE.md`. If the profile is absent, it silently starts the packaged `maintain` helper in the background; the Hook does not wait for collection, authoring, or validation to finish.
+
+This automatic path is only a first-build trigger. It skips non-Git and projectless workspaces, deduplicates an active Repo Memory job, and fails without blocking the user's prompt. Once `PROFILE.md` exists, the Hook does not validate it or evaluate whether it is stale. Relevant `repo-read` operations own later validation and policy-based incremental maintenance, while explicit build, rebuild, and update requests keep their normal routing.
+
 ## Path Convention
 
 `<skill-dir>` means the parent directory of the `references/` directory containing this file. Resolve it before running scripts, for example:
@@ -247,7 +253,7 @@ Generate memory that the `memorax-code` repo-read operation can consume progress
 - `resources/*.md` are compact human-readable routing resources with search-grade descriptions.
 - `raw/*.json` contains optional build/debug evidence for deep inspection when compact resources are insufficient.
 
-Do not duplicate the daily retrieval workflow here. The `repo-read` operation owns trigger timing, silent background-maintenance handoff, and task-specific search behavior.
+Do not duplicate the daily retrieval workflow here. The client Hook owns the missing-profile first-build trigger. The `repo-read` operation owns later validation, policy-based background-maintenance handoff, and task-specific search behavior.
 
 ## Trust Rules
 

--- a/packages/ts/memorax-code-codex-adapter/skills/memorax-code/references/repo-read.md
+++ b/packages/ts/memorax-code-codex-adapter/skills/memorax-code/references/repo-read.md
@@ -6,7 +6,9 @@ Use existing `.repo_memory/` as a routing layer for repository identity, archite
 
 Select this reference for broad repo introduction, history, architecture background, cross-module routing, PR/issue context, design rationale, or stale-memory awareness. Skip this reference for narrow tasks with a clear live-code target.
 
-Only a relevant `repo-read` invokes `maintain`. Commit arrival, PR merge, and elapsed time alone do not invoke it. Explicit build, rebuild, or update requests still route through `SKILL.md` to `repo-build.md` or `repo-update.md`.
+An eligible client `UserPromptSubmit` Hook checks whether the selected Git worktree has `.repo_memory/PROFILE.md`. When the profile is absent, the Hook silently invokes `maintain` to start the first background build. It skips non-Git and projectless workspaces, does not validate an existing bundle, and does not evaluate update staleness.
+
+For an existing profile, only a relevant `repo-read` invokes `maintain` to validate the bundle and evaluate incremental maintenance. Commit arrival, PR merge, and elapsed time alone do not invoke it. Explicit build, rebuild, or update requests still route through `SKILL.md` to `repo-build.md` or `repo-update.md`.
 
 ## Repository And Helper
 
@@ -25,7 +27,7 @@ Derive memory as `<repo>/.repo_memory`; never ask for a memory-directory path. I
 node '<skill-dir>/../../hooks/repo-memory-job.mjs' maintain --repo '<repo>'
 ```
 
-Use it only when it is a regular file. It validates the generated bundle, evaluates the configured local update policy without provider network access, and atomically selects one outcome:
+Use it only when it is a regular file. The missing-profile Hook and `repo-read` share this helper. It validates the generated bundle, evaluates the configured local update policy without provider network access, and atomically selects one outcome:
 
 - `bundle_missing` or `bundle_invalid`: start supervised build;
 - a triggered policy decision: start supervised update;

--- a/packages/ts/memorax-code-codex-adapter/test/hook-runtime-generation.test.mjs
+++ b/packages/ts/memorax-code-codex-adapter/test/hook-runtime-generation.test.mjs
@@ -39,6 +39,17 @@ test("client Hook generations stage immutably and activate atomically", async ()
       JSON.parse(await readFile(join(first.generationPath, "generation.json"), "utf8")).contentDigest,
       first.contentDigest,
     );
+    assert.equal(
+      (await readFile(join(
+        first.generationPath,
+        "lib",
+        "memorax-code-adapter-common",
+        "src",
+        "repo-memory",
+        "repo-memory-auto-build.mjs",
+      ), "utf8")).includes("generation-a:repo-memory-auto-build"),
+      true,
+    );
 
     await writeRuntimePackage(packageRoot, "1.2.3", "generation-b");
     const second = stageClientHookRuntimeGeneration({ packageRoot, memoraxCodeHome });
@@ -528,6 +539,24 @@ async function writeRuntimePackage(packageRoot, version, marker) {
       `export const marker = ${JSON.stringify(marker)};\n`,
     );
   }
+  await mkdir(join(
+    packageRoot,
+    "lib",
+    "memorax-code-adapter-common",
+    "src",
+    "repo-memory",
+  ), { recursive: true });
+  await writeFile(
+    join(
+      packageRoot,
+      "lib",
+      "memorax-code-adapter-common",
+      "src",
+      "repo-memory",
+      "repo-memory-auto-build.mjs",
+    ),
+    `export const marker = ${JSON.stringify(`${marker}:repo-memory-auto-build`)};\n`,
+  );
   for (const [adapter, components] of Object.entries({
     "memorax-code-codex-adapter": [
       "capture-cwd",

--- a/packages/ts/memorax-code-codex-adapter/test/memory-skill-reminder-hook.test.mjs
+++ b/packages/ts/memorax-code-codex-adapter/test/memory-skill-reminder-hook.test.mjs
@@ -29,6 +29,8 @@ test("manifest reuses capture-cwd for compact and keeps one serialized UserPromp
   assert.match(runtime, /RETRIEVAL_BACKEND_TIMEOUT_MS = 12_000/);
   assert.match(runtime, /DEFAULT_BACKEND_TIMEOUT_MS = 5_000/);
   assert.match(runtime, /path === "\/memory\/turn-start" \? RETRIEVAL_BACKEND_TIMEOUT_MS : DEFAULT_BACKEND_TIMEOUT_MS/);
+  assert.match(runtime, /scheduleMissingRepoMemoryBuild\(normalizedInput/);
+  assert.match(runtime, /pluginRoot: process\.env\.PLUGIN_ROOT/);
   assert.equal(manifest.hooks.SessionStart.length, 1);
   assert.deepEqual(sessionCommands, [
     "node \"$PLUGIN_ROOT/hooks/runtime-hook.mjs\" ensure-backend",

--- a/packages/ts/memorax-code-codex-adapter/test/repo-memory-auto-build.test.mjs
+++ b/packages/ts/memorax-code-codex-adapter/test/repo-memory-auto-build.test.mjs
@@ -1,0 +1,231 @@
+import { strict as assert } from "node:assert";
+import { spawnSync } from "node:child_process";
+import { mkdir, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { test } from "node:test";
+import {
+  resolveGitWorktreeRoot,
+  scheduleMissingRepoMemoryBuild,
+} from "../../memorax-code-adapter-common/src/repo-memory/repo-memory-auto-build.mjs";
+import {
+  markerPathForRepo,
+  writeRepoMemoryJobMarker,
+} from "../../memorax-code-adapter-common/src/repo-memory/repo-memory-job-marker.mjs";
+
+test("repo memory auto-build resolves normal and linked Git worktrees without invoking Git", async () => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-code-auto-build-root-"));
+  try {
+    const repo = await createRepo(root);
+    const canonicalRepo = await realpath(repo);
+    const nested = join(repo, "src", "nested");
+    await mkdir(nested, { recursive: true });
+    assert.equal(resolveGitWorktreeRoot(nested), canonicalRepo);
+
+    const linked = join(root, "linked");
+    runGit(repo, ["worktree", "add", "-b", "linked", linked]);
+    const linkedNested = join(linked, "packages", "demo");
+    await mkdir(linkedNested, { recursive: true });
+    assert.equal(resolveGitWorktreeRoot(linkedNested), await realpath(linked));
+
+    const plain = join(root, "plain");
+    await mkdir(plain);
+    assert.equal(resolveGitWorktreeRoot(plain), undefined);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("repo memory auto-build schedules maintain only when PROFILE.md is missing", async () => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-code-auto-build-missing-"));
+  const previousHome = process.env.MEMORAX_CODE_HOME;
+  const previousLog = process.env.MEMORAX_CODE_AUTO_BUILD_TEST_LOG;
+  try {
+    const repo = await createRepo(root);
+    const canonicalRepo = await realpath(repo);
+    const pluginRoot = await createFakePlugin(root);
+    const memoraxCodeHome = join(root, "memorax-code");
+    const logPath = join(root, "auto-build.log");
+    process.env.MEMORAX_CODE_HOME = memoraxCodeHome;
+    process.env.MEMORAX_CODE_AUTO_BUILD_TEST_LOG = logPath;
+
+    const scheduled = scheduleMissingRepoMemoryBuild({
+      hook_event_name: "UserPromptSubmit",
+      session_id: "session-a",
+      cwd: join(repo, "src"),
+      workspace_kind: "git",
+    }, {
+      adapterDir: "codex",
+      debugEnv: "MEMORAX_CODE_CODEX_HOOK_DEBUG",
+      pluginRoot,
+      sessionKeyPrefix: "codex",
+    });
+    assert.equal(scheduled.scheduled, true);
+    assert.equal(scheduled.reason, "profile_missing");
+    const invocation = JSON.parse(await waitForFile(logPath));
+    assert.deepEqual(invocation.args, ["maintain", "--repo", canonicalRepo]);
+    assert.equal(invocation.cwd, canonicalRepo);
+
+    await mkdir(join(repo, ".repo_memory"));
+    await writeFile(join(repo, ".repo_memory", "PROFILE.md"), "# Existing Repo Memory\n");
+    const existing = scheduleMissingRepoMemoryBuild({
+      hook_event_name: "UserPromptSubmit",
+      session_id: "session-a",
+      cwd: repo,
+    }, {
+      adapterDir: "codex",
+      pluginRoot,
+      sessionKeyPrefix: "codex",
+    });
+    assert.equal(existing.scheduled, false);
+    assert.equal(existing.reason, "profile_present");
+    await delay(100);
+    assert.equal((await readFile(logPath, "utf8")).trim().split(/\r?\n/).length, 1);
+  } finally {
+    restoreEnv("MEMORAX_CODE_HOME", previousHome);
+    restoreEnv("MEMORAX_CODE_AUTO_BUILD_TEST_LOG", previousLog);
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("repo memory auto-build uses captured workspace state and deduplicates an active job", async () => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-code-auto-build-active-"));
+  const previousHome = process.env.MEMORAX_CODE_HOME;
+  const previousLog = process.env.MEMORAX_CODE_AUTO_BUILD_TEST_LOG;
+  try {
+    const repo = await createRepo(root);
+    const canonicalRepo = await realpath(repo);
+    const pluginRoot = await createFakePlugin(root);
+    const memoraxCodeHome = join(root, "memorax-code");
+    const logPath = join(root, "auto-build.log");
+    process.env.MEMORAX_CODE_HOME = memoraxCodeHome;
+    process.env.MEMORAX_CODE_AUTO_BUILD_TEST_LOG = logPath;
+    await writeWorkspaceState(memoraxCodeHome, canonicalRepo);
+
+    const { repoKey } = markerPathForRepo(memoraxCodeHome, canonicalRepo);
+    writeRepoMemoryJobMarker({
+      memoraxCodeHome,
+      marker: {
+        version: 1,
+        repo: canonicalRepo,
+        repoKey,
+        mode: "build",
+        jobId: "20260804000000000-build-repo-1234abcd",
+        jobPath: join(root, "job.json"),
+        outputLogPath: join(root, "output.log"),
+        finalMessagePath: join(root, "final-message.txt"),
+        pid: process.pid,
+        runner: "codex",
+        runId: "a".repeat(32),
+        startedAt: new Date().toISOString(),
+      },
+    });
+
+    const result = scheduleMissingRepoMemoryBuild({
+      hook_event_name: "UserPromptSubmit",
+      session_id: "captured-session",
+    }, {
+      adapterDir: "codex",
+      pluginRoot,
+      sessionKeyPrefix: "codex",
+    });
+    assert.equal(result.scheduled, false);
+    assert.equal(result.reason, "active_job");
+    await delay(100);
+    await assert.rejects(readFile(logPath, "utf8"), /ENOENT/);
+  } finally {
+    restoreEnv("MEMORAX_CODE_HOME", previousHome);
+    restoreEnv("MEMORAX_CODE_AUTO_BUILD_TEST_LOG", previousLog);
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("repo memory auto-build skips projectless and non-Git workspaces", async () => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-code-auto-build-skip-"));
+  try {
+    const pluginRoot = await createFakePlugin(root);
+    const projectless = scheduleMissingRepoMemoryBuild({
+      hook_event_name: "UserPromptSubmit",
+      cwd: root,
+      workspace_kind: "projectless",
+    }, { pluginRoot });
+    assert.equal(projectless.reason, "projectless_workspace");
+
+    const nonGit = scheduleMissingRepoMemoryBuild({
+      hook_event_name: "UserPromptSubmit",
+      cwd: root,
+    }, { pluginRoot });
+    assert.equal(nonGit.reason, "git_worktree_unavailable");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+async function createRepo(root) {
+  const repo = join(root, "repo");
+  await mkdir(join(repo, "src"), { recursive: true });
+  runGit(repo, ["init", "-b", "main"]);
+  await writeFile(join(repo, "README.md"), "# Repo Memory auto-build fixture\n");
+  runGit(repo, ["add", "README.md"]);
+  runGit(repo, ["commit", "-m", "initial fixture"]);
+  return repo;
+}
+
+async function createFakePlugin(root) {
+  const pluginRoot = join(root, "plugin");
+  const hookPath = join(pluginRoot, "hooks", "repo-memory-job.mjs");
+  await mkdir(dirname(hookPath), { recursive: true });
+  await writeFile(hookPath, [
+    'import { appendFileSync } from "node:fs";',
+    "const path = process.env.MEMORAX_CODE_AUTO_BUILD_TEST_LOG;",
+    "appendFileSync(path, `${JSON.stringify({ args: process.argv.slice(2), cwd: process.cwd() })}\\n`);",
+    "",
+  ].join("\n"));
+  return pluginRoot;
+}
+
+async function writeWorkspaceState(memoraxCodeHome, repo) {
+  const path = join(memoraxCodeHome, "adapters", "codex", "workspaces.json");
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, `${JSON.stringify({
+    version: 1,
+    runtime: "codex",
+    sessions: {
+      "captured-session": { cwd: repo },
+    },
+  })}\n`);
+}
+
+function runGit(cwd, args) {
+  const result = spawnSync("git", [
+    "-c",
+    "user.name=Repo Memory Auto Build Test",
+    "-c",
+    "user.email=repo-memory-auto-build@example.invalid",
+    ...args,
+  ], { cwd, encoding: "utf8" });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+}
+
+async function waitForFile(path) {
+  const deadline = Date.now() + 3000;
+  while (Date.now() < deadline) {
+    try {
+      const value = await readFile(path, "utf8");
+      if (value.trim()) return value.trim().split(/\r?\n/)[0];
+    } catch (error) {
+      if (error?.code !== "ENOENT") throw error;
+    }
+    await delay(25);
+  }
+  throw new Error(`timed out waiting for ${path}`);
+}
+
+function delay(ms) {
+  return new Promise((resolveDelay) => setTimeout(resolveDelay, ms));
+}
+
+function restoreEnv(name, value) {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}

--- a/packages/ts/memorax-code-codex-adapter/test/repo-memory-auto-build.test.mjs
+++ b/packages/ts/memorax-code-codex-adapter/test/repo-memory-auto-build.test.mjs
@@ -2,8 +2,9 @@ import { strict as assert } from "node:assert";
 import { spawnSync } from "node:child_process";
 import { mkdir, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { test } from "node:test";
+import { fileURLToPath } from "node:url";
 import {
   resolveGitWorktreeRoot,
   scheduleMissingRepoMemoryBuild,
@@ -12,6 +13,13 @@ import {
   markerPathForRepo,
   writeRepoMemoryJobMarker,
 } from "../../memorax-code-adapter-common/src/repo-memory/repo-memory-job-marker.mjs";
+
+const codexPackageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const codexMemorySkillReminderPath = join(codexPackageRoot, "runtime-hooks", "memory-skill-reminder.mjs");
+const claudeMemorySkillReminderPath = resolve(
+  codexPackageRoot,
+  "../memorax-code-claude-adapter/runtime-hooks/memory-skill-reminder.mjs",
+);
 
 test("repo memory auto-build resolves normal and linked Git worktrees without invoking Git", async () => {
   const root = await mkdtemp(join(tmpdir(), "memorax-code-auto-build-root-"));
@@ -84,6 +92,71 @@ test("repo memory auto-build schedules maintain only when PROFILE.md is missing"
   } finally {
     restoreEnv("MEMORAX_CODE_HOME", previousHome);
     restoreEnv("MEMORAX_CODE_AUTO_BUILD_TEST_LOG", previousLog);
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("Codex and Claude runtime Hook components schedule only a missing profile", async () => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-code-auto-build-runtime-hooks-"));
+  try {
+    const repo = await createRepo(root);
+    const canonicalRepo = await realpath(repo);
+    const pluginRoot = await createFakePlugin(root);
+    const memoraxCodeHome = join(root, "memorax-code");
+    const logPath = join(root, "auto-build.log");
+    const input = {
+      hook_event_name: "UserPromptSubmit",
+      cwd: join(repo, "src"),
+      workspace_kind: "git",
+    };
+
+    const codex = runMemorySkillReminderComponent(codexMemorySkillReminderPath, input, {
+      client: "codex",
+      logPath,
+      memoraxCodeHome,
+      pluginRoot,
+    });
+    assert.equal(codex.status, 0, codex.stderr || codex.stdout);
+    const [codexInvocation] = await waitForLines(logPath, 1);
+    assert.deepEqual(JSON.parse(codexInvocation), {
+      args: ["maintain", "--repo", canonicalRepo],
+      client: "codex",
+      cwd: canonicalRepo,
+    });
+
+    const claude = runMemorySkillReminderComponent(claudeMemorySkillReminderPath, input, {
+      client: "claude",
+      logPath,
+      memoraxCodeHome,
+      pluginRoot,
+    });
+    assert.equal(claude.status, 0, claude.stderr || claude.stdout);
+    const invocations = await waitForLines(logPath, 2);
+    assert.deepEqual(JSON.parse(invocations[1]), {
+      args: ["maintain", "--repo", canonicalRepo],
+      client: "claude",
+      cwd: canonicalRepo,
+    });
+
+    await mkdir(join(repo, ".repo_memory"));
+    await writeFile(join(repo, ".repo_memory", "PROFILE.md"), "# Existing Repo Memory\n");
+    const existingCodex = runMemorySkillReminderComponent(codexMemorySkillReminderPath, input, {
+      client: "codex-existing",
+      logPath,
+      memoraxCodeHome,
+      pluginRoot,
+    });
+    const existingClaude = runMemorySkillReminderComponent(claudeMemorySkillReminderPath, input, {
+      client: "claude-existing",
+      logPath,
+      memoraxCodeHome,
+      pluginRoot,
+    });
+    assert.equal(existingCodex.status, 0, existingCodex.stderr || existingCodex.stdout);
+    assert.equal(existingClaude.status, 0, existingClaude.stderr || existingClaude.stdout);
+    await delay(100);
+    assert.equal((await readFile(logPath, "utf8")).trim().split(/\r?\n/).length, 2);
+  } finally {
     await rm(root, { recursive: true, force: true });
   }
 });
@@ -178,10 +251,31 @@ async function createFakePlugin(root) {
   await writeFile(hookPath, [
     'import { appendFileSync } from "node:fs";',
     "const path = process.env.MEMORAX_CODE_AUTO_BUILD_TEST_LOG;",
-    "appendFileSync(path, `${JSON.stringify({ args: process.argv.slice(2), cwd: process.cwd() })}\\n`);",
+    "appendFileSync(path, `${JSON.stringify({ args: process.argv.slice(2), client: process.env.MEMORAX_CODE_AUTO_BUILD_TEST_CLIENT, cwd: process.cwd() })}\\n`);",
     "",
   ].join("\n"));
   return pluginRoot;
+}
+
+function runMemorySkillReminderComponent(scriptPath, input, options) {
+  const env = {
+    ...process.env,
+    MEMORAX_CODE_AUTO_BUILD_TEST_CLIENT: options.client,
+    MEMORAX_CODE_AUTO_BUILD_TEST_LOG: options.logPath,
+    MEMORAX_CODE_BACKEND_URL: "http://127.0.0.1:1",
+    MEMORAX_CODE_CLAUDE_MEMORY_HOOK_TIMEOUT_MS: "100",
+    MEMORAX_CODE_CODEX_MEMORY_HOOK_TIMEOUT_MS: "100",
+    MEMORAX_CODE_HOME: options.memoraxCodeHome,
+    CLAUDE_PLUGIN_ROOT: options.pluginRoot,
+    PLUGIN_ROOT: options.pluginRoot,
+  };
+  delete env.PLUGIN_DATA;
+  return spawnSync(process.execPath, [scriptPath], {
+    encoding: "utf8",
+    env,
+    input: `${JSON.stringify(input)}\n`,
+    timeout: 5000,
+  });
 }
 
 async function writeWorkspaceState(memoraxCodeHome, repo) {
@@ -208,17 +302,22 @@ function runGit(cwd, args) {
 }
 
 async function waitForFile(path) {
+  return (await waitForLines(path, 1))[0];
+}
+
+async function waitForLines(path, count) {
   const deadline = Date.now() + 3000;
   while (Date.now() < deadline) {
     try {
       const value = await readFile(path, "utf8");
-      if (value.trim()) return value.trim().split(/\r?\n/)[0];
+      const lines = value.trim().split(/\r?\n/).filter(Boolean);
+      if (lines.length >= count) return lines;
     } catch (error) {
       if (error?.code !== "ENOENT") throw error;
     }
     await delay(25);
   }
-  throw new Error(`timed out waiting for ${path}`);
+  throw new Error(`timed out waiting for ${count} line(s) in ${path}`);
 }
 
 function delay(ms) {

--- a/packages/ts/memorax-code-codex-adapter/test/repo-memory-reader.test.mjs
+++ b/packages/ts/memorax-code-codex-adapter/test/repo-memory-reader.test.mjs
@@ -42,10 +42,13 @@ test("memorax-code repo-read reference silently schedules supervised maintenance
   assert.match(openaiYaml, /Use \$memorax-code to route/);
 });
 
-test("memorax-code repo-read delegates deterministic maintenance decisions only on relevant demand", () => {
+test("memorax-code separates Hook first-build checks from repo-read maintenance policy", () => {
   const skill = readFileSync(join(readerSkillRoot, "references", "repo-read.md"), "utf8");
 
-  assert.match(skill, /Only a relevant `repo-read` invokes `maintain`/);
+  assert.match(skill, /`UserPromptSubmit` Hook checks whether the selected Git worktree has/);
+  assert.match(skill, /profile is absent, the Hook silently invokes `maintain`/);
+  assert.match(skill, /only a relevant `repo-read` invokes `maintain`/);
+  assert.match(skill, /does not evaluate update staleness/);
   assert.match(skill, /Commit arrival, PR merge, and elapsed time alone do not invoke it/);
   assert.match(skill, /validates the generated bundle, evaluates the configured local update policy/);
   assert.match(skill, /provider network access/);

--- a/scripts/npm-package-check.sh
+++ b/scripts/npm-package-check.sh
@@ -109,6 +109,7 @@ for relative in [
     "lib/memorax-code-adapter-common/src/clients/codex-command.mjs",
     "lib/memorax-code-adapter-common/src/repo-memory/repo-procedure-memory-context.mjs",
     "lib/memorax-code-adapter-common/src/repo-memory/repo-user-profile-context.mjs",
+    "lib/memorax-code-adapter-common/src/repo-memory/repo-memory-auto-build.mjs",
     "lib/memorax-code-adapter-common/src/repo-memory/repo-memory-job-supervisor.mjs",
     "lib/memorax-code-adapter-common/src/repo-memory/repo-memory-job-worker.mjs",
     "lib/memorax-code-adapter-common/src/repo-memory/repo-memory-update-policy-evaluator.mjs",
@@ -124,6 +125,7 @@ for relative in [
     "lib/memorax-code-codex-adapter/assets/composer-icon.png",
     "lib/memorax-code-codex-adapter/assets/logo.png",
     "lib/memorax-code-codex-adapter/hooks/hooks.json",
+    "lib/memorax-code-codex-adapter/hooks/repo-memory-job.mjs",
     "lib/memorax-code-codex-adapter/hooks/runtime-hook.mjs",
     "lib/memorax-code-codex-adapter/hooks/runtime-shell.json",
     "lib/memorax-code-codex-adapter/runtime-hooks/memory-skill-reminder.mjs",
@@ -134,16 +136,19 @@ for relative in [
     "lib/memorax-code-claude-adapter/hooks/runtime-hook.mjs",
     "lib/memorax-code-claude-adapter/hooks/runtime-shell.json",
     "lib/memorax-code-claude-adapter/hooks/repo-memory-job.mjs",
+    "lib/memorax-code-claude-adapter/runtime-hooks/memory-skill-reminder.mjs",
     "lib/memorax-code-claude-adapter/runtime-hooks/memory-turn.mjs",
     "lib/memorax-code-claude-adapter/skills/memorax-code/SKILL.md",
     "lib/memorax-code-claude-marketplace/plugins/memorax-code-claude-adapter/hooks/hooks.json",
     "lib/memorax-code-claude-marketplace/plugins/memorax-code-claude-adapter/hooks/runtime-hook.mjs",
     "lib/memorax-code-claude-marketplace/plugins/memorax-code-claude-adapter/hooks/runtime-shell.json",
     "lib/memorax-code-claude-marketplace/plugins/memorax-code-claude-adapter/hooks/repo-memory-job.mjs",
+    "lib/memorax-code-claude-marketplace/plugins/memorax-code-claude-adapter/runtime-hooks/memory-skill-reminder.mjs",
     "lib/memorax-code-claude-marketplace/plugins/memorax-code-claude-adapter/runtime-hooks/memory-turn.mjs",
     "lib/memorax-code-claude-marketplace/plugins/memorax-code-claude-adapter/memorax-code-adapter-common/src/backend-connection.mjs",
     "lib/memorax-code-claude-marketplace/plugins/memorax-code-claude-adapter/memorax-code-adapter-common/src/runtime-record.mjs",
     "lib/memorax-code-claude-marketplace/plugins/memorax-code-claude-adapter/memorax-code-adapter-common/src/hooks/ensure-backend-runner.mjs",
+    "lib/memorax-code-claude-marketplace/plugins/memorax-code-claude-adapter/memorax-code-adapter-common/src/repo-memory/repo-memory-auto-build.mjs",
     "lib/memorax-code-claude-marketplace/plugins/memorax-code-claude-adapter/memorax-code-adapter-common/src/repo-memory/repo-procedure-memory-context.mjs",
     "lib/memorax-code-claude-marketplace/plugins/memorax-code-claude-adapter/memorax-code-adapter-common/src/repo-memory/repo-user-profile-context.mjs",
     "lib/memorax-code-claude-marketplace/plugins/memorax-code-claude-adapter/skills/memorax-code/SKILL.md",
@@ -283,6 +288,7 @@ for relative in \
   lib/memorax-code-adapter-common/src/clients/codex-command.mjs \
   lib/memorax-code-adapter-common/src/repo-memory/repo-procedure-memory-context.mjs \
   lib/memorax-code-adapter-common/src/repo-memory/repo-user-profile-context.mjs \
+  lib/memorax-code-adapter-common/src/repo-memory/repo-memory-auto-build.mjs \
   lib/memorax-code-adapter-common/src/repo-memory/repo-memory-job-supervisor.mjs \
   lib/memorax-code-adapter-common/src/repo-memory/repo-memory-job-worker.mjs \
   lib/memorax-code-adapter-common/src/repo-memory/repo-memory-update-policy-evaluator.mjs \
@@ -293,18 +299,23 @@ for relative in \
   lib/memorax-code-backend/dist/memory-service.js \
   lib/memorax-code-codex-adapter/hooks/runtime-hook.mjs \
   lib/memorax-code-codex-adapter/hooks/runtime-shell.json \
+  lib/memorax-code-codex-adapter/hooks/repo-memory-job.mjs \
+  lib/memorax-code-codex-adapter/runtime-hooks/memory-skill-reminder.mjs \
   lib/memorax-code-codex-adapter/runtime-hooks/memory-writeback.mjs \
   lib/memorax-code-claude-adapter/hooks/runtime-hook.mjs \
   lib/memorax-code-claude-adapter/hooks/runtime-shell.json \
   lib/memorax-code-claude-adapter/hooks/repo-memory-job.mjs \
+  lib/memorax-code-claude-adapter/runtime-hooks/memory-skill-reminder.mjs \
   lib/memorax-code-claude-adapter/runtime-hooks/memory-turn.mjs \
   lib/memorax-code-claude-marketplace/plugins/memorax-code-claude-adapter/hooks/runtime-hook.mjs \
   lib/memorax-code-claude-marketplace/plugins/memorax-code-claude-adapter/hooks/runtime-shell.json \
   lib/memorax-code-claude-marketplace/plugins/memorax-code-claude-adapter/hooks/repo-memory-job.mjs \
+  lib/memorax-code-claude-marketplace/plugins/memorax-code-claude-adapter/runtime-hooks/memory-skill-reminder.mjs \
   lib/memorax-code-claude-marketplace/plugins/memorax-code-claude-adapter/runtime-hooks/memory-turn.mjs \
   lib/memorax-code-claude-marketplace/plugins/memorax-code-claude-adapter/memorax-code-adapter-common/src/backend-connection.mjs \
   lib/memorax-code-claude-marketplace/plugins/memorax-code-claude-adapter/memorax-code-adapter-common/src/runtime-record.mjs \
   lib/memorax-code-claude-marketplace/plugins/memorax-code-claude-adapter/memorax-code-adapter-common/src/hooks/ensure-backend-runner.mjs \
+  lib/memorax-code-claude-marketplace/plugins/memorax-code-claude-adapter/memorax-code-adapter-common/src/repo-memory/repo-memory-auto-build.mjs \
   lib/memorax-code-claude-marketplace/plugins/memorax-code-claude-adapter/memorax-code-adapter-common/src/repo-memory/repo-procedure-memory-context.mjs \
   lib/memorax-code-claude-marketplace/plugins/memorax-code-claude-adapter/memorax-code-adapter-common/src/repo-memory/repo-user-profile-context.mjs \
   lib/memorax-code-claude-marketplace/plugins/memorax-code-claude-adapter/skills/memorax-code/SKILL.md
@@ -359,7 +370,10 @@ generation_manifest = json.loads((generation / "generation.json").read_text())
 assert generation_manifest["generationId"] == current["generationId"]
 assert generation_manifest["contentDigest"] == current["contentDigest"]
 assert (generation / "lib" / "memorax-code-codex-adapter" / "runtime-hooks" / "memory-writeback.mjs").exists()
+assert (generation / "lib" / "memorax-code-codex-adapter" / "runtime-hooks" / "memory-skill-reminder.mjs").exists()
 assert (generation / "lib" / "memorax-code-claude-adapter" / "runtime-hooks" / "memory-turn.mjs").exists()
+assert (generation / "lib" / "memorax-code-claude-adapter" / "runtime-hooks" / "memory-skill-reminder.mjs").exists()
+assert (generation / "lib" / "memorax-code-adapter-common" / "src" / "repo-memory" / "repo-memory-auto-build.mjs").exists()
 assert current_path.stat().st_mode & 0o777 == 0o600
 PY_POSTINSTALL
 
@@ -512,7 +526,9 @@ assert (install_path / "skills" / "memorax-code" / "SKILL.md").exists()
 assert (install_path / "hooks" / "runtime-hook.mjs").exists()
 assert (install_path / "hooks" / "runtime-shell.json").exists()
 assert (install_path / "runtime-hooks" / "memory-turn.mjs").exists()
+assert (install_path / "runtime-hooks" / "memory-skill-reminder.mjs").exists()
 assert (install_path / "hooks" / "repo-memory-job.mjs").exists()
+assert (install_path / "memorax-code-adapter-common" / "src" / "repo-memory" / "repo-memory-auto-build.mjs").exists()
 state = json.loads((memorax_code_home / "adapters" / "claude-code" / "state.json").read_text())
 assert state["version"] == 1
 assert state["runtime"] == "claude-code"


### PR DESCRIPTION
## Summary

本 PR 为 Repo Memory 增加首次自动构建机制：Git 工作树收到符合条件的 `UserPromptSubmit` 请求时，如果 `.repo_memory/PROFILE.md` 不存在，Hook 会在本地完成判断，并异步启动现有的 `maintain` 后台任务。

这个机制解决了首次构建必须等待 Agent 主动执行相关 Repo Read 的问题。Hook 不等待构建完成，也不会阻塞用户当前请求；一旦 `PROFILE.md` 已存在，首次构建检查会立即结束。

## Changes

- 新增共享的 Repo Memory 自动构建调度模块，通过只读文件系统信息定位普通 Git 工作树和 linked worktree，不通过执行 Git 命令判断仓库身份。
- 在 Codex 和 Claude Code 的 `UserPromptSubmit` Hook 中接入缺失检查。
- 当 `.repo_memory/PROFILE.md` 缺失时，异步调用 `repo-memory-job.mjs maintain --repo <repo>`。
- 当 `PROFILE.md` 已存在时直接跳过，不在该路径中校验内容，也不判断是否过期；后续校验和增量更新仍由 Repo Read 负责。
- 跳过非 Git 工作区和 Codex 无项目工作区；检测到已有 Repo Memory 后台任务时复用现有任务，避免重复构建。
- 保持失败不阻塞：路径解析、文件检查或后台启动失败时，Hook 静默结束，用户请求继续执行。
- 将新共享模块加入 Codex Hook runtime、Claude marketplace 和 npm 安装包，并补充中英文 README、配置文档、安全说明及 Repo Memory 技能文档。
- 增加普通/linked worktree、文件存在与缺失、工作区状态回退、跨客户端任务去重、真实 Codex/Claude Hook 入口和打包产物测试。

## Validation

- `node --test test/repo-memory-auto-build.test.mjs`（在 Codex adapter 目录运行）：5/5 通过。
  - Codex 和 Claude 的真实 `memory-skill-reminder` Hook 入口在缺少 `PROFILE.md` 时，都实际调用了 `maintain --repo <canonical-repo>`。
  - 创建 `.repo_memory/PROFILE.md` 后再次运行两个 Hook，后台调用数量没有增加。
  - 普通工作树、linked worktree、已有任务去重、无项目工作区跳过和非 Git 工作区跳过均通过。
- 真实 Codex 完整链路测试通过。测试使用无远端的隔离临时 Git 仓库，从 Hook 触发一直执行到后台构建和最终校验：
  - Hook 成功返回，并启动一个独立的 `codex exec` Repo Build；用户请求不等待后台构建。
  - 后台任务最终状态为 `succeeded`，退出码为 `0`。
  - 生成了 `PROFILE.md`、2 个原始数据文件和 3 个资源文件。
  - 独立运行 `validate_memory.py --pretty`，结果为 0 个错误、0 个警告，共检查 6 个文件。
  - `PROFILE.md.local_head` 与 Hook 触发时的精确提交一致。
  - 构建成功后再次运行 Hook，任务数量保持 `1 -> 1`，确认已有 Profile 时不会重复构建。
  - 临时仓库没有 GitHub/GitLab 远端，构建正确使用本地模式，并明确标记 PR、MR、Issue 证据未获取，没有伪造数据。
- `npm test --prefix packages/ts/memorax-code-codex-adapter`：205/205 通过，其中包括后台 build/update、最终 Repo Memory 校验、并发启动和失败隔离测试。
- `npm test --prefix packages/ts/memorax-code-claude-adapter`：64/64 通过。
- `make docs-check`：9/9 通过；文档约束和中英文 README 同步检查通过。
- `make npm-package-check`：149/149 通过；Backend TypeScript 构建、本地 trace 安全检查、284 个 npm pack 文件白名单、安装与更新流程均通过。
- 每次提交前执行 `git diff --cached --check`，均通过。
- 未运行完整 Backend 测试，因为本次没有修改 Backend 源码或 HTTP 接口；`make npm-package-check` 已执行 Backend TypeScript 构建。
- 未启动真实 Claude 模型进行完整构建。Claude 的真实 Hook 入口和打包 worker 流程已通过隔离测试；涉及模型调用的完整链路只在 Codex 上执行了一次。

## Risk and compatibility

- 影响 Codex 和 Claude Code 的每次符合条件的 `UserPromptSubmit`。同步部分仅包含工作区定位和本地文件存在性检查；耗时构建在独立后台进程中执行。
- 新路径只负责“首次缺失时构建”。已有 Repo Memory 不会在每次 Hook 中被校验或判断是否过期，现有 Repo Read 更新策略保持不变。
- 普通工作树与 linked worktree 按各自工作树目录检查 `.repo_memory/PROFILE.md`；跨客户端仍通过现有 per-worktree marker 防止重复任务。
- 非 Git 工作区和 Codex 无项目工作区保持原有行为，不会创建 `.repo_memory`。
- 没有新增持久化状态格式、Backend API、MemoraX 请求内容、凭证处理或 transcript 权限变化。
- Git 元数据解析拒绝符号链接和损坏的指针并按失败不阻塞处理。生成的 `.repo_memory` 仍保留在本地并由支持流程加入 Git 忽略；模型服务以及 `gh`/`glab` 的网络边界维持现有设计。
