### PR TITLE
fix: explain workspace-scope recovery

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -147,6 +147,15 @@ MemoraX Code reads filesystem Git metadata without executing Git. Linked
 worktrees share the remote repository identity; non-Git workspaces use the
 normalized folder name. Resolution never falls back to the bare base user ID.
 
+A live Codex or Claude Code session remains pinned to the repository or local
+workspace resolved at the start of the session. Starting the client from a
+parent workspace and then entering a nested Git repository does not rebind the
+session. If Search or Add reports `workspace_scope_mismatch` or
+`workspace_scope_unavailable`, start a new session from the target repository
+or local workspace. For an unavailable scope, also verify that its `.git`
+metadata is readable and valid. These failures stop Search or Add before any
+request is sent to MemoraX.
+
 Codex projectless tasks under its canonical dated-task location intentionally
 use the shared `Codex-General` memory name. Open a task in a real workspace
 when repository isolation matters.

--- a/packages/ts/memorax-code-backend/src/memory-cli.ts
+++ b/packages/ts/memorax-code-backend/src/memory-cli.ts
@@ -42,6 +42,7 @@ type MemoryCliResult = {
   effectiveUserId?: string;
   workspaceScope?: "bound" | "unavailable";
   workspaceScopeReason?: string;
+  userAction?: string;
   searchEnabled?: boolean;
   addEnabled?: boolean;
   config?: unknown;
@@ -124,7 +125,7 @@ async function memorySearch(args: string[], options: MemoryCliOptions): Promise<
   const query = queryResult.text;
   const repositoryMemory = await resolveMemoryCliRepositoryMemory(options);
   if (!repositoryMemory.ok) {
-    return { ok: false, action: "memory.search", query, error: repositoryMemory.error };
+    return memoryCliRepositoryFailure("memory.search", repositoryMemory, { query });
   }
   const observability = await memoryCliObservability(options.env);
   const response = await invokeMemoraxMemoryProvider(
@@ -186,7 +187,7 @@ async function memoryAdd(args: string[], options: MemoryCliOptions): Promise<Mem
   const contentOptions = memoryAddContentOptions(args);
   if (!contentOptions.ok) return { ok: false, action: "memory.add", error: contentOptions.error };
   const repositoryMemory = await resolveMemoryCliRepositoryMemory(options);
-  if (!repositoryMemory.ok) return { ok: false, action: "memory.add", error: repositoryMemory.error };
+  if (!repositoryMemory.ok) return memoryCliRepositoryFailure("memory.add", repositoryMemory);
 
   const sessionId = memoryCliSessionId(args, env);
   const observability = await memoryCliObservability(env);
@@ -286,6 +287,29 @@ async function resolveMemoryCliRepositoryMemory(options: MemoryCliOptions): Prom
     };
   }
   return commandMemory;
+}
+
+function memoryCliRepositoryFailure(
+  action: "memory.search" | "memory.add",
+  failure: Extract<ConfiguredRepositoryMemoryResult, { ok: false }>,
+  fields: Pick<MemoryCliResult, "query"> = {},
+): MemoryCliResult {
+  const userAction = failure.reason === "workspace_scope_mismatch"
+    ? "Start a new Codex or Claude Code session from the target repository or local workspace."
+    : failure.reason === "workspace_scope_unavailable"
+      ? "Start a new Codex or Claude Code session from the target repository or local workspace. If the problem continues, make sure its .git metadata is readable and valid."
+      : undefined;
+  return {
+    ok: false,
+    action,
+    ...fields,
+    ...(userAction ? {
+      workspaceScope: "unavailable" as const,
+      workspaceScopeReason: failure.reason,
+      userAction,
+    } : {}),
+    error: failure.error,
+  };
 }
 
 function memoryCliIdentityFields(memory: ConfiguredRepositoryMemory): Pick<

