### PR TITLE
chore(release): bump public version to 0.1.2

### DIFF
--- a/packages/npm/memorax-code/package.json
+++ b/packages/npm/memorax-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax/memorax-code",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "MemoraX Code CLI, local memory backend, Codex and Claude Code adapters, skills, and Memory Viewer.",
   "license": "MIT",
   "type": "module",

--- a/packages/ts/memorax-code-backend/package-lock.json
+++ b/packages/ts/memorax-code-backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@memorax-code/backend",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@memorax-code/backend",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "smol-toml": "^1.7.0"
       },

--- a/packages/ts/memorax-code-backend/package.json
+++ b/packages/ts/memorax-code-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/backend",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "type": "module",
   "description": "Local memory integration, lifecycle, trace, and diagnostics for MemoraX Code.",

--- a/packages/ts/memorax-code-claude-adapter/.claude-plugin/plugin.json
+++ b/packages/ts/memorax-code-claude-adapter/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorax-code-claude-adapter",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Memory skill and local hooks for MemoraX Code in Claude Code.",
   "author": {
     "name": "MemoraX Code Maintainers"

--- a/packages/ts/memorax-code-claude-adapter/hooks/runtime-shell.json
+++ b/packages/ts/memorax-code-claude-adapter/hooks/runtime-shell.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
-  "shellVersion": "0.1.1",
+  "shellVersion": "0.1.2",
   "runtimeAbi": 1
 }

--- a/packages/ts/memorax-code-claude-adapter/package.json
+++ b/packages/ts/memorax-code-claude-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/claude-adapter",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "type": "module",
   "description": "Claude Code Hook adapter for MemoraX Code memory services.",

--- a/packages/ts/memorax-code-codex-adapter/.codex-plugin/plugin.json
+++ b/packages/ts/memorax-code-codex-adapter/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorax-code-codex-adapter",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Codex adapter, memory skill, and local hooks for MemoraX Code.",
   "author": {
     "name": "MemoraX AI"

--- a/packages/ts/memorax-code-codex-adapter/hooks/runtime-shell.json
+++ b/packages/ts/memorax-code-codex-adapter/hooks/runtime-shell.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
-  "shellVersion": "0.1.1",
+  "shellVersion": "0.1.2",
   "runtimeAbi": 1
 }

--- a/packages/ts/memorax-code-codex-adapter/package.json
+++ b/packages/ts/memorax-code-codex-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/codex-adapter",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "type": "module",
   "description": "Codex Hook and memory integration for MemoraX Code.",


### PR DESCRIPTION
## Summary

Bump the public npm release from 0.1.1 to 0.1.2 so the changes already merged into `main` can be published under a new immutable npm version.

## Changes

- Update the `@memorax/memorax-code` release-version authority to `0.1.2`.
- Synchronize the Backend package metadata and lockfile, Codex and Claude Code adapter manifests, and both Hook runtime shell versions.
- Keep runtime behavior, README content, security boundaries, and data-handling behavior unchanged.

## Validation

- `make test` — Backend 501 passed / 2 platform skips; Codex 202 passed; Claude Code 65 passed; npm and local-only trace 163 passed.
- `make docs-check` — documentation contract and README language synchronization passed.
- `make npm-package-check` — package build, 285-file allowlist, install/update checks, and dependency audit passed with 0 vulnerabilities.
- `scripts/npm-publish-dry-run.sh dist/npm-publish-dry-run-0.1.2 latest` — public `latest` dry-run completed successfully.
- Installed the resulting tgz in isolated npm, MemoraX Code, Codex, and Claude Code homes; Backend and both adapters became healthy, automatic writeback remained disabled, `/memory-viewer` returned 200, and the internal-only labeling route returned 404.
- Confirmed npm currently contains only versions `0.1.0` and `0.1.1`; no package was published during validation.

## Risk and compatibility

Low. This PR changes release metadata only. The Node.js requirement remains `>=24`, and there are no configuration, persisted-state, security, or data-handling changes.
