### PR TITLE
fix: detect Claude Desktop app runtimes

### DIFF
--- a/packages/npm/memorax-code/bin/memorax-code-plugin-postinstall.mjs
+++ b/packages/npm/memorax-code/bin/memorax-code-plugin-postinstall.mjs
@@ -738,7 +738,11 @@ function runCodexPreflight() {
 
 function runClaudePreflight() {
   const version = runExternalCommand(claudeCommand, ["--version"], { print: false, timeout: 10_000 });
-  const runtimeLabel = claudeRuntime.source === "vscode-bundled" ? "Claude VS Code runtime" : "Claude CLI";
+  const runtimeLabel = claudeRuntime.source === "app-bundled"
+    ? "Claude Code App runtime"
+    : claudeRuntime.source === "vscode-bundled"
+      ? "Claude VS Code runtime"
+      : "Claude CLI";
   log(`${runtimeLabel}: ${commandSummary(version) ?? "not runnable"}`);
   if (version.status !== 0) return { ok: false };
   log("Keeping Claude Code provider config unchanged and enabling the shared memory Hook integration.");

--- a/packages/npm/memorax-code/lib/resolve-claude-command.mjs
+++ b/packages/npm/memorax-code/lib/resolve-claude-command.mjs
@@ -1,16 +1,21 @@
+import { readdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import {
   commandOnPath,
   defaultVsCodeExtensionRoots,
   findVsCodeExtensionCommand,
+  isExecutableCommand,
 } from "./vscode-extension-command.mjs";
+
+const CLAUDE_DESKTOP_CODE_RUNTIME_SEGMENTS = ["claude.app", "Contents", "MacOS", "claude"];
 
 export function resolveClaudeCommand({
   env = process.env,
   homeDir = homedir(),
   platform = process.platform,
   arch = process.arch,
+  desktopCodeRoots = [join(homeDir, "Library", "Application Support", "Claude", "claude-code")],
   vscodeExtensionRoots = defaultVsCodeExtensionRoots(homeDir),
 } = {}) {
   const configured = nonEmpty(env.MEMORAX_CODE_CLAUDE_COMMAND);
@@ -19,6 +24,9 @@ export function resolveClaudeCommand({
   if (commandOnPath("claude", env.PATH, platform, env.PATHEXT)) {
     return { command: "claude", source: "path" };
   }
+
+  const desktopCommand = findClaudeDesktopCodeCommand(desktopCodeRoots, platform);
+  if (desktopCommand) return { command: desktopCommand, source: "app-bundled" };
 
   const vscodeCommand = findVsCodeExtensionCommand({
     extensionId: "anthropic.claude-code",
@@ -39,6 +47,26 @@ export function ensureClaudeCommandEnv(options = {}) {
   const resolved = resolveClaudeCommand({ ...options, env });
   if (resolved.source !== "unavailable") env.MEMORAX_CODE_CLAUDE_COMMAND = resolved.command;
   return resolved;
+}
+
+function findClaudeDesktopCodeCommand(roots, platform) {
+  if (platform !== "darwin") return undefined;
+  for (const root of new Set(roots)) {
+    let versions;
+    try {
+      versions = readdirSync(root, { withFileTypes: true })
+        .filter((entry) => entry.isDirectory() || entry.isSymbolicLink())
+        .map((entry) => entry.name)
+        .sort((left, right) => right.localeCompare(left, "en", { numeric: true, sensitivity: "base" }));
+    } catch {
+      continue;
+    }
+    for (const version of versions) {
+      const command = join(root, version, ...CLAUDE_DESKTOP_CODE_RUNTIME_SEGMENTS);
+      if (isExecutableCommand(command, platform)) return command;
+    }
+  }
+  return undefined;
 }
 
 function nonEmpty(value) {

--- a/packages/npm/memorax-code/lib/resolve-claude-command.mjs
+++ b/packages/npm/memorax-code/lib/resolve-claude-command.mjs
@@ -1,6 +1,7 @@
+import { spawnSync } from "node:child_process";
 import { readdirSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, win32 } from "node:path";
 import {
   commandOnPath,
   defaultVsCodeExtensionRoots,
@@ -8,15 +9,20 @@ import {
   isExecutableCommand,
 } from "./vscode-extension-command.mjs";
 
-const CLAUDE_DESKTOP_CODE_RUNTIME_SEGMENTS = ["claude.app", "Contents", "MacOS", "claude"];
+const CLAUDE_DESKTOP_MACOS_RUNTIME_SEGMENTS = ["claude.app", "Contents", "MacOS", "claude"];
+const CLAUDE_DESKTOP_WINDOWS_PACKAGE_NAME = "Claude";
+const CLAUDE_DESKTOP_WINDOWS_QUERY_TIMEOUT_MS = 10_000;
+const CLAUDE_DESKTOP_WINDOWS_RUNTIME_SEGMENTS = ["claude.exe"];
 
 export function resolveClaudeCommand({
   env = process.env,
   homeDir = homedir(),
   platform = process.platform,
   arch = process.arch,
-  desktopCodeRoots = [join(homeDir, "Library", "Application Support", "Claude", "claude-code")],
+  desktopCodeRoots = defaultClaudeDesktopCodeRoots(env, homeDir, platform),
   vscodeExtensionRoots = defaultVsCodeExtensionRoots(homeDir),
+  windowsAppPackageFamilies,
+  windowsAppQuery = spawnSync,
 } = {}) {
   const configured = nonEmpty(env.MEMORAX_CODE_CLAUDE_COMMAND);
   if (configured) return { command: configured, source: "configured" };
@@ -27,6 +33,15 @@ export function resolveClaudeCommand({
 
   const desktopCommand = findClaudeDesktopCodeCommand(desktopCodeRoots, platform);
   if (desktopCommand) return { command: desktopCommand, source: "app-bundled" };
+
+  const windowsDesktopCommand = resolveWindowsClaudeDesktopCodeCommand({
+    env,
+    homeDir,
+    packageFamilies: windowsAppPackageFamilies,
+    platform,
+    spawnSyncImpl: windowsAppQuery,
+  });
+  if (windowsDesktopCommand) return { command: windowsDesktopCommand, source: "app-bundled" };
 
   const vscodeCommand = findVsCodeExtensionCommand({
     extensionId: "anthropic.claude-code",
@@ -49,8 +64,31 @@ export function ensureClaudeCommandEnv(options = {}) {
   return resolved;
 }
 
+export function resolveWindowsClaudeDesktopCodeCommand({
+  env = process.env,
+  homeDir = homedir(),
+  packageFamilies,
+  platform = process.platform,
+  spawnSyncImpl = spawnSync,
+} = {}) {
+  if (platform !== "win32") return undefined;
+  const localAppData = nonEmpty(env.LOCALAPPDATA) ?? join(homeDir, "AppData", "Local");
+  const families = packageFamilies ?? queryWindowsClaudeAppPackageFamilies(env, spawnSyncImpl);
+  const roots = families.map((family) => join(
+    localAppData,
+    "Packages",
+    family,
+    "LocalCache",
+    "Roaming",
+    "Claude",
+    "claude-code",
+  ));
+  return findClaudeDesktopCodeCommand(roots, platform);
+}
+
 function findClaudeDesktopCodeCommand(roots, platform) {
-  if (platform !== "darwin") return undefined;
+  const runtimeSegments = claudeDesktopRuntimeSegments(platform);
+  if (!runtimeSegments) return undefined;
   for (const root of new Set(roots)) {
     let versions;
     try {
@@ -62,11 +100,64 @@ function findClaudeDesktopCodeCommand(roots, platform) {
       continue;
     }
     for (const version of versions) {
-      const command = join(root, version, ...CLAUDE_DESKTOP_CODE_RUNTIME_SEGMENTS);
+      const command = join(root, version, ...runtimeSegments);
       if (isExecutableCommand(command, platform)) return command;
     }
   }
   return undefined;
+}
+
+function defaultClaudeDesktopCodeRoots(env, homeDir, platform) {
+  if (platform === "darwin") {
+    return [join(homeDir, "Library", "Application Support", "Claude", "claude-code")];
+  }
+  if (platform === "win32") {
+    const appData = nonEmpty(env.APPDATA) ?? join(homeDir, "AppData", "Roaming");
+    return [join(appData, "Claude", "claude-code")];
+  }
+  return [];
+}
+
+function claudeDesktopRuntimeSegments(platform) {
+  if (platform === "darwin") return CLAUDE_DESKTOP_MACOS_RUNTIME_SEGMENTS;
+  if (platform === "win32") return CLAUDE_DESKTOP_WINDOWS_RUNTIME_SEGMENTS;
+  return undefined;
+}
+
+function queryWindowsClaudeAppPackageFamilies(env, spawnSyncImpl) {
+  const powershell = windowsPowerShellCommand(env);
+  const script = [
+    "[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)",
+    `Get-AppxPackage -Name '${CLAUDE_DESKTOP_WINDOWS_PACKAGE_NAME}' -ErrorAction SilentlyContinue | ForEach-Object { $_.PackageFamilyName }`,
+  ].join("; ");
+  let result;
+  try {
+    result = spawnSyncImpl(
+      powershell,
+      ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", script],
+      {
+        encoding: "utf8",
+        env,
+        stdio: ["ignore", "pipe", "pipe"],
+        timeout: CLAUDE_DESKTOP_WINDOWS_QUERY_TIMEOUT_MS,
+        windowsHide: true,
+      },
+    );
+  } catch {
+    return [];
+  }
+  if (result.status !== 0 || result.error || result.signal) return [];
+  return [...new Set(String(result.stdout ?? "")
+    .split(/\r?\n/)
+    .map((value) => value.replace(/^\uFEFF/, "").trim())
+    .filter((value) => /^[A-Za-z0-9][A-Za-z0-9.-]*_[A-Za-z0-9]+$/.test(value)))];
+}
+
+function windowsPowerShellCommand(env) {
+  const systemRoot = nonEmpty(env.SystemRoot) ?? nonEmpty(env.SYSTEMROOT);
+  return systemRoot
+    ? win32.join(systemRoot, "System32", "WindowsPowerShell", "v1.0", "powershell.exe")
+    : "powershell.exe";
 }
 
 function nonEmpty(value) {

--- a/packages/npm/memorax-code/lib/resolve-claude-command.mjs
+++ b/packages/npm/memorax-code/lib/resolve-claude-command.mjs
@@ -10,6 +10,7 @@ import {
 } from "./vscode-extension-command.mjs";
 
 const CLAUDE_DESKTOP_MACOS_RUNTIME_SEGMENTS = ["claude.app", "Contents", "MacOS", "claude"];
+const CLAUDE_DESKTOP_CODE_PROBE_TIMEOUT_MS = 10_000;
 const CLAUDE_DESKTOP_WINDOWS_PACKAGE_NAME = "Claude";
 const CLAUDE_DESKTOP_WINDOWS_QUERY_TIMEOUT_MS = 10_000;
 const CLAUDE_DESKTOP_WINDOWS_RUNTIME_SEGMENTS = ["claude.exe"];
@@ -20,6 +21,7 @@ export function resolveClaudeCommand({
   platform = process.platform,
   arch = process.arch,
   desktopCodeRoots = defaultClaudeDesktopCodeRoots(env, homeDir, platform),
+  desktopCodeProbe = spawnSync,
   vscodeExtensionRoots = defaultVsCodeExtensionRoots(homeDir),
   windowsAppPackageFamilies,
   windowsAppQuery = spawnSync,
@@ -31,7 +33,12 @@ export function resolveClaudeCommand({
     return { command: "claude", source: "path" };
   }
 
-  const desktopCommand = findClaudeDesktopCodeCommand(desktopCodeRoots, platform);
+  const desktopCommand = findClaudeDesktopCodeCommand(
+    desktopCodeRoots,
+    platform,
+    env,
+    desktopCodeProbe,
+  );
   if (desktopCommand) return { command: desktopCommand, source: "app-bundled" };
 
   const windowsDesktopCommand = resolveWindowsClaudeDesktopCodeCommand({
@@ -39,6 +46,7 @@ export function resolveClaudeCommand({
     homeDir,
     packageFamilies: windowsAppPackageFamilies,
     platform,
+    desktopCodeProbe,
     spawnSyncImpl: windowsAppQuery,
   });
   if (windowsDesktopCommand) return { command: windowsDesktopCommand, source: "app-bundled" };
@@ -69,6 +77,7 @@ export function resolveWindowsClaudeDesktopCodeCommand({
   homeDir = homedir(),
   packageFamilies,
   platform = process.platform,
+  desktopCodeProbe = spawnSync,
   spawnSyncImpl = spawnSync,
 } = {}) {
   if (platform !== "win32") return undefined;
@@ -83,10 +92,10 @@ export function resolveWindowsClaudeDesktopCodeCommand({
     "Claude",
     "claude-code",
   ));
-  return findClaudeDesktopCodeCommand(roots, platform);
+  return findClaudeDesktopCodeCommand(roots, platform, env, desktopCodeProbe);
 }
 
-function findClaudeDesktopCodeCommand(roots, platform) {
+function findClaudeDesktopCodeCommand(roots, platform, env, spawnSyncImpl) {
   const runtimeSegments = claudeDesktopRuntimeSegments(platform);
   if (!runtimeSegments) return undefined;
   for (const root of new Set(roots)) {
@@ -101,10 +110,35 @@ function findClaudeDesktopCodeCommand(roots, platform) {
     }
     for (const version of versions) {
       const command = join(root, version, ...runtimeSegments);
-      if (isExecutableCommand(command, platform)) return command;
+      if (
+        isExecutableCommand(command, platform)
+        && claudeDesktopCodeCommandIsRunnable(command, env, spawnSyncImpl)
+      ) {
+        return command;
+      }
     }
   }
   return undefined;
+}
+
+function claudeDesktopCodeCommandIsRunnable(command, env, spawnSyncImpl) {
+  let result;
+  try {
+    result = spawnSyncImpl(
+      command,
+      ["--version"],
+      {
+        encoding: "utf8",
+        env,
+        stdio: ["ignore", "pipe", "pipe"],
+        timeout: CLAUDE_DESKTOP_CODE_PROBE_TIMEOUT_MS,
+        windowsHide: true,
+      },
+    );
+  } catch {
+    return false;
+  }
+  return result.status === 0 && !result.error && !result.signal;
 }
 
 function defaultClaudeDesktopCodeRoots(env, homeDir, platform) {

--- a/packages/npm/memorax-code/test/resolve-claude-command.test.mjs
+++ b/packages/npm/memorax-code/test/resolve-claude-command.test.mjs
@@ -3,7 +3,11 @@ import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
-import { ensureClaudeCommandEnv, resolveClaudeCommand } from "../lib/resolve-claude-command.mjs";
+import {
+  ensureClaudeCommandEnv,
+  resolveClaudeCommand,
+  resolveWindowsClaudeDesktopCodeCommand,
+} from "../lib/resolve-claude-command.mjs";
 
 async function executable(path) {
   await mkdir(dirname(path), { recursive: true });
@@ -33,7 +37,7 @@ test("Claude command resolution preserves an explicit command and PATH CLI prece
   }
 });
 
-test("Claude command resolution uses the newest Claude Desktop Code runtime", async () => {
+test("Claude command resolution uses the newest macOS Claude Desktop Code runtime", async () => {
   const root = await mkdtemp(join(tmpdir(), "memorax-code-claude-command-desktop-"));
   try {
     const desktopRoot = join(root, "Library", "Application Support", "Claude", "claude-code");
@@ -63,6 +67,143 @@ test("Claude command resolution uses the newest Claude Desktop Code runtime", as
   } finally {
     await rm(root, { recursive: true, force: true });
   }
+});
+
+test("Claude command resolution uses the newest Windows Claude Desktop Code runtime", async () => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-code-claude-command-windows-desktop-"));
+  try {
+    const appData = join(root, "Roaming");
+    const desktopRoot = join(appData, "Claude", "claude-code");
+    await executable(join(desktopRoot, "2.9.0", "claude.exe"));
+    const expected = await executable(join(desktopRoot, "2.10.0", "claude.exe"));
+    await mkdir(join(desktopRoot, "99.0.0"), { recursive: true });
+
+    const env = {
+      APPDATA: appData,
+      LOCALAPPDATA: join(root, "Local"),
+      PATH: join(root, "empty-bin"),
+      PATHEXT: ".EXE;.CMD;.BAT;.COM",
+    };
+    const resolved = ensureClaudeCommandEnv({
+      env,
+      homeDir: root,
+      platform: "win32",
+      arch: "x64",
+      vscodeExtensionRoots: [],
+      windowsAppQuery() {
+        throw new Error("the AppX query should not run when the AppData runtime exists");
+      },
+    });
+
+    assert.deepEqual(resolved, { command: expected, source: "app-bundled" });
+    assert.equal(env.MEMORAX_CODE_CLAUDE_COMMAND, expected);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("Claude command resolution uses the MSIX-local Windows Desktop Code runtime", async () => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-code-claude-command-windows-msix-"));
+  try {
+    const family = "Claude_pzs8sxrjxfjjc";
+    const localAppData = join(root, "Local");
+    const desktopRoot = join(
+      localAppData,
+      "Packages",
+      family,
+      "LocalCache",
+      "Roaming",
+      "Claude",
+      "claude-code",
+    );
+    const expected = await executable(join(desktopRoot, "2.10.0", "claude.exe"));
+    const calls = [];
+    const env = {
+      APPDATA: join(root, "Roaming"),
+      LOCALAPPDATA: localAppData,
+      PATH: join(root, "empty-bin"),
+      PATHEXT: ".EXE;.CMD;.BAT;.COM",
+      SystemRoot: "C:\\Windows",
+    };
+    const resolved = ensureClaudeCommandEnv({
+      env,
+      homeDir: root,
+      platform: "win32",
+      arch: "x64",
+      vscodeExtensionRoots: [],
+      windowsAppQuery(command, args, options) {
+        calls.push({ command, args, options });
+        return { status: 0, stdout: `\uFEFF${family}\r\n${family}\r\n`, stderr: "" };
+      },
+    });
+
+    assert.deepEqual(resolved, { command: expected, source: "app-bundled" });
+    assert.equal(env.MEMORAX_CODE_CLAUDE_COMMAND, expected);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].command, "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe");
+    assert.deepEqual(calls[0].args.slice(0, 4), ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command"]);
+    assert.match(calls[0].args[4], /Get-AppxPackage -Name 'Claude'/);
+    assert.match(calls[0].args[4], /\$_\.PackageFamilyName/);
+    assert.equal(calls[0].options.timeout, 10_000);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("Windows Claude Desktop resolution ignores failed and malformed package queries", async () => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-code-claude-command-windows-query-"));
+  try {
+    const malformedRuntime = join(
+      root,
+      "Packages",
+      "Claude",
+      "escape",
+      "LocalCache",
+      "Roaming",
+      "Claude",
+      "claude-code",
+      "2.10.0",
+      "claude.exe",
+    );
+    await executable(malformedRuntime);
+    const common = {
+      env: { LOCALAPPDATA: root, SystemRoot: "C:\\Windows" },
+      homeDir: root,
+      platform: "win32",
+    };
+
+    assert.equal(resolveWindowsClaudeDesktopCodeCommand({
+      ...common,
+      spawnSyncImpl: () => ({ status: 1, stdout: "", stderr: "failed" }),
+    }), undefined);
+    assert.equal(resolveWindowsClaudeDesktopCodeCommand({
+      ...common,
+      spawnSyncImpl: () => ({ status: 0, stdout: "Claude/escape\r\n", stderr: "" }),
+    }), undefined);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("an installed Windows Claude App without a downloaded Code runtime remains unavailable", () => {
+  assert.deepEqual(resolveClaudeCommand({
+    env: {
+      APPDATA: "C:\\Users\\tester\\AppData\\Roaming",
+      LOCALAPPDATA: "C:\\Users\\tester\\AppData\\Local",
+      PATH: "C:\\missing-bin",
+      PATHEXT: ".EXE;.CMD;.BAT;.COM",
+    },
+    homeDir: "C:\\Users\\tester",
+    platform: "win32",
+    arch: "x64",
+    desktopCodeRoots: [],
+    vscodeExtensionRoots: [],
+    windowsAppQuery: () => ({
+      status: 0,
+      stdout: "Claude_pzs8sxrjxfjjc\r\n",
+      stderr: "",
+    }),
+  }), { command: "claude", source: "unavailable" });
 });
 
 test("Claude command resolution uses the newest matching VS Code bundled runtime", async () => {

--- a/packages/npm/memorax-code/test/resolve-claude-command.test.mjs
+++ b/packages/npm/memorax-code/test/resolve-claude-command.test.mjs
@@ -59,6 +59,7 @@ test("Claude command resolution uses the newest macOS Claude Desktop Code runtim
       platform: "darwin",
       arch: "arm64",
       desktopCodeRoots: [desktopRoot],
+      desktopCodeProbe: () => ({ status: 0, stdout: "2.10.0\n", stderr: "" }),
       vscodeExtensionRoots: [],
     });
 
@@ -89,6 +90,7 @@ test("Claude command resolution uses the newest Windows Claude Desktop Code runt
       homeDir: root,
       platform: "win32",
       arch: "x64",
+      desktopCodeProbe: () => ({ status: 0, stdout: "2.10.0\r\n", stderr: "" }),
       vscodeExtensionRoots: [],
       windowsAppQuery() {
         throw new Error("the AppX query should not run when the AppData runtime exists");
@@ -97,6 +99,86 @@ test("Claude command resolution uses the newest Windows Claude Desktop Code runt
 
     assert.deepEqual(resolved, { command: expected, source: "app-bundled" });
     assert.equal(env.MEMORAX_CODE_CLAUDE_COMMAND, expected);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("Claude Desktop resolution skips runtimes that fail the version probe", async () => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-code-claude-command-probe-"));
+  try {
+    const desktopRoot = join(root, "Claude", "claude-code");
+    const older = await executable(join(desktopRoot, "2.9.0", "claude.exe"));
+    const newest = await executable(join(desktopRoot, "2.10.0", "claude.exe"));
+    const calls = [];
+
+    const resolved = resolveClaudeCommand({
+      env: {
+        PATH: join(root, "empty-bin"),
+        PATHEXT: ".EXE;.CMD;.BAT;.COM",
+      },
+      homeDir: root,
+      platform: "win32",
+      arch: "x64",
+      desktopCodeRoots: [desktopRoot],
+      desktopCodeProbe(command, args, options) {
+        calls.push({ command, args, options });
+        if (command === newest) {
+          return {
+            status: null,
+            stdout: "",
+            stderr: "",
+            error: Object.assign(new Error("spawn EPERM"), { code: "EPERM" }),
+          };
+        }
+        return { status: 0, stdout: "2.9.0\r\n", stderr: "" };
+      },
+      vscodeExtensionRoots: [],
+      windowsAppPackageFamilies: [],
+    });
+
+    assert.deepEqual(resolved, { command: older, source: "app-bundled" });
+    assert.deepEqual(calls.map(({ command }) => command), [newest, older]);
+    assert.deepEqual(calls[0].args, ["--version"]);
+    assert.equal(calls[0].options.timeout, 10_000);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("Claude command resolution falls back to VS Code when App runtimes fail the version probe", async () => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-code-claude-command-probe-fallback-"));
+  try {
+    const desktopRoot = join(root, "Claude", "claude-code");
+    const broken = await executable(join(desktopRoot, "2.10.0", "claude.exe"));
+    const extensions = join(root, ".vscode", "extensions");
+    const expected = await vscodeExtension(extensions, "anthropic.claude-code-2.10.0-win32-x64", {
+      publisher: "Anthropic",
+      name: "claude-code",
+      version: "2.10.0",
+      targetPlatform: "win32-x64",
+      executableName: "claude.exe",
+    });
+
+    const resolved = resolveClaudeCommand({
+      env: {
+        PATH: join(root, "empty-bin"),
+        PATHEXT: ".EXE;.CMD;.BAT;.COM",
+      },
+      homeDir: root,
+      platform: "win32",
+      arch: "x64",
+      desktopCodeRoots: [desktopRoot],
+      desktopCodeProbe: (command) => ({
+        status: 1,
+        stdout: "",
+        stderr: command === broken ? "corrupt runtime" : "unexpected runtime",
+      }),
+      vscodeExtensionRoots: [extensions],
+      windowsAppPackageFamilies: [],
+    });
+
+    assert.deepEqual(resolved, { command: expected, source: "vscode-bundled" });
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -130,6 +212,7 @@ test("Claude command resolution uses the MSIX-local Windows Desktop Code runtime
       homeDir: root,
       platform: "win32",
       arch: "x64",
+      desktopCodeProbe: () => ({ status: 0, stdout: "2.10.0\r\n", stderr: "" }),
       vscodeExtensionRoots: [],
       windowsAppQuery(command, args, options) {
         calls.push({ command, args, options });
@@ -259,6 +342,7 @@ async function vscodeExtension(extensionsRoot, directory, {
   name,
   version,
   targetPlatform,
+  executableName = "claude",
 }) {
   const extensionRoot = join(extensionsRoot, directory);
   await mkdir(join(extensionRoot, "resources", "native-binary"), { recursive: true });
@@ -268,5 +352,5 @@ async function vscodeExtension(extensionsRoot, directory, {
     version,
     __metadata: { targetPlatform },
   })}\n`);
-  return await executable(join(extensionRoot, "resources", "native-binary", "claude"));
+  return await executable(join(extensionRoot, "resources", "native-binary", executableName));
 }

--- a/packages/npm/memorax-code/test/resolve-claude-command.test.mjs
+++ b/packages/npm/memorax-code/test/resolve-claude-command.test.mjs
@@ -33,6 +33,38 @@ test("Claude command resolution preserves an explicit command and PATH CLI prece
   }
 });
 
+test("Claude command resolution uses the newest Claude Desktop Code runtime", async () => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-code-claude-command-desktop-"));
+  try {
+    const desktopRoot = join(root, "Library", "Application Support", "Claude", "claude-code");
+    await executable(join(desktopRoot, "2.9.0", "claude.app", "Contents", "MacOS", "claude"));
+    const expected = await executable(join(
+      desktopRoot,
+      "2.10.0",
+      "claude.app",
+      "Contents",
+      "MacOS",
+      "claude",
+    ));
+    await mkdir(join(desktopRoot, "99.0.0"), { recursive: true });
+
+    const env = { PATH: join(root, "empty-bin") };
+    const resolved = ensureClaudeCommandEnv({
+      env,
+      homeDir: root,
+      platform: "darwin",
+      arch: "arm64",
+      desktopCodeRoots: [desktopRoot],
+      vscodeExtensionRoots: [],
+    });
+
+    assert.deepEqual(resolved, { command: expected, source: "app-bundled" });
+    assert.equal(env.MEMORAX_CODE_CLAUDE_COMMAND, expected);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("Claude command resolution uses the newest matching VS Code bundled runtime", async () => {
   const root = await mkdtemp(join(tmpdir(), "memorax-code-claude-command-vscode-"));
   try {


### PR DESCRIPTION
## Change Summary

Detect Claude Desktop-provided Code runtimes reliably on macOS and Windows when no standalone `claude` CLI is available. Closes #8; depends on #15.

## Implementation Highlights

- Discover supported versioned Claude Desktop runtimes on macOS and Windows.
- Probe each candidate with a bounded version check and continue past stale or failing candidates.
- Preserve explicit command overrides, PATH CLI precedence, and VS Code fallback behavior.

## Validation

- `node --test packages/npm/memorax-code/test/resolve-codex-command.test.mjs packages/npm/memorax-code/test/resolve-claude-command.test.mjs packages/npm/memorax-code/test/postinstall.test.mjs`
- `make docs-check`
- `make npm-package-check`

## Complete End-to-End Validation Results

- Environment: macOS 26.5.2 host with isolated test homes; macOS and Windows discovery exercised through platform-specific fixtures.
- Scenario or matrix: Versioned Claude Desktop runtime discovery, stale or failing candidate fallback, Windows package query handling, CLI precedence, and VS Code fallback.
- Command or workflow: Targeted installer tests, documentation checks, and the staged npm package check listed above.
- Result: 83/83 targeted tests and 163/163 package checks passed on the complete installer stack.
- Evidence or artifacts: Automated test output only; no generated artifacts are committed.
- Reason not run / Remaining risk: Live Claude Desktop installations on macOS and Windows were not exercised end to end.