--- a/packages/ts/memorax-code-backend/test/memory-cli.test.mjs
+++ b/packages/ts/memorax-code-backend/test/memory-cli.test.mjs
@@ -169,6 +169,97 @@ test("memory CLI rejects a nested repository outside the current turn scope", as
 
   assert.equal(result.ok, false);
   assert.match(result.error, /does not match the current Codex turn repository\/workspace scope/);
+  assert.equal(result.workspaceScope, "unavailable");
+  assert.equal(result.workspaceScopeReason, "workspace_scope_mismatch");
+  assert.equal(
+    result.userAction,
+    "Start a new Codex or Claude Code session from the target repository or local workspace.",
+  );
+  assert.equal(requestCount, 0);
+});
+
+test("memory CLI explains malformed Git scope failures before search or add sends a request", async () => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-code-cli-invalid-git-"));
+  const workspace = join(root, "workspace");
+  await mkdir(join(workspace, ".git"), { recursive: true });
+  let requestCount = 0;
+  const env = {
+    MEMORAX_CODE_HOME: join(root, "memorax-code-home"),
+    MEMORAX_CODE_MEMORY_CLI_ADD_ENABLED: "true",
+    MEMORAX_CODE_MEMORAX_ENDPOINT: "http://memorax.test",
+    MEMORAX_CODE_MEMORAX_API_KEY: "secret",
+    MEMORAX_CODE_MEMORAX_USER_ID: "user-1",
+  };
+  const options = {
+    cwd: workspace,
+    env,
+    fetchImpl: async () => {
+      requestCount += 1;
+      return new Response("{}", { status: 200 });
+    },
+  };
+
+  const search = await runMemoryCli(["search", "--query", "must fail closed"], options);
+  const add = await runMemoryCli([
+    "add",
+    "--memory",
+    "Must preserve workspace scope.",
+    "--type",
+    "procedural",
+    "--reason",
+    "Record a verified scope invariant.",
+  ], options);
+
+  for (const result of [search, add]) {
+    assert.equal(result.ok, false);
+    assert.equal(result.workspaceScope, "unavailable");
+    assert.equal(result.workspaceScopeReason, "workspace_scope_unavailable");
+    assert.equal(
+      result.userAction,
+      "Start a new Codex or Claude Code session from the target repository or local workspace. If the problem continues, make sure its .git metadata is readable and valid.",
+    );
+  }
+  assert.equal(requestCount, 0);
+});
+
+test("memory CLI gives the same scope recovery guidance for a Claude turn", async () => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-code-cli-claude-scope-"));
+  const memoraxCodeHome = join(root, "memorax-code-home");
+  const first = join(root, "first");
+  const second = join(root, "second");
+  await mkdir(first, { recursive: true });
+  await mkdir(second, { recursive: true });
+  await writeCurrentClaudeTurn(traceContextFromClaudeHookBody({
+    session_id: "session-claude-scope",
+    prompt_id: "prompt-claude-scope",
+    cwd: first,
+  }), { memoraxCodeHome });
+  let requestCount = 0;
+
+  const result = await runMemoryCli(["search", "--query", "must not cross workspaces"], {
+    cwd: second,
+    env: {
+      MEMORAX_CODE_MEMORY_CLI_TRACE_CLIENT: "claude",
+      MEMORAX_CODE_MEMORY_CLI_TRACE_SESSION_ID: "session-claude-scope",
+      MEMORAX_CODE_HOME: memoraxCodeHome,
+      MEMORAX_CODE_MEMORAX_ENDPOINT: "http://memorax.test",
+      MEMORAX_CODE_MEMORAX_API_KEY: "secret",
+      MEMORAX_CODE_MEMORAX_USER_ID: "user-1",
+    },
+    fetchImpl: async () => {
+      requestCount += 1;
+      return new Response("{}", { status: 200 });
+    },
+  });
+
+  assert.equal(result.ok, false);
+  assert.match(result.error, /does not match the current Claude turn repository\/workspace scope/);
+  assert.equal(result.workspaceScope, "unavailable");
+  assert.equal(result.workspaceScopeReason, "workspace_scope_mismatch");
+  assert.equal(
+    result.userAction,
+    "Start a new Codex or Claude Code session from the target repository or local workspace.",
+  );
   assert.equal(requestCount, 0);
 });
 

--- a/packages/ts/memorax-code-codex-adapter/skills/memorax-code/references/memorax-add.md
+++ b/packages/ts/memorax-code-codex-adapter/skills/memorax-code/references/memorax-add.md
@@ -71,6 +71,8 @@ anchors: stable/source/path' \
 
 If add fails, report the exact failure and do not retry automatically, bypass the CLI, or call MemoraX directly.
 
+If `memorax-cli add` reports `workspace_scope_mismatch` or `workspace_scope_unavailable`, do not bypass the scope. Do not change the CLI working directory and retry. Tell the user that the memory was not submitted and no request was sent to MemoraX, then present the CLI's `userAction` in natural language. Continue the current task using only live code and documentation.
+
 ## Exclusions
 
 Do not add secrets, credentials, private URLs, raw authorization headers, exact patches, target commits, hidden tests, target diffs, vulnerability details, exploit steps, copied source, long logs, stack traces, raw transcripts, temporary errors, or facts directly recoverable from current files and git history.

