### PR TITLE
fix: avoid redundant reminder searches

### DIFF
--- a/packages/ts/memorax-code-adapter-common/src/hooks/memory-skill-reminder-hook.mjs
+++ b/packages/ts/memorax-code-adapter-common/src/hooks/memory-skill-reminder-hook.mjs
@@ -182,7 +182,7 @@ function combinedReminderContext(options, due, cadenceReminderContext, personalM
 
 function memoryReminderContext(options) {
   const invocation = stringOption(options.memorySkillInvocation) ?? DEFAULT_MEMORY_SKILL_INVOCATION;
-  return `MemoraX Code reminder: proactively invoke ${invocation} whenever coding memory might help, even when uncertain; when in doubt, run one focused coding-memory search for relevant prior knowledge. Also use ${invocation} for repository-scoped personal memory, and classify the authority before reading or writing.`;
+  return `MemoraX Code reminder: proactively invoke ${invocation} whenever coding memory might help, even when uncertain; follow the skill's router to decide whether any memory operation is needed. Also use ${invocation} for repository-scoped personal memory, and classify the authority before reading or writing.`;
 }
 
 function defaultMemoraxCodeHome() {

--- a/packages/ts/memorax-code-claude-adapter/test/memory-skill-reminder-hook.test.mjs
+++ b/packages/ts/memorax-code-claude-adapter/test/memory-skill-reminder-hook.test.mjs
@@ -12,7 +12,7 @@ const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const hookPath = join(packageRoot, "runtime-hooks", "memory-skill-reminder.mjs");
 const captureHookPath = join(packageRoot, "runtime-hooks", "capture-cwd.mjs");
 const MEMORY_SKILL_INVOCATION = "/memorax-code-claude-adapter:memorax-code";
-const MEMORY_REMINDER_CONTEXT = `MemoraX Code reminder: proactively invoke ${MEMORY_SKILL_INVOCATION} whenever coding memory might help, even when uncertain; when in doubt, run one focused coding-memory search for relevant prior knowledge. Also use ${MEMORY_SKILL_INVOCATION} for repository-scoped personal memory, and classify the authority before reading or writing.`;
+const MEMORY_REMINDER_CONTEXT = `MemoraX Code reminder: proactively invoke ${MEMORY_SKILL_INVOCATION} whenever coding memory might help, even when uncertain; follow the skill's router to decide whether any memory operation is needed. Also use ${MEMORY_SKILL_INVOCATION} for repository-scoped personal memory, and classify the authority before reading or writing.`;
 const PERSONAL_MEMORY_REMINDER_CONTEXT = `MemoraX Code personal-memory reminder: Use ${MEMORY_SKILL_INVOCATION} when the user states a durable current-repo identity or interaction preference, asks to list or recall stored personal memory, or explicitly asks to save, update, forget, or delete it. Route reusable action sequences and work rules to procedure memory; do not store repository facts, one-off task details, or secrets.`;
 
 test("Claude memory skill metadata uses the plugin-namespaced invocation", async () => {
@@ -537,7 +537,7 @@ function assertReminder(stdout) {
   assert.equal(payload.hookSpecificOutput.hookEventName, "UserPromptSubmit");
   assert.equal(context, MEMORY_REMINDER_CONTEXT);
   assert.match(context, /proactively invoke/);
-  assert.match(context, /when in doubt, run one focused coding-memory search/);
+  assert.match(context, /follow the skill's router to decide whether any memory operation is needed/);
   assert.match(context, /repository-scoped personal memory/);
   assert.doesNotMatch(context, /repo memory/i);
   assert.match(context, /classify the authority/);

--- a/packages/ts/memorax-code-codex-adapter/skills/memorax-code/SKILL.md
+++ b/packages/ts/memorax-code-codex-adapter/skills/memorax-code/SKILL.md
@@ -11,9 +11,9 @@ description: >-
   Classify the request as coding memory, repository memory, personal procedure
   memory, personal profile memory, or no persistent memory, then route it to the
   matching operation. Invoking this router does not require coding-memory
-  search. If the current conversation already contains sufficient information
-  for the request, use it directly instead of searching again. Prefer this
-  router over underlying memory workflows. Ask one focused question only when
+  search. Reuse a relevant coding-memory result already retrieved in this
+  conversation; otherwise let the matching operation decide on search. Prefer
+  this router over underlying memory workflows. Ask one focused question only when
   memory authority remains ambiguous.
 ---
 

--- a/packages/ts/memorax-code-codex-adapter/skills/memorax-code/SKILL.md
+++ b/packages/ts/memorax-code-codex-adapter/skills/memorax-code/SKILL.md
@@ -1,21 +1,20 @@
 ---
 name: memorax-code
 description: >-
-  Use this skill as the single entry point for persistent coding and
-  repository-local memory work, regardless of type, wording, or operation. Use
-  it whenever a request may involve information that should persist beyond the
-  current task,
-  knowledge remembered from prior work, repository memory,
-  reusable procedures or working rules, or durable user profile and interaction
-  preferences. This applies even when the user does not call it memory,
-  including naturally stated habits, preferences,
+  Use this skill as the single router for persistent coding and repository-local
+  memory. Invoke it whenever a request may involve prior-work knowledge,
+  repository memory, reusable procedures or rules, durable profile or
+  interaction preferences, or information worth retaining beyond the current
+  task. This applies without memory wording, including habits, preferences,
   checklists, action sequences, prerequisites, gates, exceptions, validation
   rules, communication style, preferred language, or result presentation.
-  Determine whether the request belongs to MemoraX Code coding memory,
-  repository memory, personal procedure memory, personal profile
-  memory, or no persistent memory, then route it to the appropriate operation.
-  Prefer this router over any underlying memory workflow. Ask one focused
-  question only when the memory authority remains ambiguous after routing.
+  Classify the request as coding memory, repository memory, personal procedure
+  memory, personal profile memory, or no persistent memory, then route it to the
+  matching operation. Invoking this router does not require coding-memory
+  search. If the current conversation already contains sufficient information
+  for the request, use it directly instead of searching again. Prefer this
+  router over underlying memory workflows. Ask one focused question only when
+  memory authority remains ambiguous.
 ---
 
 # MemoraX Code

--- a/packages/ts/memorax-code-codex-adapter/test/memory-skill-reminder-hook.test.mjs
+++ b/packages/ts/memorax-code-codex-adapter/test/memory-skill-reminder-hook.test.mjs
@@ -9,7 +9,7 @@ import { fileURLToPath } from "node:url";
 
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const runtimeHookPath = join(packageRoot, "hooks", "runtime-hook.mjs");
-const MEMORY_REMINDER_CONTEXT = "MemoraX Code reminder: proactively invoke $memorax-code whenever coding memory might help, even when uncertain; when in doubt, run one focused coding-memory search for relevant prior knowledge. Also use $memorax-code for repository-scoped personal memory, and classify the authority before reading or writing.";
+const MEMORY_REMINDER_CONTEXT = "MemoraX Code reminder: proactively invoke $memorax-code whenever coding memory might help, even when uncertain; follow the skill's router to decide whether any memory operation is needed. Also use $memorax-code for repository-scoped personal memory, and classify the authority before reading or writing.";
 const PROFILE_REMINDER_CONTEXT = "MemoraX Code personal-memory reminder: Use $memorax-code when the user states a durable current-repo identity or interaction preference, asks to list or recall stored personal memory, or explicitly asks to save, update, forget, or delete it. Route reusable action sequences and work rules to procedure memory; do not store repository facts, one-off task details, or secrets.";
 
 test("manifest reuses capture-cwd for compact and keeps one serialized UserPromptSubmit memory hook", async () => {
@@ -830,7 +830,7 @@ function assertMemoryReminder(stdout) {
   const context = reminderContext(stdout);
   assert.equal(context, MEMORY_REMINDER_CONTEXT);
   assert.match(context, /proactively invoke/);
-  assert.match(context, /when in doubt, run one focused coding-memory search/);
+  assert.match(context, /follow the skill's router to decide whether any memory operation is needed/);
   assert.match(context, /repository-scoped personal memory/);
   assert.doesNotMatch(context, /repo memory/i);
   assert.match(context, /classify the authority before reading or writing/);

--- a/packages/ts/memorax-code-codex-adapter/test/repo-memory-builder-collect-all.test.mjs
+++ b/packages/ts/memorax-code-codex-adapter/test/repo-memory-builder-collect-all.test.mjs
@@ -391,7 +391,7 @@ test("memorax-code repo-build is app-neutral and the router declares OpenAI and 
   const openaiYaml = readFileSync(join(builderSkillRoot, "agents", "openai.yaml"), "utf8");
   const claudeYaml = readFileSync(join(builderSkillRoot, "agents", "claude.yaml"), "utf8");
 
-  assert.match(router, /single entry point for persistent coding and\s+repository-local memory work/);
+  assert.match(router, /single router for persistent coding and repository-local\s+memory/);
   assert.match(router, /### Repo Memory/);
   assert.match(router, /references\/repo-build\.md/);
   assert.match(skill, /first-time creation, full rebuilds, or full refreshes/);

--- a/packages/ts/memorax-code-codex-adapter/test/repo-user-profile-context.test.mjs
+++ b/packages/ts/memorax-code-codex-adapter/test/repo-user-profile-context.test.mjs
@@ -12,7 +12,7 @@ const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const runtimeHookPath = join(packageRoot, "hooks", "runtime-hook.mjs");
 const hookPath = [runtimeHookPath, "memory-skill-reminder"];
 const captureHookPath = [runtimeHookPath, "capture-cwd"];
-const MEMORY_REMINDER_CONTEXT = "MemoraX Code reminder: proactively invoke $memorax-code whenever coding memory might help, even when uncertain; when in doubt, run one focused coding-memory search for relevant prior knowledge. Also use $memorax-code for repository-scoped personal memory, and classify the authority before reading or writing.";
+const MEMORY_REMINDER_CONTEXT = "MemoraX Code reminder: proactively invoke $memorax-code whenever coding memory might help, even when uncertain; follow the skill's router to decide whether any memory operation is needed. Also use $memorax-code for repository-scoped personal memory, and classify the authority before reading or writing.";
 const PROFILE_REMINDER_CONTEXT = "MemoraX Code personal-memory reminder: Use $memorax-code when the user states a durable current-repo identity or interaction preference, asks to list or recall stored personal memory, or explicitly asks to save, update, forget, or delete it. Route reusable action sequences and work rules to procedure memory; do not store repository facts, one-off task details, or secrets.";
 const PERSONAL_MEMORY_CONTEXT_OPTIONS = {
   adapterDir: "codex",


### PR DESCRIPTION
## Change Summary

Route periodic memory reminders through the shared skill decision so already available memory can be reused without redundant searches. Closes #10.

## Implementation Highlights

- Let the shared skill router decide whether a reminder requires a memory operation.
- Allow relevant coding-memory results already retrieved in the current conversation to be reused.
- Preserve normal search routing for explicit recall requests.
- Apply the same guidance to Codex and Claude Code while keeping all README files unchanged.

## Validation

- `npm run typecheck --prefix packages/ts/memorax-code-backend`
- `npm test --prefix packages/ts/memorax-code-backend`
- `npm test --prefix packages/ts/memorax-code-codex-adapter`
- `npm test --prefix packages/ts/memorax-code-claude-adapter`
- `make docs-check`
- `make npm-package-check`

## Complete End-to-End Validation Results

- Environment: macOS 26.5.2 host with isolated Backend, Codex, Claude, and package test homes.
- Scenario or matrix: Periodic reminder routing, existing automatic retrieval context, explicit recall requests, and shared skill packaging for both clients.
- Command or workflow: Backend, both adapter, documentation, and staged package checks listed above.
- Result: Backend 489 passed with 2 platform skips; Codex 200/200 passed; Claude 64/64 passed; documentation and package checks passed.
- Evidence or artifacts: Automated Hook and skill contract output only; no generated artifacts are committed.
- Reason not run / Remaining risk: Model-level search decisions were not evaluated in a live client session.
