### PR TITLE
test: stabilize Codex hook config-layer tests

### DIFF
--- a/packages/ts/memorax-code-backend/test/codex-plugin-hooks.test.mjs
+++ b/packages/ts/memorax-code-backend/test/codex-plugin-hooks.test.mjs
@@ -344,43 +344,41 @@ test("codex-plugin hooks rejects malformed hooks/list payloads", async () => {
   }
 });
 
-test("codex-plugin trust-hooks rejects ambiguous or malformed base user config layers", async (t) => {
-  for (const { mode, expected } of [
-    { mode: "missing-profile", expected: /invalid user config layer/i },
-    { mode: "profile-only", expected: /0 base user config layers/i },
-    { mode: "no-user", expected: /0 base user config layers/i },
-    { mode: "multiple-base", expected: /2 base user config layers/i },
-    { mode: "invalid-config", expected: /invalid base user config layer/i },
-  ]) {
-    await t.test(mode, async () => {
-      const root = await mkdtemp(join(tmpdir(), `memorax-code-codex-hooks-layer-${mode}-`));
-      const home = join(root, "home");
-      const codexHome = join(home, "codex");
-      const rpcLog = join(root, "rpc.log");
-      try {
-        await mkdir(codexHome, { recursive: true });
-        const fakeCodex = await createFakeCodex(root);
-        const selected = hook(`layer-${mode}`, `sha256:layer-${mode}`);
-        const result = await runMemoraxCode([
-          "codex-plugin", "trust-hooks", "--yes", "--codex-command", fakeCodex, "--workspace", root, "--json",
-        ], {
-          HOME: home,
-          CODEX_HOME: codexHome,
-          TEST_CODEX_HOOKS: JSON.stringify([selected]),
-          TEST_CODEX_RPC_LOG: rpcLog,
-          TEST_CODEX_CONFIG_LAYER_MODE: mode,
-          MEMORAX_CODE_CODEX_HOOK_TRUST_SELECTION_JSON: JSON.stringify([selected]),
-        });
-        assert.equal(result.code, 1, result.stderr);
-        assert.match(result.stderr, expected);
-        const requests = (await readFile(rpcLog, "utf8")).trim().split(/\r?\n/).map((line) => JSON.parse(line));
-        assert.equal(requests.some((request) => request.method === "config/batchWrite"), false);
-      } finally {
-        await rm(root, { recursive: true, force: true });
-      }
-    });
-  }
-});
+for (const { mode, expected } of [
+  { mode: "missing-profile", expected: /invalid user config layer/i },
+  { mode: "profile-only", expected: /0 base user config layers/i },
+  { mode: "no-user", expected: /0 base user config layers/i },
+  { mode: "multiple-base", expected: /2 base user config layers/i },
+  { mode: "invalid-config", expected: /invalid base user config layer/i },
+]) {
+  test(`codex-plugin trust-hooks rejects ambiguous or malformed base user config layers: ${mode}`, async () => {
+    const root = await mkdtemp(join(tmpdir(), `memorax-code-codex-hooks-layer-${mode}-`));
+    const home = join(root, "home");
+    const codexHome = join(home, "codex");
+    const rpcLog = join(root, "rpc.log");
+    try {
+      await mkdir(codexHome, { recursive: true });
+      const fakeCodex = await createFakeCodex(root);
+      const selected = hook(`layer-${mode}`, `sha256:layer-${mode}`);
+      const result = await runMemoraxCode([
+        "codex-plugin", "trust-hooks", "--yes", "--codex-command", fakeCodex, "--workspace", root, "--json",
+      ], {
+        HOME: home,
+        CODEX_HOME: codexHome,
+        TEST_CODEX_HOOKS: JSON.stringify([selected]),
+        TEST_CODEX_RPC_LOG: rpcLog,
+        TEST_CODEX_CONFIG_LAYER_MODE: mode,
+        MEMORAX_CODE_CODEX_HOOK_TRUST_SELECTION_JSON: JSON.stringify([selected]),
+      });
+      assert.equal(result.code, 1, result.stderr);
+      assert.match(result.stderr, expected);
+      const requests = (await readFile(rpcLog, "utf8")).trim().split(/\r?\n/).map((line) => JSON.parse(line));
+      assert.equal(requests.some((request) => request.method === "config/batchWrite"), false);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+}
 
 test("codex-plugin trust-hooks fails closed on config version conflicts without retrying", async () => {
   const root = await mkdtemp(join(tmpdir(), "memorax-code-codex-hooks-conflict-"));


### PR DESCRIPTION
## Change Summary

Split the five Codex Hook config-layer rejection scenarios into independent top-level tests so each scenario receives its own five-second test budget under parallel load. This changes test structure only and does not change runtime behavior.

## Implementation Highlights

- Preserve the existing missing-profile, profile-only, no-user, multiple-base, and invalid-config fixtures and assertions.
- Remove the shared parent-test timeout budget without increasing the Backend-wide timeout.
- Keep the change limited to one test file, with no README or data-handling changes.

## Validation

- `node --test --test-timeout=5000 --test-force-exit packages/ts/memorax-code-backend/test/codex-plugin-hooks.test.mjs`
- Three rounds of eight concurrent executions of the focused test file.
- `npm run typecheck --prefix packages/ts/memorax-code-backend`
- `npm test --prefix packages/ts/memorax-code-backend`
- `git diff --check`

## Complete End-to-End Validation Results

- Environment: macOS with Node.js 24.15.0.
- Scenario or matrix: All five invalid config-layer modes, the complete Codex Hook test file, three eight-way parallel stress rounds, and the complete Backend suite.
- Command or workflow: Focused Node test execution, local parallel stress execution, Backend typecheck, and the complete Backend test command listed above.
- Result: Focused file 15/15 passed; parallel stress 24/24 passed with no timeout; Backend typecheck passed; Backend suite passed with 492 tests and 2 platform-specific skips.
- Evidence or artifacts: Automated terminal output only; no generated artifacts are committed.
- Reason not run / Remaining risk: A GitHub-hosted CI runner was not available for this repository, so the concurrency result is from the local macOS environment.