### PR TITLE
feat: add memory payload redactor

### DIFF
--- a/packages/ts/memorax-code-backend/src/memory/payload-redaction.ts
+++ b/packages/ts/memorax-code-backend/src/memory/payload-redaction.ts
@@ -44,7 +44,7 @@ const RULES: readonly RedactionRule[] = [
     priority: 100,
   },
   {
-    pattern: /(?:^|[\r\n])[ \t]*(?:Proxy-)?Authorization\s*:\s*(?:Bearer|Token|Basic)\s+["']?([A-Za-z0-9._~+/=-]{4,})/gim,
+    pattern: /(?:^|[\r\n])[ \t]*(?:Proxy-)?Authorization\s*:\s*([^\r\n]+)/gim,
     group: 1,
     kind: "AUTH_TOKEN",
     priority: 95,

--- a/packages/ts/memorax-code-backend/src/memory/payload-redaction.ts
+++ b/packages/ts/memorax-code-backend/src/memory/payload-redaction.ts
@@ -125,7 +125,7 @@ const RULES: readonly RedactionRule[] = [
     accept: looksLikeHighEntropyOpaqueId,
   },
   {
-    pattern: /(?<![A-Za-z0-9])\+?(?:\d|\(\d)[\d ()-]*\d[Xx]?\)?(?![A-Za-z0-9])/g,
+    pattern: /(?<![A-Za-z0-9.])\+?(?:\d|\(\d)[\d ()-]*\d[Xx]?\)?(?![A-Za-z0-9]|\.\d)/g,
     kind: "LONG_NUMBER",
     priority: 50,
     accept: (value) => {

--- a/packages/ts/memorax-code-backend/src/memory/payload-redaction.ts
+++ b/packages/ts/memorax-code-backend/src/memory/payload-redaction.ts
@@ -39,7 +39,7 @@ const NON_CONTENT_LABEL_PATTERN = /\b(?:proxy-authorization|authorization|bearer
 
 const RULES: readonly RedactionRule[] = [
   {
-    pattern: /-----BEGIN ((?:(?:RSA|EC|DSA|OPENSSH|ENCRYPTED) )?PRIVATE KEY)-----[\s\S]*?(?:-----END \1-----|$)/gi,
+    pattern: /-----BEGIN ((?:(?:RSA|EC|DSA|OPENSSH|ENCRYPTED) )?PRIVATE KEY|PGP PRIVATE KEY BLOCK)-----[\s\S]*?(?:-----END \1-----|$)/gi,
     kind: "PRIVATE_KEY",
     priority: 100,
   },

--- a/packages/ts/memorax-code-backend/src/memory/payload-redaction.ts
+++ b/packages/ts/memorax-code-backend/src/memory/payload-redaction.ts
@@ -44,7 +44,7 @@ const RULES: readonly RedactionRule[] = [
     priority: 100,
   },
   {
-    pattern: /(?:^|[\r\n])[ \t]*(?:Proxy-)?Authorization\s*:\s*([^\r\n]+)/gim,
+    pattern: /(?:^|[\r\n])[ \t]*(?:Proxy-)?Authorization[ \t]*:[ \t]*([^ \t\r\n][^\r\n]*)/gim,
     group: 1,
     kind: "AUTH_TOKEN",
     priority: 95,

--- a/packages/ts/memorax-code-backend/src/memory/payload-redaction.ts
+++ b/packages/ts/memorax-code-backend/src/memory/payload-redaction.ts
@@ -1,0 +1,247 @@
+export type MemoryPayloadRedactionKind =
+  | "PRIVATE_KEY"
+  | "AUTH_TOKEN"
+  | "COOKIE"
+  | "API_KEY"
+  | "CREDENTIAL"
+  | "EMAIL"
+  | "LONG_NUMBER"
+  | "OPAQUE_ID";
+
+export type MemoryPayloadRedactionResult = Readonly<{
+  text: string;
+  counts: Readonly<Partial<Record<MemoryPayloadRedactionKind, number>>>;
+  redacted: boolean;
+}>;
+
+type RedactionSpan = {
+  start: number;
+  end: number;
+  kind: MemoryPayloadRedactionKind;
+  priority: number;
+};
+
+type RedactionRule = Readonly<{
+  pattern: RegExp;
+  kind: MemoryPayloadRedactionKind;
+  priority: number;
+  group?: number;
+  accept?: (value: string) => boolean;
+}>;
+
+const MAX_REDACTION_INPUT_CHARS = 1_000_000;
+const PLACEHOLDER_PATTERN = /\[REDACTED:[A-Z_]+\]/g;
+const PLACEHOLDER_VALUE_PATTERN = /^\[REDACTED:[A-Z_]+\]$/;
+const SENSITIVE_KEY_SOURCE = String.raw`(?:[A-Za-z_$][A-Za-z0-9_$-]*)?(?:password|passwd|pwd|client[-_$]?secret|consumer[-_$]?secret|api[-_$]?key|access[-_$]?token|refresh[-_$]?token|auth[-_$]?token|id[-_$]?token|private[-_$]?key|secret[-_$]?access[-_$]?key|secret[-_$]?key|credential|secret|token)`;
+const CREDENTIAL_VALUE_SOURCE = String.raw`(?:\[REDACTED:[A-Z_]+\]|\$\{\{[^\r\n]*?\}\}|\{\{[^\r\n]*?\}\}|\$\{[^}\r\n]+\}|\$[A-Za-z_][A-Za-z0-9_]*|"(?:\\.|[^"\\\r\n])*"|'(?:\\.|[^'\\\r\n])*'|[^,;#}\]\)\r\n]+)`;
+const SAFE_CREDENTIAL_VALUE_PATTERN = /^(?:\[REDACTED:[A-Z_]+\]|\$\{\{[^\r\n]*\}\}|\{\{[^\r\n]*\}\}|\$\{[A-Z_][A-Z0-9_]*\}|\$[A-Z_][A-Z0-9_]*|(?:process\.)?env\.[A-Z_][A-Z0-9_]*|<[^>]+>|--\S+|x{2,}|\*{2,}|\.{3}|sk[_-]x+|example|sample|change-?me|(?:your|replace)[-_][a-z0-9_-]+|string|str|number|boolean|unknown|any|null|undefined|none)$/i;
+const NON_CONTENT_LABEL_PATTERN = /\b(?:proxy-authorization|authorization|bearer|basic|cookie|set-cookie|password|passwd|pwd|client[_-]?secret|api[_-]?key|access[_-]?token|refresh[_-]?token|auth[_-]?token|private[_-]?key|credential|secret|token|jwt|email|contact|card|key|export)\b/gi;
+
+const RULES: readonly RedactionRule[] = [
+  {
+    pattern: /-----BEGIN ((?:(?:RSA|EC|DSA|OPENSSH|ENCRYPTED) )?PRIVATE KEY)-----[\s\S]*?(?:-----END \1-----|$)/gi,
+    kind: "PRIVATE_KEY",
+    priority: 100,
+  },
+  {
+    pattern: /(?:^|[\r\n])[ \t]*(?:Proxy-)?Authorization\s*:\s*(?:Bearer|Token|Basic)\s+["']?([A-Za-z0-9._~+/=-]{4,})/gim,
+    group: 1,
+    kind: "AUTH_TOKEN",
+    priority: 95,
+  },
+  {
+    pattern: /(?:^|[^A-Za-z0-9_-])(?:Bearer|Basic)\s+["']?([A-Za-z0-9._~+/=-]{16,})(?![A-Za-z0-9._~+/=-])/gi,
+    group: 1,
+    kind: "AUTH_TOKEN",
+    priority: 94,
+  },
+  {
+    pattern: /\beyJ[A-Za-z0-9_-]{5,}\.eyJ[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{16,}\b/g,
+    kind: "AUTH_TOKEN",
+    priority: 94,
+  },
+  {
+    pattern: /(?:^|[\r\n])[ \t]*(?:Set-Cookie|Cookie)\s*:\s*([^\r\n]+)/gim,
+    group: 1,
+    kind: "COOKIE",
+    priority: 92,
+  },
+  {
+    pattern: new RegExp(
+      String.raw`(?:^|[\r\n;,{}])[ \t]*(?:(?:export|const|let|var)[ \t]+)*["']?${SENSITIVE_KEY_SOURCE}["']?[ \t]*[:=][ \t]*(${CREDENTIAL_VALUE_SOURCE})`,
+      "gim",
+    ),
+    group: 1,
+    kind: "CREDENTIAL",
+    priority: 85,
+    accept: (value) => !isSafeCredentialValue(value),
+  },
+  {
+    pattern: new RegExp(
+      String.raw`--${SENSITIVE_KEY_SOURCE}(?![A-Za-z0-9_$-])(?:[ \t]+|=[ \t]*)(${CREDENTIAL_VALUE_SOURCE})`,
+      "gi",
+    ),
+    group: 1,
+    kind: "CREDENTIAL",
+    priority: 85,
+    accept: (value) => !isSafeCredentialValue(value),
+  },
+  {
+    pattern: /\b[A-Za-z][A-Za-z0-9+.-]*:\/\/[^\s/:@]*:([^\s/@]+)@/g,
+    group: 1,
+    kind: "CREDENTIAL",
+    priority: 85,
+    accept: (value) => !isSafeCredentialValue(value),
+  },
+  { pattern: /\bsk-(?:proj-)?[A-Za-z0-9_-]{16,}[A-Za-z0-9]\b/g, kind: "API_KEY", priority: 80 },
+  { pattern: /\bsk_[A-Za-z0-9_-]{8,}\b/g, kind: "API_KEY", priority: 80 },
+  { pattern: /\b(?:gh[pousr]_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,})\b/g, kind: "API_KEY", priority: 80 },
+  { pattern: /\b(?:AKIA|ASIA)[A-Z0-9]{16}\b/g, kind: "API_KEY", priority: 80 },
+  { pattern: /\bxox[baprs]-[A-Za-z0-9-]{16,}[A-Za-z0-9]\b/g, kind: "API_KEY", priority: 80 },
+  { pattern: /\b(?:(?:sk|rk)_live_[A-Za-z0-9]{16,}|whsec_[A-Za-z0-9]{16,})\b/g, kind: "API_KEY", priority: 80 },
+  { pattern: /\bglpat-[A-Za-z0-9_-]{16,}[A-Za-z0-9]\b/g, kind: "API_KEY", priority: 80 },
+  { pattern: /\bAIza[0-9A-Za-z_-]{35}\b/g, kind: "API_KEY", priority: 80 },
+  { pattern: /\bnpm_[A-Za-z0-9]{36}\b/g, kind: "API_KEY", priority: 80 },
+  {
+    pattern: /(?<![A-Z0-9._%+-])[A-Z0-9._%+-]{1,64}@[A-Z0-9](?:[A-Z0-9.-]{0,251}[A-Z0-9])?\.[A-Z]{2,63}(?![A-Z0-9-]|\.[A-Z0-9])/gi,
+    kind: "EMAIL",
+    priority: 70,
+  },
+  {
+    pattern: /(?<![A-Za-z0-9])[0-9A-Fa-f]{8}-(?:[0-9A-Fa-f]{4}-){3}[0-9A-Fa-f]{12}(?![A-Za-z0-9])/g,
+    kind: "OPAQUE_ID",
+    priority: 60,
+  },
+  {
+    pattern: /(?<![A-Za-z0-9])(?:[0-9A-Fa-f]{64}|[0-9A-Fa-f]{40}|[0-9A-Fa-f]{32})(?![A-Za-z0-9])/g,
+    kind: "OPAQUE_ID",
+    priority: 60,
+    accept: (value) => /[A-Fa-f]/.test(value),
+  },
+  {
+    pattern: /(?<![A-Za-z0-9])[A-Za-z0-9]{24,}(?![A-Za-z0-9])/g,
+    kind: "OPAQUE_ID",
+    priority: 60,
+    accept: looksLikeHighEntropyOpaqueId,
+  },
+  {
+    pattern: /(?<![A-Za-z0-9])\+?(?:\d|\(\d)[\d ()-]*\d[Xx]?\)?(?![A-Za-z0-9])/g,
+    kind: "LONG_NUMBER",
+    priority: 50,
+    accept: (value) => {
+      if (value.replace(/\D/g, "").length < 9) return false;
+      const normalized = value.trim().replace(/[()]/g, "");
+      return !/^(?:19|20)\d{2}-\d{1,2}-\d{1,2}(?:[ T-]\d{1,2})?$/.test(normalized)
+        && !/^(?:19|20)\d{2}\s+\d{1,2}\s+\d{1,2}(?:\s+\d{1,2})?$/.test(normalized);
+    },
+  },
+];
+
+export function redactMemoryPayloadText(text: string): MemoryPayloadRedactionResult {
+  if (text.length > MAX_REDACTION_INPUT_CHARS) {
+    throw new Error(`memory payload text exceeds the ${MAX_REDACTION_INPUT_CHARS} character redaction limit`);
+  }
+  if (!text) return { text, counts: {}, redacted: false };
+
+  const spans: RedactionSpan[] = [];
+  for (const rule of RULES) collectRuleSpans(text, rule, spans);
+  const selected = mergeOverlappingSpans(spans);
+  if (selected.length === 0) return { text, counts: {}, redacted: false };
+
+  const counts: Partial<Record<MemoryPayloadRedactionKind, number>> = {};
+  const output: string[] = [];
+  let offset = 0;
+  for (const span of selected) {
+    output.push(text.slice(offset, span.start), `[REDACTED:${span.kind}]`);
+    counts[span.kind] = (counts[span.kind] ?? 0) + 1;
+    offset = span.end;
+  }
+  output.push(text.slice(offset));
+  return { text: output.join(""), counts, redacted: true };
+}
+
+export function hasMeaningfulMemoryPayloadText(text: string): boolean {
+  if (!text.trim()) return false;
+  const remainder = text
+    .replace(PLACEHOLDER_PATTERN, " ")
+    .replace(NON_CONTENT_LABEL_PATTERN, " ")
+    .replace(/[\s.,;:!?"'`(){}\[\]<>/\\|=_-]+/g, "");
+  return /[\p{L}\p{N}]/u.test(remainder);
+}
+
+function collectRuleSpans(text: string, rule: RedactionRule, spans: RedactionSpan[]): void {
+  rule.pattern.lastIndex = 0;
+  for (const match of text.matchAll(rule.pattern)) {
+    const value = match[rule.group ?? 0];
+    if (match.index === undefined || !value || PLACEHOLDER_VALUE_PATTERN.test(value.trim())) continue;
+    if (rule.accept && !rule.accept(value)) continue;
+    const relativeStart = match[0].lastIndexOf(value);
+    if (relativeStart < 0) continue;
+    spans.push({
+      start: match.index + relativeStart,
+      end: match.index + relativeStart + value.length,
+      kind: rule.kind,
+      priority: rule.priority,
+    });
+  }
+}
+
+function isSafeCredentialValue(rawValue: string): boolean {
+  let value = rawValue.trim();
+  if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+    value = value.slice(1, -1).trim();
+  }
+  return !value || SAFE_CREDENTIAL_VALUE_PATTERN.test(value);
+}
+
+function looksLikeHighEntropyOpaqueId(value: string): boolean {
+  let lowercase = 0;
+  let uppercase = 0;
+  let digits = 0;
+  let transitions = 0;
+  let letterRun = 0;
+  let longestLetterRun = 0;
+  let previousWasDigit: boolean | undefined;
+  const unique = new Set<string>();
+
+  for (const character of value) {
+    const isDigit = character >= "0" && character <= "9";
+    if (isDigit) {
+      digits += 1;
+      letterRun = 0;
+    } else {
+      if (character >= "a" && character <= "z") lowercase += 1;
+      else uppercase += 1;
+      letterRun += 1;
+      longestLetterRun = Math.max(longestLetterRun, letterRun);
+    }
+    if (previousWasDigit !== undefined && previousWasDigit !== isDigit) transitions += 1;
+    previousWasDigit = isDigit;
+    unique.add(character);
+  }
+
+  return lowercase >= 2
+    && uppercase >= 2
+    && digits >= 2
+    && transitions >= 4
+    && longestLetterRun <= 5
+    && unique.size >= 12;
+}
+
+function mergeOverlappingSpans(spans: RedactionSpan[]): RedactionSpan[] {
+  const sorted = [...spans].sort((left, right) => (
+    left.start - right.start
+    || right.end - left.end
+    || right.priority - left.priority
+  ));
+  const merged: RedactionSpan[] = [];
+  for (const span of sorted) {
+    const previous = merged.at(-1);
+    if (!previous || span.start >= previous.end) {
+      merged.push({ ...span });
+      continue;
+    }
+    previous.end = Math.max(previous.end, span.end);
+  }
+  return merged;
+}

--- a/packages/ts/memorax-code-backend/src/memory/payload-redaction.ts
+++ b/packages/ts/memorax-code-backend/src/memory/payload-redaction.ts
@@ -87,6 +87,16 @@ const RULES: readonly RedactionRule[] = [
     accept: (value) => !isSafeCredentialValue(value),
   },
   {
+    pattern: new RegExp(
+      String.raw`[?&]${SENSITIVE_KEY_SOURCE}(?![A-Za-z0-9_$-])=([^&#\s"'<>]+)`,
+      "gi",
+    ),
+    group: 1,
+    kind: "CREDENTIAL",
+    priority: 85,
+    accept: (value) => !isSafeCredentialValue(value),
+  },
+  {
     pattern: /\b[A-Za-z][A-Za-z0-9+.-]*:\/\/[^\s/:@]*:([^\s/@]+)@/g,
     group: 1,
     kind: "CREDENTIAL",

--- a/packages/ts/memorax-code-backend/src/memory/payload-redaction.ts
+++ b/packages/ts/memorax-code-backend/src/memory/payload-redaction.ts
@@ -68,7 +68,7 @@ const RULES: readonly RedactionRule[] = [
   },
   {
     pattern: new RegExp(
-      String.raw`(?:^|[\r\n;,{}])[ \t]*(?:(?:export|const|let|var)[ \t]+)*["']?${SENSITIVE_KEY_SOURCE}["']?[ \t]*[:=][ \t]*(${CREDENTIAL_VALUE_SOURCE})`,
+      String.raw`(?:^|[\r\n;,{}])[ \t]*(?:-[ \t]+)?(?:(?:export|const|let|var)[ \t]+)*["']?${SENSITIVE_KEY_SOURCE}["']?[ \t]*[:=][ \t]*(${CREDENTIAL_VALUE_SOURCE})`,
       "gim",
     ),
     group: 1,

--- a/packages/ts/memorax-code-backend/test/memory/memory-payload-redaction.test.mjs
+++ b/packages/ts/memorax-code-backend/test/memory/memory-payload-redaction.test.mjs
@@ -32,6 +32,7 @@ test("memory payload redaction replaces each supported detector category", () =>
     ["vendor API key", `token ${fake.github}`, "token [REDACTED:API_KEY]", "API_KEY"],
     ["relay API key", `token sk_${"C".repeat(16)}_${"D".repeat(8)}`, "token [REDACTED:API_KEY]", "API_KEY"],
     ["assignment", `password=${fake.password}`, "password=[REDACTED:CREDENTIAL]", "CREDENTIAL"],
+    ["YAML list assignment", `- api_key: ${fake.password}`, "- api_key: [REDACTED:CREDENTIAL]", "CREDENTIAL"],
     ["CLI option", `tool --api-key ${fake.opaque}`, "tool --api-key [REDACTED:CREDENTIAL]", "CREDENTIAL"],
     ["credential URL", `postgres://user:${fake.password}@host/db`, "postgres://user:[REDACTED:CREDENTIAL]@host/db", "CREDENTIAL"],
     ["email", `contact ${fake.email}`, "contact [REDACTED:EMAIL]", "EMAIL"],

--- a/packages/ts/memorax-code-backend/test/memory/memory-payload-redaction.test.mjs
+++ b/packages/ts/memorax-code-backend/test/memory/memory-payload-redaction.test.mjs
@@ -75,6 +75,7 @@ test("memory payload redaction preserves representative non-sensitive coding tex
     "tool --password --verbose",
     "connect(password=swordfish)",
     "Authorization:   \nContent-Type: application/json",
+    "measurement=123456789.6059746146202087",
   ];
 
   for (const value of values) {

--- a/packages/ts/memorax-code-backend/test/memory/memory-payload-redaction.test.mjs
+++ b/packages/ts/memorax-code-backend/test/memory/memory-payload-redaction.test.mjs
@@ -19,6 +19,11 @@ test("memory payload redaction replaces each supported detector category", () =>
     "cHJpdmF0ZS1rZXktbWF0ZXJpYWw=",
     "-----END PRIVATE KEY-----",
   ].join("\n");
+  const pgpPrivateKey = [
+    "-----BEGIN PGP PRIVATE KEY BLOCK-----",
+    "cHJpdmF0ZS1rZXktbWF0ZXJpYWw=",
+    "-----END PGP PRIVATE KEY BLOCK-----",
+  ].join("\n");
   const jwt = [
     Buffer.from('{"alg":"HS256"}').toString("base64url"),
     Buffer.from('{"sub":"private-user"}').toString("base64url"),
@@ -26,6 +31,7 @@ test("memory payload redaction replaces each supported detector category", () =>
   ].join(".");
   const cases = [
     ["private key", `key:\n${privateKey}\nend`, "key:\n[REDACTED:PRIVATE_KEY]\nend", "PRIVATE_KEY"],
+    ["PGP private key", pgpPrivateKey, "[REDACTED:PRIVATE_KEY]", "PRIVATE_KEY"],
     ["authorization", `Authorization: Digest username="user", response="${fake.opaque}"`, "Authorization: [REDACTED:AUTH_TOKEN]", "AUTH_TOKEN"],
     ["JWT", `jwt=${jwt}`, "jwt=[REDACTED:AUTH_TOKEN]", "AUTH_TOKEN"],
     ["cookie", `Cookie: session=${fake.opaque}`, "Cookie: [REDACTED:COOKIE]", "COOKIE"],

--- a/packages/ts/memorax-code-backend/test/memory/memory-payload-redaction.test.mjs
+++ b/packages/ts/memorax-code-backend/test/memory/memory-payload-redaction.test.mjs
@@ -74,6 +74,7 @@ test("memory payload redaction preserves representative non-sensitive coding tex
     "password=${{ secrets.DB_PASSWORD }}",
     "tool --password --verbose",
     "connect(password=swordfish)",
+    "Authorization:   \nContent-Type: application/json",
   ];
 
   for (const value of values) {

--- a/packages/ts/memorax-code-backend/test/memory/memory-payload-redaction.test.mjs
+++ b/packages/ts/memorax-code-backend/test/memory/memory-payload-redaction.test.mjs
@@ -40,6 +40,7 @@ test("memory payload redaction replaces each supported detector category", () =>
     ["assignment", `password=${fake.password}`, "password=[REDACTED:CREDENTIAL]", "CREDENTIAL"],
     ["YAML list assignment", `- api_key: ${fake.password}`, "- api_key: [REDACTED:CREDENTIAL]", "CREDENTIAL"],
     ["CLI option", `tool --api-key ${fake.opaque}`, "tool --api-key [REDACTED:CREDENTIAL]", "CREDENTIAL"],
+    ["URL query credential", `https://host/callback?api_key=${fake.password}&mode=x`, "https://host/callback?api_key=[REDACTED:CREDENTIAL]&mode=x", "CREDENTIAL"],
     ["credential URL", `postgres://user:${fake.password}@host/db`, "postgres://user:[REDACTED:CREDENTIAL]@host/db", "CREDENTIAL"],
     ["email", `contact ${fake.email}`, "contact [REDACTED:EMAIL]", "EMAIL"],
     ["long number", `identity ${"1".repeat(32)}`, "identity [REDACTED:LONG_NUMBER]", "LONG_NUMBER"],

--- a/packages/ts/memorax-code-backend/test/memory/memory-payload-redaction.test.mjs
+++ b/packages/ts/memorax-code-backend/test/memory/memory-payload-redaction.test.mjs
@@ -1,0 +1,121 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  hasMeaningfulMemoryPayloadText,
+  redactMemoryPayloadText,
+} from "../../dist/memory/payload-redaction.js";
+
+const fake = {
+  opaque: "a".repeat(32),
+  openai: ["sk", "proj", "A".repeat(32)].join("-"),
+  github: ["ghp", "B".repeat(36)].join("_"),
+  password: "correct-horse-battery-staple",
+  email: ["private.user", "example.invalid"].join("@"),
+};
+
+test("memory payload redaction replaces each supported detector category", () => {
+  const privateKey = [
+    "-----BEGIN PRIVATE KEY-----",
+    "cHJpdmF0ZS1rZXktbWF0ZXJpYWw=",
+    "-----END PRIVATE KEY-----",
+  ].join("\n");
+  const jwt = [
+    Buffer.from('{"alg":"HS256"}').toString("base64url"),
+    Buffer.from('{"sub":"private-user"}').toString("base64url"),
+    "G".repeat(32),
+  ].join(".");
+  const cases = [
+    ["private key", `key:\n${privateKey}\nend`, "key:\n[REDACTED:PRIVATE_KEY]\nend", "PRIVATE_KEY"],
+    ["authorization", `Authorization: Bearer ${fake.opaque}`, "Authorization: Bearer [REDACTED:AUTH_TOKEN]", "AUTH_TOKEN"],
+    ["JWT", `jwt=${jwt}`, "jwt=[REDACTED:AUTH_TOKEN]", "AUTH_TOKEN"],
+    ["cookie", `Cookie: session=${fake.opaque}`, "Cookie: [REDACTED:COOKIE]", "COOKIE"],
+    ["vendor API key", `token ${fake.github}`, "token [REDACTED:API_KEY]", "API_KEY"],
+    ["relay API key", `token sk_${"C".repeat(16)}_${"D".repeat(8)}`, "token [REDACTED:API_KEY]", "API_KEY"],
+    ["assignment", `password=${fake.password}`, "password=[REDACTED:CREDENTIAL]", "CREDENTIAL"],
+    ["CLI option", `tool --api-key ${fake.opaque}`, "tool --api-key [REDACTED:CREDENTIAL]", "CREDENTIAL"],
+    ["credential URL", `postgres://user:${fake.password}@host/db`, "postgres://user:[REDACTED:CREDENTIAL]@host/db", "CREDENTIAL"],
+    ["email", `contact ${fake.email}`, "contact [REDACTED:EMAIL]", "EMAIL"],
+    ["long number", `identity ${"1".repeat(32)}`, "identity [REDACTED:LONG_NUMBER]", "LONG_NUMBER"],
+    ["formatted long number", "phone +1 (415) 555-2671", "phone [REDACTED:LONG_NUMBER]", "LONG_NUMBER"],
+    ["UUID", "task 00000000-0000-4000-8000-000000000001", "task [REDACTED:OPAQUE_ID]", "OPAQUE_ID"],
+    ["fixed-length hexadecimal ID", `sha256=${"a".repeat(64)}`, "sha256=[REDACTED:OPAQUE_ID]", "OPAQUE_ID"],
+    ["high-entropy opaque ID", "id=aB3dE5fG7hJ9kL2mN4pQ6rS8", "id=[REDACTED:OPAQUE_ID]", "OPAQUE_ID"],
+  ];
+
+  for (const [name, input, expected, kind] of cases) {
+    assert.deepEqual(redactMemoryPayloadText(input), {
+      text: expected,
+      counts: { [kind]: 1 },
+      redacted: true,
+    }, name);
+  }
+});
+
+test("memory payload redaction preserves representative non-sensitive coding text", () => {
+  const values = [
+    "ip=127.0.0.1",
+    "path=packages/ts/src/index.ts",
+    "url=https://example.invalid/path",
+    "class=MemoryPayloadRedactionResult2026",
+    "model=Model3DRenderer2Version4",
+    "project=memorax-code-backend-v2",
+    "timestamp=2026-08-13 17",
+    "token=${API_KEY}",
+    "token=sk_xxx",
+    "public key: -----BEGIN PUBLIC KEY-----",
+    "function connect(password: string, token: string) {}",
+    "password=${{ secrets.DB_PASSWORD }}",
+    "tool --password --verbose",
+    "connect(password=swordfish)",
+  ];
+
+  for (const value of values) {
+    assert.deepEqual(redactMemoryPayloadText(value), {
+      text: value,
+      counts: {},
+      redacted: false,
+    }, value);
+  }
+});
+
+test("memory payload redaction resolves overlaps and remains idempotent", () => {
+  const privateKey = [
+    "-----BEGIN PRIVATE KEY-----",
+    "cHJpdmF0ZS1rZXktbWF0ZXJpYWw=",
+    "-----END PRIVATE KEY-----",
+  ].join("\n");
+  const first = redactMemoryPayloadText([
+    `Authorization: Bearer ${fake.openai}`,
+    `Cookie: auth=Bearer ${fake.opaque}; session=private-session`,
+    `password: prefix ${privateKey}`,
+  ].join("\n"));
+
+  assert.equal(first.text, [
+    "Authorization: Bearer [REDACTED:AUTH_TOKEN]",
+    "Cookie: [REDACTED:COOKIE]",
+    "password: [REDACTED:CREDENTIAL]",
+  ].join("\n"));
+  assert.deepEqual(first.counts, {
+    AUTH_TOKEN: 1,
+    COOKIE: 1,
+    CREDENTIAL: 1,
+  });
+  assert.deepEqual(redactMemoryPayloadText(first.text), {
+    text: first.text,
+    counts: {},
+    redacted: false,
+  });
+});
+
+test("memory payload redaction fails closed when input exceeds its bound", () => {
+  assert.throws(
+    () => redactMemoryPayloadText("x".repeat(1_000_001)),
+    /memory payload text exceeds the 1000000 character redaction limit/,
+  );
+});
+
+test("meaningful memory payload text keeps useful context after redaction", () => {
+  assert.equal(hasMeaningfulMemoryPayloadText("  \n\t"), false);
+  assert.equal(hasMeaningfulMemoryPayloadText("[REDACTED:EMAIL], [REDACTED:API_KEY]"), false);
+  assert.equal(hasMeaningfulMemoryPayloadText("Use [REDACTED:API_KEY] through the credential store."), true);
+});

--- a/packages/ts/memorax-code-backend/test/memory/memory-payload-redaction.test.mjs
+++ b/packages/ts/memorax-code-backend/test/memory/memory-payload-redaction.test.mjs
@@ -26,7 +26,7 @@ test("memory payload redaction replaces each supported detector category", () =>
   ].join(".");
   const cases = [
     ["private key", `key:\n${privateKey}\nend`, "key:\n[REDACTED:PRIVATE_KEY]\nend", "PRIVATE_KEY"],
-    ["authorization", `Authorization: Bearer ${fake.opaque}`, "Authorization: Bearer [REDACTED:AUTH_TOKEN]", "AUTH_TOKEN"],
+    ["authorization", `Authorization: Digest username="user", response="${fake.opaque}"`, "Authorization: [REDACTED:AUTH_TOKEN]", "AUTH_TOKEN"],
     ["JWT", `jwt=${jwt}`, "jwt=[REDACTED:AUTH_TOKEN]", "AUTH_TOKEN"],
     ["cookie", `Cookie: session=${fake.opaque}`, "Cookie: [REDACTED:COOKIE]", "COOKIE"],
     ["vendor API key", `token ${fake.github}`, "token [REDACTED:API_KEY]", "API_KEY"],
@@ -92,7 +92,7 @@ test("memory payload redaction resolves overlaps and remains idempotent", () => 
   ].join("\n"));
 
   assert.equal(first.text, [
-    "Authorization: Bearer [REDACTED:AUTH_TOKEN]",
+    "Authorization: [REDACTED:AUTH_TOKEN]",
     "Cookie: [REDACTED:COOKIE]",
     "password: [REDACTED:CREDENTIAL]",
   ].join("\n"));


### PR DESCRIPTION
## Change Summary

Add a bounded, best-effort memory payload redactor that detects and replaces high-confidence secrets and sensitive identifiers before outbound Add paths adopt it.

## Implementation Highlights

- Detect private keys, authorization tokens, cookies, common API keys, credential assignments and URL passwords, email addresses, long numeric identifiers, UUIDs, fixed-length hexadecimal IDs, and conservative high-entropy opaque IDs.
- Return typed placeholders and per-category counts, preserve representative non-sensitive coding text, merge overlapping detections, keep already-redacted output idempotent, and reject inputs above the one-million-character processing bound.
- Provide a semantic-content check so callers can reject payloads that contain nothing meaningful after redaction.

## Validation

- `npm run typecheck --prefix packages/ts/memorax-code-backend`
- `npm test --prefix packages/ts/memorax-code-backend`
- `git diff --check main...HEAD`

## Full End-to-End Validation Results

- Environment: macOS local worktree, Node.js Backend test environment.
- Scenario or matrix: Detector categories, representative non-sensitive coding content, overlap resolution and idempotence, input-size bound, and meaningful-content evaluation.
- Command or workflow: Backend typecheck and full Backend test suite on `feat/memory-payload-redactor`.
- Result: Typecheck passed; 509 tests passed, 2 skipped, 0 failed; diff check passed.
- Evidence or artifacts: Unit-test output only; no private transcripts, credentials, or real user data are included.
- Reason not run / remaining risk: End-to-end MemoraX Add transmission was not run because this PR intentionally adds only the standalone detector. Explicit and automatic Add integration will follow in a separate PR. Detection is best-effort and is not intended to provide adversarial DLP guarantees.
