### PR TITLE
docs: expand English pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,17 +1,30 @@
-## Summary
+## Change Summary
+<!-- Summarize in one sentence what changed and what problem it solves. This sentence will be copied into the changelog. -->
 
-<!-- What changed, why it changed, and the user-visible outcome. -->
-
-## Changes
-
+## Implementation Highlights
+<!-- Use bullets to list the key changes or core logic so reviewers can understand the implementation. Keep it focused. -->
+-
 -
 
 ## Validation
+<!-- Describe how it was verified: unit tests, manual testing, or evaluation scripts; any one is acceptable. -->
 
-<!-- List the exact checks run and their results. Explain any relevant check that was not run. -->
+## Full End-to-End Validation Results
+<!--
+Report complete results by scenario or matrix entry; do not write only pass or fail.
+Include only redacted evidence. Do not include secrets or private transcripts.
+If end-to-end validation was not run, explain why and describe the remaining risk.
+-->
+- Environment:
+- Scenario or matrix:
+- Command or workflow:
+- Result:
+- Evidence or artifacts:
+- Reason not run / remaining risk:
 
--
-
-## Risk and compatibility
-
-<!-- Note affected clients, install/update behavior, persisted state, security, or data-handling changes. Write "None" when not applicable. -->
+<!--
+Conventions:
+- Prefix PR titles with `feat: / fix: / refactor: / perf: / docs: / chore:`.
+  The title itself becomes one changelog line.
+- Keep "Change Summary" to 1–2 sentences so reviewers can understand the change at a glance.
+-->


### PR DESCRIPTION
## Change Summary
Standardize the public repository pull request template on a richer English format so submissions consistently include implementation and end-to-end validation context.

## Implementation Highlights
- Replaces the abbreviated summary/changes/risk layout with focused change-summary and implementation sections.
- Adds a structured full end-to-end validation matrix with redaction and remaining-risk guidance.
- Documents pull request title and changelog conventions in English.

## Validation
- `make docs-check` — passed.
- `git diff --cached --check` — passed.

## Full End-to-End Validation Results
- Environment: isolated local repository worktree
- Scenario or matrix: contributor pull request template structure and documentation contracts
- Command or workflow: `make docs-check`; `git diff --cached --check`
- Result: passed
- Evidence or artifacts: 9 documentation tests passed; documentation contract and README synchronization checks passed
- Reason not run / remaining risk: runtime end-to-end testing is not applicable to a pull request template-only change
