### PR TITLE
docs: make version badge track npm releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 <p align="center">
   <a href="https://code.memorax.net/"><img src="https://img.shields.io/badge/website-code.memorax.net-2563eb" alt="MemoraX Code website"></a>
   <a href="https://www.npmjs.com/package/@memorax/memorax-code"><img src="https://img.shields.io/npm/v/@memorax/memorax-code.svg" alt="npm version"></a>
-  <img src="https://img.shields.io/badge/version-0.1.1-f59e0b" alt="Version 0.1.1">
+  <img src="https://img.shields.io/npm/v/@memorax/memorax-code.svg?label=version&color=f59e0b" alt="npm package version">
   <img src="https://img.shields.io/badge/node-%3E%3D24-339933?logo=node.js&logoColor=white" alt="Node.js 24 or newer">
 </p>
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -17,7 +17,7 @@
 <p align="center">
   <a href="https://code.memorax.net/"><img src="https://img.shields.io/badge/website-code.memorax.net-2563eb" alt="MemoraX Code 产品网站"></a>
   <a href="https://www.npmjs.com/package/@memorax/memorax-code"><img src="https://img.shields.io/npm/v/@memorax/memorax-code.svg" alt="npm 版本"></a>
-  <img src="https://img.shields.io/badge/version-0.1.1-f59e0b" alt="版本 0.1.1">
+  <img src="https://img.shields.io/npm/v/@memorax/memorax-code.svg?label=version&color=f59e0b" alt="npm 包版本">
   <img src="https://img.shields.io/badge/node-%3E%3D24-339933?logo=node.js&logoColor=white" alt="Node.js 24 或更高版本">
 </p>
 


### PR DESCRIPTION
## Summary

Make the README `version` badge read from the npm registry so it stays aligned with the published package version automatically. The previous badge was hard-coded and remained on `0.1.1` after `0.1.2` was published.

## Changes

- Replace the hard-coded version badge in `README.md` with an npm-backed Shields badge labeled `version`.
- Apply the same change to `README.zh.md` while preserving the existing orange badge color.

## Validation

- `make release-version-check` — passed (`0.1.2`; all release targets match).
- `make docs-check` — passed (9 tests plus documentation and bilingual README contracts).
- Verified the Shields endpoint currently returns `version 0.1.2` with the expected color.
- `git diff --check` — passed.

## Risk and compatibility

Documentation-only. No runtime, install/update behavior, persisted state, security, or data-handling changes.
