### PR TITLE
fix: redetect available clients on reinstall

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -59,6 +59,11 @@ disabled. The command-line override is:
 --clients codex|claude|codex,claude|all|none
 ```
 
+A normal npm install or reinstall refreshes `[clients]` from the runnable
+clients detected at that time. Update-mode postinstall runs preserve the
+existing selection so a package update does not re-enable an integration the
+user intentionally disabled.
+
 Client selection controls plugin and Hook lifecycle only. It does not change
 Codex or Claude Code provider settings. `--clients none` runs the Backend
 without managing either client integration.

--- a/packages/npm/memorax-code/bin/memorax-code-plugin-postinstall.mjs
+++ b/packages/npm/memorax-code/bin/memorax-code-plugin-postinstall.mjs
@@ -52,6 +52,7 @@ const scriptedAnswers = (canPrompt() || canPromptForHookUpdate()) && process.std
   ? parseScriptedAnswers(readFileSync(0, "utf8"))
   : undefined;
 const previousClients = readPersistedClientSelection();
+const preservePreviousClients = updatePostinstall && previousClients !== undefined;
 if (seedMissingMemoraxCodeConfig() === "failed") {
   printPostinstallSummary("not-verified");
   process.exit(0);
@@ -70,7 +71,7 @@ try {
   process.exit(0);
 }
 runCommonPreflight();
-const requestedClients = previousClients ?? ["codex", "claude"];
+const requestedClients = preservePreviousClients ? previousClients : ["codex", "claude"];
 const codexPreflight = requestedClients.includes("codex") && !skipCodexPluginInstall
   ? runCodexPreflight()
   : { ok: true, pluginCache: { marketplaceName: CLI_MARKETPLACE_NAME, versions: [] } };
@@ -81,8 +82,8 @@ const installClients = requestedClients.filter((client) => {
   if (client === "codex") return !skipCodexPluginInstall && codexPreflight.ok;
   return !skipClaudeAdapterInstall && claudePreflight.ok;
 });
-const selectedClients = previousClients ?? installClients;
-if (previousClients) {
+const selectedClients = preservePreviousClients ? previousClients : installClients;
+if (preservePreviousClients) {
   log(clientSelectionMessage(previousClients));
 } else {
   log(detectedClientMessage(installClients));

--- a/packages/npm/memorax-code/test/postinstall.test.mjs
+++ b/packages/npm/memorax-code/test/postinstall.test.mjs
@@ -999,6 +999,29 @@ test("postinstall fresh install auto-detects Codex and skips an unavailable Clau
   }
 });
 
+test("postinstall reinstall re-detects a newly available Claude runtime", async () => {
+  const run = await runPostinstall({
+    memoraxCodeConfig: [
+      "[clients]",
+      "codex = true",
+      "claude = false",
+      "",
+    ].join("\n"),
+  });
+  try {
+    assert.equal(run.result.code, 0, run.result.stderr);
+    assert.match(run.log, /^codex --version$/m);
+    assert.match(run.log, /^claude --version$/m);
+    assert.match(run.result.stderr, /Detected supported client runtimes\. Configuring MemoraX Code for Codex and Claude Code\./);
+    assert.match(run.log, /^memorax-code start --clients all$/m);
+    assert.match(run.log, /^memorax-code status --clients all$/m);
+    const config = await readFile(join(run.memoraxCodeHome, "config.toml"), "utf8");
+    assert.match(config, /\[clients\]\ncodex = true\nclaude = true/);
+  } finally {
+    await rm(run.root, { recursive: true, force: true });
+  }
+});
+
 test("postinstall update preserves client intent while skipping an uninstalled Claude runtime", async () => {
   const run = await runPostinstall({
     claudeAvailable: false,


### PR DESCRIPTION
## Change Summary

Refresh client availability during a normal install or reinstall so runtimes installed later are detected. Closes #11; depends on #16.

## Implementation Highlights

- Re-run client detection for normal install and reinstall flows.
- Replace stale availability-derived client selections with the currently runnable clients.
- Keep package-update behavior separate so updates do not silently override user intent.

## Validation

- `node --test packages/npm/memorax-code/test/resolve-codex-command.test.mjs packages/npm/memorax-code/test/resolve-claude-command.test.mjs packages/npm/memorax-code/test/postinstall.test.mjs`
- `make docs-check`
- `make npm-package-check`

## Complete End-to-End Validation Results

- Environment: macOS 26.5.2 host with isolated temporary package, client, and Backend homes.
- Scenario or matrix: Reinstall after a second client becomes runnable, persisted client refresh, and update-mode separation.
- Command or workflow: Targeted installer tests, documentation checks, and the staged npm package check listed above.
- Result: 83/83 targeted tests and 163/163 package checks passed on the complete installer stack.
- Evidence or artifacts: Automated test output only; no generated artifacts are committed.
- Reason not run / Remaining risk: A live reinstall against end-user Codex and Claude Desktop installations was not run.