--- a/packages/ts/memorax-code-codex-adapter/skills/memorax-code/references/memorax-search.md
+++ b/packages/ts/memorax-code-codex-adapter/skills/memorax-code/references/memorax-search.md
@@ -8,7 +8,7 @@ Run the CLI from the active task workspace. The installed Hook and session bindi
 
 Coding memory uses `<MemoraX base user ID>@<normalized repository name>` for Git workspaces and the normalized folder name for genuine non-Git directories. MemoraX Code resolves `.git`, `gitdir`, and `commondir` without executing Git. Linked worktrees share one repository scope; another clone, repository, or non-Git directory retains a different local session key even when its readable name matches.
 
-Require a readable active workspace binding. A CLI command from a linked worktree of the bound repository is valid. If the CLI reports `workspace_scope_mismatch`, ask the user to start a task in the target repository or local workspace. Do not retry from an unrelated scope or fall back to an unscoped user id.
+Require a readable active workspace binding. A CLI command from a linked worktree of the bound repository is valid. If `memorax-cli search` reports `workspace_scope_mismatch` or `workspace_scope_unavailable`, do not bypass the scope or fall back to an unscoped user id. Do not change the CLI working directory and retry. Tell the user that memory search was not executed and no request was sent to MemoraX, then present the CLI's `userAction` in natural language. Continue the current task using only live code and documentation.
 
 If `memorax-cli` is not on `PATH`, or memory is disabled, unconfigured, or unavailable, report that briefly and continue with live code or documentation. Authenticate through MemoraX Code configuration; never recover credentials from shell history or place tokens in prompts. Treat injected memory as a hypothesis and verify it against the current checkout.
 

--- a/packages/ts/memorax-code-codex-adapter/test/memorax-code-skill.test.mjs
+++ b/packages/ts/memorax-code-codex-adapter/test/memorax-code-skill.test.mjs
@@ -69,6 +69,10 @@ test("memorax-code references keep authority and operation boundaries explicit",
   assert.match(memoraxSearch, /without executing Git/);
   assert.match(memoraxSearch, /genuine non-Git directories/);
   assert.match(memoraxSearch, /linked worktree of the bound repository is valid/);
+  assert.match(memoraxSearch, /`workspace_scope_mismatch` or `workspace_scope_unavailable`/);
+  assert.match(memoraxSearch, /search was not executed and no request was sent to MemoraX/);
+  assert.match(memoraxSearch, /present the CLI's `userAction`/);
+  assert.match(memoraxSearch, /Do not change the CLI working directory and retry/);
   assert.doesNotMatch(memoraxSearch, /--query-file/);
   assert.match(memoraxAdd, /CODE_AGENT_MEMORY/);
   assert.match(memoraxAdd, /Route user-owned ordered actions/);
@@ -76,6 +80,10 @@ test("memorax-code references keep authority and operation boundaries explicit",
   assert.match(memoraxAdd, /language of the user's current request/);
   assert.match(memoraxAdd, /preserve exact code, API, path, workflow, and project identifiers/);
   assert.match(memoraxAdd, /memorax-cli add[\s\S]*--memory '/);
+  assert.match(memoraxAdd, /`workspace_scope_mismatch` or `workspace_scope_unavailable`/);
+  assert.match(memoraxAdd, /memory was not submitted and no request was sent to MemoraX/);
+  assert.match(memoraxAdd, /present the CLI's `userAction`/);
+  assert.match(memoraxAdd, /Do not change the CLI working directory and retry/);
   assert.doesNotMatch(memoraxAdd, /--memory-file/);
   assert.match(repoRead, /## Retrieval Budget/);
   assert.match(repoRead, /Do not read repo memory again after `maintain` returns/);


### PR DESCRIPTION
## Change Summary

Keep workspace-scope failures fail closed while giving users concrete recovery steps for mismatched and unavailable scopes. Closes #9.

## Implementation Highlights

- Explain that an active task is pinned to its initial repository or workspace and cannot be rebound.
- Provide separate recovery instructions for scope mismatch and unavailable trusted workspace authority.
- Keep the CLI, troubleshooting guide, and shared memory skill guidance aligned for Codex and Claude Code.
- Keep all README files unchanged.

## Validation

- `make test`
- `make docs-check`

## Complete End-to-End Validation Results

- Environment: macOS 26.5.2 host with isolated Backend, adapter, package, and workspace test homes.
- Scenario or matrix: Scope mismatch, unavailable scope, linked worktree acceptance, nested repository rejection, config-only status, and both client skill paths.
- Command or workflow: Full repository test profile and documentation checks listed above.
- Result: Backend 491 passed with 2 platform skips; Codex and Claude adapter suites passed; npm/local-only 149/149 passed; documentation checks passed.
- Evidence or artifacts: Automated CLI, scope, skill, and documentation test output only; no generated artifacts are committed.
- Reason not run / Remaining risk: Recovery instructions were not manually exercised inside live Codex and Claude client sessions.
