### PR TITLE
fix: report accurate uninstall outcomes

### DIFF
--- a/packages/ts/memorax-code-backend/src/server-cli.ts
+++ b/packages/ts/memorax-code-backend/src/server-cli.ts
@@ -611,7 +611,12 @@ function printLifecycleResult(report: MemoraxCodeLifecycleReport): void {
   backendLog(`${lifecycleActionLabel(report.action)}: ${report.ok ? green(degraded ? "ok (degraded)" : "ok") : red("needs attention")}`);
   if (report.message) backendLog(report.message);
   if (report.backend) {
-    backendLog(`Backend: ${report.backend.ok ? green(report.backend.degraded ? "ok (degraded)" : "ok") : red("not ok")}${report.backend.state?.url ? ` ${report.backend.state.url}` : ""}${report.backend.errorCode ? ` code=${report.backend.errorCode}` : ""}${report.backend.error ? ` error=${report.backend.error}` : ""}`);
+    const status = !report.backend.ok
+      ? red("not ok")
+      : report.backend.action === "stop"
+        ? green(report.backend.skipped ? "kept running" : "stopped")
+        : green(report.backend.degraded ? "ok (degraded)" : "ok");
+    backendLog(`Backend: ${status}${report.backend.state?.url ? ` ${report.backend.state.url}` : ""}${report.backend.errorCode ? ` code=${report.backend.errorCode}` : ""}${report.backend.error ? ` error=${report.backend.error}` : ""}`);
     for (const warning of report.backend.warnings ?? []) {
       backendLog(`Warning: ${warning.message}${warning.errorCode ? ` code=${warning.errorCode}` : ""}`);
     }

--- a/packages/ts/memorax-code-backend/src/server-cli.ts
+++ b/packages/ts/memorax-code-backend/src/server-cli.ts
@@ -719,15 +719,33 @@ function lifecycleGuidance(report: MemoraxCodeLifecycleReport): string[] {
       ];
   }
   if (report.action === "uninstall") {
-    return report.ok
-      ? [
-        green("MemoraX Code has been uninstalled from this npm installation."),
-        green("Restart or refresh Codex so it drops the removed adapter plugin."),
-      ]
-      : [
+    if (!report.ok) {
+      return [
         red("Uninstall needs attention."),
         "Run `memorax-code status` and `memorax-code logs` before retrying.",
       ];
+    }
+    const clientName = report.codexAdapter && report.claudeAdapter
+      ? "Codex and Claude Code"
+      : report.codexAdapter
+        ? "Codex"
+        : report.claudeAdapter
+          ? "Claude Code"
+          : undefined;
+    const npmPackageRemoved = report.npmPackageRemoval?.ok === true
+      && report.npmPackageRemoval.skipped !== true;
+    return [
+      ...(npmPackageRemoved
+        ? [green("MemoraX Code has been uninstalled from this npm installation.")]
+        : clientName
+          ? [green(`MemoraX Code has been uninstalled from ${clientName}.`)]
+          : []),
+      ...(clientName
+        ? [green(report.codexAdapter && report.claudeAdapter
+          ? "Restart or refresh Codex and Claude Code so they drop the removed adapter plugins."
+          : `Restart or refresh ${clientName} so it drops the removed adapter plugin.`)]
+        : []),
+    ];
   }
   return [];
 }

--- a/packages/ts/memorax-code-backend/test/backend-service.test.mjs
+++ b/packages/ts/memorax-code-backend/test/backend-service.test.mjs
@@ -912,10 +912,57 @@ test("memorax-code lifecycle CLI prints prefixed user guidance", async () => {
     assert.equal(uninstalled.code, 0, `${uninstalled.stdout}\n${uninstalled.stderr}`);
     assert.match(uninstalled.stdout, /^\[MemoraX Code Backend\]: Uninstall: .*ok/m);
     assert.match(uninstalled.stdout, /^\[MemoraX Code Backend\]: npm package: skipped partial_client_uninstall/m);
-    assert.match(uninstalled.stdout, /^\[MemoraX Code Backend\]: .*Restart or refresh Codex/m);
+    assert.doesNotMatch(uninstalled.stdout, /MemoraX Code has been uninstalled/);
+    assert.doesNotMatch(uninstalled.stdout, /Restart or refresh (?:Codex|Claude Code)/);
   } finally {
     await runCli(cliPath, ["stop", "--json", "--home", home, "--port", String(port), "--clients", "none"]);
     await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("memorax-code uninstall guidance names only the selected Claude client", async () => {
+  const home = await mkdtemp(join(tmpdir(), "memorax-code-uninstall-guidance-home-"));
+  const codexHome = await mkdtemp(join(tmpdir(), "memorax-code-uninstall-guidance-codex-"));
+  const claudeHome = await mkdtemp(join(tmpdir(), "memorax-code-uninstall-guidance-claude-"));
+  const port = await freePort();
+  const cliPath = fileURLToPath(new URL("../dist/memorax-code.js", import.meta.url));
+  const pluginCli = await prepareClaudePluginCli(home);
+  await writeManagedClientsConfig(home, { codex: true, claude: true });
+  await writeFile(join(codexHome, "config.toml"), 'model_provider = "openai"\n');
+  await writeFile(join(claudeHome, "settings.json"), "{}\n");
+  await prepareActiveCodexPlugin(codexHome);
+  const env = {
+    CLAUDE_CONFIG_DIR: claudeHome,
+    FAKE_CLAUDE_PLUGIN_CALLS: pluginCli.callsPath,
+    MEMORAX_CODE_CLAUDE_COMMAND: pluginCli.claudeCommand,
+  };
+  const commonArgs = [
+    "--home", home,
+    "--port", String(port),
+    "--codex-home", codexHome,
+    "--claude-home", claudeHome,
+  ];
+  try {
+    const started = await runCli(cliPath, ["start", "--json", ...commonArgs], { env });
+    assert.equal(started.code, 0, `${started.stdout}\n${started.stderr}`);
+
+    const uninstalled = await runCli(cliPath, [
+      "uninstall",
+      ...commonArgs,
+      "--clients", "claude",
+      "--no-npm-uninstall",
+    ], { env });
+    assert.equal(uninstalled.code, 0, `${uninstalled.stdout}\n${uninstalled.stderr}`);
+    assert.match(uninstalled.stdout, /^\[MemoraX Code Backend\]: npm package: skipped partial_client_uninstall/m);
+    assert.match(uninstalled.stdout, /MemoraX Code has been uninstalled from Claude Code\./);
+    assert.match(uninstalled.stdout, /Restart or refresh Claude Code so it drops the removed adapter plugin\./);
+    assert.doesNotMatch(uninstalled.stdout, /uninstalled from this npm installation/);
+    assert.doesNotMatch(uninstalled.stdout, /Restart or refresh Codex/);
+  } finally {
+    await runCli(cliPath, ["stop", "--json", ...commonArgs, "--clients", "codex"], { env });
+    await rm(home, { recursive: true, force: true });
+    await rm(codexHome, { recursive: true, force: true });
+    await rm(claudeHome, { recursive: true, force: true });
   }
 });
 

--- a/packages/ts/memorax-code-backend/test/backend-service.test.mjs
+++ b/packages/ts/memorax-code-backend/test/backend-service.test.mjs
@@ -900,6 +900,7 @@ test("memorax-code lifecycle CLI prints prefixed user guidance", async () => {
     ]);
     assert.equal(stopped.code, 0, `${stopped.stdout}\n${stopped.stderr}`);
     assert.match(stopped.stdout, /^\[MemoraX Code Backend\]: Stop: .*ok/m);
+    assert.match(stopped.stdout, /^\[MemoraX Code Backend\]: Backend: .*stopped/m);
     assert.match(stopped.stdout, /^\[MemoraX Code Backend\]: .*Backend is stopped\./m);
 
     const uninstalled = await runCli(cliPath, [
@@ -911,6 +912,7 @@ test("memorax-code lifecycle CLI prints prefixed user guidance", async () => {
     ]);
     assert.equal(uninstalled.code, 0, `${uninstalled.stdout}\n${uninstalled.stderr}`);
     assert.match(uninstalled.stdout, /^\[MemoraX Code Backend\]: Uninstall: .*ok/m);
+    assert.match(uninstalled.stdout, /^\[MemoraX Code Backend\]: Backend: .*stopped/m);
     assert.match(uninstalled.stdout, /^\[MemoraX Code Backend\]: npm package: skipped partial_client_uninstall/m);
     assert.doesNotMatch(uninstalled.stdout, /MemoraX Code has been uninstalled/);
     assert.doesNotMatch(uninstalled.stdout, /Restart or refresh (?:Codex|Claude Code)/);
@@ -953,13 +955,18 @@ test("memorax-code uninstall guidance names only the selected Claude client", as
       "--no-npm-uninstall",
     ], { env });
     assert.equal(uninstalled.code, 0, `${uninstalled.stdout}\n${uninstalled.stderr}`);
+    assert.match(uninstalled.stdout, /^\[MemoraX Code Backend\]: Backend: .*kept running.*127\.0\.0\.1/m);
     assert.match(uninstalled.stdout, /^\[MemoraX Code Backend\]: npm package: skipped partial_client_uninstall/m);
     assert.match(uninstalled.stdout, /MemoraX Code has been uninstalled from Claude Code\./);
     assert.match(uninstalled.stdout, /Restart or refresh Claude Code so it drops the removed adapter plugin\./);
     assert.doesNotMatch(uninstalled.stdout, /uninstalled from this npm installation/);
     assert.doesNotMatch(uninstalled.stdout, /Restart or refresh Codex/);
+
+    const stopped = await runCli(cliPath, ["stop", ...commonArgs, "--clients", "codex"], { env });
+    assert.equal(stopped.code, 0, `${stopped.stdout}\n${stopped.stderr}`);
+    assert.match(stopped.stdout, /^\[MemoraX Code Backend\]: Backend: .*stopped.*127\.0\.0\.1/m);
   } finally {
-    await runCli(cliPath, ["stop", "--json", ...commonArgs, "--clients", "codex"], { env });
+    await runCli(cliPath, ["stop", "--json", ...commonArgs, "--clients", "none"], { env });
     await rm(home, { recursive: true, force: true });
     await rm(codexHome, { recursive: true, force: true });
     await rm(claudeHome, { recursive: true, force: true });


### PR DESCRIPTION
## Change Summary

Make uninstall output reflect the clients actually changed, the npm removal outcome, and the Backend's real final state. Closes #7.

## Implementation Highlights

- Name only the selected client integrations in uninstall guidance.
- Distinguish partial integration cleanup from successful npm package removal.
- Report whether the managed Backend stopped or remained active without changing lifecycle authority.
- Keep all README files unchanged.

## Validation

- `npm run typecheck --prefix packages/ts/memorax-code-backend`
- `npm test --prefix packages/ts/memorax-code-backend`

## Complete End-to-End Validation Results

- Environment: macOS 26.5.2 host with isolated client, Backend, and package test homes.
- Scenario or matrix: Claude-only uninstall, partial cleanup, no-client selection, package removal success/failure, and final Backend state reporting.
- Command or workflow: Backend typecheck and full Backend test suite listed above.
- Result: Typecheck passed; 490 tests passed and 2 platform-specific tests were skipped.
- Evidence or artifacts: Automated lifecycle test output only; no generated artifacts are committed.
- Reason not run / Remaining risk: A real global npm uninstall was not executed against an end-user installation.
