### PR TITLE
feat: add DeepSeek Harness (DSH) support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,55 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: test (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      # The backend test suite installs its own dependencies via `npm ci`
+      # inside the Makefile (`test-ts` and `test-npm-package`), so no separate
+      # dependency install step is required here.
+      - name: Run tests
+        run: make test
+
+      - name: Check documentation
+        run: make docs-check
+
+  # `make npm-package-check` additionally builds and installs the published
+  # package and runs install/start smoke tests that require a functional
+  # `claude` and `codex` CLI on PATH (the Claude and Codex adapter setup runs
+  # their version probes). A bare GitHub runner does not ship these CLIs, and
+  # `@anthropic-ai/claude-code` does not run its native-binary install script
+  # under the default npm allow-scripts policy. This job is therefore kept
+  # non-blocking; it still exercises package staging, packing, install, and the
+  # CLI smoke checks that do not depend on those client runtimes.
+  npm-package-check:
+    name: npm package check
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Build and verify the npm package
+        run: make npm-package-check

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -24,14 +24,14 @@ authoritative.
 
 ## 2. System Shape and Package Ownership
 
-MemoraX Code integrates Codex and Claude Code with one local Backend. The
-Backend is a capability-oriented modular monolith. The clients retain
-ownership of models, model-provider credentials, native tools, model-provider
-traffic, and native transcript creation.
+MemoraX Code integrates Codex, Claude Code, and DeepSeek Harness (DSH) with one
+local Backend. The Backend is a capability-oriented modular monolith. The
+clients retain ownership of models, model-provider credentials, native tools,
+model-provider traffic, and native transcript creation.
 
 Around the Backend are:
 
-- two client deployment adapters;
+- three client deployment adapters;
 - one lower-level shared runtime source layer;
 - one npm assembly and installed-CLI layer; and
 - repository automation that builds, validates, stages, and tests artifacts.
@@ -41,11 +41,13 @@ flowchart LR
   subgraph Clients["Client-owned runtimes"]
     Codex["Codex"]
     Claude["Claude Code"]
+    Dsh["DeepSeek Harness"]
   end
 
   subgraph Adapters["Client deployment adapters"]
     CodexAdapter["Codex adapter<br/>plugin, Hooks, canonical skill"]
     ClaudeAdapter["Claude adapter<br/>plugin, Hooks, installer"]
+    DshAdapter["DSH adapter<br/>cordis bundle, session bridge"]
   end
 
   Common["adapter-common<br/>records, locks, Hook and Repo Memory helpers"]
@@ -70,8 +72,10 @@ flowchart LR
 
   Codex --> CodexAdapter
   Claude --> ClaudeAdapter
+  Dsh --> DshAdapter
   CodexAdapter -. "versioned local Hook HTTP" .-> Backend
   ClaudeAdapter -. "versioned local Hook HTTP" .-> Backend
+  DshAdapter -. "versioned local Hook HTTP" .-> Backend
 
   Backend --> MemoraX
   Backend --> Local
@@ -88,6 +92,7 @@ relationships; the arrow labels distinguish them. It is not an import graph.
 | `packages/ts/memorax-code-adapter-common` | Shared source for Backend connection authority, private runtime records, cross-process locking and configuration, Hook generations, Hook launch helpers, and Repo/Personal Memory helpers | Backend composition, native transcript interpretation, MemoraX request execution, or client plugin policy | `packages/ts/memorax-code-adapter-common/src/backend-connection.mjs`, `src/runtime-record.mjs`, `src/hooks`, and `src/repo-memory` |
 | `packages/ts/memorax-code-codex-adapter` | Codex plugin artifact, Hook shells and runtimes, session/workspace observation, diagnostics, and the canonical shared skill | Codex rollout semantics or Backend-side writeback authority | `.codex-plugin`, `hooks`, `runtime-hooks`, `src`, and `skills/memorax-code` |
 | `packages/ts/memorax-code-claude-adapter` | Claude Code plugin artifact, Hook shells and runtimes, configuration, installer, marketplace source, and diagnostics | Claude transcript semantics or Backend memory orchestration | `.claude-plugin`, `hooks`, `runtime-hooks`, `scripts`, and `src/plugin-install.mjs` |
+| `packages/ts/memorax-code-dsh-adapter` | DSH cordis bundle, DSH event-to-command session bridge, Backend forwarding, and diagnostics | DSH session-log semantics or Backend memory orchestration | `cordis.patch.yml`, `src/index.mjs`, `src/session-bridge.mjs`, and `src/backend-forwarder.mjs` |
 | `packages/npm/memorax-code` | Installed executable wrappers, update, preinstall/postinstall, npm manifest, and release-package source | Backend lifecycle semantics, uninstall orchestration, or artifact staging | `bin`, `lib/run-entrypoint.mjs`, and `package.json` |
 | `scripts` | Backend build orchestration, staging/materialization, package layout, documentation, and local-only data gates | Product runtime authority | Package-build/check scripts and executable contract scripts |
 | `.github` | Issue and pull-request contribution templates | Product runtime behavior | `.github/ISSUE_TEMPLATE` and `.github/pull_request_template.md` |
@@ -116,8 +121,12 @@ Client integration is deliberately not physically symmetric. Codex plugin
 material belongs to the Codex adapter, while current install, activation, and
 Hook-trust glue lives in Backend `clients/codex`. The Claude Code installer
 lives in the Claude adapter and is loaded by its Backend lifecycle
-participant. Preserve the participant contract and each client's actual
-authority instead of forcing matching directory shapes.
+participant. The DSH adapter is a standalone cordis bundle published
+separately and installed through `dsh plugin add`; its writeback content
+authority is the inline user/assistant text carried by DSH session events, so
+it does not read a native transcript file. Preserve the participant contract
+and each client's actual authority instead of forcing matching directory
+shapes.
 
 ## 3. Runtime Flows
 
@@ -194,7 +203,9 @@ Important distinctions:
 - Hook payload is protocol and correlation input. It is not automatic
   writeback content authority.
 - Codex rollout JSONL and Claude Code transcript JSONL are the content
-  authorities for their respective clients.
+  authorities for their respective clients. DSH session events (the inline
+  user and assistant messages accumulated by the DSH adapter) are the content
+  authority for DSH.
 - Required client/session/turn identity and repository scope fail closed when
   incomplete, conflicting, or unprovable.
 - A malformed or incomplete direct `.git` directory is the sole documented
@@ -299,6 +310,7 @@ src/
   clients/
     codex/                Codex native interpretation and lifecycle adapters
     claude/               Claude native interpretation and lifecycle participant
+    dsh/                  DSH inline-content interpretation and Hook memory runtime
   config/                 Backend and proxy/config interpretation
   entrypoints/            process and management-CLI orchestration
   lifecycle/
@@ -334,6 +346,7 @@ entrypoints and compatibility facades. It is not another implementation area.
 | `src/lifecycle/backend` | Managed process, PID/token/connection records, status probing, cleanup, and shutdown requests | Helper contracts do not depend back on the full service implementation |
 | `src/clients/codex` | Codex rollout, prompt, turn-index, and workspace interpretation; Hook memory runtime; plugin integration glue; and lifecycle participant | No Claude format fallback; request runtime remains HTTP-composition independent |
 | `src/clients/claude` | Claude transcript/turn interpretation, Hook memory runtime, and lifecycle participant | No Codex format fallback; request runtime remains HTTP-composition independent |
+| `src/clients/dsh` | DSH inline turn interpretation and Hook memory runtime for adapter-forwarded commands | No Codex or Claude format fallback; request runtime remains HTTP-composition independent |
 | `src/memory` | Memory commands, retrieval, writeback, turn coordination, repository session pinning, manual CLI, buffering/chunking, task projection, and reconciliation | Client-neutral modules do not parse native transcript formats |
 | `src/repository` | Read-only repository identity and Repo Memory readiness | Scope derivation does not execute Git or use synchronous filesystem reads |
 | `src/provider/memorax` | MemoraX config interpretation, query/add/status payloads, HTTP transport, and normalized results | Independent from server routing and plugin lifecycle |

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-ts test-codex-adapter test-claude-adapter test-npm-package docs-check npm-package-build npm-package-check npm-publish-dry-run release-version-check clean
+.PHONY: test test-ts test-codex-adapter test-claude-adapter test-dsh-adapter test-npm-package docs-check npm-package-build npm-package-check npm-publish-dry-run release-version-check clean
 
 NPM ?= npm
 
@@ -10,12 +10,16 @@ test-ts:
 	$(NPM) test --prefix packages/ts/memorax-code-backend
 	$(MAKE) test-codex-adapter
 	$(MAKE) test-claude-adapter
+	$(MAKE) test-dsh-adapter
 
 test-codex-adapter:
 	$(NPM) test --prefix packages/ts/memorax-code-codex-adapter
 
 test-claude-adapter:
 	$(NPM) test --prefix packages/ts/memorax-code-claude-adapter
+
+test-dsh-adapter:
+	$(NPM) test --prefix packages/ts/memorax-code-dsh-adapter
 
 test-npm-package:
 	$(NPM) ci --prefix packages/ts/memorax-code-backend

--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ Coding agents are good at the task in front of them, but a new session often
 starts without the architecture, failed attempts, repository rules, or working
 preferences established before it.
 
-MemoraX Code gives Codex and Claude Code a shared memory layer for that context.
-It can recall prior engineering knowledge, capture reusable lessons from
-completed work, maintain repository knowledge, and carry your procedures and
-preferences into future sessions.
+MemoraX Code gives Codex, Claude Code, and DeepSeek Harness (DSH) a shared
+memory layer for that context. It can recall prior engineering knowledge,
+capture reusable lessons from completed work, maintain repository knowledge,
+and carry your procedures and preferences into future sessions.
 
 The goal is not to remember everything. It is to bring back the small amount of
 memory relevant to the current task so the agent can reach useful investigation
@@ -42,8 +42,8 @@ and validation sooner.
 
 ## Quick Start
 
-Prepare Node.js 24+ and either Codex or Claude Code. Python 3 is required for
-Repo Memory operations.
+Prepare Node.js 24+ and Codex, Claude Code, or DeepSeek Harness (DSH). Python 3
+is required for Repo Memory operations.
 
 ### Install and Connect
 
@@ -67,6 +67,19 @@ and trust when prompted.
 
 If setup is skipped or cannot prompt, the package remains installed but
 MemoraX-backed search, retrieval, and writeback remain unavailable.
+
+#### 3. Connect DeepSeek Harness (optional)
+
+Install the DSH adapter into a profile to enable automatic memory retrieval and
+writeback for DSH sessions:
+
+```bash
+dsh plugin --profile <name> add @memorax/memorax-code-dsh-adapter
+```
+
+The adapter reads the same Backend as the npm package through
+`MEMORAX_CODE_BACKEND_URL` and `MEMORAX_CODE_BACKEND_TOKEN`. It fails silently
+when the Backend is unreachable so it never blocks a DSH turn.
 
 ### Try Cross-Session Memory
 
@@ -124,7 +137,7 @@ the current repository.
 | **Procedure reuse** | Records reusable task procedures and reminds future agents to apply them. |
 | **Background Repo Memory maintenance** | Automatically organizes repository structure, entry points, and history evidence in the background, then updates them according to policy to reduce repeated searching and summarization. |
 | **Active memory control** | Lets you search and add memory through the bundled MemoraX Code skill (`$memorax-code` in Codex or `/memorax-code` in Claude Code) or the CLI. |
-| **Hook integration** | Uses Codex and Claude Code Hooks to trigger memory retrieval, reminders, and writeback. |
+| **Hook integration** | Uses Codex, Claude Code, and DSH hooks to trigger memory retrieval, reminders, and writeback. |
 | **Local visualization** | Uses the local Memory Viewer to summarize activity counts, retrieval, and writeback status. |
 
 ## Your Memory, Your Control

--- a/README.md
+++ b/README.md
@@ -71,11 +71,17 @@ MemoraX-backed search, retrieval, and writeback remain unavailable.
 #### 3. Connect DeepSeek Harness (optional)
 
 Install the DSH adapter into a profile to enable automatic memory retrieval and
-writeback for DSH sessions:
+writeback for DSH sessions. The adapter is not yet published to npm; install it
+from a local checkout of the repository:
 
 ```bash
-dsh plugin --profile <name> add @memorax/memorax-code-dsh-adapter
+git clone https://github.com/memorax-ai/memorax-code.git
+dsh plugin --profile <name> add ./memorax-code/packages/ts/memorax-code-dsh-adapter
 ```
+
+Publishing `@memorax/memorax-code-dsh-adapter` to npm is pending maintainer
+action; once published it can be installed with
+`dsh plugin --profile <name> add @memorax/memorax-code-dsh-adapter`.
 
 The adapter reads the same Backend as the npm package through
 `MEMORAX_CODE_BACKEND_URL` and `MEMORAX_CODE_BACKEND_TOKEN`. It fails silently

--- a/README.zh.md
+++ b/README.zh.md
@@ -62,11 +62,16 @@ API Key；Codex 用户还需按提示完成 Hook 的激活和信任确认。
 
 #### 3. 接入 DeepSeek Harness（可选）
 
-将 DSH 适配器安装到某个 profile，即可为 DSH 会话启用自动记忆召回和写回：
+将 DSH 适配器安装到某个 profile，即可为 DSH 会话启用自动记忆召回和写回。该适配器尚未发布到
+npm，请从仓库的本地检出安装：
 
 ```bash
-dsh plugin --profile <name> add @memorax/memorax-code-dsh-adapter
+git clone https://github.com/memorax-ai/memorax-code.git
+dsh plugin --profile <name> add ./memorax-code/packages/ts/memorax-code-dsh-adapter
 ```
+
+`@memorax/memorax-code-dsh-adapter` 的 npm 发布待维护者操作；发布后即可通过
+`dsh plugin --profile <name> add @memorax/memorax-code-dsh-adapter` 安装。
 
 适配器通过 `MEMORAX_CODE_BACKEND_URL` 与 `MEMORAX_CODE_BACKEND_TOKEN` 访问与 npm 包相同的
 Backend。当 Backend 不可达时它静默降级，绝不阻塞 DSH 对话。

--- a/README.zh.md
+++ b/README.zh.md
@@ -30,7 +30,7 @@
 Coding Agent 擅长解决眼前的问题，但新会话不会自动继承此前积累的架构认知、踩坑经验、仓库规则
 和协作偏好。
 
-MemoraX Code 让 Codex 和 Claude Code 共享一套能够持续积累的记忆。它会沉淀代码任务中的工程经验，
+MemoraX Code 让 Codex、Claude Code 和 DeepSeek Harness（DSH）共享一套能够持续积累的记忆。它会沉淀代码任务中的工程经验，
 持续整理仓库知识，并在后续任务中找回相关的工作流程和偏好。
 
 它追求的不是“记得更多”，而是在需要时带回与当前任务相关的 Memory，让 Agent 减少重复搜索和试错，
@@ -38,7 +38,7 @@ MemoraX Code 让 Codex 和 Claude Code 共享一套能够持续积累的记忆�
 
 ## 快速开始
 
-开始前，请确保已安装 Node.js 24 或更高版本，以及 Codex 或 Claude Code。
+开始前，请确保已安装 Node.js 24 或更高版本，以及 Codex、Claude Code 或 DeepSeek Harness（DSH）。
 Repo Memory 操作还需要 Python 3。
 
 ### 安装与接入
@@ -59,6 +59,17 @@ npm install -g @memorax/memorax-code --foreground-scripts
 API Key；Codex 用户还需按提示完成 Hook 的激活和信任确认。
 
 如果跳过配置或安装过程无法交互，npm 包仍会安装，但 MemoraX 搜索、召回和写回功能无法使用。
+
+#### 3. 接入 DeepSeek Harness（可选）
+
+将 DSH 适配器安装到某个 profile，即可为 DSH 会话启用自动记忆召回和写回：
+
+```bash
+dsh plugin --profile <name> add @memorax/memorax-code-dsh-adapter
+```
+
+适配器通过 `MEMORAX_CODE_BACKEND_URL` 与 `MEMORAX_CODE_BACKEND_TOKEN` 访问与 npm 包相同的
+Backend。当 Backend 不可达时它静默降级，绝不阻塞 DSH 对话。
 
 ### 体验跨会话记忆
 
@@ -109,7 +120,7 @@ cd test-repo
 | **Procedure 自动复用** | 记录可复用的任务流程，并在后续任务中自动提醒 Agent 按流程执行。 |
 | **Repo Memory 后台整理** | 在后台整理仓库结构、代码入口和历史证据，并按策略自动更新，避免反复搜索和总结。 |
 | **主动记忆控制** | 使用内置的 MemoraX Code Skill（Codex 中为 `$memorax-code`，Claude Code 中为 `/memorax-code`）或 CLI，主动查找和添加记忆。 |
-| **Hook 集成** | 借助 Codex 和 Claude Code 的 Hook 触发记忆检索、提醒和写入。 |
+| **Hook 集成** | 借助 Codex、Claude Code 和 DSH 的 Hook 触发记忆检索、提醒和写入。 |
 | **本地可视化** | 通过本地 Memory Viewer 查看活动统计、召回与写入状态。 |
 
 ## 你的记忆，由你控制

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,9 +1,10 @@
 # Security Policy
 
-MemoraX Code is a local-first integration for Codex and Claude Code with an
-optional external bind mode and required communication with MemoraX for
-cloud-backed memory. Security reports should distinguish the local Backend,
-client-owned provider traffic, and MemoraX memory traffic.
+MemoraX Code is a local-first integration for Codex, Claude Code, and
+DeepSeek Harness (DSH) with an optional external bind mode and required
+communication with MemoraX for cloud-backed memory. Security reports should
+distinguish the local Backend, client-owned provider traffic, and MemoraX
+memory traffic.
 
 ## Supported Versions
 
@@ -28,9 +29,9 @@ Please allow time for triage and remediation before public disclosure.
 
 ### Client and local Backend
 
-- Codex and Claude Code own provider credentials, models, native tools, and
-  provider traffic. MemoraX Code does not proxy OpenAI Responses or Anthropic
-  Messages traffic and does not need client provider credentials.
+- Codex, Claude Code, and DSH own provider credentials, models, native tools,
+  and provider traffic. MemoraX Code does not proxy OpenAI Responses, Anthropic
+  Messages, or DSH model traffic and does not need client provider credentials.
 - The managed Backend binds to loopback by default. External binding requires
   explicit opt-in and a Backend token; deployment operators must provide an
   appropriate authenticated and encrypted network boundary.
@@ -64,8 +65,21 @@ Memory searches send the query and repository-scoped identity to MemoraX.
 Active adds and automatic writeback send the selected content needed to create
 memory. Automatic writeback may include selected user instructions and the
 matching final assistant response from an exact Codex or Claude Code
-transcript turn. It does not send the retained trace file, raw transcript
+transcript turn, or from the inline user/assistant text carried by DSH session
+events. It does not send the retained trace file, raw transcript
 path, or trace-only provenance as part of that payload.
+
+DSH does not produce a native transcript file that the Backend can read, so
+its automatic writeback content authority is the inline session-event payload
+(the user and assistant text the DSH adapter forwards over the versioned local
+Hook HTTP command), not an on-disk transcript. The DSH adapter therefore owns
+the trust decision that maps DSH session events to Backend commands, and the
+Backend validates the exact command shape and refuses writeback without a
+matching, accepted turn-start. Treat that event-to-Backend chain as a trust
+boundary: a process able to emit DSH session events or speak the local Hook
+HTTP surface with a valid Backend token can attempt to submit turn content, so
+the same localhost-is-not-an-isolation-boundary rule and Backend-token
+protections apply.
 
 Automatic writeback bounds each selected message to its configured Add limit,
 then applies a local best-effort detector before hashing, buffering, chunking,
@@ -113,11 +127,11 @@ the product creates or tightens the home to mode `0700` and newly seeded
 configuration to mode `0600`; Windows relies on the current user's filesystem
 ACLs.
 
-Codex and Claude Code local trace capture is enabled by default and may include
-prompts, responses, recalled memory, writeback content, reminder text, and
-local paths. Trace files stay under `MEMORAX_CODE_HOME`. The shipped package
-has no trace uploader, collector, receiver, or export command. This does not
-change the separate MemoraX queries and writeback described above.
+Codex, Claude Code, and DSH local trace capture is enabled by default and may
+include prompts, responses, recalled memory, writeback content, reminder text,
+and local paths. Trace files stay under `MEMORAX_CODE_HOME`. The shipped
+package has no trace uploader, collector, receiver, or export command. This
+does not change the separate MemoraX queries and writeback described above.
 
 The local `/memory-viewer` surface is a content-free activity summary. It must
 not expose conversation or memory text, session/turn identifiers, paths, or
@@ -155,8 +169,9 @@ cleanup runs.
   retained trace files, private memories, `.env.local`, or machine-specific
   diagnostic state.
 - Preserve workspace traversal and symlink protections, client/session
-  isolation, exact-transcript writeback authority, bounded parsing, and
-  fail-closed behavior for uncertain identity or runtime records.
+  isolation, exact-transcript writeback authority (and DSH inline-event
+  writeback authority), bounded parsing, and fail-closed behavior for
+  uncertain identity or runtime records.
 - Use isolated client and MemoraX Code homes for lifecycle or destructive
   tests.
 - Add focused regression coverage for changes to authentication, paths,

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -81,6 +81,18 @@ HTTP surface with a valid Backend token can attempt to submit turn content, so
 the same localhost-is-not-an-isolation-boundary rule and Backend-token
 protections apply.
 
+Two implementation details bound that surface. First, the memory Hook
+endpoints only accept `POST` requests carrying an `application/json` content
+type and refuse any request with an `Origin` header, so ordinary browsers
+(including a hostile web page attempting cross-site requests against the
+loopback Backend) cannot drive turn-start, writeback, or discard commands;
+native clients never send `Origin`. Second, if the in-memory DSH turn
+metadata is gone (Backend restart or the shared 256-turn cap evicting older
+DSH turns), writeback falls back to the local current-turn trace file that the
+accepted turn-start wrote, and is refused when that file does not attest the
+same session and turn. The trace fallback re-resolves the repository scope
+and is reported through diagnostics as `current_turn_trace`.
+
 Automatic writeback bounds each selected message to its configured Add limit,
 then applies a local best-effort detector before hashing, buffering, chunking,
 observability, or network dispatch. Recognized private keys, authorization

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -74,11 +74,17 @@ Codex or Claude Code provider settings. `--clients none` runs the Backend
 without managing either client integration.
 
 DeepSeek Harness (DSH) is not part of `[clients]`. It is a standalone adapter
-installed into a DSH profile:
+installed into a DSH profile. The adapter is not yet published to npm, so
+install it from a local checkout of the repository:
 
 ```sh
-dsh plugin --profile <name> add @memorax/memorax-code-dsh-adapter
+git clone https://github.com/memorax-ai/memorax-code.git
+dsh plugin --profile <name> add ./memorax-code/packages/ts/memorax-code-dsh-adapter
 ```
+
+Publishing `@memorax/memorax-code-dsh-adapter` to npm is pending maintainer
+action; once published it can be installed with
+`dsh plugin --profile <name> add @memorax/memorax-code-dsh-adapter`.
 
 The adapter forwards DSH `turn/start` and `turn/end` events to the same
 Backend. It resolves its connection from `MEMORAX_CODE_BACKEND_URL`,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -87,13 +87,43 @@ action; once published it can be installed with
 `dsh plugin --profile <name> add @memorax/memorax-code-dsh-adapter`.
 
 The adapter forwards DSH `turn/start` and `turn/end` events to the same
-Backend. It resolves its connection from `MEMORAX_CODE_BACKEND_URL`,
-`MEMORAX_CODE_BACKEND_HOST`/`PORT`, and `MEMORAX_CODE_BACKEND_TOKEN`, and
-times out requests with `MEMORAX_CODE_DSH_HOOK_TIMEOUT_MS` (default `5000`).
-Set `MEMORAX_CODE_DSH_RETRIEVAL_INJECT=true` to inject retrieved context back
-into the DSH conversation; `MEMORAX_CODE_DSH_HOOK_DEBUG=true` prints adapter
-diagnostics to stderr. When the Backend is unreachable the adapter fails
-silently and never blocks a DSH turn.
+Backend. It resolves its connection in this order: the plugin's `backendUrl`
+config, `MEMORAX_CODE_BACKEND_URL`, `MEMORAX_CODE_BACKEND_HOST`/`PORT`, the
+managed Backend's connection record under the MemoraX Code home
+(`runtime/backend/backend-connection.json`, which also points at the Backend
+token file when the Backend runs with a token), and finally
+`http://127.0.0.1:8787`. The token comes from `MEMORAX_CODE_BACKEND_TOKEN`,
+the plugin's `backendToken` config, or that token file — but the file's token
+is only used when the URL itself came from the connection record, so a
+managed token is never sent to a manually configured URL. An invalid
+connection record is reported to stderr and skipped, never fatal. Requests
+time out with `MEMORAX_CODE_DSH_HOOK_TIMEOUT_MS` (default `5000`).
+Set `MEMORAX_CODE_DSH_HOOK_DEBUG=true` to print adapter diagnostics to stderr;
+with debug on, Backend-side writeback skips (`turn_metadata_missing`,
+`prompt_mismatch`) are logged too. When the Backend is unreachable the
+adapter fails silently and never blocks a DSH turn.
+
+Retrieval injection into DSH conversations needs BOTH switches, and neither
+one alone is enough:
+
+1. Backend-side automatic retrieval (`[memory.retrieval]` /
+   `MEMORAX_CODE_MEMORY_RETRIEVAL_ENABLED`, default `false`). The Backend only
+   computes and returns `additionalContext` when this is enabled.
+2. Adapter-side injection (`MEMORAX_CODE_DSH_RETRIEVAL_INJECT=true`). The
+   adapter only weaves returned context into the live DSH conversation when
+   this is enabled.
+
+With only the Backend switch on, retrieved context is computed but never
+reaches the DSH conversation; with only the adapter switch on, the Backend
+returns nothing to inject. Codex and Claude Code are unaffected by the
+adapter switch.
+
+The Backend keeps DSH turn metadata in memory (exempt from the five-minute
+TTL, but sharing the same 256-turn cap as Codex and Claude Code turns), so a
+very long-running session can evict its oldest DSH turns. If the metadata for
+a writeback is gone, the Backend recovers the turn from the local current-turn
+trace file written at turn-start, and skips the writeback when that file does
+not attest the same session and turn.
 
 ## MemoraX connection
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -73,6 +73,22 @@ Client selection controls plugin and Hook lifecycle only. It does not change
 Codex or Claude Code provider settings. `--clients none` runs the Backend
 without managing either client integration.
 
+DeepSeek Harness (DSH) is not part of `[clients]`. It is a standalone adapter
+installed into a DSH profile:
+
+```sh
+dsh plugin --profile <name> add @memorax/memorax-code-dsh-adapter
+```
+
+The adapter forwards DSH `turn/start` and `turn/end` events to the same
+Backend. It resolves its connection from `MEMORAX_CODE_BACKEND_URL`,
+`MEMORAX_CODE_BACKEND_HOST`/`PORT`, and `MEMORAX_CODE_BACKEND_TOKEN`, and
+times out requests with `MEMORAX_CODE_DSH_HOOK_TIMEOUT_MS` (default `5000`).
+Set `MEMORAX_CODE_DSH_RETRIEVAL_INJECT=true` to inject retrieved context back
+into the DSH conversation; `MEMORAX_CODE_DSH_HOOK_DEBUG=true` prints adapter
+diagnostics to stderr. When the Backend is unreachable the adapter fails
+silently and never blocks a DSH turn.
+
 ## MemoraX connection
 
 MemoraX is the required remote-memory service:
@@ -210,15 +226,15 @@ initial build instead of falling back to its local `cwd`.
 
 ## Local traces
 
-`[trace.codex]` and `[trace.claude]` support the same fields:
+`[trace.codex]`, `[trace.claude]`, and `[trace.dsh]` support the same fields:
 
-| Field | Codex environment | Claude environment | Fallback |
-| --- | --- | --- | --- |
-| `enabled` | `MEMORAX_CODE_CODEX_TRACE_ENABLED` | `MEMORAX_CODE_CLAUDE_TRACE_ENABLED` | `true` |
-| `capture_content` | `MEMORAX_CODE_CODEX_TRACE_CAPTURE_CONTENT` | `MEMORAX_CODE_CLAUDE_TRACE_CAPTURE_CONTENT` | `true` |
-| `retention_days` | `MEMORAX_CODE_CODEX_TRACE_RETENTION_DAYS` | `MEMORAX_CODE_CLAUDE_TRACE_RETENTION_DAYS` | `7` |
-| `max_event_chars` | `MEMORAX_CODE_CODEX_TRACE_MAX_EVENT_CHARS` | `MEMORAX_CODE_CLAUDE_TRACE_MAX_EVENT_CHARS` | `20000` |
-| `max_file_bytes` | `MEMORAX_CODE_CODEX_TRACE_MAX_FILE_BYTES` | `MEMORAX_CODE_CLAUDE_TRACE_MAX_FILE_BYTES` | `52428800` |
+| Field | Codex environment | Claude environment | DSH environment | Fallback |
+| --- | --- | --- | --- | --- |
+| `enabled` | `MEMORAX_CODE_CODEX_TRACE_ENABLED` | `MEMORAX_CODE_CLAUDE_TRACE_ENABLED` | `MEMORAX_CODE_DSH_TRACE_ENABLED` | `true` |
+| `capture_content` | `MEMORAX_CODE_CODEX_TRACE_CAPTURE_CONTENT` | `MEMORAX_CODE_CLAUDE_TRACE_CAPTURE_CONTENT` | `MEMORAX_CODE_DSH_TRACE_CAPTURE_CONTENT` | `true` |
+| `retention_days` | `MEMORAX_CODE_CODEX_TRACE_RETENTION_DAYS` | `MEMORAX_CODE_CLAUDE_TRACE_RETENTION_DAYS` | `MEMORAX_CODE_DSH_TRACE_RETENTION_DAYS` | `7` |
+| `max_event_chars` | `MEMORAX_CODE_CODEX_TRACE_MAX_EVENT_CHARS` | `MEMORAX_CODE_CLAUDE_TRACE_MAX_EVENT_CHARS` | `MEMORAX_CODE_DSH_TRACE_MAX_EVENT_CHARS` | `20000` |
+| `max_file_bytes` | `MEMORAX_CODE_CODEX_TRACE_MAX_FILE_BYTES` | `MEMORAX_CODE_CLAUDE_TRACE_MAX_FILE_BYTES` | `MEMORAX_CODE_DSH_TRACE_MAX_FILE_BYTES` | `52428800` |
 
 Content capture can include prompts, responses, recalled memory, writeback
 content, reminder text, and local paths. Set `capture_content=false` for

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "memorax-fix-pkg",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "memorax-fix-pkg",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/packages/npm/memorax-code/test/postinstall.test.mjs
+++ b/packages/npm/memorax-code/test/postinstall.test.mjs
@@ -1361,7 +1361,9 @@ test("postinstall does not auto-install Codex plugin when no cache exists yet", 
   }
 });
 
-test("postinstall uses the Codex App bundled runtime when no standalone CLI is installed", async () => {
+test("postinstall uses the Codex App bundled runtime when no standalone CLI is installed", {
+  skip: process.platform !== "darwin" && process.platform !== "win32",
+}, async () => {
   const run = await runPostinstall({
     codexAvailable: false,
     codexAppOnly: true,

--- a/packages/npm/memorax-code/test/release-version.test.mjs
+++ b/packages/npm/memorax-code/test/release-version.test.mjs
@@ -42,6 +42,13 @@ test("release version check detects drift and write aligns only declared targets
   }
 });
 
+test("release version targets include every adapter package", () => {
+  const targetFiles = RELEASE_VERSION_TARGETS.map((target) => target.file);
+  assert.ok(targetFiles.includes("packages/ts/memorax-code-codex-adapter/package.json"));
+  assert.ok(targetFiles.includes("packages/ts/memorax-code-claude-adapter/package.json"));
+  assert.ok(targetFiles.includes("packages/ts/memorax-code-dsh-adapter/package.json"));
+});
+
 function addFixtureField(files, target, value) {
   const document = files.get(target.file) ?? { fixtureMarker: "preserved" };
   let current = document;

--- a/packages/ts/memorax-code-adapter-common/src/config-utils.mjs
+++ b/packages/ts/memorax-code-adapter-common/src/config-utils.mjs
@@ -78,11 +78,22 @@ export function atomicWriteJson(path, value) {
 
 export function atomicWriteText(path, value) {
   mkdirSync(dirname(path), { recursive: true });
-  const tmp = `${path}.${process.pid}.${Date.now()}.tmp`;
+  const tmp = `${path}.${process.pid}.${randomUUID()}.tmp`;
+  let descriptor;
   try {
-    writeFileSync(tmp, value);
+    descriptor = openSync(tmp, "wx", 0o600);
+    writeFileSync(descriptor, value);
+    closeSync(descriptor);
+    descriptor = undefined;
     renameSync(tmp, path);
   } catch (error) {
+    if (descriptor !== undefined) {
+      try {
+        closeSync(descriptor);
+      } catch {
+        // Best-effort cleanup after an incomplete write.
+      }
+    }
     rmSync(tmp, { force: true });
     throw error;
   }

--- a/packages/ts/memorax-code-backend/src/app/backend-server.ts
+++ b/packages/ts/memorax-code-backend/src/app/backend-server.ts
@@ -93,7 +93,7 @@ export function createBackendServer(
       path: url.pathname,
     });
     try {
-      if (req.method === "GET" && url.pathname === "/health") return handleHealthRequest(state, res);
+      if (req.method === "GET" && url.pathname === "/health") return handleHealthRequest(state, req, res, url);
       if (!authorized(state, req, url)) return json(res, 401, { ok: false, error: "unauthorized" });
       if (
         url.pathname === "/memory-viewer"

--- a/packages/ts/memorax-code-backend/src/clients/dsh/memory-hook-runtime.ts
+++ b/packages/ts/memorax-code-backend/src/clients/dsh/memory-hook-runtime.ts
@@ -6,8 +6,10 @@ import {
   type AutomaticMemoryWritebackRuntime,
 } from "../../memory/automatic-writeback.js";
 import type {
+  DshTurnDiscardCommand,
   DshTurnStartCommand,
   DshWritebackCommand,
+  MemoryHookTurnDiscardResult,
   MemoryHookTurnStartResult,
 } from "../../memory/hook-command.js";
 import type { MemoryDiagnosticLogger, MemoryObservabilityHook } from "../../memory/observability.js";
@@ -46,6 +48,7 @@ type DshMemoryHookWritebackSkipReason =
   | "turn_id_missing"
   | "user_text_missing"
   | "assistant_text_missing"
+  | "prompt_mismatch"
   | "turn_metadata_missing"
   | "turn_metadata_mismatch"
   | "config_missing"
@@ -74,6 +77,7 @@ export type DshMemoryHookRuntimeOptions = {
 export type DshMemoryHookRuntime = {
   recordTurnStart(command: DshTurnStartCommand): Promise<MemoryHookTurnStartResult>;
   writeback(command: DshWritebackCommand): Promise<DshMemoryHookWritebackResult>;
+  discardTurn(command: DshTurnDiscardCommand): Promise<MemoryHookTurnDiscardResult>;
   size(): number;
   close(): void;
 };
@@ -133,6 +137,7 @@ export function createDshMemoryHookRuntime(
         cwd: turn.cwd,
         workspaceKind: turn.workspaceKind,
         transcriptPath: turn.transcriptPath,
+        prompt: turn.prompt,
         createdAt: turn.createdAt,
         traceContext: turn.traceContext,
         repositoryMemory,
@@ -214,6 +219,15 @@ export function createDshMemoryHookRuntime(
         });
         return skipped("turn_metadata_missing");
       }
+      if (entry.prompt !== undefined && !dshPromptMatches(entry.prompt, request.userText)) {
+        options.diagnosticLogger?.("dsh_memory_hook.writeback", {
+          scheduled: false,
+          reason: "prompt_mismatch",
+          sessionId: request.sessionId,
+          turnId: request.turnId,
+        });
+        return skipped("prompt_mismatch");
+      }
       const traceContext = traceContextForWriteback(request, entry);
       await recordDshTurnEnd(
         options,
@@ -261,6 +275,20 @@ export function createDshMemoryHookRuntime(
         contentSource: "dsh_session_event",
       });
       return { ok: true, scheduled: true };
+    },
+    async discardTurn(command) {
+      turnCoordinator.pruneExpired();
+      if (!command.sessionId || !command.turnId) return { ok: true, discarded: false };
+      const key = dshTurnKey(command.sessionId, command.turnId);
+      const entry = turnCoordinator.getTurn(key);
+      if (!entry) return { ok: true, discarded: false };
+      await recordDshTurnInterrupted(options, entry.traceContext);
+      turnCoordinator.discardTurn(key, "interrupted");
+      options.diagnosticLogger?.("dsh_memory_hook.turn_discarded", {
+        sessionId: command.sessionId,
+        turnId: command.turnId,
+      });
+      return { ok: true, discarded: true };
     },
     size() {
       return turnCoordinator.size(DSH_MEMORY_TURN_CLIENT);
@@ -379,6 +407,31 @@ async function recordDshTurnEnd(
   ), options.diagnosticLogger);
 }
 
+async function recordDshTurnInterrupted(
+  options: DshMemoryHookRuntimeOptions,
+  traceContext: TraceContext | undefined,
+): Promise<void> {
+  await recordTraceBestEffort("dsh_memory_hook.turn_end_event", recordDshTraceEvent({
+    eventId: traceTurnEventId(traceContext, "turn_end"),
+    memoraxCodeHome: options.memoraxCodeHome,
+    env: options.env,
+    traceContext,
+    type: "turn_end",
+    source: "dsh-hook",
+    operation: "reply",
+    ok: true,
+    outcome: "interrupted",
+  }), options.diagnosticLogger);
+  await recordTraceBestEffort("dsh_memory_hook.current_turn_close", markCurrentDshTurnOutcome(
+    traceContext,
+    "interrupted",
+    {
+      memoraxCodeHome: options.memoraxCodeHome,
+      env: options.env,
+    },
+  ), options.diagnosticLogger);
+}
+
 function traceContextForWriteback(
   request: DshMemoryHookWritebackRequest,
   entry: MemoryTurnState | undefined,
@@ -400,6 +453,10 @@ function dshTurnKey(sessionId: string, turnId: string) {
     sessionId,
     clientTurnId: turnId,
   } as const;
+}
+
+function dshPromptMatches(startedPrompt: string, userText: string): boolean {
+  return userText === startedPrompt || userText.startsWith(startedPrompt);
 }
 
 function claimAutomaticRetrievalTurn(

--- a/packages/ts/memorax-code-backend/src/clients/dsh/memory-hook-runtime.ts
+++ b/packages/ts/memorax-code-backend/src/clients/dsh/memory-hook-runtime.ts
@@ -94,10 +94,10 @@ const DSH_MEMORY_TURN_CLIENT = "dsh" as const;
 // gets its own (much wider) hard deadline.
 export const DSH_TURN_RECOVERY_WINDOW_MS = 24 * 60 * 60 * 1000;
 
-// Upper bound for the in-memory recovery tombstones below; a cap keeps a
+// Upper bound for the in-memory finalized-turn set below; a cap keeps a
 // pathological session from growing the map without bound. Oldest entries are
 // evicted first (Map iteration order is insertion order).
-const RECOVERED_TURN_TOMBSTONE_LIMIT = 512;
+const FINALIZED_TURN_LIMIT = 512;
 
 export function createDshMemoryHookRuntime(
   options: DshMemoryHookRuntimeOptions = {},
@@ -127,13 +127,13 @@ export function createDshMemoryHookRuntime(
   const automaticRetrievalTurns = new Set<string>();
   const automaticRetrievalTurnLimit = positiveInteger(options.maxEntries, 256);
   const writebackLocks = new Map<string, Promise<unknown>>();
-  // Recovery writebacks leave no coordinator entry behind (there was none to
-  // consume), so their only durable replay gate is closing the on-disk
-  // attestation — which is best-effort and can fail silently (disk full,
-  // permissions, one of the two record files). This in-memory tombstone set is
-  // the second gate: a turn recovered once in this process is never accepted
-  // through the recovery path again.
-  const recoveredTurnCompletions = new Map<string, number>();
+  // Turns that reached a terminal state (completed writeback or discard) in
+  // this process. Writeback consumes the coordinator entry, so without this
+  // set a replayed turn-start for a COMPLETED turn would rebuild the entry and
+  // let the replayed writeback schedule a second memory. It is also the
+  // in-memory second gate for recovery writebacks (the attestation close on
+  // disk is best-effort and can fail silently).
+  const finalizedTurns = new Map<string, number>();
 
   async function materializeDshTurn(
     coordinatorKey: ReturnType<typeof dshTurnKey>,
@@ -143,7 +143,6 @@ export function createDshMemoryHookRuntime(
     let metadata: MemoryTurnState | undefined = entry;
     let metadataSource: "coordinator" | "current_turn_trace" = "coordinator";
     let attestedTraceContext: TraceContext | undefined = entry?.traceContext;
-    let recoveryKey: string | undefined;
     if (entry) {
       if (entry.prompt !== undefined && !dshPromptMatches(entry.prompt, request.userText)) {
         options.diagnosticLogger?.("dsh_memory_hook.writeback", {
@@ -160,8 +159,8 @@ export function createDshMemoryHookRuntime(
       // current-turn trace written at turn-start still attests that this exact
       // session/turn reached an accepted turn-start. Recover the writeback
       // from that attestation instead of silently dropping it.
-      const recoveryKeyForCheck = recoveredTurnKey(request.sessionId, request.turnId);
-      if (recoveredTurnCompletions.has(recoveryKeyForCheck)) {
+      const recoveryKeyForCheck = finalizedTurnKey(request.sessionId, request.turnId);
+      if (finalizedTurns.has(recoveryKeyForCheck)) {
         // This exact turn was already recovered (and scheduled) once in this
         // process: the attestation close is best-effort, so the tombstone is
         // what makes a replayed recovery writeback fail closed.
@@ -181,7 +180,6 @@ export function createDshMemoryHookRuntime(
         expectedSessionId: request.sessionId,
         allowStale: true,
       });
-      recoveryKey = recoveredTurnKey(request.sessionId, request.turnId);
       if (!attestation.ok || attestation.traceContext.turnId !== request.turnId) {
         options.diagnosticLogger?.("dsh_memory_hook.writeback", {
           scheduled: false,
@@ -283,12 +281,15 @@ export function createDshMemoryHookRuntime(
       return skipped(writeback.reason);
     }
     await recordDshTurnEnd(options, traceContext, request.assistantText);
-    if (metadataSource === "current_turn_trace" && recoveryKey !== undefined) {
-      // No coordinator entry existed to consume, so the (best-effort)
-      // attestation close above is the only durable gate against replaying
-      // this exact writeback. Tombstone the turn in memory as well.
-      rememberRecoveredCompletion(recoveredTurnCompletions, recoveryKey, now());
-    }
+    // Both paths (coordinator entry and trace recovery) end a terminal turn:
+    // record it so a replayed turn-start cannot rebuild the turn and schedule
+    // the same memory twice. For the recovery path this is also the
+    // in-memory second gate when the best-effort attestation close fails.
+    rememberFinalizedTurn(
+      finalizedTurns,
+      finalizedTurnKey(request.sessionId, request.turnId),
+      now(),
+    );
     options.diagnosticLogger?.("dsh_memory_hook.writeback", {
       scheduled: true,
       metadataDisposition: writeback.metadataDisposition,
@@ -316,7 +317,41 @@ export function createDshMemoryHookRuntime(
     }
   > {
     const existing = turnCoordinator.getTurn(coordinatorKey);
-      if (existing) {
+    if (!existing) {
+      // Completed/interrupted turns must not restart. Writeback consumes the
+      // coordinator entry, so its absence cannot distinguish "never started"
+      // from "already finished" — and a DSH reconnect that replays session
+      // events re-sends the SAME turnId, which would otherwise rebuild the
+      // entry and let the replayed writeback schedule a second memory.
+      const finalizationKey = finalizedTurnKey(turn.sessionId, turn.turnId);
+      let finalized = finalizedTurns.has(finalizationKey);
+      if (!finalized) {
+        // After a Backend restart the in-memory set is empty; the on-disk
+        // current-turn record still remembers the last finalized turn.
+        const onDisk = await readOpenDshTurn({
+          memoraxCodeHome: options.memoraxCodeHome,
+          env: options.env,
+          expectedSessionId: turn.sessionId,
+          allowStale: true,
+        });
+        if (!onDisk.ok && onDisk.reason === "closed" && onDisk.traceContext.turnId === turn.turnId) {
+          rememberFinalizedTurn(finalizedTurns, finalizationKey, now());
+          finalized = true;
+        }
+      }
+      if (finalized) {
+        options.diagnosticLogger?.("dsh_memory_hook.turn_start_after_finalize", {
+          sessionId: turn.sessionId,
+          turnId: turn.turnId,
+          promptChars: turn.prompt.length,
+        });
+        // Fail silent like every other DSH hook skip: the replayed start is
+        // acknowledged (ok:true) but no entry is recorded, so any replayed
+        // writeback has nothing to match against.
+        return { ok: true, fresh: false };
+      }
+    }
+    if (existing) {
         if (existing.prompt !== undefined && existing.prompt !== turn.prompt) {
           // Self-heal a colliding turnId instead of dead-ending the turn: the
           // newest start wins. Without this the coordinator would keep
@@ -381,6 +416,7 @@ export function createDshMemoryHookRuntime(
       if (attestation.ok && attestation.traceContext.turnId === command.turnId) {
         await recordDshTurnInterrupted(options, attestation.traceContext);
         releaseAutomaticRetrievalTurn(automaticRetrievalTurns, command.sessionId, command.turnId);
+        rememberFinalizedTurn(finalizedTurns, finalizedTurnKey(command.sessionId, command.turnId), now());
         options.diagnosticLogger?.("dsh_memory_hook.turn_discarded", {
           sessionId: command.sessionId,
           turnId: command.turnId,
@@ -392,6 +428,7 @@ export function createDshMemoryHookRuntime(
     await recordDshTurnInterrupted(options, entry.traceContext);
     turnCoordinator.discardTurn(key, "interrupted");
     releaseAutomaticRetrievalTurn(automaticRetrievalTurns, command.sessionId, command.turnId);
+    rememberFinalizedTurn(finalizedTurns, finalizedTurnKey(command.sessionId, command.turnId), now());
     options.diagnosticLogger?.("dsh_memory_hook.turn_discarded", {
       sessionId: command.sessionId,
       turnId: command.turnId,
@@ -654,21 +691,21 @@ async function recordDshTurnEnd(
   }
 }
 
-function recoveredTurnKey(sessionId: string, turnId: string): string {
+function finalizedTurnKey(sessionId: string, turnId: string): string {
   return JSON.stringify([sessionId, turnId]);
 }
 
-function rememberRecoveredCompletion(
-  tombstones: Map<string, number>,
+function rememberFinalizedTurn(
+  finalized: Map<string, number>,
   key: string,
   timestamp: number,
 ): void {
-  tombstones.delete(key);
-  tombstones.set(key, timestamp);
-  while (tombstones.size > RECOVERED_TURN_TOMBSTONE_LIMIT) {
-    const oldest = tombstones.keys().next().value;
+  finalized.delete(key);
+  finalized.set(key, timestamp);
+  while (finalized.size > FINALIZED_TURN_LIMIT) {
+    const oldest = finalized.keys().next().value;
     if (typeof oldest !== "string") return;
-    tombstones.delete(oldest);
+    finalized.delete(oldest);
   }
 }
 

--- a/packages/ts/memorax-code-backend/src/clients/dsh/memory-hook-runtime.ts
+++ b/packages/ts/memorax-code-backend/src/clients/dsh/memory-hook-runtime.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { retrieveAutomaticMemoryContext } from "../../memory/automatic-retrieval.js";
 import {
   createAutomaticMemoryWritebackRuntime,
@@ -30,9 +31,11 @@ import {
   markCurrentDshTurnOutcome,
   readOpenDshTurn,
   recordDshTraceEvent,
+  tracePromptAttestation,
   traceTurnEventId,
   writeCurrentDshTurn,
   type DshTurnOutcome,
+  type TracePromptAttestation,
 } from "../../trace/store.js";
 
 type DshMemoryHookTurnStart = Omit<DshTurnStartCommand, "version" | "client"> & {
@@ -85,6 +88,17 @@ export type DshMemoryHookRuntime = {
 
 const DSH_MEMORY_TURN_CLIENT = "dsh" as const;
 
+// The coordinator entry is only read with allowStale: true on the recovery
+// path, which skips the 30-minute current-turn TTL entirely. A recovery is a
+// crash/restart fallback, not an indefinite replay credential, so it still
+// gets its own (much wider) hard deadline.
+export const DSH_TURN_RECOVERY_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+// Upper bound for the in-memory recovery tombstones below; a cap keeps a
+// pathological session from growing the map without bound. Oldest entries are
+// evicted first (Map iteration order is insertion order).
+const RECOVERED_TURN_TOMBSTONE_LIMIT = 512;
+
 export function createDshMemoryHookRuntime(
   options: DshMemoryHookRuntimeOptions = {},
 ): DshMemoryHookRuntime {
@@ -113,6 +127,13 @@ export function createDshMemoryHookRuntime(
   const automaticRetrievalTurns = new Set<string>();
   const automaticRetrievalTurnLimit = positiveInteger(options.maxEntries, 256);
   const writebackLocks = new Map<string, Promise<unknown>>();
+  // Recovery writebacks leave no coordinator entry behind (there was none to
+  // consume), so their only durable replay gate is closing the on-disk
+  // attestation — which is best-effort and can fail silently (disk full,
+  // permissions, one of the two record files). This in-memory tombstone set is
+  // the second gate: a turn recovered once in this process is never accepted
+  // through the recovery path again.
+  const recoveredTurnCompletions = new Map<string, number>();
 
   async function materializeDshTurn(
     coordinatorKey: ReturnType<typeof dshTurnKey>,
@@ -121,6 +142,8 @@ export function createDshMemoryHookRuntime(
     const entry = turnCoordinator.getTurn(coordinatorKey);
     let metadata: MemoryTurnState | undefined = entry;
     let metadataSource: "coordinator" | "current_turn_trace" = "coordinator";
+    let attestedTraceContext: TraceContext | undefined = entry?.traceContext;
+    let recoveryKey: string | undefined;
     if (entry) {
       if (entry.prompt !== undefined && !dshPromptMatches(entry.prompt, request.userText)) {
         options.diagnosticLogger?.("dsh_memory_hook.writeback", {
@@ -137,14 +160,29 @@ export function createDshMemoryHookRuntime(
       // current-turn trace written at turn-start still attests that this exact
       // session/turn reached an accepted turn-start. Recover the writeback
       // from that attestation instead of silently dropping it.
+      const recoveryKeyForCheck = recoveredTurnKey(request.sessionId, request.turnId);
+      if (recoveredTurnCompletions.has(recoveryKeyForCheck)) {
+        // This exact turn was already recovered (and scheduled) once in this
+        // process: the attestation close is best-effort, so the tombstone is
+        // what makes a replayed recovery writeback fail closed.
+        options.diagnosticLogger?.("dsh_memory_hook.writeback", {
+          scheduled: false,
+          reason: "turn_metadata_missing",
+          metadataSource: "current_turn_trace",
+          replayedRecovery: true,
+          sessionId: request.sessionId,
+          turnId: request.turnId,
+        });
+        return skipped("turn_metadata_missing");
+      }
       const attestation = await readOpenDshTurn({
         memoraxCodeHome: options.memoraxCodeHome,
         env: options.env,
         expectedSessionId: request.sessionId,
         allowStale: true,
       });
-      const attested = attestation.ok && attestation.traceContext.turnId === request.turnId;
-      if (!attested) {
+      recoveryKey = recoveredTurnKey(request.sessionId, request.turnId);
+      if (!attestation.ok || attestation.traceContext.turnId !== request.turnId) {
         options.diagnosticLogger?.("dsh_memory_hook.writeback", {
           scheduled: false,
           reason: "turn_metadata_missing",
@@ -153,19 +191,68 @@ export function createDshMemoryHookRuntime(
         });
         return skipped("turn_metadata_missing");
       }
+      // allowStale skips the current-turn TTL, so enforce the recovery window
+      // here: an attestation older than DSH_TURN_RECOVERY_WINDOW_MS (or one
+      // whose capturedAt cannot be parsed) is not a valid writeback credential.
+      const capturedAtMs = Date.parse(attestation.traceContext.capturedAt);
+      if (!Number.isFinite(capturedAtMs) || now() - capturedAtMs > DSH_TURN_RECOVERY_WINDOW_MS) {
+        options.diagnosticLogger?.("dsh_memory_hook.writeback", {
+          scheduled: false,
+          reason: "turn_metadata_missing",
+          metadataSource: "current_turn_trace",
+          attestationExpired: true,
+          sessionId: request.sessionId,
+          turnId: request.turnId,
+        });
+        return skipped("turn_metadata_missing");
+      }
+      // Without an attested cwd there is nothing to bind the recovered turn's
+      // repository scope to, and the fallback would be the writeback request's
+      // self-reported cwd — the exact trust hole the attestation exists to
+      // close. Refuse the recovery instead.
+      if (!attestation.traceContext.cwd) {
+        options.diagnosticLogger?.("dsh_memory_hook.writeback", {
+          scheduled: false,
+          reason: "turn_metadata_missing",
+          metadataSource: "current_turn_trace",
+          attestedCwdMissing: true,
+          sessionId: request.sessionId,
+          turnId: request.turnId,
+        });
+        return skipped("turn_metadata_missing");
+      }
+      // The attestation is only a valid writeback credential when it also pins
+      // the started prompt. Without this check the recovery path would accept
+      // any userText for an attested turnId; records that predate the
+      // prompt attestation field (or carry a torn record) fail closed here.
+      if (!attestation.promptAttestation
+        || !attestedPromptMatches(attestation.promptAttestation, request.userText)) {
+        options.diagnosticLogger?.("dsh_memory_hook.writeback", {
+          scheduled: false,
+          reason: "prompt_mismatch",
+          metadataSource: "current_turn_trace",
+          sessionId: request.sessionId,
+          turnId: request.turnId,
+        });
+        return skipped("prompt_mismatch");
+      }
+      attestedTraceContext = attestation.traceContext;
       metadata = undefined;
       metadataSource = "current_turn_trace";
     }
-    const traceContext = traceContextForWriteback(request, entry);
-    await recordDshTurnEnd(options, traceContext, request.assistantText);
+    // Repository binding comes from what turn-start attested (coordinator
+    // entry first, then the trace attestation). The writeback request's own
+    // cwd is only a last-resort fallback: a later request must not be able to
+    // re-bind an already-started turn to an unrelated workspace.
+    const traceContext = traceContextForWriteback(request, entry, attestedTraceContext);
     const writeback = await turnCoordinator.completeMaterializedTurn({
       key: coordinatorKey,
       metadata,
       resolveRepositoryMemory: () => resolveCurrentHookRepositoryMemory(
-        entry,
         request,
         options,
         repositoryMemorySession,
+        attestedTraceContext,
       ),
       userText: request.userText,
       assistantText: request.assistantText,
@@ -180,6 +267,11 @@ export function createDshMemoryHookRuntime(
       },
     });
     if (!writeback.scheduled) {
+      // The writeback was not accepted. Deliberately keep the current-turn
+      // attestation OPEN: closing it here would turn a transient rejection
+      // (for example a disabled writeback config) into a permanent one,
+      // because the retry could no longer recover the turn after the
+      // coordinator entry is gone.
       options.diagnosticLogger?.("dsh_memory_hook.writeback", {
         scheduled: false,
         reason: writeback.reason,
@@ -189,6 +281,13 @@ export function createDshMemoryHookRuntime(
         turnId: request.turnId,
       });
       return skipped(writeback.reason);
+    }
+    await recordDshTurnEnd(options, traceContext, request.assistantText);
+    if (metadataSource === "current_turn_trace" && recoveryKey !== undefined) {
+      // No coordinator entry existed to consume, so the (best-effort)
+      // attestation close above is the only durable gate against replaying
+      // this exact writeback. Tombstone the turn in memory as well.
+      rememberRecoveredCompletion(recoveredTurnCompletions, recoveryKey, now());
     }
     options.diagnosticLogger?.("dsh_memory_hook.writeback", {
       scheduled: true,
@@ -230,6 +329,17 @@ export function createDshMemoryHookRuntime(
             turnId: turn.turnId,
             previousCreatedAt: existing.createdAt,
           });
+          // The replaced incarnation already claimed automatic retrieval under
+          // this (sessionId, turnId). Release the claim so the new prompt can
+          // claim it again; without this the self-healed turn would silently
+          // lose its retrieval context while the stale claim rots in the set.
+          releaseAutomaticRetrievalTurn(automaticRetrievalTurns, turn.sessionId, turn.turnId);
+          // Close the replaced incarnation's attestation before overwriting
+          // it: the new turn's current-turn write below is best-effort, and if
+          // it fails the OPEN record would still vouch for the OLD prompt —
+          // letting a writeback carrying the old prompt through the recovery
+          // path after an eviction/restart.
+          await recordDshTurnInterrupted(options, existing.traceContext);
           turnCoordinator.discardTurn(coordinatorKey, "rolled_back");
         } else {
           return { ok: true, fresh: false };
@@ -243,7 +353,6 @@ export function createDshMemoryHookRuntime(
       clientTurnId: turn.turnId,
       cwd: turn.cwd,
       workspaceKind: turn.workspaceKind,
-      transcriptPath: turn.transcriptPath,
       prompt: turn.prompt,
       createdAt: turn.createdAt,
       traceContext: turn.traceContext,
@@ -257,7 +366,29 @@ export function createDshMemoryHookRuntime(
     command: DshTurnDiscardCommand,
   ): Promise<MemoryHookTurnDiscardResult> {
     const entry = turnCoordinator.getTurn(key);
-    if (!entry) return { ok: true, discarded: false };
+    if (!entry) {
+      // The coordinator entry is gone (Backend restart or cap eviction), but
+      // the on-disk attestation may still be OPEN for this exact turn. Close
+      // it now: an open attestation for a discarded turn would let a delayed
+      // or replayed writeback pass the recovery check and write a turn the
+      // client explicitly abandoned.
+      const attestation = await readOpenDshTurn({
+        memoraxCodeHome: options.memoraxCodeHome,
+        env: options.env,
+        expectedSessionId: command.sessionId,
+        allowStale: true,
+      });
+      if (attestation.ok && attestation.traceContext.turnId === command.turnId) {
+        await recordDshTurnInterrupted(options, attestation.traceContext);
+        releaseAutomaticRetrievalTurn(automaticRetrievalTurns, command.sessionId, command.turnId);
+        options.diagnosticLogger?.("dsh_memory_hook.turn_discarded", {
+          sessionId: command.sessionId,
+          turnId: command.turnId,
+          metadataSource: "current_turn_trace",
+        });
+      }
+      return { ok: true, discarded: false };
+    }
     await recordDshTurnInterrupted(options, entry.traceContext);
     turnCoordinator.discardTurn(key, "interrupted");
     releaseAutomaticRetrievalTurn(automaticRetrievalTurns, command.sessionId, command.turnId);
@@ -292,6 +423,7 @@ export function createDshMemoryHookRuntime(
       );
       if (!materialized.fresh) return { ok: true };
       const { repositoryMemory, repoMemoryWorktree } = materialized;
+      const promptAttestation = tracePromptAttestation(turn.prompt);
       options.diagnosticLogger?.("dsh_memory_hook.turn_start", {
         sessionId: turn.sessionId,
         turnId: turn.turnId,
@@ -300,29 +432,51 @@ export function createDshMemoryHookRuntime(
         workspace: repositoryMemory.ok ? repositoryMemory.memory.scope?.repositorySlug : undefined,
         workspaceScopeReason: repositoryMemory.ok ? undefined : repositoryMemory.reason,
       });
-      await recordTraceBestEffort("dsh_memory_hook.turn_start_event", recordDshTraceEvent({
-        eventId: traceTurnEventId(turn.traceContext, "turn_start"),
-        memoraxCodeHome: options.memoraxCodeHome,
-        env: options.env,
-        traceContext: turn.traceContext,
-        type: "turn_start",
-        source: "unknown",
-        operation: "query",
-        ok: true,
-        request: {
-          prompt: turn.prompt,
-          cwd: turn.cwd,
-          transcriptPath: turn.transcriptPath,
-        },
-      }), options.diagnosticLogger);
-      await recordTraceBestEffort("dsh_memory_hook.current_turn_write", writeCurrentDshTurn(
-        turn.traceContext,
-        {
+      // Both trace writes share the turn's serialization lock with
+      // materializeTurnStart / writeback / discard. Writing them unlocked
+      // allowed this race: ESC-discard runs mark(turn) against a record that
+      // has not been written yet, then the turn-start write lands afterwards
+      // and leaves an OPEN attestation for a turn that was already discarded.
+      await runSerialized(writebackLocks, dshTurnLockKey(coordinatorKey), async () => {
+        await recordTraceBestEffort("dsh_memory_hook.turn_start_event", recordDshTraceEvent({
+          eventId: traceTurnEventId(turn.traceContext, "turn_start"),
           memoraxCodeHome: options.memoraxCodeHome,
           env: options.env,
-          now: () => new Date(now()),
-        },
-      ), options.diagnosticLogger);
+          traceContext: turn.traceContext,
+          type: "turn_start",
+          source: "unknown",
+          operation: "query",
+          ok: true,
+          request: {
+            // Hash only, never the prompt text: with the default
+            // captureContent=true the event file would otherwise store the
+            // plaintext right next to the hashed attestation, destroying the
+            // secret the recovery path's prompt check relies on.
+            promptChars: promptAttestation.chars,
+            promptSha256: promptAttestation.sha256,
+            cwd: turn.cwd,
+          },
+        }), options.diagnosticLogger);
+        await recordTraceBestEffort("dsh_memory_hook.current_turn_write", writeCurrentDshTurn(
+          turn.traceContext,
+          {
+            memoraxCodeHome: options.memoraxCodeHome,
+            env: options.env,
+            now: () => new Date(now()),
+            // Pin the started prompt so the writeback recovery path can verify
+            // the userText it is asked to schedule (hash only: the trace file
+            // never receives the prompt itself).
+            promptAttestation,
+          },
+        ), options.diagnosticLogger);
+        if (!turnCoordinator.getTurn(coordinatorKey)) {
+          // A concurrent discard won the lock between materializeTurnStart and
+          // this write: the entry is gone but the attestation we just wrote is
+          // OPEN. Close it now instead of leaving a replay credential for an
+          // abandoned turn.
+          await recordDshTurnInterrupted(options, turn.traceContext);
+        }
+      });
       if (!claimAutomaticRetrievalTurn(
         automaticRetrievalTurns,
         automaticRetrievalTurnLimit,
@@ -404,16 +558,18 @@ async function resolveHookRepositoryMemory(
 }
 
 async function resolveCurrentHookRepositoryMemory(
-  entry: MemoryTurnState | undefined,
   request: DshMemoryHookWritebackRequest,
   options: DshMemoryHookRuntimeOptions,
   repositoryMemorySession: RepositoryMemorySessionRuntime,
+  attestedTraceContext: TraceContext | undefined,
 ): Promise<ConfiguredRepositoryMemoryResult> {
   return await repositoryMemorySession.resolve({
     client: DSH_MEMORY_TURN_CLIENT,
     sessionId: request.sessionId,
-    workspaceRoot: request.cwd ?? entry?.cwd,
-    workspaceKind: request.workspaceKind ?? entry?.workspaceKind,
+    // The cwd/workspaceKind attested at turn-start win over the writeback
+    // request: a writeback cannot re-bind the turn to another workspace.
+    workspaceRoot: attestedTraceContext?.cwd ?? request.cwd,
+    workspaceKind: attestedTraceContext?.workspaceKind ?? request.workspaceKind,
     memoraxCodeHome: options.memoraxCodeHome ?? options.env?.MEMORAX_CODE_HOME,
     env: options.env,
   });
@@ -428,7 +584,6 @@ function turnStartFromCommand(
     turnId: command.turnId,
     cwd: command.cwd,
     workspaceKind: command.workspaceKind,
-    transcriptPath: command.transcriptPath,
     prompt: command.prompt,
     createdAt,
     traceContext: traceContextFromDshHookBody({
@@ -436,7 +591,6 @@ function turnStartFromCommand(
       turnId: command.turnId,
       cwd: command.cwd,
       workspaceKind: command.workspaceKind,
-      transcriptPath: command.transcriptPath,
     }, new Date(createdAt).toISOString()),
   };
 }
@@ -451,13 +605,11 @@ function writebackRequestFromCommand(
     assistantText: command.assistantText,
     cwd: command.cwd,
     workspaceKind: command.workspaceKind,
-    transcriptPath: command.transcriptPath,
     traceContext: traceContextFromDshHookBody({
       sessionId: command.sessionId,
       turnId: command.turnId,
       cwd: command.cwd,
       workspaceKind: command.workspaceKind,
-      transcriptPath: command.transcriptPath,
     }),
   };
 }
@@ -483,7 +635,7 @@ async function recordDshTurnEnd(
       assistantMessage: assistantText,
     },
   }), options.diagnosticLogger);
-  await recordTraceBestEffort("dsh_memory_hook.current_turn_close", markCurrentDshTurnOutcome(
+  const closed = await recordTraceBestEffort("dsh_memory_hook.current_turn_close", markCurrentDshTurnOutcome(
     traceContext,
     outcome,
     {
@@ -491,6 +643,33 @@ async function recordDshTurnEnd(
       env: options.env,
     },
   ), options.diagnosticLogger);
+  if (closed && !closed.updated) {
+    // The attestation was not closed (not_current_turn / record missing), and
+    // recordTraceBestEffort would have swallowed this silently. After a
+    // recovery writeback this is the replay gate failing — surface it.
+    options.diagnosticLogger?.("dsh_memory_hook.current_turn_close_missed", {
+      reason: closed.reason,
+      turnId: traceContext?.turnId,
+    });
+  }
+}
+
+function recoveredTurnKey(sessionId: string, turnId: string): string {
+  return JSON.stringify([sessionId, turnId]);
+}
+
+function rememberRecoveredCompletion(
+  tombstones: Map<string, number>,
+  key: string,
+  timestamp: number,
+): void {
+  tombstones.delete(key);
+  tombstones.set(key, timestamp);
+  while (tombstones.size > RECOVERED_TURN_TOMBSTONE_LIMIT) {
+    const oldest = tombstones.keys().next().value;
+    if (typeof oldest !== "string") return;
+    tombstones.delete(oldest);
+  }
 }
 
 async function recordDshTurnInterrupted(
@@ -521,15 +700,19 @@ async function recordDshTurnInterrupted(
 function traceContextForWriteback(
   request: DshMemoryHookWritebackRequest,
   entry: MemoryTurnState | undefined,
+  attestedTraceContext: TraceContext | undefined,
 ): TraceContext | undefined {
-  if (!entry?.traceContext) return request.traceContext;
-  if (!request.traceContext) return entry.traceContext;
+  // The context recorded at turn-start is the turn's canonical provenance;
+  // the writeback request may only fill fields the attestation lacks.
+  const base = entry?.traceContext ?? attestedTraceContext;
+  if (!base) return request.traceContext;
+  if (!request.traceContext) return base;
   return {
-    ...entry.traceContext,
     ...request.traceContext,
-    transcriptPath: request.traceContext.transcriptPath ?? entry.traceContext.transcriptPath,
-    cwd: request.traceContext.cwd ?? entry.traceContext.cwd,
-    workspaceKind: request.traceContext.workspaceKind ?? entry.traceContext.workspaceKind,
+    ...base,
+    transcriptPath: base.transcriptPath ?? request.traceContext.transcriptPath,
+    cwd: base.cwd ?? request.traceContext.cwd,
+    workspaceKind: base.workspaceKind ?? request.traceContext.workspaceKind,
   };
 }
 
@@ -571,6 +754,26 @@ function dshPromptMatches(startedPrompt: string, userText: string): boolean {
   if (userText === startedPrompt) return true;
   if (!startedPrompt) return false;
   return userText.startsWith(startedPrompt + PROMPT_DELIMITER);
+}
+
+// Hash-based mirror of dshPromptMatches for the trace-recovery path: the
+// current-turn record stores only sha256(prompt) and prompt.length, never the
+// prompt itself. The writeback userText is accepted when it is exactly the
+// started prompt, or the started prompt followed by the join delimiter and
+// further messages — the same shape the in-memory coordinator accepts.
+function attestedPromptMatches(attestation: TracePromptAttestation, userText: string): boolean {
+  if (userText.length === attestation.chars) {
+    return sha256Hex(userText) === attestation.sha256;
+  }
+  if (userText.length < attestation.chars + PROMPT_DELIMITER.length) return false;
+  if (userText.slice(attestation.chars, attestation.chars + PROMPT_DELIMITER.length) !== PROMPT_DELIMITER) {
+    return false;
+  }
+  return sha256Hex(userText.slice(0, attestation.chars)) === attestation.sha256;
+}
+
+function sha256Hex(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
 }
 
 function claimAutomaticRetrievalTurn(

--- a/packages/ts/memorax-code-backend/src/clients/dsh/memory-hook-runtime.ts
+++ b/packages/ts/memorax-code-backend/src/clients/dsh/memory-hook-runtime.ts
@@ -46,6 +46,7 @@ type DshMemoryHookWritebackSkipReason =
   | "turn_id_missing"
   | "user_text_missing"
   | "assistant_text_missing"
+  | "turn_metadata_missing"
   | "turn_metadata_mismatch"
   | "config_missing"
   | RepositoryMemoryScopeFailureReason
@@ -204,6 +205,15 @@ export function createDshMemoryHookRuntime(
       if (!request.assistantText) return skipped("assistant_text_missing");
       const coordinatorKey = dshTurnKey(request.sessionId, request.turnId);
       const entry = turnCoordinator.getTurn(coordinatorKey);
+      if (!entry) {
+        options.diagnosticLogger?.("dsh_memory_hook.writeback", {
+          scheduled: false,
+          reason: "turn_metadata_missing",
+          sessionId: request.sessionId,
+          turnId: request.turnId,
+        });
+        return skipped("turn_metadata_missing");
+      }
       const traceContext = traceContextForWriteback(request, entry);
       await recordDshTurnEnd(
         options,

--- a/packages/ts/memorax-code-backend/src/clients/dsh/memory-hook-runtime.ts
+++ b/packages/ts/memorax-code-backend/src/clients/dsh/memory-hook-runtime.ts
@@ -274,6 +274,7 @@ export function createDshMemoryHookRuntime(
         assistantChars: request.assistantText.length,
         contentSource: "dsh_session_event",
       });
+      releaseAutomaticRetrievalTurn(automaticRetrievalTurns, request.sessionId, request.turnId);
       return { ok: true, scheduled: true };
     },
     async discardTurn(command) {
@@ -284,6 +285,7 @@ export function createDshMemoryHookRuntime(
       if (!entry) return { ok: true, discarded: false };
       await recordDshTurnInterrupted(options, entry.traceContext);
       turnCoordinator.discardTurn(key, "interrupted");
+      releaseAutomaticRetrievalTurn(automaticRetrievalTurns, command.sessionId, command.turnId);
       options.diagnosticLogger?.("dsh_memory_hook.turn_discarded", {
         sessionId: command.sessionId,
         turnId: command.turnId,
@@ -474,6 +476,14 @@ function claimAutomaticRetrievalTurn(
     turns.delete(oldest);
   }
   return true;
+}
+
+function releaseAutomaticRetrievalTurn(
+  turns: Set<string>,
+  sessionId: string,
+  turnId: string,
+): void {
+  turns.delete(JSON.stringify([sessionId, turnId]));
 }
 
 function skipped(reason: DshMemoryHookWritebackSkipReason): DshMemoryHookWritebackResult {

--- a/packages/ts/memorax-code-backend/src/clients/dsh/memory-hook-runtime.ts
+++ b/packages/ts/memorax-code-backend/src/clients/dsh/memory-hook-runtime.ts
@@ -533,13 +533,12 @@ async function runSerialized<T>(
   }
 }
 
-const PROMPT_DELIMITER_PATTERN = /[\s\p{P}]/u;
+const PROMPT_DELIMITER = "\n\n";
 
 function dshPromptMatches(startedPrompt: string, userText: string): boolean {
   if (userText === startedPrompt) return true;
-  if (!startedPrompt || !userText.startsWith(startedPrompt)) return false;
-  const boundary = userText[startedPrompt.length];
-  return boundary !== undefined && PROMPT_DELIMITER_PATTERN.test(boundary);
+  if (!startedPrompt) return false;
+  return userText.startsWith(startedPrompt + PROMPT_DELIMITER);
 }
 
 function claimAutomaticRetrievalTurn(

--- a/packages/ts/memorax-code-backend/src/clients/dsh/memory-hook-runtime.ts
+++ b/packages/ts/memorax-code-backend/src/clients/dsh/memory-hook-runtime.ts
@@ -28,6 +28,7 @@ import type { RepositoryMemoryScopeFailureReason } from "../../repository/scope.
 import { traceContextFromDshHookBody, type TraceContext } from "../../trace/context.js";
 import {
   markCurrentDshTurnOutcome,
+  readOpenDshTurn,
   recordDshTraceEvent,
   traceTurnEventId,
   writeCurrentDshTurn,
@@ -118,29 +119,48 @@ export function createDshMemoryHookRuntime(
     request: DshMemoryHookWritebackRequest,
   ): Promise<DshMemoryHookWritebackResult> {
     const entry = turnCoordinator.getTurn(coordinatorKey);
-    if (!entry) {
-      options.diagnosticLogger?.("dsh_memory_hook.writeback", {
-        scheduled: false,
-        reason: "turn_metadata_missing",
-        sessionId: request.sessionId,
-        turnId: request.turnId,
+    let metadata: MemoryTurnState | undefined = entry;
+    let metadataSource: "coordinator" | "current_turn_trace" = "coordinator";
+    if (entry) {
+      if (entry.prompt !== undefined && !dshPromptMatches(entry.prompt, request.userText)) {
+        options.diagnosticLogger?.("dsh_memory_hook.writeback", {
+          scheduled: false,
+          reason: "prompt_mismatch",
+          sessionId: request.sessionId,
+          turnId: request.turnId,
+        });
+        return skipped("prompt_mismatch");
+      }
+    } else {
+      // The coordinator entry is gone (evicted by the shared turn cap or a
+      // Backend restart). DSH has no transcript file to re-read, but the local
+      // current-turn trace written at turn-start still attests that this exact
+      // session/turn reached an accepted turn-start. Recover the writeback
+      // from that attestation instead of silently dropping it.
+      const attestation = await readOpenDshTurn({
+        memoraxCodeHome: options.memoraxCodeHome,
+        env: options.env,
+        expectedSessionId: request.sessionId,
+        allowStale: true,
       });
-      return skipped("turn_metadata_missing");
-    }
-    if (entry.prompt !== undefined && !dshPromptMatches(entry.prompt, request.userText)) {
-      options.diagnosticLogger?.("dsh_memory_hook.writeback", {
-        scheduled: false,
-        reason: "prompt_mismatch",
-        sessionId: request.sessionId,
-        turnId: request.turnId,
-      });
-      return skipped("prompt_mismatch");
+      const attested = attestation.ok && attestation.traceContext.turnId === request.turnId;
+      if (!attested) {
+        options.diagnosticLogger?.("dsh_memory_hook.writeback", {
+          scheduled: false,
+          reason: "turn_metadata_missing",
+          sessionId: request.sessionId,
+          turnId: request.turnId,
+        });
+        return skipped("turn_metadata_missing");
+      }
+      metadata = undefined;
+      metadataSource = "current_turn_trace";
     }
     const traceContext = traceContextForWriteback(request, entry);
     await recordDshTurnEnd(options, traceContext, request.assistantText);
     const writeback = await turnCoordinator.completeMaterializedTurn({
       key: coordinatorKey,
-      metadata: entry,
+      metadata,
       resolveRepositoryMemory: () => resolveCurrentHookRepositoryMemory(
         entry,
         request,
@@ -164,6 +184,7 @@ export function createDshMemoryHookRuntime(
         scheduled: false,
         reason: writeback.reason,
         metadataDisposition: writeback.metadataDisposition,
+        metadataSource,
         sessionId: request.sessionId,
         turnId: request.turnId,
       });
@@ -172,6 +193,7 @@ export function createDshMemoryHookRuntime(
     options.diagnosticLogger?.("dsh_memory_hook.writeback", {
       scheduled: true,
       metadataDisposition: writeback.metadataDisposition,
+      metadataSource,
       sessionId: request.sessionId,
       turnId: request.turnId,
       promptChars: request.userText.length,
@@ -186,7 +208,6 @@ export function createDshMemoryHookRuntime(
     coordinatorKey: ReturnType<typeof dshTurnKey>,
     turn: DshMemoryHookTurnStart,
   ): Promise<
-    | { ok: false; error: "conflicting_turn_start" }
     | { ok: true; fresh: false }
     | {
       ok: true;
@@ -196,16 +217,24 @@ export function createDshMemoryHookRuntime(
     }
   > {
     const existing = turnCoordinator.getTurn(coordinatorKey);
-    if (existing) {
-      if (existing.prompt !== undefined && existing.prompt !== turn.prompt) {
-        options.diagnosticLogger?.("dsh_memory_hook.turn_start_conflict", {
-          sessionId: turn.sessionId,
-          turnId: turn.turnId,
-        });
-        return { ok: false, error: "conflicting_turn_start" };
+      if (existing) {
+        if (existing.prompt !== undefined && existing.prompt !== turn.prompt) {
+          // Self-heal a colliding turnId instead of dead-ending the turn: the
+          // newest start wins. Without this the coordinator would keep
+          // answering conflicting_turn_start forever, and the writeback for
+          // the live turn could never be accepted. The adapter now avoids
+          // collisions within a process (incarnation-suffixed turnIds), so a
+          // residual conflict means a rebuilt session or adapter restart.
+          options.diagnosticLogger?.("dsh_memory_hook.turn_start_conflict_replaced", {
+            sessionId: turn.sessionId,
+            turnId: turn.turnId,
+            previousCreatedAt: existing.createdAt,
+          });
+          turnCoordinator.discardTurn(coordinatorKey, "rolled_back");
+        } else {
+          return { ok: true, fresh: false };
+        }
       }
-      return { ok: true, fresh: false };
-    }
     const repositoryMemory = await resolveHookRepositoryMemory(turn, options, repositoryMemorySession);
     const repoMemoryWorktree = resolvedRepoMemoryWorktree(repositoryMemory);
     turnCoordinator.recordTurnStart({
@@ -261,7 +290,6 @@ export function createDshMemoryHookRuntime(
         dshTurnLockKey(coordinatorKey),
         () => materializeTurnStart(coordinatorKey, turn),
       );
-      if (!materialized.ok) return materialized;
       if (!materialized.fresh) return { ok: true };
       const { repositoryMemory, repoMemoryWorktree } = materialized;
       options.diagnosticLogger?.("dsh_memory_hook.turn_start", {
@@ -533,7 +561,11 @@ async function runSerialized<T>(
   }
 }
 
-const PROMPT_DELIMITER = "\n\n";
+// The DSH adapter joins the messages of one turn with MESSAGE_JOIN_DELIMITER
+// (memorax-code-dsh-adapter/src/session-bridge.mjs) and the prefix match
+// below depends on that exact delimiter. The cross-package contract test
+// (test/memory/dsh-adapter-contract.test.mjs) fails when either side drifts.
+export const PROMPT_DELIMITER = "\n\n";
 
 function dshPromptMatches(startedPrompt: string, userText: string): boolean {
   if (userText === startedPrompt) return true;

--- a/packages/ts/memorax-code-backend/src/clients/dsh/memory-hook-runtime.ts
+++ b/packages/ts/memorax-code-backend/src/clients/dsh/memory-hook-runtime.ts
@@ -111,6 +111,92 @@ export function createDshMemoryHookRuntime(
   const ownsRepositoryMemorySession = options.repositoryMemorySession === undefined;
   const automaticRetrievalTurns = new Set<string>();
   const automaticRetrievalTurnLimit = positiveInteger(options.maxEntries, 256);
+  const writebackLocks = new Map<string, Promise<unknown>>();
+
+  async function materializeDshTurn(
+    coordinatorKey: ReturnType<typeof dshTurnKey>,
+    request: DshMemoryHookWritebackRequest,
+  ): Promise<DshMemoryHookWritebackResult> {
+    const entry = turnCoordinator.getTurn(coordinatorKey);
+    if (!entry) {
+      options.diagnosticLogger?.("dsh_memory_hook.writeback", {
+        scheduled: false,
+        reason: "turn_metadata_missing",
+        sessionId: request.sessionId,
+        turnId: request.turnId,
+      });
+      return skipped("turn_metadata_missing");
+    }
+    if (entry.prompt !== undefined && !dshPromptMatches(entry.prompt, request.userText)) {
+      options.diagnosticLogger?.("dsh_memory_hook.writeback", {
+        scheduled: false,
+        reason: "prompt_mismatch",
+        sessionId: request.sessionId,
+        turnId: request.turnId,
+      });
+      return skipped("prompt_mismatch");
+    }
+    const traceContext = traceContextForWriteback(request, entry);
+    await recordDshTurnEnd(options, traceContext, request.assistantText);
+    const writeback = await turnCoordinator.completeMaterializedTurn({
+      key: coordinatorKey,
+      metadata: entry,
+      resolveRepositoryMemory: () => resolveCurrentHookRepositoryMemory(
+        entry,
+        request,
+        options,
+        repositoryMemorySession,
+      ),
+      userText: request.userText,
+      assistantText: request.assistantText,
+      writeback: {
+        client: DSH_MEMORY_TURN_CLIENT,
+        sessionKey: request.sessionId,
+        env: options.env ?? process.env,
+        fetchImpl: options.fetchImpl,
+        memoryObservability: options.memoryObservability,
+        memoryObservabilitySource: "dsh_hook_writeback",
+        traceContext,
+      },
+    });
+    if (!writeback.scheduled) {
+      options.diagnosticLogger?.("dsh_memory_hook.writeback", {
+        scheduled: false,
+        reason: writeback.reason,
+        metadataDisposition: writeback.metadataDisposition,
+        sessionId: request.sessionId,
+        turnId: request.turnId,
+      });
+      return skipped(writeback.reason);
+    }
+    options.diagnosticLogger?.("dsh_memory_hook.writeback", {
+      scheduled: true,
+      metadataDisposition: writeback.metadataDisposition,
+      sessionId: request.sessionId,
+      turnId: request.turnId,
+      promptChars: request.userText.length,
+      assistantChars: request.assistantText.length,
+      contentSource: "dsh_session_event",
+    });
+    releaseAutomaticRetrievalTurn(automaticRetrievalTurns, request.sessionId, request.turnId);
+    return { ok: true, scheduled: true };
+  }
+
+  async function discardDshTurn(
+    key: ReturnType<typeof dshTurnKey>,
+    command: DshTurnDiscardCommand,
+  ): Promise<MemoryHookTurnDiscardResult> {
+    const entry = turnCoordinator.getTurn(key);
+    if (!entry) return { ok: true, discarded: false };
+    await recordDshTurnInterrupted(options, entry.traceContext);
+    turnCoordinator.discardTurn(key, "interrupted");
+    releaseAutomaticRetrievalTurn(automaticRetrievalTurns, command.sessionId, command.turnId);
+    options.diagnosticLogger?.("dsh_memory_hook.turn_discarded", {
+      sessionId: command.sessionId,
+      turnId: command.turnId,
+    });
+    return { ok: true, discarded: true };
+  }
 
   return {
     async recordTurnStart(command) {
@@ -128,6 +214,18 @@ export function createDshMemoryHookRuntime(
         return { ok: true };
       }
       turnCoordinator.pruneExpired();
+      const coordinatorKey = dshTurnKey(turn.sessionId, turn.turnId);
+      const existing = turnCoordinator.getTurn(coordinatorKey);
+      if (existing) {
+        if (existing.prompt !== undefined && existing.prompt !== turn.prompt) {
+          options.diagnosticLogger?.("dsh_memory_hook.turn_start_conflict", {
+            sessionId: turn.sessionId,
+            turnId: turn.turnId,
+          });
+          return { ok: false, error: "conflicting_turn_start" };
+        }
+        return { ok: true };
+      }
       const repositoryMemory = await resolveHookRepositoryMemory(turn, options, repositoryMemorySession);
       const repoMemoryWorktree = resolvedRepoMemoryWorktree(repositoryMemory);
       turnCoordinator.recordTurnStart({
@@ -209,94 +307,28 @@ export function createDshMemoryHookRuntime(
       if (!request.userText) return skipped("user_text_missing");
       if (!request.assistantText) return skipped("assistant_text_missing");
       const coordinatorKey = dshTurnKey(request.sessionId, request.turnId);
-      const entry = turnCoordinator.getTurn(coordinatorKey);
-      if (!entry) {
-        options.diagnosticLogger?.("dsh_memory_hook.writeback", {
-          scheduled: false,
-          reason: "turn_metadata_missing",
-          sessionId: request.sessionId,
-          turnId: request.turnId,
-        });
-        return skipped("turn_metadata_missing");
-      }
-      if (entry.prompt !== undefined && !dshPromptMatches(entry.prompt, request.userText)) {
-        options.diagnosticLogger?.("dsh_memory_hook.writeback", {
-          scheduled: false,
-          reason: "prompt_mismatch",
-          sessionId: request.sessionId,
-          turnId: request.turnId,
-        });
-        return skipped("prompt_mismatch");
-      }
-      const traceContext = traceContextForWriteback(request, entry);
-      await recordDshTurnEnd(
-        options,
-        traceContext,
-        request.assistantText,
+      return await runSerialized(
+        writebackLocks,
+        dshTurnLockKey(coordinatorKey),
+        () => materializeDshTurn(coordinatorKey, request),
       );
-      const writeback = await turnCoordinator.completeMaterializedTurn({
-        key: coordinatorKey,
-        metadata: entry,
-        resolveRepositoryMemory: () => resolveCurrentHookRepositoryMemory(
-          entry,
-          request,
-          options,
-          repositoryMemorySession,
-        ),
-        userText: request.userText,
-        assistantText: request.assistantText,
-        writeback: {
-          client: DSH_MEMORY_TURN_CLIENT,
-          sessionKey: request.sessionId,
-          env: options.env ?? process.env,
-          fetchImpl: options.fetchImpl,
-          memoryObservability: options.memoryObservability,
-          memoryObservabilitySource: "dsh_hook_writeback",
-          traceContext,
-        },
-      });
-      if (!writeback.scheduled) {
-        options.diagnosticLogger?.("dsh_memory_hook.writeback", {
-          scheduled: false,
-          reason: writeback.reason,
-          metadataDisposition: writeback.metadataDisposition,
-          sessionId: request.sessionId,
-          turnId: request.turnId,
-        });
-        return skipped(writeback.reason);
-      }
-      options.diagnosticLogger?.("dsh_memory_hook.writeback", {
-        scheduled: true,
-        metadataDisposition: writeback.metadataDisposition,
-        sessionId: request.sessionId,
-        turnId: request.turnId,
-        promptChars: request.userText.length,
-        assistantChars: request.assistantText.length,
-        contentSource: "dsh_session_event",
-      });
-      releaseAutomaticRetrievalTurn(automaticRetrievalTurns, request.sessionId, request.turnId);
-      return { ok: true, scheduled: true };
     },
     async discardTurn(command) {
       turnCoordinator.pruneExpired();
       if (!command.sessionId || !command.turnId) return { ok: true, discarded: false };
       const key = dshTurnKey(command.sessionId, command.turnId);
-      const entry = turnCoordinator.getTurn(key);
-      if (!entry) return { ok: true, discarded: false };
-      await recordDshTurnInterrupted(options, entry.traceContext);
-      turnCoordinator.discardTurn(key, "interrupted");
-      releaseAutomaticRetrievalTurn(automaticRetrievalTurns, command.sessionId, command.turnId);
-      options.diagnosticLogger?.("dsh_memory_hook.turn_discarded", {
-        sessionId: command.sessionId,
-        turnId: command.turnId,
-      });
-      return { ok: true, discarded: true };
+      return await runSerialized(
+        writebackLocks,
+        dshTurnLockKey(key),
+        () => discardDshTurn(key, command),
+      );
     },
     size() {
       return turnCoordinator.size(DSH_MEMORY_TURN_CLIENT);
     },
     close() {
       automaticRetrievalTurns.clear();
+      writebackLocks.clear();
       if (ownsTurnCoordinator) turnCoordinator.close();
       if (ownsRepositoryMemorySession) repositoryMemorySession.close();
       automaticWritebackRuntime?.close?.();
@@ -455,6 +487,26 @@ function dshTurnKey(sessionId: string, turnId: string) {
     sessionId,
     clientTurnId: turnId,
   } as const;
+}
+
+function dshTurnLockKey(key: { client: string; sessionId: string; clientTurnId: string }): string {
+  return JSON.stringify([key.client, key.sessionId, key.clientTurnId.trim()]);
+}
+
+async function runSerialized<T>(
+  locks: Map<string, Promise<unknown>>,
+  key: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const previous = locks.get(key) ?? Promise.resolve();
+  const run = previous.then(operation, operation);
+  const tail = run.then(() => undefined, () => undefined);
+  locks.set(key, tail);
+  try {
+    return await run;
+  } finally {
+    if (locks.get(key) === tail) locks.delete(key);
+  }
 }
 
 function dshPromptMatches(startedPrompt: string, userText: string): boolean {

--- a/packages/ts/memorax-code-backend/src/clients/dsh/memory-hook-runtime.ts
+++ b/packages/ts/memorax-code-backend/src/clients/dsh/memory-hook-runtime.ts
@@ -1,0 +1,435 @@
+import { retrieveAutomaticMemoryContext } from "../../memory/automatic-retrieval.js";
+import {
+  createAutomaticMemoryWritebackRuntime,
+  type AutomaticMemoryWritebackEnqueue,
+  type AutomaticMemoryWritebackRejectionReason,
+  type AutomaticMemoryWritebackRuntime,
+} from "../../memory/automatic-writeback.js";
+import type {
+  DshTurnStartCommand,
+  DshWritebackCommand,
+  MemoryHookTurnStartResult,
+} from "../../memory/hook-command.js";
+import type { MemoryDiagnosticLogger, MemoryObservabilityHook } from "../../memory/observability.js";
+import {
+  createMemoryTurnCoordinator,
+  type MemoryTurnCoordinator,
+  type MemoryTurnState,
+} from "../../memory/turn-coordinator.js";
+import {
+  createRepositoryMemorySessionRuntime,
+  resolvedRepoMemoryWorktree,
+  type ConfiguredRepositoryMemoryResult,
+  type RepositoryMemorySessionRuntime,
+} from "../../memory/repository-session.js";
+import type { RepositoryMemoryScopeFailureReason } from "../../repository/scope.js";
+import { traceContextFromDshHookBody, type TraceContext } from "../../trace/context.js";
+import {
+  markCurrentDshTurnOutcome,
+  recordDshTraceEvent,
+  traceTurnEventId,
+  writeCurrentDshTurn,
+  type DshTurnOutcome,
+} from "../../trace/store.js";
+
+type DshMemoryHookTurnStart = Omit<DshTurnStartCommand, "version" | "client"> & {
+  createdAt: number;
+  traceContext?: TraceContext;
+};
+
+type DshMemoryHookWritebackRequest = Omit<DshWritebackCommand, "version" | "client"> & {
+  traceContext?: TraceContext;
+};
+
+type DshMemoryHookWritebackSkipReason =
+  | "missing_session_id"
+  | "turn_id_missing"
+  | "user_text_missing"
+  | "assistant_text_missing"
+  | "turn_metadata_mismatch"
+  | "config_missing"
+  | RepositoryMemoryScopeFailureReason
+  | AutomaticMemoryWritebackRejectionReason;
+
+export type DshMemoryHookWritebackResult =
+  | { ok: true; scheduled: true }
+  | { ok: true; scheduled: false; reason: DshMemoryHookWritebackSkipReason };
+
+export type DshMemoryHookRuntimeOptions = {
+  automaticWriteback?: AutomaticMemoryWritebackEnqueue;
+  diagnosticLogger?: MemoryDiagnosticLogger;
+  env?: Record<string, string | undefined>;
+  fetchImpl?: typeof fetch;
+  now?: () => number;
+  ttlMs?: number;
+  maxEntries?: number;
+  cleanupIntervalMs?: number;
+  memoryObservability?: MemoryObservabilityHook;
+  memoraxCodeHome?: string;
+  repositoryMemorySession?: RepositoryMemorySessionRuntime;
+  turnCoordinator?: MemoryTurnCoordinator;
+};
+
+export type DshMemoryHookRuntime = {
+  recordTurnStart(command: DshTurnStartCommand): Promise<MemoryHookTurnStartResult>;
+  writeback(command: DshWritebackCommand): Promise<DshMemoryHookWritebackResult>;
+  size(): number;
+  close(): void;
+};
+
+const DSH_MEMORY_TURN_CLIENT = "dsh" as const;
+
+export function createDshMemoryHookRuntime(
+  options: DshMemoryHookRuntimeOptions = {},
+): DshMemoryHookRuntime {
+  const now = options.now ?? (() => Date.now());
+  const automaticWritebackRuntime: {
+    enqueue: AutomaticMemoryWritebackEnqueue;
+    discardForScopeUpgrade?: AutomaticMemoryWritebackRuntime["discardForScopeUpgrade"];
+    close?: () => void;
+  } | undefined = options.turnCoordinator
+    ? undefined
+    : options.automaticWriteback
+      ? { enqueue: options.automaticWriteback }
+      : createAutomaticMemoryWritebackRuntime({ diagnosticLogger: options.diagnosticLogger });
+  const turnCoordinator = options.turnCoordinator ?? createMemoryTurnCoordinator({
+    automaticWriteback: automaticWritebackRuntime!.enqueue,
+    now,
+    ttlMs: options.ttlMs,
+    maxEntries: options.maxEntries,
+    cleanupIntervalMs: options.cleanupIntervalMs,
+  });
+  const ownsTurnCoordinator = options.turnCoordinator === undefined;
+  const repositoryMemorySession = options.repositoryMemorySession ?? createRepositoryMemorySessionRuntime({
+    onScopeUpgrade: automaticWritebackRuntime?.discardForScopeUpgrade,
+  });
+  const ownsRepositoryMemorySession = options.repositoryMemorySession === undefined;
+  const automaticRetrievalTurns = new Set<string>();
+  const automaticRetrievalTurnLimit = positiveInteger(options.maxEntries, 256);
+
+  return {
+    async recordTurnStart(command) {
+      const turn = turnStartFromCommand(command, now());
+      if (!turn.sessionId || !turn.turnId || !turn.prompt) {
+        options.diagnosticLogger?.("dsh_memory_hook.turn_start_skipped", {
+          reason: !turn.sessionId
+            ? "missing_session_id"
+            : !turn.turnId
+              ? "turn_id_missing"
+              : "prompt_missing",
+          sessionId: turn.sessionId,
+          turnId: turn.turnId,
+        });
+        return { ok: true };
+      }
+      turnCoordinator.pruneExpired();
+      const repositoryMemory = await resolveHookRepositoryMemory(turn, options, repositoryMemorySession);
+      const repoMemoryWorktree = resolvedRepoMemoryWorktree(repositoryMemory);
+      turnCoordinator.recordTurnStart({
+        client: DSH_MEMORY_TURN_CLIENT,
+        sessionId: turn.sessionId,
+        clientTurnId: turn.turnId,
+        cwd: turn.cwd,
+        workspaceKind: turn.workspaceKind,
+        transcriptPath: turn.transcriptPath,
+        createdAt: turn.createdAt,
+        traceContext: turn.traceContext,
+        repositoryMemory,
+      });
+      options.diagnosticLogger?.("dsh_memory_hook.turn_start", {
+        sessionId: turn.sessionId,
+        turnId: turn.turnId,
+        promptChars: turn.prompt.length,
+        cacheSize: turnCoordinator.size(DSH_MEMORY_TURN_CLIENT),
+        workspace: repositoryMemory.ok ? repositoryMemory.memory.scope?.repositorySlug : undefined,
+        workspaceScopeReason: repositoryMemory.ok ? undefined : repositoryMemory.reason,
+      });
+      await recordTraceBestEffort("dsh_memory_hook.turn_start_event", recordDshTraceEvent({
+        eventId: traceTurnEventId(turn.traceContext, "turn_start"),
+        memoraxCodeHome: options.memoraxCodeHome,
+        env: options.env,
+        traceContext: turn.traceContext,
+        type: "turn_start",
+        source: "unknown",
+        operation: "query",
+        ok: true,
+        request: {
+          prompt: turn.prompt,
+          cwd: turn.cwd,
+          transcriptPath: turn.transcriptPath,
+        },
+      }), options.diagnosticLogger);
+      await recordTraceBestEffort("dsh_memory_hook.current_turn_write", writeCurrentDshTurn(
+        turn.traceContext,
+        {
+          memoraxCodeHome: options.memoraxCodeHome,
+          env: options.env,
+          now: () => new Date(now()),
+        },
+      ), options.diagnosticLogger);
+      if (!claimAutomaticRetrievalTurn(
+        automaticRetrievalTurns,
+        automaticRetrievalTurnLimit,
+        turn.sessionId,
+        turn.turnId,
+      )) {
+        return {
+          ok: true,
+          ...(repoMemoryWorktree ? { repoMemoryWorktree } : {}),
+        };
+      }
+      const retrieval = await retrieveAutomaticMemoryContext({
+        diagnosticLogger: options.diagnosticLogger,
+        env: options.env ?? process.env,
+        fetchImpl: options.fetchImpl,
+        memoryObservability: options.memoryObservability,
+        memoryObservabilitySource: "dsh_hook_retrieval",
+        query: turn.prompt,
+        repositoryMemory,
+        sessionKey: turn.sessionId,
+        traceContext: turn.traceContext,
+      });
+      return {
+        ok: true,
+        ...(repoMemoryWorktree ? { repoMemoryWorktree } : {}),
+        ...(retrieval.context ? { additionalContext: retrieval.context } : {}),
+      };
+    },
+    async writeback(command) {
+      turnCoordinator.pruneExpired();
+      const request = writebackRequestFromCommand(command);
+      if (!request.sessionId) return skipped("missing_session_id");
+      if (!request.turnId) return skipped("turn_id_missing");
+      if (!request.userText) return skipped("user_text_missing");
+      if (!request.assistantText) return skipped("assistant_text_missing");
+      const coordinatorKey = dshTurnKey(request.sessionId, request.turnId);
+      const entry = turnCoordinator.getTurn(coordinatorKey);
+      const traceContext = traceContextForWriteback(request, entry);
+      await recordDshTurnEnd(
+        options,
+        traceContext,
+        request.assistantText,
+      );
+      const writeback = await turnCoordinator.completeMaterializedTurn({
+        key: coordinatorKey,
+        metadata: entry,
+        resolveRepositoryMemory: () => resolveCurrentHookRepositoryMemory(
+          entry,
+          request,
+          options,
+          repositoryMemorySession,
+        ),
+        userText: request.userText,
+        assistantText: request.assistantText,
+        writeback: {
+          client: DSH_MEMORY_TURN_CLIENT,
+          sessionKey: request.sessionId,
+          env: options.env ?? process.env,
+          fetchImpl: options.fetchImpl,
+          memoryObservability: options.memoryObservability,
+          memoryObservabilitySource: "dsh_hook_writeback",
+          traceContext,
+        },
+      });
+      if (!writeback.scheduled) {
+        options.diagnosticLogger?.("dsh_memory_hook.writeback", {
+          scheduled: false,
+          reason: writeback.reason,
+          metadataDisposition: writeback.metadataDisposition,
+          sessionId: request.sessionId,
+          turnId: request.turnId,
+        });
+        return skipped(writeback.reason);
+      }
+      options.diagnosticLogger?.("dsh_memory_hook.writeback", {
+        scheduled: true,
+        metadataDisposition: writeback.metadataDisposition,
+        sessionId: request.sessionId,
+        turnId: request.turnId,
+        promptChars: request.userText.length,
+        assistantChars: request.assistantText.length,
+        contentSource: "dsh_session_event",
+      });
+      return { ok: true, scheduled: true };
+    },
+    size() {
+      return turnCoordinator.size(DSH_MEMORY_TURN_CLIENT);
+    },
+    close() {
+      automaticRetrievalTurns.clear();
+      if (ownsTurnCoordinator) turnCoordinator.close();
+      if (ownsRepositoryMemorySession) repositoryMemorySession.close();
+      automaticWritebackRuntime?.close?.();
+    },
+  };
+}
+
+async function resolveHookRepositoryMemory(
+  entry: Pick<DshMemoryHookTurnStart, "sessionId" | "cwd" | "workspaceKind">,
+  options: DshMemoryHookRuntimeOptions,
+  repositoryMemorySession: RepositoryMemorySessionRuntime,
+): Promise<ConfiguredRepositoryMemoryResult> {
+  return await repositoryMemorySession.resolve({
+    client: DSH_MEMORY_TURN_CLIENT,
+    sessionId: entry.sessionId,
+    workspaceRoot: entry.cwd,
+    workspaceKind: entry.workspaceKind,
+    memoraxCodeHome: options.memoraxCodeHome ?? options.env?.MEMORAX_CODE_HOME,
+    env: options.env,
+  });
+}
+
+async function resolveCurrentHookRepositoryMemory(
+  entry: MemoryTurnState | undefined,
+  request: DshMemoryHookWritebackRequest,
+  options: DshMemoryHookRuntimeOptions,
+  repositoryMemorySession: RepositoryMemorySessionRuntime,
+): Promise<ConfiguredRepositoryMemoryResult> {
+  return await repositoryMemorySession.resolve({
+    client: DSH_MEMORY_TURN_CLIENT,
+    sessionId: request.sessionId,
+    workspaceRoot: request.cwd ?? entry?.cwd,
+    workspaceKind: request.workspaceKind ?? entry?.workspaceKind,
+    memoraxCodeHome: options.memoraxCodeHome ?? options.env?.MEMORAX_CODE_HOME,
+    env: options.env,
+  });
+}
+
+function turnStartFromCommand(
+  command: DshTurnStartCommand,
+  createdAt: number,
+): DshMemoryHookTurnStart {
+  return {
+    sessionId: command.sessionId,
+    turnId: command.turnId,
+    cwd: command.cwd,
+    workspaceKind: command.workspaceKind,
+    transcriptPath: command.transcriptPath,
+    prompt: command.prompt,
+    createdAt,
+    traceContext: traceContextFromDshHookBody({
+      sessionId: command.sessionId,
+      turnId: command.turnId,
+      cwd: command.cwd,
+      workspaceKind: command.workspaceKind,
+      transcriptPath: command.transcriptPath,
+    }, new Date(createdAt).toISOString()),
+  };
+}
+
+function writebackRequestFromCommand(
+  command: DshWritebackCommand,
+): DshMemoryHookWritebackRequest {
+  return {
+    sessionId: command.sessionId,
+    turnId: command.turnId,
+    userText: command.userText,
+    assistantText: command.assistantText,
+    cwd: command.cwd,
+    workspaceKind: command.workspaceKind,
+    transcriptPath: command.transcriptPath,
+    traceContext: traceContextFromDshHookBody({
+      sessionId: command.sessionId,
+      turnId: command.turnId,
+      cwd: command.cwd,
+      workspaceKind: command.workspaceKind,
+      transcriptPath: command.transcriptPath,
+    }),
+  };
+}
+
+async function recordDshTurnEnd(
+  options: DshMemoryHookRuntimeOptions,
+  traceContext: TraceContext | undefined,
+  assistantText: string,
+  details: { outcome?: DshTurnOutcome } = {},
+): Promise<void> {
+  const outcome = details.outcome ?? "completed";
+  await recordTraceBestEffort("dsh_memory_hook.turn_end_event", recordDshTraceEvent({
+    eventId: traceTurnEventId(traceContext, "turn_end"),
+    memoraxCodeHome: options.memoraxCodeHome,
+    env: options.env,
+    traceContext,
+    type: "turn_end",
+    source: "dsh-hook",
+    operation: "reply",
+    ok: true,
+    outcome,
+    response: {
+      assistantMessage: assistantText,
+    },
+  }), options.diagnosticLogger);
+  await recordTraceBestEffort("dsh_memory_hook.current_turn_close", markCurrentDshTurnOutcome(
+    traceContext,
+    outcome,
+    {
+      memoraxCodeHome: options.memoraxCodeHome,
+      env: options.env,
+    },
+  ), options.diagnosticLogger);
+}
+
+function traceContextForWriteback(
+  request: DshMemoryHookWritebackRequest,
+  entry: MemoryTurnState | undefined,
+): TraceContext | undefined {
+  if (!entry?.traceContext) return request.traceContext;
+  if (!request.traceContext) return entry.traceContext;
+  return {
+    ...entry.traceContext,
+    ...request.traceContext,
+    transcriptPath: request.traceContext.transcriptPath ?? entry.traceContext.transcriptPath,
+    cwd: request.traceContext.cwd ?? entry.traceContext.cwd,
+    workspaceKind: request.traceContext.workspaceKind ?? entry.traceContext.workspaceKind,
+  };
+}
+
+function dshTurnKey(sessionId: string, turnId: string) {
+  return {
+    client: DSH_MEMORY_TURN_CLIENT,
+    sessionId,
+    clientTurnId: turnId,
+  } as const;
+}
+
+function claimAutomaticRetrievalTurn(
+  turns: Set<string>,
+  limit: number,
+  sessionId: string,
+  turnId: string,
+): boolean {
+  const key = JSON.stringify([sessionId, turnId]);
+  if (turns.has(key)) return false;
+  turns.add(key);
+  while (turns.size > limit) {
+    const oldest = turns.values().next().value;
+    if (typeof oldest !== "string") break;
+    turns.delete(oldest);
+  }
+  return true;
+}
+
+function skipped(reason: DshMemoryHookWritebackSkipReason): DshMemoryHookWritebackResult {
+  return { ok: true, scheduled: false, reason };
+}
+
+async function recordTraceBestEffort<T>(
+  label: string,
+  promise: Promise<T>,
+  diagnosticLogger?: MemoryDiagnosticLogger,
+): Promise<T | undefined> {
+  try {
+    return await promise;
+  } catch (error) {
+    diagnosticLogger?.("dsh_trace.write_failed", {
+      label,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return undefined;
+  }
+}
+
+function positiveInteger(value: unknown, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}

--- a/packages/ts/memorax-code-backend/src/clients/dsh/memory-hook-runtime.ts
+++ b/packages/ts/memorax-code-backend/src/clients/dsh/memory-hook-runtime.ts
@@ -182,6 +182,47 @@ export function createDshMemoryHookRuntime(
     return { ok: true, scheduled: true };
   }
 
+  async function materializeTurnStart(
+    coordinatorKey: ReturnType<typeof dshTurnKey>,
+    turn: DshMemoryHookTurnStart,
+  ): Promise<
+    | { ok: false; error: "conflicting_turn_start" }
+    | { ok: true; fresh: false }
+    | {
+      ok: true;
+      fresh: true;
+      repositoryMemory: ConfiguredRepositoryMemoryResult;
+      repoMemoryWorktree: string | undefined;
+    }
+  > {
+    const existing = turnCoordinator.getTurn(coordinatorKey);
+    if (existing) {
+      if (existing.prompt !== undefined && existing.prompt !== turn.prompt) {
+        options.diagnosticLogger?.("dsh_memory_hook.turn_start_conflict", {
+          sessionId: turn.sessionId,
+          turnId: turn.turnId,
+        });
+        return { ok: false, error: "conflicting_turn_start" };
+      }
+      return { ok: true, fresh: false };
+    }
+    const repositoryMemory = await resolveHookRepositoryMemory(turn, options, repositoryMemorySession);
+    const repoMemoryWorktree = resolvedRepoMemoryWorktree(repositoryMemory);
+    turnCoordinator.recordTurnStart({
+      client: DSH_MEMORY_TURN_CLIENT,
+      sessionId: turn.sessionId,
+      clientTurnId: turn.turnId,
+      cwd: turn.cwd,
+      workspaceKind: turn.workspaceKind,
+      transcriptPath: turn.transcriptPath,
+      prompt: turn.prompt,
+      createdAt: turn.createdAt,
+      traceContext: turn.traceContext,
+      repositoryMemory,
+    });
+    return { ok: true, fresh: true, repositoryMemory, repoMemoryWorktree };
+  }
+
   async function discardDshTurn(
     key: ReturnType<typeof dshTurnKey>,
     command: DshTurnDiscardCommand,
@@ -215,31 +256,14 @@ export function createDshMemoryHookRuntime(
       }
       turnCoordinator.pruneExpired();
       const coordinatorKey = dshTurnKey(turn.sessionId, turn.turnId);
-      const existing = turnCoordinator.getTurn(coordinatorKey);
-      if (existing) {
-        if (existing.prompt !== undefined && existing.prompt !== turn.prompt) {
-          options.diagnosticLogger?.("dsh_memory_hook.turn_start_conflict", {
-            sessionId: turn.sessionId,
-            turnId: turn.turnId,
-          });
-          return { ok: false, error: "conflicting_turn_start" };
-        }
-        return { ok: true };
-      }
-      const repositoryMemory = await resolveHookRepositoryMemory(turn, options, repositoryMemorySession);
-      const repoMemoryWorktree = resolvedRepoMemoryWorktree(repositoryMemory);
-      turnCoordinator.recordTurnStart({
-        client: DSH_MEMORY_TURN_CLIENT,
-        sessionId: turn.sessionId,
-        clientTurnId: turn.turnId,
-        cwd: turn.cwd,
-        workspaceKind: turn.workspaceKind,
-        transcriptPath: turn.transcriptPath,
-        prompt: turn.prompt,
-        createdAt: turn.createdAt,
-        traceContext: turn.traceContext,
-        repositoryMemory,
-      });
+      const materialized = await runSerialized(
+        writebackLocks,
+        dshTurnLockKey(coordinatorKey),
+        () => materializeTurnStart(coordinatorKey, turn),
+      );
+      if (!materialized.ok) return materialized;
+      if (!materialized.fresh) return { ok: true };
+      const { repositoryMemory, repoMemoryWorktree } = materialized;
       options.diagnosticLogger?.("dsh_memory_hook.turn_start", {
         sessionId: turn.sessionId,
         turnId: turn.turnId,
@@ -509,8 +533,13 @@ async function runSerialized<T>(
   }
 }
 
+const PROMPT_DELIMITER_PATTERN = /[\s\p{P}]/u;
+
 function dshPromptMatches(startedPrompt: string, userText: string): boolean {
-  return userText === startedPrompt || userText.startsWith(startedPrompt);
+  if (userText === startedPrompt) return true;
+  if (!startedPrompt || !userText.startsWith(startedPrompt)) return false;
+  const boundary = userText[startedPrompt.length];
+  return boundary !== undefined && PROMPT_DELIMITER_PATTERN.test(boundary);
 }
 
 function claimAutomaticRetrievalTurn(

--- a/packages/ts/memorax-code-backend/src/config/memorax-code.ts
+++ b/packages/ts/memorax-code-backend/src/config/memorax-code.ts
@@ -84,6 +84,13 @@ export type MemoraxCodeConfig = Readonly<{
       max_event_chars?: number;
       max_file_bytes?: number;
     }>;
+    dsh?: Readonly<{
+      enabled?: boolean;
+      capture_content?: boolean;
+      retention_days?: number;
+      max_event_chars?: number;
+      max_file_bytes?: number;
+    }>;
   }>;
 }>;
 
@@ -143,6 +150,10 @@ export function renderDefaultMemoraxCodeConfig(): string {
     "[trace.claude]",
     "enabled = true # Enable local Claude session memory trace collection.",
     "capture_content = true # Store content in local Claude trace events.",
+    "",
+    "[trace.dsh]",
+    "enabled = true # Enable local DSH session memory trace collection.",
+    "capture_content = true # Store content in local DSH trace events.",
     "",
   ].join("\n");
 }
@@ -223,6 +234,7 @@ function normalizeMemoraxCodeConfig(value: unknown): MemoraxCodeConfig {
   const repoUpdate = recordValue(memory?.repo_update);
   const traceCodex = recordValue(trace?.codex);
   const traceClaude = recordValue(trace?.claude);
+  const traceDsh = recordValue(trace?.dsh);
 
   return (prune({
     clients: prune({
@@ -291,6 +303,13 @@ function normalizeMemoraxCodeConfig(value: unknown): MemoraxCodeConfig {
         retention_days: numberField(traceClaude, "retention_days"),
         max_event_chars: numberField(traceClaude, "max_event_chars"),
         max_file_bytes: numberField(traceClaude, "max_file_bytes"),
+      }),
+      dsh: prune({
+        enabled: booleanField(traceDsh, "enabled"),
+        capture_content: booleanField(traceDsh, "capture_content"),
+        retention_days: numberField(traceDsh, "retention_days"),
+        max_event_chars: numberField(traceDsh, "max_event_chars"),
+        max_file_bytes: numberField(traceDsh, "max_file_bytes"),
       }),
     }),
   }) ?? {}) as MemoraxCodeConfig;

--- a/packages/ts/memorax-code-backend/src/lifecycle/backend/service.ts
+++ b/packages/ts/memorax-code-backend/src/lifecycle/backend/service.ts
@@ -560,13 +560,7 @@ async function readBackendOwnership(
         token,
       );
       if (result.ok) {
-        health = result.body.ok === true
-          && result.body.service === "memorax-code-backend"
-          && result.body.instanceId === state.instanceId
-          && typeof result.body.state?.sessionHome === "string"
-          && resolve(result.body.state.sessionHome) === resolve(expectedSessionHome)
-          ? "matched"
-          : "conflicting";
+        health = classifyBackendHealth(result.body, state.instanceId, expectedSessionHome);
       }
     } catch {
       // Process evidence can still prove ownership for a hung Backend.
@@ -649,6 +643,27 @@ function describeInconclusiveProcessProbe(
     probe.signal ? `signal ${probe.signal}` : undefined,
   ].filter((value): value is string => value !== undefined);
   return `ownership probe was inconclusive (${details.join(", ")})`;
+}
+
+function classifyBackendHealth(
+  body: {
+    ok?: boolean;
+    service?: string;
+    instanceId?: string;
+    state?: { sessionHome?: string };
+  },
+  expectedInstanceId: string,
+  expectedSessionHome: string,
+): BackendHealthEvidence {
+  if (
+    body.ok !== true
+    || body.service !== "memorax-code-backend"
+    || body.instanceId !== expectedInstanceId
+  ) return "conflicting";
+  if (typeof body.state?.sessionHome !== "string") return "inconclusive";
+  return resolve(body.state.sessionHome) === resolve(expectedSessionHome)
+    ? "matched"
+    : "conflicting";
 }
 
 function isTrustedServiceState(state: BackendServiceState): boolean {

--- a/packages/ts/memorax-code-backend/src/lifecycle/backend/service.ts
+++ b/packages/ts/memorax-code-backend/src/lifecycle/backend/service.ts
@@ -174,6 +174,7 @@ export async function startBackendService(
       options.timeoutMs ?? 5000,
       backendServiceHome(options),
       runtime,
+      token,
     );
     if (canReportRunning(ownership)) {
       return { ok: true, action: "start", alreadyRunning: true, state: existing };
@@ -286,6 +287,7 @@ export async function startBackendService(
     instanceId,
     backendServiceHome(options),
     runtime,
+    token,
   );
   if (!healthy) {
     const terminated = (runtime.terminateProcessTree ?? terminateProcessTree)(state.pid);
@@ -389,6 +391,14 @@ function backendServiceTokenCandidate(options: BackendServiceOptions, endpoint: 
   return token;
 }
 
+function stopBackendToken(options: BackendServiceOptions): string | undefined {
+  try {
+    return readBackendToken(options)?.token;
+  } catch {
+    return undefined;
+  }
+}
+
 export async function stopBackendService(
   options: BackendServiceOptions = {},
   runtime: BackendServiceRuntime = {},
@@ -426,6 +436,7 @@ export async function stopBackendService(
         timeoutMs,
         backendServiceHome(options),
         runtime,
+        stopBackendToken(options),
       );
       if (processAlive(state.pid)) {
         if (!canForceStop(ownership)) {
@@ -483,6 +494,7 @@ async function waitForHealth(
   instanceId: string,
   expectedSessionHome: string,
   runtime: BackendServiceRuntime,
+  token?: string,
 ): Promise<boolean> {
   const budgetMs = Number.isFinite(timeoutMs) ? Math.max(0, Math.trunc(timeoutMs)) : 0;
   const deadline = Date.now() + budgetMs;
@@ -493,6 +505,7 @@ async function waitForHealth(
         new URL("/health", url),
         remainingMs,
         runtime.fetch,
+        token,
       );
       if (health.ok
         && health.body.ok === true
@@ -534,6 +547,7 @@ async function readBackendOwnership(
   timeoutMs: number,
   expectedSessionHome: string,
   runtime: BackendServiceRuntime,
+  token?: string,
 ): Promise<BackendOwnershipEvidence> {
   if (!isTrustedServiceState(state)) return { status: "invalid_state" };
   let health: BackendHealthEvidence = "inconclusive";
@@ -543,6 +557,7 @@ async function readBackendOwnership(
         new URL("/health", state.url),
         timeoutMs,
         runtime.fetch,
+        token,
       );
       if (result.ok) {
         health = result.body.ok === true
@@ -673,6 +688,7 @@ async function readHealthWithTimeout(
   url: URL,
   timeoutMs: number,
   fetchImpl: typeof fetch = fetch,
+  token?: string,
 ): Promise<{
   ok: boolean;
   body: {
@@ -687,7 +703,10 @@ async function readHealthWithTimeout(
   const timeout = setTimeout(() => controller.abort(), boundedTimeoutMs);
   try {
     const response = await fetchImpl(url, {
-      headers: { connection: "close" },
+      headers: {
+        connection: "close",
+        ...(token ? { authorization: `Bearer ${token}` } : {}),
+      },
       signal: controller.signal,
     });
     if (!response.ok) return { ok: false, body: {} };

--- a/packages/ts/memorax-code-backend/src/memory/automatic-writeback.ts
+++ b/packages/ts/memorax-code-backend/src/memory/automatic-writeback.ts
@@ -36,7 +36,7 @@ import {
   type MemoryPayloadRedactionKind,
 } from "./payload-redaction.js";
 
-export type AutomaticMemoryWritebackClient = "codex" | "claude-code";
+export type AutomaticMemoryWritebackClient = "codex" | "claude-code" | "dsh";
 
 export type AutomaticMemoryWritebackOptions = {
   client: AutomaticMemoryWritebackClient;

--- a/packages/ts/memorax-code-backend/src/memory/hook-command.ts
+++ b/packages/ts/memorax-code-backend/src/memory/hook-command.ts
@@ -71,13 +71,16 @@ export type DshTurnStartCommand = MemoryHookCommandBase<"dsh"> & Readonly<{
 
 export type TurnStartCommand = CodexTurnStartCommand | ClaudeTurnStartCommand | DshTurnStartCommand;
 
+// Turn-start is idempotent: a colliding turnId self-heals server-side (the
+// newest start wins, see the DSH runtime's turn_start_conflict_replaced
+// diagnostic), so every runtime answers ok:true. There is deliberately no
+// ok:false variant — an earlier revision carried a dead
+// "conflicting_turn_start" error that no code path ever returned, which
+// invited defensive branches and tests for a shape the Backend never sends.
 export type MemoryHookTurnStartResult = Readonly<{
   ok: true;
   additionalContext?: string;
   repoMemoryWorktree?: string;
-}> | Readonly<{
-  ok: false;
-  error: "conflicting_turn_start";
 }>;
 
 export type CodexWritebackCommand = MemoryHookCommandBase<"codex"> & Readonly<{

--- a/packages/ts/memorax-code-backend/src/memory/hook-command.ts
+++ b/packages/ts/memorax-code-backend/src/memory/hook-command.ts
@@ -75,6 +75,9 @@ export type MemoryHookTurnStartResult = Readonly<{
   ok: true;
   additionalContext?: string;
   repoMemoryWorktree?: string;
+}> | Readonly<{
+  ok: false;
+  error: "conflicting_turn_start";
 }>;
 
 export type CodexWritebackCommand = MemoryHookCommandBase<"codex"> & Readonly<{

--- a/packages/ts/memorax-code-backend/src/memory/hook-command.ts
+++ b/packages/ts/memorax-code-backend/src/memory/hook-command.ts
@@ -12,10 +12,13 @@ const BASE_COMMAND_KEYS = [
   "cwd",
   "workspaceKind",
 ] as const;
+// DSH deliberately accepts NO transcriptPath in any command: DSH turns are
+// inline text and have no transcript file, so a client-supplied path would be
+// an unbacked "trusted provenance" string injected into local trace records.
 const TURN_START_KEYS: Readonly<Record<MemoryHookClient, ReadonlySet<string>>> = {
   codex: new Set([...BASE_COMMAND_KEYS, "turnId", "prompt", "transcriptPath"]),
   "claude-code": new Set([...BASE_COMMAND_KEYS, "promptId", "prompt", "transcriptPath"]),
-  dsh: new Set([...BASE_COMMAND_KEYS, "turnId", "prompt", "transcriptPath"]),
+  dsh: new Set([...BASE_COMMAND_KEYS, "turnId", "prompt"]),
 };
 const WRITEBACK_KEYS: Readonly<Record<MemoryHookClient, ReadonlySet<string>>> = {
   codex: new Set([...BASE_COMMAND_KEYS, "turnId", "lastAssistantMessage", "transcriptPath"]),
@@ -30,7 +33,6 @@ const WRITEBACK_KEYS: Readonly<Record<MemoryHookClient, ReadonlySet<string>>> = 
     "turnId",
     "userText",
     "assistantText",
-    "transcriptPath",
   ]),
 };
 const TURN_DISCARD_KEYS: Readonly<Record<MemoryHookClient, ReadonlySet<string>>> = {
@@ -66,7 +68,6 @@ export type ClaudeTurnStartCommand = MemoryHookCommandBase<"claude-code"> & Read
 export type DshTurnStartCommand = MemoryHookCommandBase<"dsh"> & Readonly<{
   turnId: string;
   prompt: string;
-  transcriptPath?: string;
 }>;
 
 export type TurnStartCommand = CodexTurnStartCommand | ClaudeTurnStartCommand | DshTurnStartCommand;
@@ -99,7 +100,6 @@ export type DshWritebackCommand = MemoryHookCommandBase<"dsh"> & Readonly<{
   turnId: string;
   userText: string;
   assistantText: string;
-  transcriptPath?: string;
 }>;
 
 export type WritebackCommand = CodexWritebackCommand | ClaudeWritebackCommand | DshWritebackCommand;
@@ -160,8 +160,7 @@ export function parseTurnStartCommand(
   }
   if (base.client === "dsh") {
     const turnId = requiredStringField(value, "turnId");
-    const transcriptPath = optionalStringField(value, "transcriptPath");
-    if (!turnId || !transcriptPath.ok) return invalidCommand();
+    if (!turnId) return invalidCommand();
     return {
       ok: true,
       command: {
@@ -169,7 +168,6 @@ export function parseTurnStartCommand(
         client: "dsh",
         turnId,
         prompt,
-        ...(transcriptPath.value ? { transcriptPath: transcriptPath.value } : {}),
       },
     };
   }
@@ -215,8 +213,7 @@ export function parseWritebackCommand(
     const turnId = requiredStringField(value, "turnId");
     const userText = requiredStringField(value, "userText");
     const assistantText = requiredStringField(value, "assistantText");
-    const transcriptPath = optionalStringField(value, "transcriptPath");
-    if (!turnId || !userText || !assistantText || !transcriptPath.ok) return invalidCommand();
+    if (!turnId || !userText || !assistantText) return invalidCommand();
     return {
       ok: true,
       command: {
@@ -225,7 +222,6 @@ export function parseWritebackCommand(
         turnId,
         userText,
         assistantText,
-        ...(transcriptPath.value ? { transcriptPath: transcriptPath.value } : {}),
       },
     };
   }

--- a/packages/ts/memorax-code-backend/src/memory/hook-command.ts
+++ b/packages/ts/memorax-code-backend/src/memory/hook-command.ts
@@ -3,7 +3,7 @@ import { isRecord } from "../shared/record.js";
 export const MEMORY_HOOK_COMMAND_VERSION = 1 as const;
 export const INVALID_MEMORY_HOOK_COMMAND = "invalid memory Hook command";
 
-export type MemoryHookClient = "codex" | "claude-code";
+export type MemoryHookClient = "codex" | "claude-code" | "dsh";
 
 const BASE_COMMAND_KEYS = [
   "version",
@@ -15,6 +15,7 @@ const BASE_COMMAND_KEYS = [
 const TURN_START_KEYS: Readonly<Record<MemoryHookClient, ReadonlySet<string>>> = {
   codex: new Set([...BASE_COMMAND_KEYS, "turnId", "prompt", "transcriptPath"]),
   "claude-code": new Set([...BASE_COMMAND_KEYS, "promptId", "prompt", "transcriptPath"]),
+  dsh: new Set([...BASE_COMMAND_KEYS, "turnId", "prompt", "transcriptPath"]),
 };
 const WRITEBACK_KEYS: Readonly<Record<MemoryHookClient, ReadonlySet<string>>> = {
   codex: new Set([...BASE_COMMAND_KEYS, "turnId", "lastAssistantMessage", "transcriptPath"]),
@@ -24,10 +25,18 @@ const WRITEBACK_KEYS: Readonly<Record<MemoryHookClient, ReadonlySet<string>>> = 
     "lastAssistantMessage",
     "transcriptPath",
   ]),
+  dsh: new Set([
+    ...BASE_COMMAND_KEYS,
+    "turnId",
+    "userText",
+    "assistantText",
+    "transcriptPath",
+  ]),
 };
 const SKILL_REMINDER_KEYS: Readonly<Record<MemoryHookClient, ReadonlySet<string>>> = {
   codex: new Set([...BASE_COMMAND_KEYS, "turnId", "transcriptPath", "content", "triggers"]),
   "claude-code": new Set([...BASE_COMMAND_KEYS, "promptId", "transcriptPath", "content", "triggers"]),
+  dsh: new Set([...BASE_COMMAND_KEYS, "turnId", "transcriptPath", "content", "triggers"]),
 };
 
 type MemoryHookCommandBase<Client extends MemoryHookClient> = Readonly<{
@@ -50,7 +59,13 @@ export type ClaudeTurnStartCommand = MemoryHookCommandBase<"claude-code"> & Read
   transcriptPath: string;
 }>;
 
-export type TurnStartCommand = CodexTurnStartCommand | ClaudeTurnStartCommand;
+export type DshTurnStartCommand = MemoryHookCommandBase<"dsh"> & Readonly<{
+  turnId: string;
+  prompt: string;
+  transcriptPath?: string;
+}>;
+
+export type TurnStartCommand = CodexTurnStartCommand | ClaudeTurnStartCommand | DshTurnStartCommand;
 
 export type MemoryHookTurnStartResult = Readonly<{
   ok: true;
@@ -70,7 +85,14 @@ export type ClaudeWritebackCommand = MemoryHookCommandBase<"claude-code"> & Read
   transcriptPath: string;
 }>;
 
-export type WritebackCommand = CodexWritebackCommand | ClaudeWritebackCommand;
+export type DshWritebackCommand = MemoryHookCommandBase<"dsh"> & Readonly<{
+  turnId: string;
+  userText: string;
+  assistantText: string;
+  transcriptPath?: string;
+}>;
+
+export type WritebackCommand = CodexWritebackCommand | ClaudeWritebackCommand | DshWritebackCommand;
 
 export type SkillReminderTrigger = "cadence" | "post_compaction";
 
@@ -101,11 +123,11 @@ export function parseTurnStartCommand(
   const base = parseCommandBase(value, TURN_START_KEYS);
   if (!base) return invalidCommand();
   const prompt = requiredStringField(value, "prompt");
-  const transcriptPath = requiredStringField(value, "transcriptPath");
-  if (!prompt || !transcriptPath) return invalidCommand();
+  if (!prompt) return invalidCommand();
   if (base.client === "codex") {
     const turnId = optionalStringField(value, "turnId");
-    if (!turnId.ok) return invalidCommand();
+    const transcriptPath = requiredStringField(value, "transcriptPath");
+    if (!turnId.ok || !transcriptPath) return invalidCommand();
     return {
       ok: true,
       command: {
@@ -117,8 +139,24 @@ export function parseTurnStartCommand(
       },
     };
   }
+  if (base.client === "dsh") {
+    const turnId = requiredStringField(value, "turnId");
+    const transcriptPath = optionalStringField(value, "transcriptPath");
+    if (!turnId || !transcriptPath.ok) return invalidCommand();
+    return {
+      ok: true,
+      command: {
+        ...base,
+        client: "dsh",
+        turnId,
+        prompt,
+        ...(transcriptPath.value ? { transcriptPath: transcriptPath.value } : {}),
+      },
+    };
+  }
   const promptId = requiredStringField(value, "promptId");
-  if (!promptId) return invalidCommand();
+  const transcriptPath = requiredStringField(value, "transcriptPath");
+  if (!promptId || !transcriptPath) return invalidCommand();
   return {
     ok: true,
     command: {
@@ -137,9 +175,9 @@ export function parseWritebackCommand(
   if (!isRecord(value)) return invalidCommand();
   const base = parseCommandBase(value, WRITEBACK_KEYS);
   if (!base) return invalidCommand();
-  const lastAssistantMessage = requiredStringField(value, "lastAssistantMessage");
-  if (!lastAssistantMessage) return invalidCommand();
   if (base.client === "codex") {
+    const lastAssistantMessage = requiredStringField(value, "lastAssistantMessage");
+    if (!lastAssistantMessage) return invalidCommand();
     const turnId = optionalStringField(value, "turnId");
     const transcriptPath = optionalStringField(value, "transcriptPath");
     if (!turnId.ok || !transcriptPath.ok) return invalidCommand();
@@ -154,9 +192,28 @@ export function parseWritebackCommand(
       },
     };
   }
+  if (base.client === "dsh") {
+    const turnId = requiredStringField(value, "turnId");
+    const userText = requiredStringField(value, "userText");
+    const assistantText = requiredStringField(value, "assistantText");
+    const transcriptPath = optionalStringField(value, "transcriptPath");
+    if (!turnId || !userText || !assistantText || !transcriptPath.ok) return invalidCommand();
+    return {
+      ok: true,
+      command: {
+        ...base,
+        client: "dsh",
+        turnId,
+        userText,
+        assistantText,
+        ...(transcriptPath.value ? { transcriptPath: transcriptPath.value } : {}),
+      },
+    };
+  }
+  const lastAssistantMessage = requiredStringField(value, "lastAssistantMessage");
   const promptId = requiredStringField(value, "promptId");
   const transcriptPath = requiredStringField(value, "transcriptPath");
-  if (!promptId || !transcriptPath) return invalidCommand();
+  if (!lastAssistantMessage || !promptId || !transcriptPath) return invalidCommand();
   return {
     ok: true,
     command: {
@@ -194,6 +251,7 @@ export function parseSkillReminderCommand(
       },
     };
   }
+  if (base.client === "dsh") return invalidCommand();
   const promptId = requiredStringField(value, "promptId");
   if (!promptId) return invalidCommand();
   return {
@@ -215,7 +273,7 @@ function parseCommandBase(
 ): MemoryHookCommandBase<MemoryHookClient> | undefined {
   if (value.version !== MEMORY_HOOK_COMMAND_VERSION) return undefined;
   const client = value.client;
-  if (client !== "codex" && client !== "claude-code") return undefined;
+  if (client !== "codex" && client !== "claude-code" && client !== "dsh") return undefined;
   if (Object.keys(value).some((key) => !allowedKeys[client].has(key))) return undefined;
   const sessionId = requiredStringField(value, "sessionId");
   if (!sessionId) return undefined;

--- a/packages/ts/memorax-code-backend/src/memory/hook-command.ts
+++ b/packages/ts/memorax-code-backend/src/memory/hook-command.ts
@@ -33,6 +33,11 @@ const WRITEBACK_KEYS: Readonly<Record<MemoryHookClient, ReadonlySet<string>>> = 
     "transcriptPath",
   ]),
 };
+const TURN_DISCARD_KEYS: Readonly<Record<MemoryHookClient, ReadonlySet<string>>> = {
+  codex: new Set([...BASE_COMMAND_KEYS, "turnId"]),
+  "claude-code": new Set([...BASE_COMMAND_KEYS, "turnId"]),
+  dsh: new Set([...BASE_COMMAND_KEYS, "turnId"]),
+};
 const SKILL_REMINDER_KEYS: Readonly<Record<MemoryHookClient, ReadonlySet<string>>> = {
   codex: new Set([...BASE_COMMAND_KEYS, "turnId", "transcriptPath", "content", "triggers"]),
   "claude-code": new Set([...BASE_COMMAND_KEYS, "promptId", "transcriptPath", "content", "triggers"]),
@@ -93,6 +98,15 @@ export type DshWritebackCommand = MemoryHookCommandBase<"dsh"> & Readonly<{
 }>;
 
 export type WritebackCommand = CodexWritebackCommand | ClaudeWritebackCommand | DshWritebackCommand;
+
+export type DshTurnDiscardCommand = MemoryHookCommandBase<"dsh"> & Readonly<{
+  turnId: string;
+}>;
+
+export type MemoryHookTurnDiscardResult = Readonly<{
+  ok: true;
+  discarded: boolean;
+}>;
 
 export type SkillReminderTrigger = "cadence" | "post_compaction";
 
@@ -222,6 +236,24 @@ export function parseWritebackCommand(
       promptId,
       lastAssistantMessage,
       transcriptPath,
+    },
+  };
+}
+
+export function parseTurnDiscardCommand(
+  value: unknown,
+): MemoryHookCommandParseResult<DshTurnDiscardCommand> {
+  if (!isRecord(value)) return invalidCommand();
+  const base = parseCommandBase(value, TURN_DISCARD_KEYS);
+  if (!base || base.client !== "dsh") return invalidCommand();
+  const turnId = requiredStringField(value, "turnId");
+  if (!turnId) return invalidCommand();
+  return {
+    ok: true,
+    command: {
+      ...base,
+      client: "dsh",
+      turnId,
     },
   };
 }

--- a/packages/ts/memorax-code-backend/src/memory/hook-command.ts
+++ b/packages/ts/memorax-code-backend/src/memory/hook-command.ts
@@ -38,10 +38,9 @@ const TURN_DISCARD_KEYS: Readonly<Record<MemoryHookClient, ReadonlySet<string>>>
   "claude-code": new Set([...BASE_COMMAND_KEYS, "turnId"]),
   dsh: new Set([...BASE_COMMAND_KEYS, "turnId"]),
 };
-const SKILL_REMINDER_KEYS: Readonly<Record<MemoryHookClient, ReadonlySet<string>>> = {
+const SKILL_REMINDER_KEYS: Readonly<Partial<Record<MemoryHookClient, ReadonlySet<string>>>> = {
   codex: new Set([...BASE_COMMAND_KEYS, "turnId", "transcriptPath", "content", "triggers"]),
   "claude-code": new Set([...BASE_COMMAND_KEYS, "promptId", "transcriptPath", "content", "triggers"]),
-  dsh: new Set([...BASE_COMMAND_KEYS, "turnId", "transcriptPath", "content", "triggers"]),
 };
 
 type MemoryHookCommandBase<Client extends MemoryHookClient> = Readonly<{
@@ -283,7 +282,6 @@ export function parseSkillReminderCommand(
       },
     };
   }
-  if (base.client === "dsh") return invalidCommand();
   const promptId = requiredStringField(value, "promptId");
   if (!promptId) return invalidCommand();
   return {
@@ -301,12 +299,14 @@ export function parseSkillReminderCommand(
 
 function parseCommandBase(
   value: Record<string, unknown>,
-  allowedKeys: Readonly<Record<MemoryHookClient, ReadonlySet<string>>>,
+  allowedKeys: Readonly<Partial<Record<MemoryHookClient, ReadonlySet<string>>>>,
 ): MemoryHookCommandBase<MemoryHookClient> | undefined {
   if (value.version !== MEMORY_HOOK_COMMAND_VERSION) return undefined;
   const client = value.client;
   if (client !== "codex" && client !== "claude-code" && client !== "dsh") return undefined;
-  if (Object.keys(value).some((key) => !allowedKeys[client].has(key))) return undefined;
+  const allowed = allowedKeys[client];
+  if (!allowed) return undefined;
+  if (Object.keys(value).some((key) => !allowed.has(key))) return undefined;
   const sessionId = requiredStringField(value, "sessionId");
   if (!sessionId) return undefined;
   const cwd = optionalStringField(value, "cwd");

--- a/packages/ts/memorax-code-backend/src/memory/observability.ts
+++ b/packages/ts/memorax-code-backend/src/memory/observability.ts
@@ -7,6 +7,8 @@ export type MemoryObservabilitySource =
   | "codex_hook_retrieval"
   | "claude_hook_retrieval"
   | "claude_hook_writeback"
+  | "dsh_hook_retrieval"
+  | "dsh_hook_writeback"
   | "memory_cli"
   | "writeback_reconciler"
   | "unknown";

--- a/packages/ts/memorax-code-backend/src/memory/service.ts
+++ b/packages/ts/memorax-code-backend/src/memory/service.ts
@@ -9,6 +9,11 @@ import {
   type ClaudeMemoryHookRuntimeOptions,
   type ClaudeMemoryHookWritebackResult,
 } from "../clients/claude/memory-hook-runtime.js";
+import {
+  createDshMemoryHookRuntime,
+  type DshMemoryHookRuntimeOptions,
+  type DshMemoryHookWritebackResult,
+} from "../clients/dsh/memory-hook-runtime.js";
 import { createMemoryTurnCoordinator } from "./turn-coordinator.js";
 import {
   createRepositoryMemorySessionRuntime,
@@ -26,7 +31,8 @@ export type MemoryServiceOptions = Omit<
 
 type MemoryHookWritebackResult =
   | CodexMemoryHookWritebackResult
-  | ClaudeMemoryHookWritebackResult;
+  | ClaudeMemoryHookWritebackResult
+  | DshMemoryHookWritebackResult;
 
 export type MemoryService = {
   recordTurnStart(command: TurnStartCommand): Promise<MemoryHookTurnStartResult>;
@@ -59,6 +65,11 @@ export function createMemoryService(options: MemoryServiceOptions = {}): MemoryS
     repositoryMemorySession,
     turnCoordinator,
   });
+  const dshHook = createDshMemoryHookRuntime({
+    ...options,
+    repositoryMemorySession,
+    turnCoordinator,
+  });
   let closed = false;
   return {
     async recordTurnStart(command) {
@@ -67,6 +78,8 @@ export function createMemoryService(options: MemoryServiceOptions = {}): MemoryS
           return await codexHook.recordTurnStart(command);
         case "claude-code":
           return await claudeHook.recordTurnStart(command);
+        case "dsh":
+          return await dshHook.recordTurnStart(command);
       }
       return unsupportedMemoryHookCommand(command);
     },
@@ -76,6 +89,8 @@ export function createMemoryService(options: MemoryServiceOptions = {}): MemoryS
           return await codexHook.writeback(command);
         case "claude-code":
           return await claudeHook.writeback(command);
+        case "dsh":
+          return await dshHook.writeback(command);
       }
       return unsupportedMemoryHookCommand(command);
     },
@@ -87,6 +102,7 @@ export function createMemoryService(options: MemoryServiceOptions = {}): MemoryS
       closed = true;
       codexHook.close();
       claudeHook.close();
+      dshHook.close();
       turnCoordinator.close();
       repositoryMemorySession.close();
       automaticWriteback.close();

--- a/packages/ts/memorax-code-backend/src/memory/service.ts
+++ b/packages/ts/memorax-code-backend/src/memory/service.ts
@@ -19,6 +19,8 @@ import {
   createRepositoryMemorySessionRuntime,
 } from "./repository-session.js";
 import type {
+  DshTurnDiscardCommand,
+  MemoryHookTurnDiscardResult,
   MemoryHookTurnStartResult,
   TurnStartCommand,
   WritebackCommand,
@@ -37,6 +39,7 @@ type MemoryHookWritebackResult =
 export type MemoryService = {
   recordTurnStart(command: TurnStartCommand): Promise<MemoryHookTurnStartResult>;
   writebackTurn(command: WritebackCommand): Promise<MemoryHookWritebackResult>;
+  discardTurn(command: DshTurnDiscardCommand): Promise<MemoryHookTurnDiscardResult>;
   drain(): Promise<void>;
   close(): void;
 };
@@ -93,6 +96,9 @@ export function createMemoryService(options: MemoryServiceOptions = {}): MemoryS
           return await dshHook.writeback(command);
       }
       return unsupportedMemoryHookCommand(command);
+    },
+    async discardTurn(command) {
+      return await dshHook.discardTurn(command);
     },
     async drain() {
       await automaticWriteback.drain();

--- a/packages/ts/memorax-code-backend/src/memory/turn-coordinator.ts
+++ b/packages/ts/memorax-code-backend/src/memory/turn-coordinator.ts
@@ -25,6 +25,7 @@ export type MemoryTurnStart = MemoryTurnKey & Readonly<{
   cwd?: string;
   workspaceKind?: string;
   transcriptPath?: string;
+  prompt?: string;
   createdAt: number;
   sessionTurnIndex?: number;
   traceContext?: TraceContext;
@@ -109,6 +110,7 @@ export function createMemoryTurnCoordinator(options: MemoryTurnCoordinatorOption
         cwd: input.cwd,
         workspaceKind: input.workspaceKind,
         transcriptPath: input.transcriptPath,
+        prompt: input.prompt,
         createdAt: input.createdAt,
         sessionTurnIndex: input.sessionTurnIndex,
         traceContext: input.traceContext,

--- a/packages/ts/memorax-code-backend/src/memory/turn-coordinator.ts
+++ b/packages/ts/memorax-code-backend/src/memory/turn-coordinator.ts
@@ -236,6 +236,7 @@ function turnMetadataDisposition(
 
 function cleanupExpired(turns: Map<string, MemoryTurnState>, nowMs: number, ttlMs: number): void {
   for (const [key, turn] of turns.entries()) {
+    if (turn.client === "dsh") continue;
     if (nowMs - turn.createdAt > ttlMs) turns.delete(key);
   }
 }

--- a/packages/ts/memorax-code-backend/src/memory/writeback-buffer.ts
+++ b/packages/ts/memorax-code-backend/src/memory/writeback-buffer.ts
@@ -11,8 +11,10 @@ import {
 } from "../repository/scope.js";
 import type { TraceContext } from "../trace/context.js";
 
+export type MemoryWritebackBufferClient = "codex" | "claude-code" | "dsh";
+
 export type MemoryWritebackBufferDecision = {
-  client: "codex" | "claude-code";
+  client: MemoryWritebackBufferClient;
   sessionKey: string;
   idempotencyKey: string;
   messages: WritebackMessage[];

--- a/packages/ts/memorax-code-backend/src/trace/config.ts
+++ b/packages/ts/memorax-code-backend/src/trace/config.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { loadMemoraxCodeConfig, type MemoraxCodeConfig } from "../config/memorax-code.js";
 import { isTraceClient, type TraceClient } from "./context.js";
 
-export const TRACE_CLIENTS: readonly TraceClient[] = ["codex", "claude"];
+export const TRACE_CLIENTS: readonly TraceClient[] = ["codex", "claude", "dsh"];
 
 export type ClientTraceConfig = Readonly<{
   enabled: boolean;
@@ -16,6 +16,7 @@ export type ClientTraceConfig = Readonly<{
 
 export type CodexTraceConfig = ClientTraceConfig;
 export type ClaudeTraceConfig = ClientTraceConfig;
+export type DshTraceConfig = ClientTraceConfig;
 
 export type ClientTracePaths = Readonly<{
   root: string;
@@ -29,6 +30,7 @@ export type ClientTracePaths = Readonly<{
 
 export type CodexTracePaths = ClientTracePaths;
 export type ClaudeTracePaths = ClientTracePaths;
+export type DshTracePaths = ClientTracePaths;
 
 export const CODEX_TRACE_DEFAULT_CONFIG: CodexTraceConfig = {
   enabled: true,
@@ -39,6 +41,14 @@ export const CODEX_TRACE_DEFAULT_CONFIG: CodexTraceConfig = {
 };
 
 export const CLAUDE_TRACE_DEFAULT_CONFIG: ClaudeTraceConfig = {
+  enabled: true,
+  captureContent: true,
+  retentionDays: 7,
+  maxEventChars: 20_000,
+  maxFileBytes: 52_428_800,
+};
+
+export const DSH_TRACE_DEFAULT_CONFIG: DshTraceConfig = {
   enabled: true,
   captureContent: true,
   retentionDays: 7,
@@ -67,6 +77,13 @@ export function claudeTraceConfigFromEnv(
   return clientTraceConfigFromEnv("claude", env, fileConfig);
 }
 
+export function dshTraceConfigFromEnv(
+  env: Record<string, string | undefined> = process.env,
+  fileConfig?: MemoraxCodeConfig,
+): DshTraceConfig {
+  return clientTraceConfigFromEnv("dsh", env, fileConfig);
+}
+
 export function clientTraceConfigFromEnv(
   client: TraceClient,
   env: Record<string, string | undefined> = process.env,
@@ -75,8 +92,16 @@ export function clientTraceConfigFromEnv(
   assertTraceClient(client);
   const config = fileConfig ?? loadMemoraxCodeConfig(memoraxCodeHomeForTrace(env), { warn: () => undefined });
   const section = config.trace?.[client];
-  const defaults = client === "claude" ? CLAUDE_TRACE_DEFAULT_CONFIG : CODEX_TRACE_DEFAULT_CONFIG;
-  const prefix = client === "claude" ? "MEMORAX_CODE_CLAUDE_TRACE" : "MEMORAX_CODE_CODEX_TRACE";
+  const defaults = client === "claude"
+    ? CLAUDE_TRACE_DEFAULT_CONFIG
+    : client === "dsh"
+      ? DSH_TRACE_DEFAULT_CONFIG
+      : CODEX_TRACE_DEFAULT_CONFIG;
+  const prefix = client === "claude"
+    ? "MEMORAX_CODE_CLAUDE_TRACE"
+    : client === "dsh"
+      ? "MEMORAX_CODE_DSH_TRACE"
+      : "MEMORAX_CODE_CODEX_TRACE";
   return {
     enabled: booleanValue(env[`${prefix}_ENABLED`], section?.enabled ?? defaults.enabled),
     captureContent: booleanValue(env[`${prefix}_CAPTURE_CONTENT`], section?.capture_content ?? defaults.captureContent),
@@ -96,6 +121,10 @@ export function tracePaths(memoraxCodeHome = memoraxCodeHomeForTrace(process.env
 
 export function claudeTracePaths(memoraxCodeHome = memoraxCodeHomeForTrace(process.env)): ClaudeTracePaths {
   return clientTracePaths("claude", memoraxCodeHome);
+}
+
+export function dshTracePaths(memoraxCodeHome = memoraxCodeHomeForTrace(process.env)): DshTracePaths {
+  return clientTracePaths("dsh", memoraxCodeHome);
 }
 
 export function clientTracePaths(

--- a/packages/ts/memorax-code-backend/src/trace/context.ts
+++ b/packages/ts/memorax-code-backend/src/trace/context.ts
@@ -7,9 +7,10 @@ import {
 export type TraceContextOrigin =
   | "codex-hook-body"
   | "claude-hook-body"
+  | "dsh-hook-body"
   | "current-turn-file"
   | "manual";
-export type TraceClient = "codex" | "claude";
+export type TraceClient = "codex" | "claude" | "dsh";
 
 export type TraceRelatedTurn = Readonly<{
   turnId?: string;
@@ -82,6 +83,28 @@ export function traceContextFromClaudeHookBody(
   });
 }
 
+export function traceContextFromDshHookBody(
+  body: unknown,
+  capturedAt = new Date().toISOString(),
+): TraceContext | undefined {
+  if (!isRecord(body)) return undefined;
+  const sessionId = stringField(body, "session_id") ?? stringField(body, "sessionId");
+  if (!sessionId) return undefined;
+  const cwd = stringField(body, "cwd");
+  return pruneTraceContext({
+    schemaVersion: "1",
+    client: "dsh",
+    sessionId,
+    turnId: stringField(body, "turn_id") ?? stringField(body, "turnId"),
+    transcriptPath: stringField(body, "transcript_path") ?? stringField(body, "transcriptPath"),
+    cwd,
+    memoryProject: resolveMemoryProject(cwd),
+    workspaceKind: stringField(body, "workspace_kind") ?? stringField(body, "workspaceKind"),
+    contextOrigin: "dsh-hook-body",
+    capturedAt,
+  });
+}
+
 export function traceContextFromCurrentTurnRecord(
   value: unknown,
 ): TraceContext | undefined {
@@ -142,7 +165,7 @@ function pruneRecord<T extends Record<string, unknown>>(value: T): T {
 }
 
 export function isTraceClient(value: unknown): value is TraceClient {
-  return value === "codex" || value === "claude";
+  return value === "codex" || value === "claude" || value === "dsh";
 }
 
 function stringField(record: Record<string, unknown>, key: string): string | undefined {

--- a/packages/ts/memorax-code-backend/src/trace/store.ts
+++ b/packages/ts/memorax-code-backend/src/trace/store.ts
@@ -76,6 +76,18 @@ export type TraceCurrentTurnOptions = Readonly<{
   expectedSessionId?: string;
   allowStale?: boolean;
   now?: () => Date;
+  // When present the current-turn record pins the started prompt as a
+  // sha256 plus its character length. The DSH writeback recovery path
+  // verifies the writeback userText against this attestation: the hash keeps
+  // the prompt out of the trace file while still allowing the same
+  // prefix-match semantics as the in-memory coordinator check
+  // (exact prompt, or prompt + MESSAGE_JOIN_DELIMITER + further messages).
+  promptAttestation?: TracePromptAttestation;
+}>;
+
+export type TracePromptAttestation = Readonly<{
+  sha256: string;
+  chars: number;
 }>;
 
 export type CodexCurrentTurnOptions = Omit<TraceCurrentTurnOptions, "client">;
@@ -207,14 +219,16 @@ export async function writeCurrentTraceTurn(
   if (!traceContext?.sessionId) return { written: false, reason: "missing_trace_context" };
   const paths = clientTracePaths(client, memoraxCodeHome);
   const capturedAt = (options.now?.() ?? new Date()).toISOString();
-  const record = `${JSON.stringify({
+  const record = `${JSON.stringify(pruneRecord({
     schema_version: "1",
     turn_state: "open",
+    prompt_sha256: options.promptAttestation?.sha256,
+    prompt_chars: options.promptAttestation?.chars,
     trace: traceContextJson({
       ...traceContext,
       capturedAt,
     }),
-  }, null, 2)}\n`;
+  }), null, 2)}\n`;
   await mkdir(paths.root, { recursive: true });
   await mkdir(paths.sessionDir(traceContext.sessionId), { recursive: true });
   await Promise.all([
@@ -251,12 +265,12 @@ export async function writeCurrentDshTurn(
 export async function readCurrentTraceTurn(
   options: TraceCurrentTurnReadOptions,
 ): Promise<
-  | { ok: true; traceContext: TraceContext }
+  | { ok: true; traceContext: TraceContext; promptAttestation?: TracePromptAttestation }
   | { ok: false; reason: "disabled" | "missing" | "invalid" | "stale" | "session_mismatch" }
 > {
   const current = await readCurrentTraceTurnRecord(options);
   return current.ok
-    ? { ok: true, traceContext: current.traceContext }
+    ? { ok: true, traceContext: current.traceContext, promptAttestation: current.promptAttestation }
     : current;
 }
 
@@ -290,7 +304,7 @@ export async function readCurrentDshTurn(
 export async function readOpenTraceTurn(
   options: TraceCurrentTurnReadOptions,
 ): Promise<
-  | { ok: true; traceContext: TraceContext }
+  | { ok: true; traceContext: TraceContext; promptAttestation?: TracePromptAttestation }
   | { ok: false; reason: "disabled" | "missing" | "invalid" | "stale" | "session_mismatch" }
   | { ok: false; reason: "closed"; outcome: TraceTurnOutcome }
 > {
@@ -299,13 +313,17 @@ export async function readOpenTraceTurn(
   if (current.turnState !== "open") {
     return { ok: false, reason: "closed", outcome: current.turnState };
   }
-  return { ok: true, traceContext: current.traceContext };
+  return {
+    ok: true,
+    traceContext: current.traceContext,
+    promptAttestation: current.promptAttestation,
+  };
 }
 
 export async function readOpenCodexTurn(
   options: CodexCurrentTurnOptions = {},
 ): Promise<
-  | { ok: true; traceContext: TraceContext }
+  | { ok: true; traceContext: TraceContext; promptAttestation?: TracePromptAttestation }
   | { ok: false; reason: "disabled" | "missing" | "invalid" | "stale" | "session_mismatch" }
   | { ok: false; reason: "closed"; outcome: CodexTurnOutcome }
 > {
@@ -315,7 +333,7 @@ export async function readOpenCodexTurn(
 export async function readOpenClaudeTurn(
   options: ClaudeCurrentTurnOptions = {},
 ): Promise<
-  | { ok: true; traceContext: TraceContext }
+  | { ok: true; traceContext: TraceContext; promptAttestation?: TracePromptAttestation }
   | { ok: false; reason: "disabled" | "missing" | "invalid" | "stale" | "session_mismatch" }
   | { ok: false; reason: "closed"; outcome: TraceTurnOutcome }
 > {
@@ -325,7 +343,7 @@ export async function readOpenClaudeTurn(
 export async function readOpenDshTurn(
   options: DshCurrentTurnOptions = {},
 ): Promise<
-  | { ok: true; traceContext: TraceContext }
+  | { ok: true; traceContext: TraceContext; promptAttestation?: TracePromptAttestation }
   | { ok: false; reason: "disabled" | "missing" | "invalid" | "stale" | "session_mismatch" }
   | { ok: false; reason: "closed"; outcome: DshTurnOutcome }
 > {
@@ -387,7 +405,7 @@ export async function markCurrentDshTurnOutcome(
 async function readCurrentTraceTurnRecord(
   options: TraceCurrentTurnReadOptions,
 ): Promise<
-  | { ok: true; traceContext: TraceContext; turnState: TraceCurrentTurnState }
+  | { ok: true; traceContext: TraceContext; turnState: TraceCurrentTurnState; promptAttestation?: TracePromptAttestation }
   | { ok: false; reason: "disabled" | "missing" | "invalid" | "stale" | "session_mismatch" }
 > {
   const client = options.client;
@@ -441,7 +459,7 @@ async function readCurrentTraceTurnPath(
   allowStale: boolean,
   expectedClient: TraceClient,
 ): Promise<
-  | { ok: true; traceContext: TraceContext; turnState: TraceCurrentTurnState }
+  | { ok: true; traceContext: TraceContext; turnState: TraceCurrentTurnState; promptAttestation?: TracePromptAttestation }
   | { ok: false; reason: "missing" | "invalid" | "stale" }
 > {
   let raw: unknown;
@@ -464,6 +482,25 @@ async function readCurrentTraceTurnPath(
     ok: true,
     traceContext,
     turnState,
+    promptAttestation: promptAttestationFromRecord(raw),
+  };
+}
+
+function promptAttestationFromRecord(raw: Record<string, unknown>): TracePromptAttestation | undefined {
+  const sha256 = normalizedString(raw.prompt_sha256);
+  const chars = Number(raw.prompt_chars);
+  // Both fields must be present and well-formed together; a record carrying
+  // only one of them (hand-edited or torn write) attests nothing.
+  if (!sha256 || !/^[0-9a-f]{64}$/.test(sha256) || !Number.isInteger(chars) || chars < 0) {
+    return undefined;
+  }
+  return { sha256, chars };
+}
+
+export function tracePromptAttestation(prompt: string): TracePromptAttestation {
+  return {
+    sha256: createHash("sha256").update(prompt).digest("hex"),
+    chars: prompt.length,
   };
 }
 

--- a/packages/ts/memorax-code-backend/src/trace/store.ts
+++ b/packages/ts/memorax-code-backend/src/trace/store.ts
@@ -28,8 +28,17 @@ export type TraceTurnOutcome = "completed" | "interrupted";
 export type TraceCurrentTurnState = "open" | TraceTurnOutcome;
 export type CodexTurnOutcome = TraceTurnOutcome;
 export type CodexCurrentTurnState = TraceCurrentTurnState;
+export type DshTurnOutcome = TraceTurnOutcome;
+export type DshCurrentTurnState = TraceCurrentTurnState;
 export type TraceTurnActivity = CodexTurnActivity | ClaudeTurnActivity;
-export type TraceTurnTokenUsage = CodexTurnTokenUsage | ClaudeTurnTokenUsage;
+export type DshTurnTokenUsage = Readonly<{
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens?: number;
+  cacheWriteTokens?: number;
+  reasoningTokens?: number;
+}>;
+export type TraceTurnTokenUsage = CodexTurnTokenUsage | ClaudeTurnTokenUsage | DshTurnTokenUsage;
 
 export type TraceEventInput = Readonly<{
   eventId?: string;
@@ -54,6 +63,7 @@ export type TraceEventInput = Readonly<{
 
 export type CodexTraceEventInput = TraceEventInput;
 export type ClaudeTraceEventInput = TraceEventInput;
+export type DshTraceEventInput = TraceEventInput;
 export type TraceEventWriteResult =
   | { written: true; path: string }
   | { written: false; reason: string };
@@ -70,6 +80,7 @@ export type TraceCurrentTurnOptions = Readonly<{
 
 export type CodexCurrentTurnOptions = Omit<TraceCurrentTurnOptions, "client">;
 export type ClaudeCurrentTurnOptions = Omit<TraceCurrentTurnOptions, "client">;
+export type DshCurrentTurnOptions = Omit<TraceCurrentTurnOptions, "client">;
 export type TraceCurrentTurnReadOptions = TraceCurrentTurnOptions & Readonly<{
   client: TraceClient;
 }>;
@@ -84,6 +95,7 @@ export type TraceRetentionOptions = Readonly<{
 
 export type CodexTraceRetentionOptions = Omit<TraceRetentionOptions, "client">;
 export type ClaudeTraceRetentionOptions = Omit<TraceRetentionOptions, "client">;
+export type DshTraceRetentionOptions = Omit<TraceRetentionOptions, "client">;
 
 type ExistingTraceJson = Record<string, unknown> & {
   created_at?: unknown;
@@ -160,6 +172,12 @@ export async function recordClaudeTraceEvent(
   return recordTraceEventForClient("claude", input);
 }
 
+export async function recordDshTraceEvent(
+  input: DshTraceEventInput,
+): Promise<TraceEventWriteResult> {
+  return recordTraceEventForClient("dsh", input);
+}
+
 export function traceTurnEventId(
   traceContext: TraceContext | undefined,
   type: "turn_start" | "turn_end" | "turn_materialized",
@@ -223,6 +241,13 @@ export async function writeCurrentClaudeTurn(
   return writeCurrentTraceTurn(traceContext, { ...options, client: "claude" });
 }
 
+export async function writeCurrentDshTurn(
+  traceContext: TraceContext | undefined,
+  options: DshCurrentTurnOptions = {},
+): Promise<{ written: true } | { written: false; reason: string }> {
+  return writeCurrentTraceTurn(traceContext, { ...options, client: "dsh" });
+}
+
 export async function readCurrentTraceTurn(
   options: TraceCurrentTurnReadOptions,
 ): Promise<
@@ -251,6 +276,15 @@ export async function readCurrentClaudeTurn(
   | { ok: false; reason: "disabled" | "missing" | "invalid" | "stale" | "session_mismatch" }
 > {
   return readCurrentTraceTurn({ ...options, client: "claude" });
+}
+
+export async function readCurrentDshTurn(
+  options: DshCurrentTurnOptions = {},
+): Promise<
+  | { ok: true; traceContext: TraceContext }
+  | { ok: false; reason: "disabled" | "missing" | "invalid" | "stale" | "session_mismatch" }
+> {
+  return readCurrentTraceTurn({ ...options, client: "dsh" });
 }
 
 export async function readOpenTraceTurn(
@@ -286,6 +320,16 @@ export async function readOpenClaudeTurn(
   | { ok: false; reason: "closed"; outcome: TraceTurnOutcome }
 > {
   return readOpenTraceTurn({ ...options, client: "claude" });
+}
+
+export async function readOpenDshTurn(
+  options: DshCurrentTurnOptions = {},
+): Promise<
+  | { ok: true; traceContext: TraceContext }
+  | { ok: false; reason: "disabled" | "missing" | "invalid" | "stale" | "session_mismatch" }
+  | { ok: false; reason: "closed"; outcome: DshTurnOutcome }
+> {
+  return readOpenTraceTurn({ ...options, client: "dsh" });
 }
 
 export async function markCurrentTraceTurnOutcome(
@@ -330,6 +374,14 @@ export async function markCurrentClaudeTurnOutcome(
   options: ClaudeCurrentTurnOptions = {},
 ): Promise<{ updated: true } | { updated: false; reason: string }> {
   return markCurrentTraceTurnOutcome(traceContext, outcome, { ...options, client: "claude" });
+}
+
+export async function markCurrentDshTurnOutcome(
+  traceContext: TraceContext | undefined,
+  outcome: DshTurnOutcome,
+  options: DshCurrentTurnOptions = {},
+): Promise<{ updated: true } | { updated: false; reason: string }> {
+  return markCurrentTraceTurnOutcome(traceContext, outcome, { ...options, client: "dsh" });
 }
 
 async function readCurrentTraceTurnRecord(
@@ -488,6 +540,12 @@ export async function pruneExpiredClaudeTraceSessions(
   options: ClaudeTraceRetentionOptions = {},
 ): Promise<void> {
   return pruneExpiredTraceSessionsForClient({ ...options, client: "claude" });
+}
+
+export async function pruneExpiredDshTraceSessions(
+  options: DshTraceRetentionOptions = {},
+): Promise<void> {
+  return pruneExpiredTraceSessionsForClient({ ...options, client: "dsh" });
 }
 
 function buildTraceEvent(

--- a/packages/ts/memorax-code-backend/src/trace/store.ts
+++ b/packages/ts/memorax-code-backend/src/trace/store.ts
@@ -306,12 +306,15 @@ export async function readOpenTraceTurn(
 ): Promise<
   | { ok: true; traceContext: TraceContext; promptAttestation?: TracePromptAttestation }
   | { ok: false; reason: "disabled" | "missing" | "invalid" | "stale" | "session_mismatch" }
-  | { ok: false; reason: "closed"; outcome: TraceTurnOutcome }
+  | { ok: false; reason: "closed"; outcome: TraceTurnOutcome; traceContext: TraceContext }
 > {
   const current = await readCurrentTraceTurnRecord(options);
   if (!current.ok) return current;
   if (current.turnState !== "open") {
-    return { ok: false, reason: "closed", outcome: current.turnState };
+    // The traceContext travels with the closed record so callers can decide
+    // WHICH turn was finalized (the DSH turn-start replay gate compares the
+    // turnId before refusing to restart a completed turn).
+    return { ok: false, reason: "closed", outcome: current.turnState, traceContext: current.traceContext };
   }
   return {
     ok: true,
@@ -325,7 +328,7 @@ export async function readOpenCodexTurn(
 ): Promise<
   | { ok: true; traceContext: TraceContext; promptAttestation?: TracePromptAttestation }
   | { ok: false; reason: "disabled" | "missing" | "invalid" | "stale" | "session_mismatch" }
-  | { ok: false; reason: "closed"; outcome: CodexTurnOutcome }
+  | { ok: false; reason: "closed"; outcome: CodexTurnOutcome; traceContext: TraceContext }
 > {
   return readOpenTraceTurn({ ...options, client: "codex" });
 }
@@ -335,7 +338,7 @@ export async function readOpenClaudeTurn(
 ): Promise<
   | { ok: true; traceContext: TraceContext; promptAttestation?: TracePromptAttestation }
   | { ok: false; reason: "disabled" | "missing" | "invalid" | "stale" | "session_mismatch" }
-  | { ok: false; reason: "closed"; outcome: TraceTurnOutcome }
+  | { ok: false; reason: "closed"; outcome: TraceTurnOutcome; traceContext: TraceContext }
 > {
   return readOpenTraceTurn({ ...options, client: "claude" });
 }
@@ -345,7 +348,7 @@ export async function readOpenDshTurn(
 ): Promise<
   | { ok: true; traceContext: TraceContext; promptAttestation?: TracePromptAttestation }
   | { ok: false; reason: "disabled" | "missing" | "invalid" | "stale" | "session_mismatch" }
-  | { ok: false; reason: "closed"; outcome: DshTurnOutcome }
+  | { ok: false; reason: "closed"; outcome: DshTurnOutcome; traceContext: TraceContext }
 > {
   return readOpenTraceTurn({ ...options, client: "dsh" });
 }

--- a/packages/ts/memorax-code-backend/src/transport/http/health.ts
+++ b/packages/ts/memorax-code-backend/src/transport/http/health.ts
@@ -1,9 +1,15 @@
-import type { ServerResponse } from "node:http";
+import type { IncomingMessage, ServerResponse } from "node:http";
 import type { BackendState } from "../../app/state.js";
 import { json } from "./json.js";
+import { authorized } from "./request.js";
 
-export function handleHealthRequest(state: BackendState, res: ServerResponse): void {
-  return json(res, 200, {
+export function handleHealthRequest(
+  state: BackendState,
+  req: IncomingMessage,
+  res: ServerResponse,
+  url: URL,
+): void {
+  const response = {
     ok: true,
     service: "memorax-code-backend",
     instanceId: process.env.MEMORAX_CODE_BACKEND_INSTANCE_ID,
@@ -12,8 +18,8 @@ export function handleHealthRequest(state: BackendState, res: ServerResponse): v
       mode: state.security.mode,
       allowExternalAccess: state.security.allowExternalAccess,
     },
-    state: {
-      sessionHome: state.sessionHome,
-    },
-  });
+  };
+  return json(res, 200, authorized(state, req, url)
+    ? { ...response, state: { sessionHome: state.sessionHome } }
+    : response);
 }

--- a/packages/ts/memorax-code-backend/src/transport/http/memory-hook.ts
+++ b/packages/ts/memorax-code-backend/src/transport/http/memory-hook.ts
@@ -1,6 +1,7 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { MemoryReminderTraceRecorder } from "../../memory/reminder-trace-recorder.js";
 import {
+  parseTurnDiscardCommand,
   parseTurnStartCommand,
   parseWritebackCommand,
 } from "../../memory/hook-command.js";
@@ -24,6 +25,7 @@ export async function handleMemoryHookRequest(
     url.pathname !== "/memory/turn-start"
     && url.pathname !== "/memory/skill-reminder"
     && url.pathname !== "/memory/writeback"
+    && url.pathname !== "/memory/turn-discard"
   ) return false;
   const body = await readJson(req);
   if (url.pathname === "/memory/skill-reminder") {
@@ -37,6 +39,15 @@ export async function handleMemoryHookRequest(
       return true;
     }
     json(res, 200, await dependencies.memoryService.recordTurnStart(parsed.command));
+    return true;
+  }
+  if (url.pathname === "/memory/turn-discard") {
+    const parsed = parseTurnDiscardCommand(body);
+    if (!parsed.ok) {
+      json(res, 400, { ok: false, error: parsed.error });
+      return true;
+    }
+    json(res, 200, await dependencies.memoryService.discardTurn(parsed.command));
     return true;
   }
   const parsed = parseWritebackCommand(body);

--- a/packages/ts/memorax-code-backend/src/transport/http/memory-hook.ts
+++ b/packages/ts/memorax-code-backend/src/transport/http/memory-hook.ts
@@ -9,6 +9,23 @@ import type { MemoryService } from "../../memory/service.js";
 import { readJson } from "./request.js";
 import { json } from "./json.js";
 
+function headerValue(value: string | string[] | undefined): string | undefined {
+  if (Array.isArray(value)) return value[0];
+  return value;
+}
+
+// The DSH adapter dispatches to these exact paths (MEMORY_HOOK_PATHS in
+// memorax-code-dsh-adapter/src/session-bridge.mjs). The cross-package
+// contract test (test/memory/dsh-adapter-contract.test.mjs) fails when
+// either side drifts, because a path mismatch would surface only as silent
+// 404s swallowed by the fail-silent plugin.
+export const MEMORY_HOOK_PATHS = {
+  turnStart: "/memory/turn-start",
+  skillReminder: "/memory/skill-reminder",
+  writeback: "/memory/writeback",
+  turnDiscard: "/memory/turn-discard",
+} as const;
+
 export type MemoryHookRequestDependencies = {
   memoryService: MemoryService;
   memoryReminderTraceRecorder: MemoryReminderTraceRecorder;
@@ -22,17 +39,34 @@ export async function handleMemoryHookRequest(
 ): Promise<boolean> {
   if (req.method !== "POST") return false;
   if (
-    url.pathname !== "/memory/turn-start"
-    && url.pathname !== "/memory/skill-reminder"
-    && url.pathname !== "/memory/writeback"
-    && url.pathname !== "/memory/turn-discard"
+    url.pathname !== MEMORY_HOOK_PATHS.turnStart
+    && url.pathname !== MEMORY_HOOK_PATHS.skillReminder
+    && url.pathname !== MEMORY_HOOK_PATHS.writeback
+    && url.pathname !== MEMORY_HOOK_PATHS.turnDiscard
   ) return false;
+  // Hook commands come from local client processes over node fetch/http, which
+  // never attach an Origin header. Browsers attach Origin to every cross-site
+  // (and same-site) POST, so any Origin here means a web page is trying to
+  // drive the local Hook surface (for example to poison cloud memory through
+  // the victim's turn-start/writeback). Refuse it outright.
+  if (req.headers.origin !== undefined) {
+    json(res, 403, { ok: false, error: "cross-origin hook requests are not accepted" });
+    return true;
+  }
+  // Require an explicit JSON content type. Browsers can send cross-site forms
+  // and text/plain bodies that would otherwise be parsed here as JSON.
+  const contentType = headerValue(req.headers["content-type"]);
+  const mediaType = contentType?.split(";")[0]?.trim().toLowerCase();
+  if (mediaType !== "application/json") {
+    json(res, 415, { ok: false, error: "content-type must be application/json" });
+    return true;
+  }
   const body = await readJson(req);
-  if (url.pathname === "/memory/skill-reminder") {
+  if (url.pathname === MEMORY_HOOK_PATHS.skillReminder) {
     json(res, 200, await dependencies.memoryReminderTraceRecorder.recordSkillReminder(body));
     return true;
   }
-  if (url.pathname === "/memory/turn-start") {
+  if (url.pathname === MEMORY_HOOK_PATHS.turnStart) {
     const parsed = parseTurnStartCommand(body);
     if (!parsed.ok) {
       json(res, 400, { ok: false, error: parsed.error });
@@ -41,7 +75,7 @@ export async function handleMemoryHookRequest(
     json(res, 200, await dependencies.memoryService.recordTurnStart(parsed.command));
     return true;
   }
-  if (url.pathname === "/memory/turn-discard") {
+  if (url.pathname === MEMORY_HOOK_PATHS.turnDiscard) {
     const parsed = parseTurnDiscardCommand(body);
     if (!parsed.ok) {
       json(res, 400, { ok: false, error: parsed.error });

--- a/packages/ts/memorax-code-backend/src/viewer/store.ts
+++ b/packages/ts/memorax-code-backend/src/viewer/store.ts
@@ -103,9 +103,7 @@ const events: MemoryViewerEvent[] = [];
 let liveEventsVersion = 0;
 
 type CombinedTraceHistory = Readonly<{
-  codex: readonly MemoryViewerEvent[];
-  claude: readonly MemoryViewerEvent[];
-  claudeLocal: readonly MemoryViewerEvent[];
+  inputs: readonly (readonly MemoryViewerEvent[])[];
   values: MemoryViewerEvent[];
 }>;
 
@@ -480,48 +478,55 @@ async function readTraceHistory(
     return {
       values: combinedTraceHistory(
         `${historyCacheRoot}\u0000client=claude\u0000source=${claudeProjectsRoot || "disabled"}`,
-        EMPTY_MEMORY_VIEWER_HISTORY,
-        claude.values,
-        claudeLocal,
+        [claude.values],
+        [claudeLocal],
       ),
       complete: claude.complete,
       claudeLocal,
     };
   }
 
-  const [codex, claude, claudeLocal] = await Promise.all([
+  if (client === "dsh") {
+    // DSH sessions live in their own trace root; without this branch the
+    // filter fell through to the codex+claude sweep below and the viewer
+    // showed DSH live events but never their on-disk history.
+    const dsh = await readClient("dsh");
+    return { ...dsh, claudeLocal: EMPTY_MEMORY_VIEWER_HISTORY };
+  }
+
+  const [codex, claude, dsh, claudeLocal] = await Promise.all([
     readClient("codex"),
     readClient("claude"),
+    readClient("dsh"),
     claudeLocalPromise,
   ]);
   return {
     values: combinedTraceHistory(
       `${historyCacheRoot}\u0000client=all\u0000source=${claudeProjectsRoot || "disabled"}`,
-      codex.values,
-      claude.values,
-      claudeLocal,
+      [codex.values, claude.values, dsh.values],
+      [claudeLocal],
     ),
-    complete: codex.complete && claude.complete,
+    complete: codex.complete && claude.complete && dsh.complete,
     claudeLocal,
   };
 }
 
 function combinedTraceHistory(
   cacheKey: string,
-  codex: readonly MemoryViewerEvent[],
-  claude: readonly MemoryViewerEvent[],
-  claudeLocal: readonly MemoryViewerEvent[],
+  merged: readonly (readonly MemoryViewerEvent[])[],
+  invalidateOnly: readonly (readonly MemoryViewerEvent[])[] = [],
 ): MemoryViewerEvent[] {
+  const inputs = [...merged, ...invalidateOnly];
   const cached = combinedTraceHistories.get(cacheKey);
-  if (cached?.codex === codex
-    && cached.claude === claude
-    && cached.claudeLocal === claudeLocal) {
+  if (cached?.inputs.length === inputs.length
+    && inputs.every((group, index) => cached.inputs[index] === group)) {
     return cached.values;
   }
   // Native Claude transcripts invalidate this cached identity, but they are
-  // admitted only after retained and live Hook trace events are merged.
-  const values = [...codex, ...claude].sort(compareMemoryViewerEvents);
-  combinedTraceHistories.set(cacheKey, { codex, claude, claudeLocal, values });
+  // admitted only after retained and live Hook trace events are merged, so
+  // they participate in the identity check without being merged into values.
+  const values = merged.flat().sort(compareMemoryViewerEvents);
+  combinedTraceHistories.set(cacheKey, { inputs, values });
   return values;
 }
 
@@ -1226,6 +1231,10 @@ function persistedMemoryViewerEventId(client: TraceClient, eventId: string): str
 
 function memoryViewerProjectionKey(memoraxCodeHome: string, client: TraceClient | undefined): string {
   if (client === "claude") return clientTracePaths("claude", memoraxCodeHome).sessionsRoot;
+  // Each client has its own trace root and its own projection cache entry;
+  // letting DSH fall through to the codex key made the DSH history projection
+  // read (and be invalidated by) the codex sessions directory.
+  if (client === "dsh") return clientTracePaths("dsh", memoraxCodeHome).sessionsRoot;
   const codexSessionsRoot = tracePaths(memoraxCodeHome).sessionsRoot;
   return client === "codex" ? `${codexSessionsRoot}\u0000client=codex` : codexSessionsRoot;
 }

--- a/packages/ts/memorax-code-backend/src/viewer/store.ts
+++ b/packages/ts/memorax-code-backend/src/viewer/store.ts
@@ -1205,19 +1205,23 @@ function sessionId(value: unknown): string {
 function memoryViewerClient(input: MemoryObservabilityEvent): TraceClient {
   if (input.traceContext?.client === "claude") return "claude";
   if (input.traceContext?.client === "codex") return "codex";
+  if (input.traceContext?.client === "dsh") return "dsh";
   if (input.source === "claude_hook_retrieval" || input.source === "claude_hook_writeback") return "claude";
+  if (input.source === "dsh_hook_retrieval" || input.source === "dsh_hook_writeback") return "dsh";
   return "codex";
 }
 
 function memoryViewerEventId(client: TraceClient, eventId: string | undefined): string {
   if (eventId) return persistedMemoryViewerEventId(client, eventId);
-  return client === "codex"
-    ? `memory-viewer:${randomUUID()}`
-    : `claude-memory-viewer:${randomUUID()}`;
+  if (client === "codex") return `memory-viewer:${randomUUID()}`;
+  if (client === "claude") return `claude-memory-viewer:${randomUUID()}`;
+  return `dsh-memory-viewer:${randomUUID()}`;
 }
 
 function persistedMemoryViewerEventId(client: TraceClient, eventId: string): string {
-  return client === "codex" ? `trace:${eventId}` : `claude-trace:${eventId}`;
+  if (client === "codex") return `trace:${eventId}`;
+  if (client === "claude") return `claude-trace:${eventId}`;
+  return `dsh-trace:${eventId}`;
 }
 
 function memoryViewerProjectionKey(memoraxCodeHome: string, client: TraceClient | undefined): string {

--- a/packages/ts/memorax-code-backend/test/app/backend-config.test.mjs
+++ b/packages/ts/memorax-code-backend/test/app/backend-config.test.mjs
@@ -70,6 +70,37 @@ test("Backend health reports current lifecycle and security state", async () => 
   }
 });
 
+test("Backend health hides sessionHome from unauthenticated clients when auth is required", async () => {
+  const sessionHome = await mkdtemp(join(tmpdir(), "memorax-code-health-auth-"));
+  const server = createBackendServer(createBackendState("127.0.0.1", {
+    sessionHome,
+    authToken: "secret-token",
+    security: {
+      mode: "local",
+      allowExternalAccess: false,
+    },
+  }));
+  const backendUrl = await listen(server);
+  try {
+    const anonymous = await fetch(new URL("/health", backendUrl));
+    assert.equal(anonymous.status, 200);
+    const anonymousBody = await anonymous.json();
+    assert.equal(anonymousBody.ok, true);
+    assert.equal(anonymousBody.authRequired, true);
+    assert.equal(anonymousBody.state, undefined);
+
+    const authenticated = await fetch(new URL("/health", backendUrl), {
+      headers: { authorization: "Bearer secret-token" },
+    });
+    assert.equal(authenticated.status, 200);
+    const authenticatedBody = await authenticated.json();
+    assert.deepEqual(authenticatedBody.state, { sessionHome });
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+    await rm(sessionHome, { recursive: true, force: true });
+  }
+});
+
 test("Backend lifecycle starts writeback reconciliation and persists terminal status", { concurrency: false }, async () => {
   const sessionHome = await mkdtemp(join(tmpdir(), "memorax-code-backend-writeback-reconciler-"));
   const sessionDir = join(sessionHome, "debug", "traces", "codex", "sessions", "session-lifecycle");

--- a/packages/ts/memorax-code-backend/test/architecture/source-boundaries.test.mjs
+++ b/packages/ts/memorax-code-backend/test/architecture/source-boundaries.test.mjs
@@ -40,6 +40,7 @@ const rules = [
       "clients/claude/memory-hook-runtime.ts",
       "clients/claude/transcript-turn.ts",
       "clients/codex/memory-hook-runtime.ts",
+      "clients/dsh/memory-hook-runtime.ts",
       "memory/turn-coordinator.ts",
       "memory/service.ts",
       "memory/writeback-buffer.ts",
@@ -59,6 +60,7 @@ const rules = [
       "memory/automatic-writeback.ts",
       "clients/claude/memory-hook-runtime.ts",
       "clients/codex/memory-hook-runtime.ts",
+      "clients/dsh/memory-hook-runtime.ts",
       "provider/memorax/adapter.ts",
       "memory/turn-coordinator.ts",
       "memory/service.ts",
@@ -77,7 +79,7 @@ const rules = [
   },
   {
     name: "Hook memory runtimes use normalized automatic writeback",
-    importers: ["clients/claude/memory-hook-runtime.ts", "clients/codex/memory-hook-runtime.ts", "memory/turn-coordinator.ts"],
+    importers: ["clients/claude/memory-hook-runtime.ts", "clients/codex/memory-hook-runtime.ts", "clients/dsh/memory-hook-runtime.ts", "memory/turn-coordinator.ts"],
     forbidden: ["memory/writeback"],
   },
   {
@@ -88,6 +90,11 @@ const rules = [
   {
     name: "Claude memory hook runtime stays independent from HTTP and Backend composition",
     importers: ["clients/claude/memory-hook-runtime.ts", "clients/claude/transcript-turn.ts"],
+    forbidden: ["node:http", "server-", "entrypoints/", "transport/http/", "app/state"],
+  },
+  {
+    name: "DSH memory hook runtime stays independent from HTTP and Backend composition",
+    importers: ["clients/dsh/memory-hook-runtime.ts"],
     forbidden: ["node:http", "server-", "entrypoints/", "transport/http/", "app/state"],
   },
   {

--- a/packages/ts/memorax-code-backend/test/clients/claude/claude-memory-hook-runtime.test.mjs
+++ b/packages/ts/memorax-code-backend/test/clients/claude/claude-memory-hook-runtime.test.mjs
@@ -377,15 +377,19 @@ test("Claude Hooks persist the same immediate trace lifecycle as Codex Hooks", a
     assert.equal(events[1].session_turn_index, 1);
     assert.deepEqual(events[1].activities, [{ index: 1, type: "memory_cli_search" }]);
     assert.deepEqual(events[1].usage, expectedCompletedUsage());
-    assert.deepEqual(await readOpenClaudeTurn({
+    const closedLifecycle = await readOpenClaudeTurn({
       memoraxCodeHome: fixture.root,
       expectedSessionId: SESSION_ID,
       allowStale: true,
-    }), {
-      ok: false,
-      reason: "closed",
-      outcome: "completed",
     });
+    assert.equal(closedLifecycle.ok, false);
+    assert.equal(closedLifecycle.reason, "closed");
+    assert.equal(closedLifecycle.outcome, "completed");
+    // Round 10: the closed record carries its traceContext so callers can
+    // tell WHICH turn was finalized (the DSH finalized-turn gate compares
+    // the turnId before refusing to restart a completed turn).
+    assert.equal(closedLifecycle.traceContext.sessionId, SESSION_ID);
+    assert.equal(closedLifecycle.traceContext.turnId, PROMPT_ID);
     assert.equal(writebacks[0].assistantText, "Trace transcript answer.");
     assert.equal(writebacks[0].traceContext.turnId, PROMPT_ID);
   } finally {
@@ -560,15 +564,16 @@ test("Claude Stop closes trace even when exact transcript validation blocks writ
     assert.equal(events[1].session_turn_index, undefined);
     assert.equal(events[1].activities, undefined);
     assert.equal(events[1].usage, undefined);
-    assert.deepEqual(await readOpenClaudeTurn({
+    const closedUnvalidated = await readOpenClaudeTurn({
       memoraxCodeHome: root,
       expectedSessionId: SESSION_ID,
       allowStale: true,
-    }), {
-      ok: false,
-      reason: "closed",
-      outcome: "completed",
     });
+    assert.equal(closedUnvalidated.ok, false);
+    assert.equal(closedUnvalidated.reason, "closed");
+    assert.equal(closedUnvalidated.outcome, "completed");
+    assert.equal(closedUnvalidated.traceContext.sessionId, SESSION_ID);
+    assert.equal(closedUnvalidated.traceContext.turnId, PROMPT_ID);
     assert.equal(writebacks.length, 0);
   } finally {
     runtime.close();

--- a/packages/ts/memorax-code-backend/test/lifecycle/backend/service-lifecycle.test.mjs
+++ b/packages/ts/memorax-code-backend/test/lifecycle/backend/service-lifecycle.test.mjs
@@ -711,6 +711,48 @@ test("current Backend health instance mismatch fails closed despite a matching p
   }
 });
 
+test("stop recovers when the auth token is unavailable and health omits sessionHome", async () => {
+  const home = await mkdtemp(join(tmpdir(), "memorax-code-backend-stop-token-unavailable-"));
+  const runtime = join(home, "runtime", "backend");
+  let alive = true;
+  let terminated = false;
+  try {
+    await mkdir(runtime, { recursive: true });
+    await writeFile(join(runtime, "backend.pid.json"), JSON.stringify({
+      version: 1,
+      pid: process.pid,
+      instanceId: "verified-instance",
+      host: "127.0.0.1",
+      port: 18789,
+      url: "http://127.0.0.1:18789",
+      logPath: join(runtime, "backend.log"),
+      startedAt: "2026-07-15T00:00:00.000Z",
+    }));
+    const result = await stopBackendService({ home, timeoutMs: 50 }, {
+      fetch: async () => new Response(JSON.stringify({
+        ok: true,
+        service: "memorax-code-backend",
+        instanceId: "verified-instance",
+        authRequired: true,
+      }), { status: 200 }),
+      isProcessAlive: () => alive,
+      probeProcessCommandLine: () => successfulProcessProbe(
+        `${process.execPath} /tmp/memorax-code-backend/dist/service-entrypoint.js --memorax-code-backend-instance verified-instance`,
+      ),
+      terminateProcessTree: () => {
+        terminated = true;
+        alive = false;
+        return true;
+      },
+    });
+    assert.equal(result.ok, true, result.error);
+    assert.equal(terminated, true);
+    assert.equal(readBackendServiceState({ home }), undefined);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
 test("stop retains verified Backend state when termination fails or the PID remains alive", async (t) => {
   for (const [name, terminateProcessTree] of [
     ["termination failure", () => false],

--- a/packages/ts/memorax-code-backend/test/memory/dsh-adapter-contract.test.mjs
+++ b/packages/ts/memorax-code-backend/test/memory/dsh-adapter-contract.test.mjs
@@ -1,0 +1,149 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+// Cross-package contract test: the DSH adapter is a standalone cordis plugin
+// (plain .mjs, no dependency on the Backend's TypeScript packages), so every
+// field it exchanges with the Backend is defined twice — once here, once
+// there. This test imports BOTH sides and fails the build when they drift.
+// Without it, a rename on one side surfaces only as silent 404s, 400s, or
+// prompt_mismatch skips swallowed by the fail-silent plugin.
+import { MEMORY_HOOK_COMMAND_VERSION as ADAPTER_COMMAND_VERSION } from "../../../memorax-code-dsh-adapter/src/config.mjs";
+import {
+  MEMORY_HOOK_PATHS as ADAPTER_PATHS,
+  MESSAGE_JOIN_DELIMITER,
+  buildTurnDiscardCommand,
+  buildTurnStartCommand,
+  buildWritebackCommand,
+} from "../../../memorax-code-dsh-adapter/src/session-bridge.mjs";
+import {
+  MEMORY_HOOK_COMMAND_VERSION as BACKEND_COMMAND_VERSION,
+  parseTurnDiscardCommand,
+  parseTurnStartCommand,
+  parseWritebackCommand,
+} from "../../dist/memory/hook-command.js";
+import { MEMORY_HOOK_PATHS as BACKEND_PATHS } from "../../dist/transport/http/memory-hook.js";
+import { PROMPT_DELIMITER } from "../../dist/clients/dsh/memory-hook-runtime.js";
+
+function adapterState() {
+  return {
+    sessionId: "contract-session",
+    cwd: "/repo",
+    firstLiveSeq: 7,
+    turn: 3,
+    sessionGeneration: 1,
+  };
+}
+
+test("adapter turn-start commands parse as Backend DSH turn-start commands", () => {
+  const command = buildTurnStartCommand({ ...adapterState(), userText: "hello" });
+  assert.ok(command, "adapter must build a turn-start command");
+  const parsed = parseTurnStartCommand(command);
+  assert.equal(parsed.ok, true);
+  assert.deepEqual(parsed.ok ? parsed.command : undefined, command);
+});
+
+test("adapter writeback commands parse as Backend DSH writeback commands", () => {
+  const command = buildWritebackCommand(adapterState(), 3, "hello", "world");
+  assert.ok(command, "adapter must build a writeback command");
+  const parsed = parseWritebackCommand(command);
+  assert.equal(parsed.ok, true);
+  assert.deepEqual(parsed.ok ? parsed.command : undefined, command);
+});
+
+test("adapter discard commands parse as Backend DSH discard commands", () => {
+  const command = buildTurnDiscardCommand(adapterState(), 3);
+  assert.ok(command, "adapter must build a discard command");
+  const parsed = parseTurnDiscardCommand(command);
+  assert.equal(parsed.ok, true);
+  assert.deepEqual(parsed.ok ? parsed.command : undefined, command);
+});
+
+test("multi-message turns join with the delimiter the Backend matches against", () => {
+  // The adapter joins a turn's messages with MESSAGE_JOIN_DELIMITER and the
+  // Backend accepts a writeback whose userText is the started prompt plus
+  // further messages: userText.startsWith(prompt + PROMPT_DELIMITER). A
+  // delimiter mismatch would make every multi-message writeback fail
+  // prompt_mismatch.
+  assert.equal(MESSAGE_JOIN_DELIMITER, PROMPT_DELIMITER);
+  const startedPrompt = "first";
+  const userText = ["first", "second", "third"].join(MESSAGE_JOIN_DELIMITER);
+  assert.equal(userText.startsWith(startedPrompt + PROMPT_DELIMITER), true);
+});
+
+test("adapter hook paths route on the Backend transport", () => {
+  assert.equal(ADAPTER_PATHS.turnStart, BACKEND_PATHS.turnStart);
+  assert.equal(ADAPTER_PATHS.writeback, BACKEND_PATHS.writeback);
+  assert.equal(ADAPTER_PATHS.turnDiscard, BACKEND_PATHS.turnDiscard);
+});
+
+test("adapter and Backend agree on the memory hook command version", () => {
+  assert.equal(ADAPTER_COMMAND_VERSION, BACKEND_COMMAND_VERSION);
+});
+
+test("adapter authority record matches the adapter-common authority record shape", async () => {
+  // The DSH adapter cannot import adapter-common (standalone plugin), so it
+  // mirrors the authority record validation. Pin the mirrored rules against
+  // the canonical implementation: the same records must be accepted and
+  // rejected by both readers, and the mirrored defaults must agree.
+  const { mkdtempSync, mkdirSync, rmSync, writeFileSync } = await import("node:fs");
+  const { tmpdir } = await import("node:os");
+  const { join } = await import("node:path");
+  const adapterCommon = await import("../../../memorax-code-adapter-common/src/backend-connection.mjs");
+  const dshConfig = await import("../../../memorax-code-dsh-adapter/src/config.mjs");
+
+  assert.equal(dshConfig.DEFAULT_BACKEND_URL, adapterCommon.DEFAULT_BACKEND_URL);
+
+  const home = mkdtempSync(join(tmpdir(), "memorax-contract-"));
+  try {
+    const dir = join(home, "runtime", "backend");
+    mkdirSync(dir, { recursive: true });
+    const connectionPath = join(dir, "backend-connection.json");
+    const tokenPath = join(dir, "backend-token.json");
+    const valid = { version: 1, url: "http://127.0.0.1:9001", tokenPath };
+    const invalid = [
+      { version: 2, url: "http://127.0.0.1:9001" },
+      { version: 1, url: "http://127.0.0.1:9001", extra: true },
+      { version: 1, url: "ftp://127.0.0.1:9001" },
+      { version: 1, url: "http://127.0.0.1:9001/path" },
+      { version: 1, url: "http://127.0.0.1:9001", tokenPath: "/elsewhere/token.json" },
+    ];
+
+    writeFileSync(connectionPath, JSON.stringify(valid), "utf8");
+    writeFileSync(tokenPath, JSON.stringify({
+      version: 1,
+      token: "managed-token",
+      createdAt: "2026-01-01T00:00:00.000Z",
+    }), "utf8");
+    const canonical = adapterCommon.readBackendConnectionAuthority(home);
+    assert.equal(canonical.status, "valid");
+    const mirrored = mirrorResolve(dshConfig, home);
+    assert.equal(mirrored.connection.backendUrl, "http://127.0.0.1:9001");
+    assert.equal(mirrored.connection.urlSource, "authority");
+    assert.equal(mirrored.connection.token, "managed-token");
+    assert.equal(mirrored.connection.tokenSource, "authority-file");
+    assert.deepEqual(mirrored.issues, []);
+
+    for (const record of invalid) {
+      writeFileSync(connectionPath, JSON.stringify(record), "utf8");
+      const canonicalState = adapterCommon.readBackendConnectionAuthority(home);
+      assert.notEqual(canonicalState.status, "valid", `canonical must reject ${JSON.stringify(record)}`);
+      const mirroredState = mirrorResolve(dshConfig, home);
+      assert.notEqual(mirroredState.connection.urlSource, "authority", `mirror must reject ${JSON.stringify(record)}`);
+      assert.equal(mirroredState.issues.length, 1, `mirror must warn for ${JSON.stringify(record)}`);
+    }
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+
+  function mirrorResolve(configModule, memoraxCodeHome) {
+    // The mirror exposes its reader only through resolveBackendConnection;
+    // drive it with a clean environment so the authority record decides.
+    const issues = [];
+    const connection = configModule.resolveBackendConnection(
+      {},
+      { MEMORAX_CODE_HOME: memoraxCodeHome },
+      { onAuthorityIssue: (reason) => issues.push(reason) },
+    );
+    return { connection, issues };
+  }
+});

--- a/packages/ts/memorax-code-backend/test/memory/dsh-adapter-contract.test.mjs
+++ b/packages/ts/memorax-code-backend/test/memory/dsh-adapter-contract.test.mjs
@@ -147,3 +147,69 @@ test("adapter authority record matches the adapter-common authority record shape
     return { connection, issues };
   }
 });
+
+test("Backend result envelopes carry the exact fields the adapter consumes", async (t) => {
+  // The adapter reads additionalContext (session-bridge), scheduled/reason
+  // (writeback skip), and discarded (turn-discard) straight off Backend
+  // response bodies. Both sides define those names independently, and a
+  // rename would fail silently — this test runs the real Backend runtime and
+  // pins the response keys against the adapter's consumption.
+  const { createDshMemoryHookRuntime } = await import("../../dist/clients/dsh/memory-hook-runtime.js");
+  const { mkdtempSync, rmSync, readFileSync } = await import("node:fs");
+  const { tmpdir } = await import("node:os");
+  const { join } = await import("node:path");
+
+  const home = mkdtempSync(join(tmpdir(), "dsh-contract-envelope-"));
+  t.after(() => rmSync(home, { recursive: true, force: true }));
+  const runtime = createDshMemoryHookRuntime({
+    memoraxCodeHome: home,
+    env: {
+      MEMORAX_CODE_HOME: home,
+      MEMORAX_CODE_DSH_TRACE_ENABLED: "false",
+      MEMORAX_CODE_MEMORY_RETRIEVAL_ENABLED: "false",
+      MEMORAX_CODE_MEMORY_WRITEBACK_ENABLED: "false",
+    },
+  });
+  t.after(() => runtime.close());
+
+  const turnStart = await runtime.recordTurnStart({
+    version: BACKEND_COMMAND_VERSION, client: "dsh",
+    sessionId: "contract-envelope", turnId: "dsh-0-0", prompt: "hello", cwd: "/repo",
+  });
+  assert.equal(turnStart.ok, true);
+  assert.ok(!("additionalContext" in turnStart) || typeof turnStart.additionalContext === "string",
+    "turn-start responses expose additionalContext as a string when present");
+
+  const writeback = await runtime.writeback({
+    version: BACKEND_COMMAND_VERSION, client: "dsh",
+    sessionId: "contract-envelope", turnId: "dsh-0-0",
+    userText: "hello", assistantText: "world", cwd: "/repo",
+  });
+  assert.equal(writeback.ok, true);
+  assert.equal(writeback.scheduled, false);
+  assert.equal(typeof writeback.reason, "string",
+    "skipped writebacks must carry the reason field the adapter debug-logs");
+
+  const discard = await runtime.discardTurn({
+    version: BACKEND_COMMAND_VERSION, client: "dsh",
+    sessionId: "contract-envelope", turnId: "dsh-0-0",
+  });
+  assert.equal(discard.ok, true);
+  assert.equal(typeof discard.discarded, "boolean",
+    "turn-discard responses must carry the discarded field the adapter debug-logs");
+});
+
+test("both sides hardcode the same Backend token header name", async () => {
+  const { readFile } = await import("node:fs/promises");
+  const TOKEN_HEADER = "x-memorax-code-backend-token";
+  const adapterSource = await readFile(
+    new URL("../../../memorax-code-dsh-adapter/src/backend-forwarder.mjs", import.meta.url), "utf8",
+  );
+  const backendSource = await readFile(
+    new URL("../../src/transport/http/request.ts", import.meta.url), "utf8",
+  );
+  assert.ok(adapterSource.includes(TOKEN_HEADER),
+    "the adapter must still send the token header the Backend expects");
+  assert.ok(backendSource.includes(TOKEN_HEADER),
+    "the Backend must still accept the token header the adapter sends");
+});

--- a/packages/ts/memorax-code-backend/test/memory/dsh-memory-hook-runtime.test.mjs
+++ b/packages/ts/memorax-code-backend/test/memory/dsh-memory-hook-runtime.test.mjs
@@ -56,7 +56,20 @@ test("DSH runtime releases an automatic retrieval turn when the turn is discarde
 
     assert.deepEqual(await runtime.discardTurn(DISCARD), { ok: true, discarded: true });
 
-    await runtime.recordTurnStart(TURN_START);
+    // Round 10 R10-1: a discarded turn is terminal. Replaying the SAME
+    // turnId is acked fail-silent but must NOT restart the turn, so it
+    // claims no retrieval. (The claim release itself is hygiene — its only
+    // behavioral consumer, a same-key re-claim, is the conflicting-turn-start
+    // self-heal covered by the test below.)
+    assert.deepEqual(await runtime.recordTurnStart(TURN_START), { ok: true });
+    assert.equal(retrievalCount(events), 1);
+    assert.equal(
+      events.some((event) => event.message === "dsh_memory_hook.turn_start_after_finalize"),
+      true,
+    );
+
+    // Successor turns keep claiming retrieval after the discard.
+    await runtime.recordTurnStart({ ...TURN_START, turnId: "dsh-0-1" });
     assert.equal(retrievalCount(events), 2);
   } finally {
     runtime.close();
@@ -288,7 +301,18 @@ test("DSH runtime releases an automatic retrieval turn after a scheduled writeba
       cwd: workspace,
     }), { ok: true, scheduled: true });
 
-    await runtime.recordTurnStart({ ...TURN_START, cwd: workspace });
+    // Round 10 R10-1: a completed turn is terminal. Replaying the SAME
+    // turnId after the writeback must NOT restart it (no second retrieval,
+    // no second writeback credential).
+    assert.deepEqual(await runtime.recordTurnStart({ ...TURN_START, cwd: workspace }), { ok: true });
+    assert.equal(retrievalCount(events), 1);
+    assert.equal(
+      events.some((event) => event.message === "dsh_memory_hook.turn_start_after_finalize"),
+      true,
+    );
+
+    // Successor turns keep claiming retrieval after the completed turn.
+    await runtime.recordTurnStart({ ...TURN_START, turnId: "dsh-0-1", cwd: workspace });
     assert.equal(retrievalCount(events), 2);
     assert.ok(requests.length >= 1);
   } finally {

--- a/packages/ts/memorax-code-backend/test/memory/dsh-memory-hook-runtime.test.mjs
+++ b/packages/ts/memorax-code-backend/test/memory/dsh-memory-hook-runtime.test.mjs
@@ -1,0 +1,141 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { createDshMemoryHookRuntime } from "../../dist/clients/dsh/memory-hook-runtime.js";
+import { memoraxConfigFromEnv } from "../../dist/provider/memorax/config.js";
+
+const TURN_START = {
+  version: 1,
+  client: "dsh",
+  sessionId: "session-dsh",
+  turnId: "dsh-0-0",
+  prompt: "first turn",
+};
+
+const DISCARD = {
+  version: 1,
+  client: "dsh",
+  sessionId: "session-dsh",
+  turnId: "dsh-0-0",
+};
+
+function notConfiguredRepositoryMemorySession() {
+  return {
+    async resolve() {
+      return { ok: false, reason: "config_missing", error: "no memorax config" };
+    },
+    close() {},
+  };
+}
+
+function retrievalCount(events) {
+  return events.filter((event) => event.message === "automatic.memory_retrieval").length;
+}
+
+test("DSH runtime releases an automatic retrieval turn when the turn is discarded", async () => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-code-dsh-retrieval-release-"));
+  const events = [];
+  const runtime = createDshMemoryHookRuntime({
+    diagnosticLogger(message, fields) {
+      events.push({ message, fields });
+    },
+    env: {
+      MEMORAX_CODE_HOME: root,
+      MEMORAX_CODE_DSH_TRACE_ENABLED: "false",
+      MEMORAX_CODE_MEMORY_RETRIEVAL_ENABLED: "false",
+    },
+    memoraxCodeHome: root,
+    repositoryMemorySession: notConfiguredRepositoryMemorySession(),
+    now: () => 1,
+  });
+  try {
+    await runtime.recordTurnStart(TURN_START);
+    assert.equal(retrievalCount(events), 1);
+
+    assert.deepEqual(await runtime.discardTurn(DISCARD), { ok: true, discarded: true });
+
+    await runtime.recordTurnStart(TURN_START);
+    assert.equal(retrievalCount(events), 2);
+  } finally {
+    runtime.close();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("DSH runtime releases an automatic retrieval turn after a scheduled writeback", async () => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-code-dsh-retrieval-writeback-"));
+  const workspace = join(root, "workspace");
+  await mkdir(join(workspace, ".git"), { recursive: true });
+  const env = {
+    MEMORAX_CODE_HOME: root,
+    MEMORAX_CODE_DSH_TRACE_ENABLED: "false",
+    MEMORAX_CODE_MEMORY_RETRIEVAL_ENABLED: "false",
+    MEMORAX_CODE_MEMORY_WRITEBACK_ENABLED: "true",
+    MEMORAX_CODE_MEMORY_WRITEBACK_BUFFER_ENABLED: "false",
+    MEMORAX_CODE_MEMORAX_ENDPOINT: "http://memorax.test",
+    MEMORAX_CODE_MEMORAX_API_KEY: "secret",
+    MEMORAX_CODE_MEMORAX_USER_ID: "user-1",
+  };
+  const config = memoraxConfigFromEnv(env);
+  assert.equal(config.ok, true);
+  const scope = {
+    schemaVersion: "workspace-memory-scope.v1",
+    baseUserId: config.config.userId,
+    effectiveUserId: `${config.config.userId}@test-repository`,
+    repositoryKey: "workspace-directory:test-repository",
+    repositorySlug: "test-repository",
+    repositoryName: "Test Repository",
+    identitySource: "workspace-directory",
+    scopeKind: "local-directory",
+    boundWorkspaceRoot: workspace,
+  };
+  const events = [];
+  const requests = [];
+  const runtime = createDshMemoryHookRuntime({
+    diagnosticLogger(message, fields) {
+      events.push({ message, fields });
+    },
+    env,
+    fetchImpl: async (url, init) => {
+      requests.push({ url: String(url), body: JSON.parse(init.body) });
+      return new Response(JSON.stringify({
+        success: true,
+        data: { task_id: "dsh-task", status: "queued" },
+      }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    },
+    memoraxCodeHome: root,
+    repositoryMemorySession: {
+      async resolve() {
+        return { ok: true, memory: { config: config.config, scope } };
+      },
+      close() {},
+    },
+    now: () => 1,
+  });
+  try {
+    await runtime.recordTurnStart({ ...TURN_START, cwd: workspace });
+    assert.equal(retrievalCount(events), 1);
+
+    assert.deepEqual(await runtime.writeback({
+      version: 1,
+      client: "dsh",
+      sessionId: "session-dsh",
+      turnId: "dsh-0-0",
+      userText: "first turn",
+      assistantText: "reply",
+      cwd: workspace,
+    }), { ok: true, scheduled: true });
+
+    await runtime.recordTurnStart({ ...TURN_START, cwd: workspace });
+    assert.equal(retrievalCount(events), 2);
+    assert.ok(requests.length >= 1);
+  } finally {
+    runtime.close();
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/packages/ts/memorax-code-backend/test/memory/dsh-memory-hook-runtime.test.mjs
+++ b/packages/ts/memorax-code-backend/test/memory/dsh-memory-hook-runtime.test.mjs
@@ -400,7 +400,7 @@ test("DSH runtime serializes concurrent turn-starts and rejects a conflicting pr
   }
 });
 
-test("DSH runtime requires a prompt delimiter for a longer writeback user text", async () => {
+test("DSH runtime requires the exact bridge delimiter for a longer writeback user text", async () => {
   const root = await mkdtemp(join(tmpdir(), "memorax-code-dsh-prompt-delimiter-"));
   const events = [];
   const runtime = createDshMemoryHookRuntime({
@@ -434,6 +434,12 @@ test("DSH runtime requires a prompt delimiter for a longer writeback user text",
     });
 
     assert.deepEqual(await runtime.writeback(writeback("Fix the build. now")), {
+      ok: true,
+      scheduled: false,
+      reason: "prompt_mismatch",
+    });
+
+    assert.deepEqual(await runtime.writeback(writeback("Fix the build.\n\nAlso run the tests.")), {
       ok: true,
       scheduled: false,
       reason: "config_missing",

--- a/packages/ts/memorax-code-backend/test/memory/dsh-memory-hook-runtime.test.mjs
+++ b/packages/ts/memorax-code-backend/test/memory/dsh-memory-hook-runtime.test.mjs
@@ -357,3 +357,89 @@ test("DSH runtime serializes a discard with a writeback for one turn", async () 
     await rm(root, { recursive: true, force: true });
   }
 });
+
+test("DSH runtime serializes concurrent turn-starts and rejects a conflicting prompt", async () => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-code-dsh-turn-start-serial-"));
+  const events = [];
+  let resolveCount = 0;
+  let releaseResolve;
+  const gate = new Promise((resolve) => { releaseResolve = resolve; });
+  const runtime = createDshMemoryHookRuntime({
+    diagnosticLogger(message, fields) {
+      events.push({ message, fields });
+    },
+    env: {
+      MEMORAX_CODE_HOME: root,
+      MEMORAX_CODE_DSH_TRACE_ENABLED: "false",
+      MEMORAX_CODE_MEMORY_RETRIEVAL_ENABLED: "false",
+    },
+    memoraxCodeHome: root,
+    repositoryMemorySession: {
+      async resolve() {
+        resolveCount += 1;
+        await gate;
+        return { ok: false, reason: "config_missing", error: "no memorax config" };
+      },
+      close() {},
+    },
+    now: () => 1,
+  });
+  try {
+    const first = runtime.recordTurnStart({ ...TURN_START, prompt: "first prompt" });
+    const second = runtime.recordTurnStart({ ...TURN_START, prompt: "second prompt" });
+    releaseResolve();
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+    assert.equal(resolveCount, 1);
+    const results = [firstResult, secondResult];
+    assert.equal(results.filter((result) => result.ok).length, 1);
+    assert.equal(results.filter((result) => !result.ok && result.error === "conflicting_turn_start").length, 1);
+    assert.equal(events.some((event) => event.message === "dsh_memory_hook.turn_start_conflict"), true);
+  } finally {
+    runtime.close();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("DSH runtime requires a prompt delimiter for a longer writeback user text", async () => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-code-dsh-prompt-delimiter-"));
+  const events = [];
+  const runtime = createDshMemoryHookRuntime({
+    diagnosticLogger(message, fields) {
+      events.push({ message, fields });
+    },
+    env: {
+      MEMORAX_CODE_HOME: root,
+      MEMORAX_CODE_DSH_TRACE_ENABLED: "false",
+      MEMORAX_CODE_MEMORY_RETRIEVAL_ENABLED: "false",
+    },
+    memoraxCodeHome: root,
+    repositoryMemorySession: notConfiguredRepositoryMemorySession(),
+    now: () => 1,
+  });
+  const writeback = (userText) => ({
+    version: 1,
+    client: "dsh",
+    sessionId: "session-dsh",
+    turnId: "dsh-0-0",
+    userText,
+    assistantText: "reply",
+  });
+  try {
+    await runtime.recordTurnStart({ ...TURN_START, prompt: "Fix the build." });
+
+    assert.deepEqual(await runtime.writeback(writeback("Fix the build.evil")), {
+      ok: true,
+      scheduled: false,
+      reason: "prompt_mismatch",
+    });
+
+    assert.deepEqual(await runtime.writeback(writeback("Fix the build. now")), {
+      ok: true,
+      scheduled: false,
+      reason: "config_missing",
+    });
+  } finally {
+    runtime.close();
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/packages/ts/memorax-code-backend/test/memory/dsh-memory-hook-runtime.test.mjs
+++ b/packages/ts/memorax-code-backend/test/memory/dsh-memory-hook-runtime.test.mjs
@@ -64,6 +64,163 @@ test("DSH runtime releases an automatic retrieval turn when the turn is discarde
   }
 });
 
+test("DSH runtime recovers a writeback from the current-turn trace after a coordinator loss", async () => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-code-dsh-trace-recovery-"));
+  const workspace = join(root, "workspace");
+  await mkdir(join(workspace, ".git"), { recursive: true });
+  const env = {
+    MEMORAX_CODE_HOME: root,
+    MEMORAX_CODE_MEMORY_RETRIEVAL_ENABLED: "false",
+    MEMORAX_CODE_MEMORY_WRITEBACK_ENABLED: "true",
+    MEMORAX_CODE_MEMORY_WRITEBACK_BUFFER_ENABLED: "false",
+    MEMORAX_CODE_MEMORAX_ENDPOINT: "http://memorax.test",
+    MEMORAX_CODE_MEMORAX_API_KEY: "secret",
+    MEMORAX_CODE_MEMORAX_USER_ID: "user-1",
+  };
+  const config = memoraxConfigFromEnv(env);
+  assert.equal(config.ok, true);
+  const scope = {
+    schemaVersion: "workspace-memory-scope.v1",
+    baseUserId: config.config.userId,
+    effectiveUserId: `${config.config.userId}@test-repository`,
+    repositoryKey: "workspace-directory:test-repository",
+    repositorySlug: "test-repository",
+    repositoryName: "Test Repository",
+    identitySource: "workspace-directory",
+    scopeKind: "local-directory",
+    boundWorkspaceRoot: workspace,
+  };
+  const events = [];
+  let enqueued = 0;
+  const runtimeOptions = () => ({
+    env,
+    memoraxCodeHome: root,
+    diagnosticLogger(message, fields) {
+      events.push({ message, fields });
+    },
+    automaticWriteback: () => {
+      enqueued += 1;
+      return { accepted: true };
+    },
+    repositoryMemorySession: {
+      async resolve() {
+        return { ok: true, memory: { config: config.config, scope } };
+      },
+      close() {},
+    },
+    now: () => 1,
+  });
+  const firstRuntime = createDshMemoryHookRuntime(runtimeOptions());
+  try {
+    await firstRuntime.recordTurnStart({ ...TURN_START, prompt: "recover me", cwd: workspace });
+  } finally {
+    firstRuntime.close();
+  }
+  // A restart (or coordinator eviction) drops the in-memory turn metadata;
+  // the on-disk current-turn trace still attests the accepted turn-start.
+  const secondRuntime = createDshMemoryHookRuntime(runtimeOptions());
+  try {
+    const recovered = await secondRuntime.writeback({
+      version: 1,
+      client: "dsh",
+      sessionId: TURN_START.sessionId,
+      turnId: TURN_START.turnId,
+      userText: "recover me",
+      assistantText: "recovered reply",
+      cwd: workspace,
+    });
+    assert.deepEqual(recovered, { ok: true, scheduled: true });
+    assert.equal(enqueued, 1);
+    const writebackEvents = events.filter((event) => event.message === "dsh_memory_hook.writeback");
+    assert.equal(writebackEvents.length, 1);
+    assert.equal(writebackEvents[0].fields.metadataSource, "current_turn_trace");
+
+    // A turnId with no attestation is still refused.
+    const unattested = await secondRuntime.writeback({
+      version: 1,
+      client: "dsh",
+      sessionId: TURN_START.sessionId,
+      turnId: "dsh-9-9",
+      userText: "recover me",
+      assistantText: "nope",
+      cwd: workspace,
+    });
+    assert.deepEqual(unattested, { ok: true, scheduled: false, reason: "turn_metadata_missing" });
+
+    // An attestation for a different session does not vouch for this one.
+    const wrongSession = await secondRuntime.writeback({
+      version: 1,
+      client: "dsh",
+      sessionId: "session-other",
+      turnId: TURN_START.turnId,
+      userText: "recover me",
+      assistantText: "nope",
+      cwd: workspace,
+    });
+    assert.deepEqual(wrongSession, { ok: true, scheduled: false, reason: "turn_metadata_missing" });
+  } finally {
+    secondRuntime.close();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("DSH runtime caps in-memory turn metadata and drops the oldest DSH turns", async () => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-code-dsh-saturation-"));
+  const events = [];
+  const runtime = createDshMemoryHookRuntime({
+    maxEntries: 4,
+    diagnosticLogger(message, fields) {
+      events.push({ message, fields });
+    },
+    env: {
+      MEMORAX_CODE_HOME: root,
+      MEMORAX_CODE_DSH_TRACE_ENABLED: "false",
+      MEMORAX_CODE_MEMORY_RETRIEVAL_ENABLED: "false",
+    },
+    memoraxCodeHome: root,
+    repositoryMemorySession: notConfiguredRepositoryMemorySession(),
+    now: () => 1,
+  });
+  try {
+    for (let turn = 0; turn < 5; turn += 1) {
+      await runtime.recordTurnStart({ ...TURN_START, turnId: `dsh-0-${turn}`, prompt: `turn ${turn}` });
+    }
+    // DSH turns share the coordinator pool: the cap holds and the oldest turn
+    // was evicted.
+    assert.equal(runtime.size(), 4);
+    const cacheSizes = events
+      .filter((event) => event.message === "dsh_memory_hook.turn_start")
+      .map((event) => event.fields.cacheSize);
+    assert.deepEqual(cacheSizes, [1, 2, 3, 4, 4]);
+
+    // The evicted oldest turn has no coordinator metadata and, with trace
+    // disabled, no attestation to recover from.
+    const evicted = await runtime.writeback({
+      version: 1,
+      client: "dsh",
+      sessionId: TURN_START.sessionId,
+      turnId: "dsh-0-0",
+      userText: "turn 0",
+      assistantText: "reply",
+    });
+    assert.deepEqual(evicted, { ok: true, scheduled: false, reason: "turn_metadata_missing" });
+
+    // The newest turn is still covered.
+    const newest = await runtime.writeback({
+      version: 1,
+      client: "dsh",
+      sessionId: TURN_START.sessionId,
+      turnId: "dsh-0-4",
+      userText: "turn 4",
+      assistantText: "reply",
+    });
+    assert.equal(newest.ok, true);
+  } finally {
+    runtime.close();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("DSH runtime releases an automatic retrieval turn after a scheduled writeback", async () => {
   const root = await mkdtemp(join(tmpdir(), "memorax-code-dsh-retrieval-writeback-"));
   const workspace = join(root, "workspace");
@@ -140,7 +297,7 @@ test("DSH runtime releases an automatic retrieval turn after a scheduled writeba
   }
 });
 
-test("DSH runtime rejects a conflicting repeated turn-start and accepts an idempotent one", async () => {
+test("DSH runtime self-heals a conflicting repeated turn-start and accepts an idempotent one", async () => {
   const root = await mkdtemp(join(tmpdir(), "memorax-code-dsh-conflicting-turn-start-"));
   const events = [];
   const runtime = createDshMemoryHookRuntime({
@@ -157,13 +314,24 @@ test("DSH runtime rejects a conflicting repeated turn-start and accepts an idemp
     now: () => 1,
   });
   try {
+    // Idempotent replay of the same prompt stays a no-op.
     assert.deepEqual(await runtime.recordTurnStart({ ...TURN_START, prompt: "first turn" }), { ok: true });
     assert.deepEqual(await runtime.recordTurnStart({ ...TURN_START, prompt: "first turn" }), { ok: true });
-    assert.deepEqual(await runtime.recordTurnStart({ ...TURN_START, prompt: "different turn" }), {
-      ok: false,
-      error: "conflicting_turn_start",
+    // A colliding turnId with a new prompt replaces the dead entry instead of
+    // dead-ending the turn with conflicting_turn_start.
+    assert.deepEqual(await runtime.recordTurnStart({ ...TURN_START, prompt: "different turn" }), { ok: true });
+    assert.equal(events.some((event) => event.message === "dsh_memory_hook.turn_start_conflict_replaced"), true);
+    // The replaced turn is gone: a writeback for the new prompt is accepted,
+    // and the writeback for the old prompt no longer matches.
+    const writebackResult = await runtime.writeback({
+      version: 1,
+      client: "dsh",
+      sessionId: TURN_START.sessionId,
+      turnId: TURN_START.turnId,
+      userText: "different turn",
+      assistantText: "reply",
     });
-    assert.equal(events.some((event) => event.message === "dsh_memory_hook.turn_start_conflict"), true);
+    assert.equal(writebackResult.ok, true);
   } finally {
     runtime.close();
     await rm(root, { recursive: true, force: true });
@@ -358,7 +526,7 @@ test("DSH runtime serializes a discard with a writeback for one turn", async () 
   }
 });
 
-test("DSH runtime serializes concurrent turn-starts and rejects a conflicting prompt", async () => {
+test("DSH runtime serializes concurrent turn-starts and self-heals a conflicting prompt", async () => {
   const root = await mkdtemp(join(tmpdir(), "memorax-code-dsh-turn-start-serial-"));
   const events = [];
   let resolveCount = 0;
@@ -389,11 +557,16 @@ test("DSH runtime serializes concurrent turn-starts and rejects a conflicting pr
     const second = runtime.recordTurnStart({ ...TURN_START, prompt: "second prompt" });
     releaseResolve();
     const [firstResult, secondResult] = await Promise.all([first, second]);
-    assert.equal(resolveCount, 1);
-    const results = [firstResult, secondResult];
-    assert.equal(results.filter((result) => result.ok).length, 1);
-    assert.equal(results.filter((result) => !result.ok && result.error === "conflicting_turn_start").length, 1);
-    assert.equal(events.some((event) => event.message === "dsh_memory_hook.turn_start_conflict"), true);
+    // The conflicting second start replaces the first entry instead of
+    // dead-ending the turn; serialization keeps the coordinator consistent.
+    assert.deepEqual(firstResult, { ok: true });
+    assert.deepEqual(secondResult, { ok: true });
+    // The first start resolves scope once; the replaced start resolves it again.
+    assert.equal(resolveCount, 2);
+    assert.equal(events.filter((event) => event.message === "dsh_memory_hook.turn_start_conflict_replaced").length, 1);
+    const turnStarts = events.filter((event) => event.message === "dsh_memory_hook.turn_start");
+    assert.equal(turnStarts.length, 2);
+    assert.deepEqual(turnStarts.map((event) => event.fields.promptChars), ["first prompt".length, "second prompt".length]);
   } finally {
     runtime.close();
     await rm(root, { recursive: true, force: true });

--- a/packages/ts/memorax-code-backend/test/memory/dsh-memory-hook-runtime.test.mjs
+++ b/packages/ts/memorax-code-backend/test/memory/dsh-memory-hook-runtime.test.mjs
@@ -139,3 +139,221 @@ test("DSH runtime releases an automatic retrieval turn after a scheduled writeba
     await rm(root, { recursive: true, force: true });
   }
 });
+
+test("DSH runtime rejects a conflicting repeated turn-start and accepts an idempotent one", async () => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-code-dsh-conflicting-turn-start-"));
+  const events = [];
+  const runtime = createDshMemoryHookRuntime({
+    diagnosticLogger(message, fields) {
+      events.push({ message, fields });
+    },
+    env: {
+      MEMORAX_CODE_HOME: root,
+      MEMORAX_CODE_DSH_TRACE_ENABLED: "false",
+      MEMORAX_CODE_MEMORY_RETRIEVAL_ENABLED: "false",
+    },
+    memoraxCodeHome: root,
+    repositoryMemorySession: notConfiguredRepositoryMemorySession(),
+    now: () => 1,
+  });
+  try {
+    assert.deepEqual(await runtime.recordTurnStart({ ...TURN_START, prompt: "first turn" }), { ok: true });
+    assert.deepEqual(await runtime.recordTurnStart({ ...TURN_START, prompt: "first turn" }), { ok: true });
+    assert.deepEqual(await runtime.recordTurnStart({ ...TURN_START, prompt: "different turn" }), {
+      ok: false,
+      error: "conflicting_turn_start",
+    });
+    assert.equal(events.some((event) => event.message === "dsh_memory_hook.turn_start_conflict"), true);
+  } finally {
+    runtime.close();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("DSH runtime serializes concurrent writebacks so only one materializes", async () => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-code-dsh-writeback-serial-"));
+  const workspace = join(root, "workspace");
+  await mkdir(join(workspace, ".git"), { recursive: true });
+  const env = {
+    MEMORAX_CODE_HOME: root,
+    MEMORAX_CODE_DSH_TRACE_ENABLED: "false",
+    MEMORAX_CODE_MEMORY_RETRIEVAL_ENABLED: "false",
+    MEMORAX_CODE_MEMORY_WRITEBACK_ENABLED: "true",
+    MEMORAX_CODE_MEMORY_WRITEBACK_BUFFER_ENABLED: "false",
+    MEMORAX_CODE_MEMORAX_ENDPOINT: "http://memorax.test",
+    MEMORAX_CODE_MEMORAX_API_KEY: "secret",
+    MEMORAX_CODE_MEMORAX_USER_ID: "user-1",
+  };
+  const config = memoraxConfigFromEnv(env);
+  assert.equal(config.ok, true);
+  const scope = {
+    schemaVersion: "workspace-memory-scope.v1",
+    baseUserId: config.config.userId,
+    effectiveUserId: `${config.config.userId}@test-repository`,
+    repositoryKey: "workspace-directory:test-repository",
+    repositorySlug: "test-repository",
+    repositoryName: "Test Repository",
+    identitySource: "workspace-directory",
+    scopeKind: "local-directory",
+    boundWorkspaceRoot: workspace,
+  };
+  let enqueued = 0;
+  const runtime = createDshMemoryHookRuntime({
+    env,
+    automaticWriteback: () => {
+      enqueued += 1;
+      return { accepted: true };
+    },
+    repositoryMemorySession: {
+      async resolve() {
+        return { ok: true, memory: { config: config.config, scope } };
+      },
+      close() {},
+    },
+    now: () => 1,
+  });
+  try {
+    await runtime.recordTurnStart({ ...TURN_START, cwd: workspace });
+    const writeback = {
+      version: 1,
+      client: "dsh",
+      sessionId: "session-dsh",
+      turnId: "dsh-0-0",
+      userText: "first turn",
+      assistantText: "reply",
+      cwd: workspace,
+    };
+    const results = await Promise.all([runtime.writeback(writeback), runtime.writeback(writeback)]);
+    assert.equal(enqueued, 1);
+    assert.deepEqual(
+      results.map((result) => (result.scheduled ? "scheduled" : `skip:${result.reason}`)).sort(),
+      ["scheduled", "skip:turn_metadata_missing"],
+    );
+  } finally {
+    runtime.close();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("DSH runtime writeback survives past the shared TTL", async () => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-code-dsh-ttl-"));
+  const workspace = join(root, "workspace");
+  await mkdir(join(workspace, ".git"), { recursive: true });
+  const env = {
+    MEMORAX_CODE_HOME: root,
+    MEMORAX_CODE_DSH_TRACE_ENABLED: "false",
+    MEMORAX_CODE_MEMORY_RETRIEVAL_ENABLED: "false",
+    MEMORAX_CODE_MEMORY_WRITEBACK_ENABLED: "true",
+    MEMORAX_CODE_MEMORY_WRITEBACK_BUFFER_ENABLED: "false",
+    MEMORAX_CODE_MEMORAX_ENDPOINT: "http://memorax.test",
+    MEMORAX_CODE_MEMORAX_API_KEY: "secret",
+    MEMORAX_CODE_MEMORAX_USER_ID: "user-1",
+  };
+  const config = memoraxConfigFromEnv(env);
+  assert.equal(config.ok, true);
+  const scope = {
+    schemaVersion: "workspace-memory-scope.v1",
+    baseUserId: config.config.userId,
+    effectiveUserId: `${config.config.userId}@test-repository`,
+    repositoryKey: "workspace-directory:test-repository",
+    repositorySlug: "test-repository",
+    repositoryName: "Test Repository",
+    identitySource: "workspace-directory",
+    scopeKind: "local-directory",
+    boundWorkspaceRoot: workspace,
+  };
+  let nowMs = 0;
+  const runtime = createDshMemoryHookRuntime({
+    env,
+    automaticWriteback: () => ({ accepted: true }),
+    repositoryMemorySession: {
+      async resolve() {
+        return { ok: true, memory: { config: config.config, scope } };
+      },
+      close() {},
+    },
+    now: () => nowMs,
+    ttlMs: 100,
+  });
+  try {
+    await runtime.recordTurnStart({ ...TURN_START, cwd: workspace });
+    nowMs = 10_000;
+    assert.deepEqual(await runtime.writeback({
+      version: 1,
+      client: "dsh",
+      sessionId: "session-dsh",
+      turnId: "dsh-0-0",
+      userText: "first turn",
+      assistantText: "reply",
+      cwd: workspace,
+    }), { ok: true, scheduled: true });
+  } finally {
+    runtime.close();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("DSH runtime serializes a discard with a writeback for one turn", async () => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-code-dsh-discard-writeback-"));
+  const workspace = join(root, "workspace");
+  await mkdir(join(workspace, ".git"), { recursive: true });
+  const env = {
+    MEMORAX_CODE_HOME: root,
+    MEMORAX_CODE_DSH_TRACE_ENABLED: "false",
+    MEMORAX_CODE_MEMORY_RETRIEVAL_ENABLED: "false",
+    MEMORAX_CODE_MEMORY_WRITEBACK_ENABLED: "true",
+    MEMORAX_CODE_MEMORY_WRITEBACK_BUFFER_ENABLED: "false",
+    MEMORAX_CODE_MEMORAX_ENDPOINT: "http://memorax.test",
+    MEMORAX_CODE_MEMORAX_API_KEY: "secret",
+    MEMORAX_CODE_MEMORAX_USER_ID: "user-1",
+  };
+  const config = memoraxConfigFromEnv(env);
+  assert.equal(config.ok, true);
+  const scope = {
+    schemaVersion: "workspace-memory-scope.v1",
+    baseUserId: config.config.userId,
+    effectiveUserId: `${config.config.userId}@test-repository`,
+    repositoryKey: "workspace-directory:test-repository",
+    repositorySlug: "test-repository",
+    repositoryName: "Test Repository",
+    identitySource: "workspace-directory",
+    scopeKind: "local-directory",
+    boundWorkspaceRoot: workspace,
+  };
+  let enqueued = 0;
+  const runtime = createDshMemoryHookRuntime({
+    env,
+    automaticWriteback: () => {
+      enqueued += 1;
+      return { accepted: true };
+    },
+    repositoryMemorySession: {
+      async resolve() {
+        return { ok: true, memory: { config: config.config, scope } };
+      },
+      close() {},
+    },
+    now: () => 1,
+  });
+  try {
+    await runtime.recordTurnStart({ ...TURN_START, cwd: workspace });
+    const [discardResult, writebackResult] = await Promise.all([
+      runtime.discardTurn(DISCARD),
+      runtime.writeback({
+        version: 1,
+        client: "dsh",
+        sessionId: "session-dsh",
+        turnId: "dsh-0-0",
+        userText: "first turn",
+        assistantText: "reply",
+        cwd: workspace,
+      }),
+    ]);
+    assert.deepEqual(discardResult, { ok: true, discarded: true });
+    assert.deepEqual(writebackResult, { ok: true, scheduled: false, reason: "turn_metadata_missing" });
+    assert.equal(enqueued, 0);
+  } finally {
+    runtime.close();
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/packages/ts/memorax-code-backend/test/memory/dsh-memory-hook.test.mjs
+++ b/packages/ts/memorax-code-backend/test/memory/dsh-memory-hook.test.mjs
@@ -248,6 +248,134 @@ test("DSH memory service records a turn start and schedules an inline writeback"
   }
 });
 
+test("DSH reconnect cannot restart a completed turn id (finalized-turn gate)", async () => {
+  // Round 10 #1: writeback consumes the coordinator entry, so its absence
+  // cannot distinguish "never started" from "already finished". A DSH
+  // reconnect replays session events and re-sends the SAME turnId; without
+  // the finalized-turn gate the replayed start would rebuild the entry and
+  // the replayed writeback would schedule a SECOND memory.
+  const root = await mkdtemp(join(tmpdir(), "memorax-code-dsh-finalized-"));
+  const memoraxCodeHome = join(root, "home");
+  const workspace = join(root, "workspace");
+  await Promise.all([
+    mkdir(memoraxCodeHome, { recursive: true }),
+    mkdir(join(workspace, ".git"), { recursive: true }),
+  ]);
+  const diagnosticEvents = [];
+  const requests = [];
+  // Trace stays ENABLED (the default): the on-disk current-turn record is the
+  // gate that survives a Backend restart, so it must be written and closed.
+  const env = {
+    MEMORAX_CODE_HOME: memoraxCodeHome,
+    MEMORAX_CODE_DSH_TRACE_ENABLED: "true",
+    MEMORAX_CODE_MEMORY_RETRIEVAL_ENABLED: "false",
+    MEMORAX_CODE_MEMORY_WRITEBACK_ENABLED: "true",
+    MEMORAX_CODE_MEMORY_WRITEBACK_BUFFER_ENABLED: "false",
+    MEMORAX_CODE_MEMORAX_ENDPOINT: "http://memorax.test",
+    MEMORAX_CODE_MEMORAX_API_KEY: "secret",
+    MEMORAX_CODE_MEMORAX_USER_ID: "user-1",
+  };
+  const fetchImpl = async (url) => {
+    requests.push({ url: String(url) });
+    return new Response(JSON.stringify({
+      success: true,
+      data: { task_id: "dsh-task", status: "queued" },
+    }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  };
+  const makeService = () => createMemoryService({
+    diagnosticLogger(message, fields) {
+      diagnosticEvents.push({ message, fields });
+    },
+    env,
+    fetchImpl,
+    memoraxCodeHome,
+  });
+
+  const service = makeService();
+  try {
+    assert.equal((await service.recordTurnStart({
+      version: 1,
+      client: "dsh",
+      sessionId: "session-dsh",
+      turnId: "dsh-0-1",
+      prompt: "Original prompt.",
+      cwd: workspace,
+    })).ok, true);
+    assert.equal((await service.writebackTurn({
+      version: 1,
+      client: "dsh",
+      sessionId: "session-dsh",
+      turnId: "dsh-0-1",
+      userText: "Original prompt.",
+      assistantText: "Recorded.",
+      cwd: workspace,
+    })).scheduled, true);
+    await waitFor(() => requests.length === 1, "first writeback did not reach MemoraX add");
+
+    // Reconnect replay, same process: the in-memory finalized set must gate
+    // the start (acked fail-silent, no entry rebuilt, no second memory).
+    assert.deepEqual(await service.recordTurnStart({
+      version: 1,
+      client: "dsh",
+      sessionId: "session-dsh",
+      turnId: "dsh-0-1",
+      prompt: "Original prompt.",
+      cwd: workspace,
+    }), { ok: true });
+    assert.equal(
+      diagnosticEvents.some((event) => event.message === "dsh_memory_hook.turn_start_after_finalize"),
+      true,
+    );
+    assert.deepEqual(await service.writebackTurn({
+      version: 1,
+      client: "dsh",
+      sessionId: "session-dsh",
+      turnId: "dsh-0-1",
+      userText: "Original prompt.",
+      assistantText: "Recorded.",
+      cwd: workspace,
+    }), { ok: true, scheduled: false, reason: "turn_metadata_missing" });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    assert.equal(requests.length, 1);
+    await service.drain();
+  } finally {
+    service.close();
+  }
+
+  // Backend restart: the in-memory finalized set is empty again, so the
+  // on-disk current-turn record (closed for this exact turnId) must carry
+  // the gate. Without it a restart would resurrect the turn.
+  const restarted = makeService();
+  try {
+    assert.deepEqual(await restarted.recordTurnStart({
+      version: 1,
+      client: "dsh",
+      sessionId: "session-dsh",
+      turnId: "dsh-0-1",
+      prompt: "Original prompt.",
+      cwd: workspace,
+    }), { ok: true });
+    assert.deepEqual(await restarted.writebackTurn({
+      version: 1,
+      client: "dsh",
+      sessionId: "session-dsh",
+      turnId: "dsh-0-1",
+      userText: "Original prompt.",
+      assistantText: "Recorded.",
+      cwd: workspace,
+    }), { ok: true, scheduled: false, reason: "turn_metadata_missing" });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    assert.equal(requests.length, 1);
+    await restarted.drain();
+  } finally {
+    restarted.close();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("DSH memory service isolates the same native id from other clients", async () => {
   const root = await mkdtemp(join(tmpdir(), "memorax-code-dsh-isolation-"));
   const memoraxCodeHome = join(root, "home");

--- a/packages/ts/memorax-code-backend/test/memory/dsh-memory-hook.test.mjs
+++ b/packages/ts/memorax-code-backend/test/memory/dsh-memory-hook.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
@@ -29,7 +29,10 @@ test("parseTurnStartCommand accepts a minimal DSH turn-start command", () => {
   });
 });
 
-test("parseTurnStartCommand accepts an optional DSH transcript path", () => {
+test("parseTurnStartCommand rejects a DSH command carrying a transcript path", () => {
+  // DSH turns are inline text and have no transcript file: a client-supplied
+  // path would be an unbacked provenance string injected into local traces,
+  // so the parser must refuse it outright (Codex round 8, hook-command.ts:18).
   const result = parseTurnStartCommand({
     version: 1,
     client: "dsh",
@@ -39,9 +42,20 @@ test("parseTurnStartCommand accepts an optional DSH transcript path", () => {
     cwd: "/repo",
     transcriptPath: "/tmp/session.jsonl",
   });
-  assert.equal(result.ok, true);
-  assert.equal(result.command.transcriptPath, "/tmp/session.jsonl");
-  assert.equal(result.command.cwd, "/repo");
+  assert.equal(result.ok, false);
+});
+
+test("parseWritebackCommand rejects a DSH writeback carrying a transcript path", () => {
+  const result = parseWritebackCommand({
+    version: 1,
+    client: "dsh",
+    sessionId: "session-dsh",
+    turnId: "dsh-0-3",
+    userText: "hello",
+    assistantText: "world",
+    transcriptPath: "/tmp/session.jsonl",
+  });
+  assert.equal(result.ok, false);
 });
 
 test("parseTurnStartCommand rejects a DSH command missing its turn id", () => {
@@ -562,6 +576,273 @@ test("DSH discard removes turn metadata and closes the current turn", async () =
   }
 });
 
+// ---------------------------------------------------------------------------
+// Codex round 8: the trace-recovery writeback path (coordinator entry gone,
+// current-turn attestation on disk) and its trust chain.
+// ---------------------------------------------------------------------------
+
+async function createDshTraceRecoveryHarness(t) {
+  const root = await mkdtemp(join(tmpdir(), "memorax-code-dsh-recovery-"));
+  const memoraxCodeHome = join(root, "home");
+  const workspace = join(root, "workspace");
+  const unrelatedDir = join(root, "unrelated");
+  await Promise.all([
+    mkdir(memoraxCodeHome, { recursive: true }),
+    mkdir(join(workspace, ".git"), { recursive: true }),
+    mkdir(unrelatedDir, { recursive: true }),
+  ]);
+  const requests = [];
+  const diagnosticEvents = [];
+  const fetchImpl = async (url, init) => {
+    requests.push({ url: String(url), body: init?.body ? JSON.parse(init.body) : undefined });
+    return new Response(JSON.stringify({
+      success: true,
+      data: { task_id: "dsh-task", status: "queued" },
+    }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  };
+  const createService = (envOverrides = {}) => createMemoryService({
+    diagnosticLogger(message, fields) {
+      diagnosticEvents.push({ message, fields });
+    },
+    env: {
+      MEMORAX_CODE_HOME: memoraxCodeHome,
+      // The recovery path only exists when the on-disk current-turn
+      // attestation is written, so trace stays ON for every service here.
+      MEMORAX_CODE_DSH_TRACE_ENABLED: "true",
+      MEMORAX_CODE_MEMORY_RETRIEVAL_ENABLED: "false",
+      MEMORAX_CODE_MEMORY_WRITEBACK_ENABLED: "true",
+      MEMORAX_CODE_MEMORY_WRITEBACK_BUFFER_ENABLED: "false",
+      MEMORAX_CODE_MEMORAX_ENDPOINT: "http://memorax.test",
+      MEMORAX_CODE_MEMORAX_API_KEY: "secret",
+      MEMORAX_CODE_MEMORAX_USER_ID: "user-1",
+      ...envOverrides,
+    },
+    fetchImpl,
+    memoraxCodeHome,
+  });
+  t.after(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+  return { workspace, unrelatedDir, memoraxCodeHome, requests, diagnosticEvents, createService };
+}
+
+test("trace recovery verifies the attested prompt and binds the attested cwd", async (t) => {
+  const { workspace, unrelatedDir, requests, diagnosticEvents, createService } = await createDshTraceRecoveryHarness(t);
+
+  // Service 1 accepts the turn-start and writes the current-turn attestation.
+  const first = createService();
+  try {
+    assert.deepEqual(await first.recordTurnStart({
+      version: 1,
+      client: "dsh",
+      sessionId: "session-dsh",
+      turnId: "dsh-0-0",
+      prompt: "Recovered turn.",
+      cwd: workspace,
+    }), { ok: true });
+  } finally {
+    first.close();
+  }
+
+  // Service 2 simulates a Backend restart: the in-memory coordinator entry is
+  // gone and only the attestation remains.
+  const second = createService();
+  try {
+    // Round 8 #1: a forged userText must not ride an attested turnId.
+    assert.deepEqual(await second.writebackTurn({
+      version: 1,
+      client: "dsh",
+      sessionId: "session-dsh",
+      turnId: "dsh-0-0",
+      userText: "A forged different prompt.",
+      assistantText: "Reply.",
+      cwd: workspace,
+    }), { ok: true, scheduled: false, reason: "prompt_mismatch" });
+    assert.equal(
+      diagnosticEvents.some((event) => (
+        event.message === "dsh_memory_hook.writeback"
+        && event.fields?.reason === "prompt_mismatch"
+        && event.fields?.metadataSource === "current_turn_trace"
+      )),
+      true,
+    );
+
+    // Round 8 #2: the writeback request's cwd points at a directory with no
+    // repository. The turn must stay bound to the attested workspace; without
+    // that binding this writeback would be rejected by repository resolution
+    // (or worse, silently bound to the unrelated directory).
+    assert.deepEqual(await second.writebackTurn({
+      version: 1,
+      client: "dsh",
+      sessionId: "session-dsh",
+      turnId: "dsh-0-0",
+      userText: "Recovered turn.",
+      assistantText: "Recovered reply.",
+      cwd: unrelatedDir,
+    }), { ok: true, scheduled: true });
+    await waitFor(() => requests.length === 1, "recovered writeback did not reach MemoraX add");
+    assert.equal(requests[0].url, "http://memorax.test/v1/memories/add");
+    await second.drain();
+  } finally {
+    second.close();
+  }
+});
+
+test("a rejected trace-recovery writeback keeps the attestation open for retry", async (t) => {
+  const { workspace, requests, diagnosticEvents, createService } = await createDshTraceRecoveryHarness(t);
+
+  const first = createService();
+  try {
+    await first.recordTurnStart({
+      version: 1,
+      client: "dsh",
+      sessionId: "session-dsh",
+      turnId: "dsh-0-0",
+      prompt: "Transient failure turn.",
+      cwd: workspace,
+    });
+  } finally {
+    first.close();
+  }
+
+  // Round 8 #3: the writeback is rejected for a transient reason (writeback
+  // disabled). The attestation must stay OPEN so a later retry can recover.
+  const rejected = createService({ MEMORAX_CODE_MEMORY_WRITEBACK_ENABLED: "false" });
+  try {
+    const attempt = await rejected.writebackTurn({
+      version: 1,
+      client: "dsh",
+      sessionId: "session-dsh",
+      turnId: "dsh-0-0",
+      userText: "Transient failure turn.",
+      assistantText: "Reply.",
+      cwd: workspace,
+    });
+    assert.equal(attempt.ok, true);
+    assert.equal(attempt.scheduled, false);
+    assert.equal(typeof attempt.reason, "string");
+    assert.equal(
+      diagnosticEvents.some((event) => (
+        event.message === "dsh_memory_hook.writeback"
+        && event.fields?.scheduled === false
+        && event.fields?.metadataSource === "current_turn_trace"
+      )),
+      true,
+      "the rejected recovery must be diagnosable as coming from the trace path",
+    );
+  } finally {
+    rejected.close();
+  }
+
+  const retried = createService();
+  try {
+    assert.deepEqual(await retried.writebackTurn({
+      version: 1,
+      client: "dsh",
+      sessionId: "session-dsh",
+      turnId: "dsh-0-0",
+      userText: "Transient failure turn.",
+      assistantText: "Reply.",
+      cwd: workspace,
+    }), { ok: true, scheduled: true });
+    await waitFor(() => requests.length === 1, "retried writeback did not reach MemoraX add");
+    await retried.drain();
+  } finally {
+    retried.close();
+  }
+});
+
+test("discarding an evicted turn closes its trace attestation", async (t) => {
+  const { workspace, requests, diagnosticEvents, createService } = await createDshTraceRecoveryHarness(t);
+
+  const first = createService();
+  try {
+    await first.recordTurnStart({
+      version: 1,
+      client: "dsh",
+      sessionId: "session-dsh",
+      turnId: "dsh-0-0",
+      prompt: "Abandoned turn.",
+      cwd: workspace,
+    });
+  } finally {
+    first.close();
+  }
+
+  // Round 8 #7: the coordinator entry is gone, so the discard falls back to
+  // the attestation and must CLOSE it — an open attestation for a discarded
+  // turn would let a delayed or replayed writeback punch through.
+  const second = createService();
+  try {
+    assert.deepEqual(await second.discardTurn({
+      version: 1,
+      client: "dsh",
+      sessionId: "session-dsh",
+      turnId: "dsh-0-0",
+    }), { ok: true, discarded: false });
+    assert.equal(
+      diagnosticEvents.some((event) => (
+        event.message === "dsh_memory_hook.turn_discarded"
+        && event.fields?.metadataSource === "current_turn_trace"
+      )),
+      true,
+    );
+
+    assert.deepEqual(await second.writebackTurn({
+      version: 1,
+      client: "dsh",
+      sessionId: "session-dsh",
+      turnId: "dsh-0-0",
+      userText: "Abandoned turn.",
+      assistantText: "Delayed reply.",
+      cwd: workspace,
+    }), { ok: true, scheduled: false, reason: "turn_metadata_missing" });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    assert.equal(requests.length, 0);
+  } finally {
+    second.close();
+  }
+});
+
+test("a self-healed conflicting turn-start re-claims automatic retrieval", async (t) => {
+  const { workspace, diagnosticEvents, createService } = await createDshTraceRecoveryHarness(t);
+
+  // Round 8 #5: the conflicting turn-start self-heals by replacing the
+  // coordinator entry; the replaced claim on automaticRetrievalTurns must be
+  // released so the new prompt gets its retrieval pass too. Retrieval is
+  // disabled here on purpose: the automatic.memory_retrieval diagnostic still
+  // fires once per successful claim, which is exactly the observable.
+  const service = createService();
+  try {
+    await service.recordTurnStart({
+      version: 1,
+      client: "dsh",
+      sessionId: "session-dsh",
+      turnId: "dsh-0-0",
+      prompt: "First prompt.",
+      cwd: workspace,
+    });
+    const firstPasses = diagnosticEvents.filter((event) => event.message === "automatic.memory_retrieval").length;
+    assert.equal(firstPasses, 1);
+
+    await service.recordTurnStart({
+      version: 1,
+      client: "dsh",
+      sessionId: "session-dsh",
+      turnId: "dsh-0-0",
+      prompt: "A different prompt for the same turn id.",
+      cwd: workspace,
+    });
+    const secondPasses = diagnosticEvents.filter((event) => event.message === "automatic.memory_retrieval").length;
+    assert.equal(secondPasses, 2, "the self-healed turn must claim retrieval again");
+  } finally {
+    service.close();
+  }
+});
+
 async function waitFor(predicate, message) {
   const deadline = Date.now() + 1000;
   while (Date.now() < deadline) {
@@ -569,4 +850,198 @@ async function waitFor(predicate, message) {
     await new Promise((resolve) => setTimeout(resolve, 10));
   }
   throw new Error(message);
+}
+test("recovered writebacks bind the repository scope to the attested workspace", async (t) => {
+  const { workspace, unrelatedDir, requests, createService } = await createDshTraceRecoveryHarness(t);
+  // Make the unrelated directory a REAL second repository: if the recovery
+  // ever falls back to the writeback request's own cwd, the MemoraX user_id
+  // (derived per-repo) differs from the attested workspace's.
+  await mkdir(join(unrelatedDir, ".git"), { recursive: true });
+
+  // Only ONE current-turn attestation exists at a time, so the turns must be
+  // started and recovered strictly one after another.
+  const starter = createService();
+  try {
+    await starter.recordTurnStart({
+      version: 1, client: "dsh", sessionId: "session-scope",
+      turnId: "dsh-0-0", prompt: "Scope probe turn.", cwd: workspace,
+    });
+  } finally {
+    starter.close();
+  }
+
+  const middle = createService();
+  try {
+    assert.deepEqual(await middle.writebackTurn({
+      version: 1, client: "dsh", sessionId: "session-scope",
+      turnId: "dsh-0-0", userText: "Scope probe turn.",
+      assistantText: "A.", cwd: unrelatedDir,
+    }), { ok: true, scheduled: true });
+    await middle.drain();
+    // Start the second turn from a live service so it overwrites the (now
+    // closed) attestation with a fresh OPEN record for the next recovery.
+    assert.deepEqual(await middle.recordTurnStart({
+      version: 1, client: "dsh", sessionId: "session-scope",
+      turnId: "dsh-0-1", prompt: "Scope probe second turn.", cwd: workspace,
+    }), { ok: true });
+  } finally {
+    middle.close();
+  }
+
+  const finisher = createService();
+  try {
+    assert.deepEqual(await finisher.writebackTurn({
+      version: 1, client: "dsh", sessionId: "session-scope",
+      turnId: "dsh-0-1", userText: "Scope probe second turn.",
+      assistantText: "B.", cwd: workspace,
+    }), { ok: true, scheduled: true });
+    await waitFor(() => requests.length === 2, "both recovered writebacks did not reach MemoraX add");
+    await finisher.drain();
+    assert.equal(typeof requests[0].body.user_id, "string");
+    assert.equal(requests[0].body.user_id, requests[1].body.user_id,
+      "recovery must scope the memory to the attested workspace, not the writeback's self-reported cwd");
+  } finally {
+    finisher.close();
+  }
+});
+
+test("a replayed recovery writeback is rejected by the in-memory tombstone", async (t) => {
+  const { workspace, requests, diagnosticEvents, createService } = await createDshTraceRecoveryHarness(t);
+
+  const first = createService();
+  try {
+    await first.recordTurnStart({
+      version: 1, client: "dsh", sessionId: "session-dsh",
+      turnId: "dsh-0-0", prompt: "Replay gate turn.", cwd: workspace,
+    });
+  } finally {
+    first.close();
+  }
+
+  const second = createService();
+  try {
+    const command = {
+      version: 1, client: "dsh", sessionId: "session-dsh",
+      turnId: "dsh-0-0", userText: "Replay gate turn.",
+      assistantText: "Original reply.", cwd: workspace,
+    };
+    assert.deepEqual(await second.writebackTurn(command), { ok: true, scheduled: true });
+    await waitFor(() => requests.length === 1, "recovered writeback did not reach MemoraX add");
+    await second.drain();
+
+    // Replaying the exact same command must not schedule a second memory even
+    // if the on-disk attestation close silently failed: the tombstone set in
+    // memory is the second, independent gate.
+    assert.deepEqual(await second.writebackTurn({
+      ...command, assistantText: "Replayed reply.",
+    }), { ok: true, scheduled: false, reason: "turn_metadata_missing" });
+    assert.equal(
+      diagnosticEvents.some((event) => (
+        event.message === "dsh_memory_hook.writeback"
+        && event.fields?.reason === "turn_metadata_missing"
+        && event.fields?.replayedRecovery === true
+      )),
+      true,
+    );
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    assert.equal(requests.length, 1, "the replayed writeback must not reach MemoraX");
+  } finally {
+    second.close();
+  }
+});
+
+test("an attestation older than the recovery window is not a writeback credential", async (t) => {
+  const { workspace, memoraxCodeHome, requests, diagnosticEvents, createService } = await createDshTraceRecoveryHarness(t);
+
+  const first = createService();
+  try {
+    await first.recordTurnStart({
+      version: 1, client: "dsh", sessionId: "session-dsh",
+      turnId: "dsh-0-0", prompt: "Ancient turn.", cwd: workspace,
+    });
+  } finally {
+    first.close();
+  }
+
+  // Age the on-disk attestation past the 24h recovery window.
+  for (const record of await findTraceFiles(memoraxCodeHome, ".current-turn.json")) {
+    const value = JSON.parse(await readFile(record, "utf8"));
+    ageCapturedAt(value);
+    await writeFile(record, JSON.stringify(value), "utf8");
+  }
+
+  const second = createService();
+  try {
+    assert.deepEqual(await second.writebackTurn({
+      version: 1, client: "dsh", sessionId: "session-dsh",
+      turnId: "dsh-0-0", userText: "Ancient turn.",
+      assistantText: "Late reply.", cwd: workspace,
+    }), { ok: true, scheduled: false, reason: "turn_metadata_missing" });
+    assert.equal(
+      diagnosticEvents.some((event) => (
+        event.message === "dsh_memory_hook.writeback"
+        && event.fields?.reason === "turn_metadata_missing"
+        && event.fields?.attestationExpired === true
+      )),
+      true,
+    );
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    assert.equal(requests.length, 0);
+  } finally {
+    second.close();
+  }
+});
+
+test("the turn_start trace event never stores the prompt plaintext", async (t) => {
+  const { workspace, memoraxCodeHome, createService } = await createDshTraceRecoveryHarness(t);
+
+  const service = createService();
+  try {
+    await service.recordTurnStart({
+      version: 1, client: "dsh", sessionId: "session-dsh",
+      turnId: "dsh-0-0", prompt: "SECRET PROMPT TOKEN FOR TRACE AUDIT.", cwd: workspace,
+    });
+  } finally {
+    service.close();
+  }
+
+  const events = await findTraceFiles(memoraxCodeHome, "events.jsonl");
+  assert.equal(events.length > 0, true, "expected at least one events.jsonl");
+  for (const path of events) {
+    const content = await readFile(path, "utf8");
+    assert.equal(content.includes("SECRET PROMPT TOKEN"), false,
+      `events.jsonl must not contain the prompt plaintext (${path})`);
+    assert.equal(content.includes("promptSha256"), true,
+      `the turn_start event must record the prompt hash instead (${path})`);
+  }
+});
+
+async function findTraceFiles(home, fileName) {
+  const found = [];
+  async function walk(dir) {
+    let entries;
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const path = join(dir, entry.name);
+      if (entry.isDirectory()) await walk(path);
+      else if (entry.name === fileName) found.push(path);
+    }
+  }
+  await walk(home);
+  return found;
+}
+
+function ageCapturedAt(value) {
+  if (!value || typeof value !== "object") return;
+  for (const [key, nested] of Object.entries(value)) {
+    if (key === "captured_at" && typeof nested === "string") {
+      value[key] = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString();
+    } else {
+      ageCapturedAt(nested);
+    }
+  }
 }

--- a/packages/ts/memorax-code-backend/test/memory/dsh-memory-hook.test.mjs
+++ b/packages/ts/memorax-code-backend/test/memory/dsh-memory-hook.test.mjs
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
 import {
+  parseTurnDiscardCommand,
   parseTurnStartCommand,
   parseWritebackCommand,
 } from "../../dist/memory/hook-command.js";
@@ -81,6 +82,35 @@ test("parseWritebackCommand rejects a DSH command missing assistant text", () =>
     userText: "Fix the build",
   });
   assert.equal(result.ok, false);
+});
+
+test("parseTurnDiscardCommand accepts a DSH discard command and rejects other clients", () => {
+  const result = parseTurnDiscardCommand({
+    version: 1,
+    client: "dsh",
+    sessionId: "session-dsh",
+    turnId: "dsh-0-3",
+  });
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.command, {
+    version: 1,
+    client: "dsh",
+    sessionId: "session-dsh",
+    turnId: "dsh-0-3",
+  });
+
+  assert.equal(parseTurnDiscardCommand({
+    version: 1,
+    client: "dsh",
+    sessionId: "session-dsh",
+  }).ok, false);
+
+  assert.equal(parseTurnDiscardCommand({
+    version: 1,
+    client: "codex",
+    sessionId: "session-dsh",
+    turnId: "dsh-0-3",
+  }).ok, false);
 });
 
 test("DSH memory service records a turn start and schedules an inline writeback", async () => {
@@ -274,6 +304,221 @@ test("DSH writeback without matching turn metadata is rejected", async () => {
       )),
       true,
     );
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    assert.equal(requests.length, 0);
+  } finally {
+    service.close();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("DSH writeback with a mismatched prompt is rejected and does not consume metadata", async () => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-code-dsh-prompt-mismatch-"));
+  const memoraxCodeHome = join(root, "home");
+  const workspace = join(root, "workspace");
+  await Promise.all([
+    mkdir(memoraxCodeHome, { recursive: true }),
+    mkdir(join(workspace, ".git"), { recursive: true }),
+  ]);
+  const diagnosticEvents = [];
+  const requests = [];
+  const service = createMemoryService({
+    diagnosticLogger(message, fields) {
+      diagnosticEvents.push({ message, fields });
+    },
+    env: {
+      MEMORAX_CODE_HOME: memoraxCodeHome,
+      MEMORAX_CODE_DSH_TRACE_ENABLED: "false",
+      MEMORAX_CODE_MEMORY_RETRIEVAL_ENABLED: "false",
+      MEMORAX_CODE_MEMORY_WRITEBACK_ENABLED: "true",
+      MEMORAX_CODE_MEMORY_WRITEBACK_BUFFER_ENABLED: "false",
+      MEMORAX_CODE_MEMORAX_ENDPOINT: "http://memorax.test",
+      MEMORAX_CODE_MEMORAX_API_KEY: "secret",
+      MEMORAX_CODE_MEMORAX_USER_ID: "user-1",
+    },
+    fetchImpl: async (url, init) => {
+      requests.push({ url: String(url), body: JSON.parse(init.body) });
+      return new Response(JSON.stringify({
+        success: true,
+        data: { task_id: "dsh-task", status: "queued" },
+      }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    },
+    memoraxCodeHome,
+  });
+  try {
+    await service.recordTurnStart({
+      version: 1,
+      client: "dsh",
+      sessionId: "session-dsh",
+      turnId: "dsh-0-0",
+      prompt: "Remember this turn.",
+      cwd: workspace,
+    });
+
+    assert.deepEqual(await service.writebackTurn({
+      version: 1,
+      client: "dsh",
+      sessionId: "session-dsh",
+      turnId: "dsh-0-0",
+      userText: "A forged different prompt.",
+      assistantText: "I will remember this turn.",
+      cwd: workspace,
+    }), { ok: true, scheduled: false, reason: "prompt_mismatch" });
+    assert.equal(
+      diagnosticEvents.some((event) => (
+        event.message === "dsh_memory_hook.writeback"
+        && event.fields?.reason === "prompt_mismatch"
+      )),
+      true,
+    );
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    assert.equal(requests.length, 0);
+
+    // The rejected writeback must not consume metadata, so the correct
+    // userText can still be written back afterwards.
+    assert.deepEqual(await service.writebackTurn({
+      version: 1,
+      client: "dsh",
+      sessionId: "session-dsh",
+      turnId: "dsh-0-0",
+      userText: "Remember this turn.",
+      assistantText: "I will remember this turn.",
+      cwd: workspace,
+    }), { ok: true, scheduled: true });
+    await waitFor(() => requests.length === 1, "matching writeback did not reach MemoraX add");
+    await service.drain();
+  } finally {
+    service.close();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("DSH writeback accepts a userText that extends the started prompt", async () => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-code-dsh-prompt-prefix-"));
+  const memoraxCodeHome = join(root, "home");
+  const workspace = join(root, "workspace");
+  await Promise.all([
+    mkdir(memoraxCodeHome, { recursive: true }),
+    mkdir(join(workspace, ".git"), { recursive: true }),
+  ]);
+  const requests = [];
+  const service = createMemoryService({
+    env: {
+      MEMORAX_CODE_HOME: memoraxCodeHome,
+      MEMORAX_CODE_DSH_TRACE_ENABLED: "false",
+      MEMORAX_CODE_MEMORY_RETRIEVAL_ENABLED: "false",
+      MEMORAX_CODE_MEMORY_WRITEBACK_ENABLED: "true",
+      MEMORAX_CODE_MEMORY_WRITEBACK_BUFFER_ENABLED: "false",
+      MEMORAX_CODE_MEMORAX_ENDPOINT: "http://memorax.test",
+      MEMORAX_CODE_MEMORAX_API_KEY: "secret",
+      MEMORAX_CODE_MEMORAX_USER_ID: "user-1",
+    },
+    fetchImpl: async (url, init) => {
+      requests.push({ url: String(url), body: JSON.parse(init.body) });
+      return new Response(JSON.stringify({
+        success: true,
+        data: { task_id: "dsh-task", status: "queued" },
+      }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    },
+    memoraxCodeHome,
+  });
+  try {
+    await service.recordTurnStart({
+      version: 1,
+      client: "dsh",
+      sessionId: "session-dsh",
+      turnId: "dsh-0-0",
+      prompt: "Fix the build.",
+      cwd: workspace,
+    });
+    assert.deepEqual(await service.writebackTurn({
+      version: 1,
+      client: "dsh",
+      sessionId: "session-dsh",
+      turnId: "dsh-0-0",
+      userText: "Fix the build.\n\nAlso run the tests.",
+      assistantText: "Done.",
+      cwd: workspace,
+    }), { ok: true, scheduled: true });
+    await waitFor(() => requests.length === 1, "prefix writeback did not reach MemoraX add");
+    await service.drain();
+  } finally {
+    service.close();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("DSH discard removes turn metadata and closes the current turn", async () => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-code-dsh-discard-"));
+  const memoraxCodeHome = join(root, "home");
+  const workspace = join(root, "workspace");
+  await Promise.all([
+    mkdir(memoraxCodeHome, { recursive: true }),
+    mkdir(join(workspace, ".git"), { recursive: true }),
+  ]);
+  const diagnosticEvents = [];
+  const requests = [];
+  const service = createMemoryService({
+    diagnosticLogger(message, fields) {
+      diagnosticEvents.push({ message, fields });
+    },
+    env: {
+      MEMORAX_CODE_HOME: memoraxCodeHome,
+      MEMORAX_CODE_DSH_TRACE_ENABLED: "false",
+      MEMORAX_CODE_MEMORY_RETRIEVAL_ENABLED: "false",
+      MEMORAX_CODE_MEMORY_WRITEBACK_ENABLED: "true",
+      MEMORAX_CODE_MEMORY_WRITEBACK_BUFFER_ENABLED: "false",
+      MEMORAX_CODE_MEMORAX_ENDPOINT: "http://memorax.test",
+      MEMORAX_CODE_MEMORAX_API_KEY: "secret",
+      MEMORAX_CODE_MEMORAX_USER_ID: "user-1",
+    },
+    fetchImpl: async (url) => {
+      requests.push({ url: String(url) });
+      return new Response(JSON.stringify({
+        success: true,
+        data: { task_id: "dsh-task", status: "queued" },
+      }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    },
+    memoraxCodeHome,
+  });
+  try {
+    await service.recordTurnStart({
+      version: 1,
+      client: "dsh",
+      sessionId: "session-dsh",
+      turnId: "dsh-0-0",
+      prompt: "Interrupted turn.",
+      cwd: workspace,
+    });
+    assert.deepEqual(await service.discardTurn({
+      version: 1,
+      client: "dsh",
+      sessionId: "session-dsh",
+      turnId: "dsh-0-0",
+    }), { ok: true, discarded: true });
+    assert.equal(
+      diagnosticEvents.some((event) => event.message === "dsh_memory_hook.turn_discarded"),
+      true,
+    );
+
+    assert.deepEqual(await service.writebackTurn({
+      version: 1,
+      client: "dsh",
+      sessionId: "session-dsh",
+      turnId: "dsh-0-0",
+      userText: "Interrupted turn.",
+      assistantText: "Reply.",
+      cwd: workspace,
+    }), { ok: true, scheduled: false, reason: "turn_metadata_missing" });
     await new Promise((resolve) => setTimeout(resolve, 50));
     assert.equal(requests.length, 0);
   } finally {

--- a/packages/ts/memorax-code-backend/test/memory/dsh-memory-hook.test.mjs
+++ b/packages/ts/memorax-code-backend/test/memory/dsh-memory-hook.test.mjs
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
 import {
+  parseSkillReminderCommand,
   parseTurnDiscardCommand,
   parseTurnStartCommand,
   parseWritebackCommand,
@@ -111,6 +112,40 @@ test("parseTurnDiscardCommand accepts a DSH discard command and rejects other cl
     sessionId: "session-dsh",
     turnId: "dsh-0-3",
   }).ok, false);
+});
+
+test("parseSkillReminderCommand rejects DSH and keeps codex and claude-code reminders", () => {
+  assert.equal(parseSkillReminderCommand({
+    version: 1,
+    client: "dsh",
+    sessionId: "session-dsh",
+    turnId: "dsh-0-0",
+    transcriptPath: "/tmp/dsh.jsonl",
+    content: "reminder",
+    triggers: ["cadence"],
+  }).ok, false);
+
+  const codex = parseSkillReminderCommand({
+    version: 1,
+    client: "codex",
+    sessionId: "session-dsh",
+    turnId: "turn-1",
+    transcriptPath: "/tmp/codex.jsonl",
+    content: "reminder",
+    triggers: ["cadence"],
+  });
+  assert.equal(codex.ok, true);
+
+  const claude = parseSkillReminderCommand({
+    version: 1,
+    client: "claude-code",
+    sessionId: "session-dsh",
+    promptId: "prompt-1",
+    transcriptPath: "/tmp/claude.jsonl",
+    content: "reminder",
+    triggers: ["post_compaction"],
+  });
+  assert.equal(claude.ok, true);
 });
 
 test("DSH memory service records a turn start and schedules an inline writeback", async () => {

--- a/packages/ts/memorax-code-backend/test/memory/dsh-memory-hook.test.mjs
+++ b/packages/ts/memorax-code-backend/test/memory/dsh-memory-hook.test.mjs
@@ -148,7 +148,8 @@ test("DSH memory service records a turn start and schedules an inline writeback"
       { role: "assistant", content: "I will remember this turn." },
     ]);
 
-    // Replaying the same completed turn must not produce a duplicate writeback.
+    // Replaying the same completed turn must not produce a duplicate writeback;
+    // its turn metadata is already consumed, so the replay is rejected.
     assert.deepEqual(await service.writebackTurn({
       version: 1,
       client: "dsh",
@@ -157,7 +158,7 @@ test("DSH memory service records a turn start and schedules an inline writeback"
       userText: "Remember this turn.",
       assistantText: "I will remember this turn.",
       cwd: workspace,
-    }), { ok: true, scheduled: true });
+    }), { ok: true, scheduled: false, reason: "turn_metadata_missing" });
     await new Promise((resolve) => setTimeout(resolve, 50));
     assert.equal(requests.length, 1);
 
@@ -214,6 +215,67 @@ test("DSH memory service isolates the same native id from other clients", async 
     assert.equal(diagnosticEvents.some((event) => event.message === "dsh_memory_hook.writeback"), true);
     assert.equal(diagnosticEvents.some((event) => event.message === "codex_memory_hook.writeback"), false);
     assert.equal(diagnosticEvents.some((event) => event.message === "claude_memory_hook.writeback"), false);
+  } finally {
+    service.close();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("DSH writeback without matching turn metadata is rejected", async () => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-code-dsh-missing-metadata-"));
+  const memoraxCodeHome = join(root, "home");
+  const workspace = join(root, "workspace");
+  await Promise.all([
+    mkdir(memoraxCodeHome, { recursive: true }),
+    mkdir(join(workspace, ".git"), { recursive: true }),
+  ]);
+  const diagnosticEvents = [];
+  const requests = [];
+  const service = createMemoryService({
+    diagnosticLogger(message, fields) {
+      diagnosticEvents.push({ message, fields });
+    },
+    env: {
+      MEMORAX_CODE_HOME: memoraxCodeHome,
+      MEMORAX_CODE_DSH_TRACE_ENABLED: "false",
+      MEMORAX_CODE_MEMORY_RETRIEVAL_ENABLED: "false",
+      MEMORAX_CODE_MEMORY_WRITEBACK_ENABLED: "true",
+      MEMORAX_CODE_MEMORY_WRITEBACK_BUFFER_ENABLED: "false",
+      MEMORAX_CODE_MEMORAX_ENDPOINT: "http://memorax.test",
+      MEMORAX_CODE_MEMORAX_API_KEY: "secret",
+      MEMORAX_CODE_MEMORAX_USER_ID: "user-1",
+    },
+    fetchImpl: async (url) => {
+      requests.push({ url: String(url) });
+      return new Response(JSON.stringify({
+        success: true,
+        data: { task_id: "dsh-task", status: "queued" },
+      }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    },
+    memoraxCodeHome,
+  });
+  try {
+    assert.deepEqual(await service.writebackTurn({
+      version: 1,
+      client: "dsh",
+      sessionId: "session-dsh",
+      turnId: "dsh-0-0",
+      userText: "orphan turn.",
+      assistantText: "orphan reply.",
+      cwd: workspace,
+    }), { ok: true, scheduled: false, reason: "turn_metadata_missing" });
+    assert.equal(
+      diagnosticEvents.some((event) => (
+        event.message === "dsh_memory_hook.writeback"
+        && event.fields?.reason === "turn_metadata_missing"
+      )),
+      true,
+    );
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    assert.equal(requests.length, 0);
   } finally {
     service.close();
     await rm(root, { recursive: true, force: true });

--- a/packages/ts/memorax-code-backend/test/memory/dsh-memory-hook.test.mjs
+++ b/packages/ts/memorax-code-backend/test/memory/dsh-memory-hook.test.mjs
@@ -1,0 +1,230 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import {
+  parseTurnStartCommand,
+  parseWritebackCommand,
+} from "../../dist/memory/hook-command.js";
+import { createMemoryService } from "../../dist/memory/service.js";
+
+test("parseTurnStartCommand accepts a minimal DSH turn-start command", () => {
+  const result = parseTurnStartCommand({
+    version: 1,
+    client: "dsh",
+    sessionId: "session-dsh",
+    turnId: "dsh-0-3",
+    prompt: "Find the failing test",
+  });
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.command, {
+    version: 1,
+    client: "dsh",
+    sessionId: "session-dsh",
+    turnId: "dsh-0-3",
+    prompt: "Find the failing test",
+  });
+});
+
+test("parseTurnStartCommand accepts an optional DSH transcript path", () => {
+  const result = parseTurnStartCommand({
+    version: 1,
+    client: "dsh",
+    sessionId: "session-dsh",
+    turnId: "dsh-0-3",
+    prompt: "hello",
+    cwd: "/repo",
+    transcriptPath: "/tmp/session.jsonl",
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.command.transcriptPath, "/tmp/session.jsonl");
+  assert.equal(result.command.cwd, "/repo");
+});
+
+test("parseTurnStartCommand rejects a DSH command missing its turn id", () => {
+  const result = parseTurnStartCommand({
+    version: 1,
+    client: "dsh",
+    sessionId: "session-dsh",
+    prompt: "hello",
+  });
+  assert.equal(result.ok, false);
+});
+
+test("parseWritebackCommand accepts inline DSH user and assistant text", () => {
+  const result = parseWritebackCommand({
+    version: 1,
+    client: "dsh",
+    sessionId: "session-dsh",
+    turnId: "dsh-0-3",
+    userText: "Fix the build",
+    assistantText: "The build is fixed",
+  });
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.command, {
+    version: 1,
+    client: "dsh",
+    sessionId: "session-dsh",
+    turnId: "dsh-0-3",
+    userText: "Fix the build",
+    assistantText: "The build is fixed",
+  });
+});
+
+test("parseWritebackCommand rejects a DSH command missing assistant text", () => {
+  const result = parseWritebackCommand({
+    version: 1,
+    client: "dsh",
+    sessionId: "session-dsh",
+    turnId: "dsh-0-3",
+    userText: "Fix the build",
+  });
+  assert.equal(result.ok, false);
+});
+
+test("DSH memory service records a turn start and schedules an inline writeback", async () => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-code-dsh-service-"));
+  const memoraxCodeHome = join(root, "home");
+  const workspace = join(root, "workspace");
+  await Promise.all([
+    mkdir(memoraxCodeHome, { recursive: true }),
+    mkdir(join(workspace, ".git"), { recursive: true }),
+  ]);
+  const diagnosticEvents = [];
+  const requests = [];
+  const service = createMemoryService({
+    diagnosticLogger(message, fields) {
+      diagnosticEvents.push({ message, fields });
+    },
+    env: {
+      MEMORAX_CODE_HOME: memoraxCodeHome,
+      MEMORAX_CODE_DSH_TRACE_ENABLED: "false",
+      MEMORAX_CODE_MEMORY_RETRIEVAL_ENABLED: "false",
+      MEMORAX_CODE_MEMORY_WRITEBACK_ENABLED: "true",
+      MEMORAX_CODE_MEMORY_WRITEBACK_BUFFER_ENABLED: "false",
+      MEMORAX_CODE_MEMORAX_ENDPOINT: "http://memorax.test",
+      MEMORAX_CODE_MEMORAX_API_KEY: "secret",
+      MEMORAX_CODE_MEMORAX_USER_ID: "user-1",
+    },
+    fetchImpl: async (url, init) => {
+      requests.push({ url: String(url), body: JSON.parse(init.body) });
+      return new Response(JSON.stringify({
+        success: true,
+        data: { task_id: "dsh-task", status: "queued" },
+      }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    },
+    memoraxCodeHome,
+  });
+  try {
+    assert.deepEqual(await service.recordTurnStart({
+      version: 1,
+      client: "dsh",
+      sessionId: "session-dsh",
+      turnId: "dsh-0-0",
+      prompt: "Remember this turn.",
+      cwd: workspace,
+    }), { ok: true });
+    assert.equal(diagnosticEvents.some((event) => event.message === "dsh_memory_hook.turn_start"), true);
+
+    assert.deepEqual(await service.writebackTurn({
+      version: 1,
+      client: "dsh",
+      sessionId: "session-dsh",
+      turnId: "dsh-0-0",
+      userText: "Remember this turn.",
+      assistantText: "I will remember this turn.",
+      cwd: workspace,
+    }), { ok: true, scheduled: true });
+    assert.equal(diagnosticEvents.some((event) => event.message === "dsh_memory_hook.writeback" && event.fields?.scheduled === true), true);
+
+    await waitFor(() => requests.length === 1, "DSH writeback did not reach MemoraX add");
+    assert.equal(requests[0].url, "http://memorax.test/v1/memories/add");
+    assert.deepEqual(requests[0].body.messages.map(({ role, content }) => ({ role, content })), [
+      { role: "user", content: "Remember this turn." },
+      { role: "assistant", content: "I will remember this turn." },
+    ]);
+
+    // Replaying the same completed turn must not produce a duplicate writeback.
+    assert.deepEqual(await service.writebackTurn({
+      version: 1,
+      client: "dsh",
+      sessionId: "session-dsh",
+      turnId: "dsh-0-0",
+      userText: "Remember this turn.",
+      assistantText: "I will remember this turn.",
+      cwd: workspace,
+    }), { ok: true, scheduled: true });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    assert.equal(requests.length, 1);
+
+    await service.drain();
+  } finally {
+    service.close();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("DSH memory service isolates the same native id from other clients", async () => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-code-dsh-isolation-"));
+  const memoraxCodeHome = join(root, "home");
+  const workspace = join(root, "workspace");
+  await Promise.all([
+    mkdir(memoraxCodeHome, { recursive: true }),
+    mkdir(join(workspace, ".git"), { recursive: true }),
+  ]);
+  const diagnosticEvents = [];
+  const service = createMemoryService({
+    diagnosticLogger(message, fields) {
+      diagnosticEvents.push({ message, fields });
+    },
+    env: {
+      MEMORAX_CODE_HOME: memoraxCodeHome,
+      MEMORAX_CODE_DSH_TRACE_ENABLED: "false",
+      MEMORAX_CODE_MEMORY_RETRIEVAL_ENABLED: "false",
+      MEMORAX_CODE_MEMORY_WRITEBACK_ENABLED: "true",
+      MEMORAX_CODE_MEMORY_WRITEBACK_BUFFER_ENABLED: "false",
+      MEMORAX_CODE_MEMORAX_ENDPOINT: "http://memorax.test",
+      MEMORAX_CODE_MEMORAX_API_KEY: "secret",
+      MEMORAX_CODE_MEMORAX_USER_ID: "user-1",
+    },
+    memoraxCodeHome,
+  });
+  try {
+    await service.recordTurnStart({
+      version: 1,
+      client: "dsh",
+      sessionId: "session-shared",
+      turnId: "dsh-0-0",
+      prompt: "DSH turn.",
+      cwd: workspace,
+    });
+    assert.deepEqual(await service.writebackTurn({
+      version: 1,
+      client: "dsh",
+      sessionId: "session-shared",
+      turnId: "dsh-0-0",
+      userText: "DSH turn.",
+      assistantText: "DSH reply.",
+      cwd: workspace,
+    }), { ok: true, scheduled: true });
+    assert.equal(diagnosticEvents.some((event) => event.message === "dsh_memory_hook.writeback"), true);
+    assert.equal(diagnosticEvents.some((event) => event.message === "codex_memory_hook.writeback"), false);
+    assert.equal(diagnosticEvents.some((event) => event.message === "claude_memory_hook.writeback"), false);
+  } finally {
+    service.close();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+async function waitFor(predicate, message) {
+  const deadline = Date.now() + 1000;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(message);
+}

--- a/packages/ts/memorax-code-backend/test/memory/memory-turn-coordinator.test.mjs
+++ b/packages/ts/memorax-code-backend/test/memory/memory-turn-coordinator.test.mjs
@@ -402,6 +402,28 @@ test("memory turn coordinator never consumes replacement metadata after async re
   }
 });
 
+test("memory turn coordinator does not expire DSH turns", () => {
+  let now = 100;
+  const coordinator = createMemoryTurnCoordinator({
+    automaticWriteback() {
+      return { accepted: true };
+    },
+    now: () => now,
+    ttlMs: 10,
+    cleanupIntervalMs: 60_000,
+  });
+  try {
+    coordinator.recordTurnStart(turnStart("codex"));
+    coordinator.recordTurnStart(turnStart("dsh"));
+    now = 120;
+    coordinator.pruneExpired();
+    assert.equal(coordinator.size(), 1);
+    assert.equal(coordinator.getTurn(turnKey("dsh"))?.client, "dsh");
+  } finally {
+    coordinator.close();
+  }
+});
+
 function turnStart(client, scope = repositoryScope("repo-a")) {
   return {
     ...turnKey(client),

--- a/packages/ts/memorax-code-backend/test/trace/claude-memory-trace.test.mjs
+++ b/packages/ts/memorax-code-backend/test/trace/claude-memory-trace.test.mjs
@@ -258,15 +258,18 @@ test("Claude current-turn state is isolated and closes without changing Codex st
     assert.deepEqual(await markCurrentClaudeTurnOutcome(context, "completed", { memoraxCodeHome: root }), {
       updated: true,
     });
-    assert.deepEqual(await readOpenClaudeTurn({
+    const closedClaude = await readOpenClaudeTurn({
       memoraxCodeHome: root,
       expectedSessionId: context.sessionId,
       allowStale: true,
-    }), {
-      ok: false,
-      reason: "closed",
-      outcome: "completed",
     });
+    assert.equal(closedClaude.ok, false);
+    assert.equal(closedClaude.reason, "closed");
+    assert.equal(closedClaude.outcome, "completed");
+    // Round 10: the closed record carries its traceContext (the DSH
+    // finalized-turn gate compares the turnId on this field).
+    assert.equal(closedClaude.traceContext.sessionId, context.sessionId);
+    assert.equal(closedClaude.traceContext.turnId, context.turnId);
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/packages/ts/memorax-code-backend/test/trace/codex-memory-trace.test.mjs
+++ b/packages/ts/memorax-code-backend/test/trace/codex-memory-trace.test.mjs
@@ -708,11 +708,18 @@ test("current turn bridge preserves recent context after closing rollout reconci
     });
     assert.equal(recent.ok, true);
     assert.equal(recent.traceContext.turnId, "turn-state");
-    assert.deepEqual(await readOpenCodexTurn({
+    const closedCodex = await readOpenCodexTurn({
       memoraxCodeHome: root,
       expectedSessionId: "session-state",
       now: () => new Date("2026-07-09T00:06:00.000Z"),
-    }), { ok: false, reason: "closed", outcome: "completed" });
+    });
+    assert.equal(closedCodex.ok, false);
+    assert.equal(closedCodex.reason, "closed");
+    assert.equal(closedCodex.outcome, "completed");
+    // Round 10: the closed record carries its traceContext (the DSH
+    // finalized-turn gate compares the turnId on this field).
+    assert.equal(closedCodex.traceContext.sessionId, "session-state");
+    assert.equal(closedCodex.traceContext.turnId, "turn-state");
 
     const closedGlobal = JSON.parse(await readFile(paths.currentTurnPath, "utf8"));
     const closedScoped = JSON.parse(await readFile(paths.sessionCurrentTurnPath("session-state"), "utf8"));

--- a/packages/ts/memorax-code-backend/test/trace/dsh-memory-trace.test.mjs
+++ b/packages/ts/memorax-code-backend/test/trace/dsh-memory-trace.test.mjs
@@ -1,0 +1,131 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { loadMemoraxCodeConfig } from "../../dist/config/memorax-code.js";
+import {
+  dshTraceConfigFromEnv,
+  dshTracePaths,
+} from "../../dist/trace/config.js";
+import { traceContextFromDshHookBody } from "../../dist/trace/context.js";
+import {
+  markCurrentDshTurnOutcome,
+  readOpenDshTurn,
+  recordDshTraceEvent,
+  writeCurrentDshTurn,
+} from "../../dist/trace/store.js";
+
+test("dsh trace config defaults to enabled and reads config.toml overrides", async () => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-code-dsh-trace-config-"));
+  try {
+    assert.deepEqual(dshTraceConfigFromEnv({ MEMORAX_CODE_HOME: root }), {
+      enabled: true,
+      captureContent: true,
+      retentionDays: 7,
+      maxEventChars: 20_000,
+      maxFileBytes: 52_428_800,
+    });
+
+    await writeFile(join(root, "config.toml"), [
+      "[trace.dsh]",
+      "enabled = false",
+      "capture_content = false",
+      "retention_days = 3",
+      "max_event_chars = 1234",
+      "max_file_bytes = 9999",
+      "",
+    ].join("\n"), "utf8");
+
+    const config = loadMemoraxCodeConfig(root);
+    assert.deepEqual(dshTraceConfigFromEnv({ MEMORAX_CODE_HOME: root }, config), {
+      enabled: false,
+      captureContent: false,
+      retentionDays: 3,
+      maxEventChars: 1234,
+      maxFileBytes: 9999,
+    });
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("trace context factory normalizes DSH Hook body fields", () => {
+  const context = traceContextFromDshHookBody({
+    session_id: "session-dsh",
+    turn_id: "dsh-0-1",
+    transcript_path: "/tmp/dsh.jsonl",
+    cwd: "/repo",
+    workspace_kind: "projectless",
+  }, "2026-07-09T00:01:00.000Z");
+
+  assert.deepEqual(context, {
+    schemaVersion: "1",
+    client: "dsh",
+    sessionId: "session-dsh",
+    turnId: "dsh-0-1",
+    transcriptPath: "/tmp/dsh.jsonl",
+    cwd: "/repo",
+    workspaceKind: "projectless",
+    contextOrigin: "dsh-hook-body",
+    capturedAt: "2026-07-09T00:01:00.000Z",
+  });
+});
+
+test("DSH trace store writes turn events and closes the current turn", async () => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-code-dsh-trace-store-"));
+  try {
+    const context = traceContextFromDshHookBody({
+      session_id: "session-dsh-trace",
+      turn_id: "dsh-0-2",
+      cwd: "/repo",
+    }, "2026-07-09T00:00:00.000Z");
+
+    assert.deepEqual(await writeCurrentDshTurn(context, { memoraxCodeHome: root }), { written: true });
+
+    const open = await readOpenDshTurn({
+      memoraxCodeHome: root,
+      expectedSessionId: "session-dsh-trace",
+    });
+    assert.equal(open.ok, true);
+    assert.equal(open.traceContext.client, "dsh");
+
+    await recordDshTraceEvent({
+      memoraxCodeHome: root,
+      traceContext: context,
+      type: "turn_start",
+      source: "unknown",
+      operation: "query",
+      ok: true,
+      now: () => new Date("2026-07-09T00:00:01.000Z"),
+    });
+
+    const eventsPath = dshTracePaths(root).eventsJsonl("session-dsh-trace");
+    const event = JSON.parse((await readFile(eventsPath, "utf8")).trim());
+    assert.equal(event.trace.client, "dsh");
+    assert.equal(event.trace.context_origin, "dsh-hook-body");
+
+    await markCurrentDshTurnOutcome(context, "completed", { memoraxCodeHome: root });
+    const closed = await readOpenDshTurn({
+      memoraxCodeHome: root,
+      expectedSessionId: "session-dsh-trace",
+    });
+    assert.equal(closed.ok, false);
+    assert.equal(closed.reason, "closed");
+    assert.equal(closed.outcome, "completed");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("DSH trace paths resolve under the client-specific trace root", async () => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-code-dsh-trace-paths-"));
+  try {
+    await mkdir(root, { recursive: true });
+    const paths = dshTracePaths(root);
+    assert.match(paths.root, /traces\/dsh$/);
+    assert.match(paths.sessionDir("session-x"), /traces\/dsh\/sessions\/session-x$/);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/packages/ts/memorax-code-backend/test/transport/http/memory-hook.test.mjs
+++ b/packages/ts/memorax-code-backend/test/transport/http/memory-hook.test.mjs
@@ -109,6 +109,13 @@ test("Backend DSH turn-discard endpoint discards turn metadata", async () => {
       }),
     });
     assert.equal(start.status, 200);
+    // The adapter treats body.ok=false on turn-start as a hard rejection, so
+    // pin the actual DSH turn-start response shape at the HTTP layer: an
+    // accepted start must answer { ok: true } (plus optional context fields),
+    // never a body-level error.
+    const startBody = await start.json();
+    assert.equal(startBody.ok, true);
+    assert.equal(startBody.error, undefined);
 
     const discard = await originalFetch(`${url}/memory/turn-discard`, {
       method: "POST",
@@ -478,6 +485,80 @@ test("Backend memory hook endpoints write client-isolated trace events", async (
     globalThis.fetch = originalFetch;
     restoreEnv();
     await rm(sessionHome, { recursive: true, force: true });
+  }
+});
+
+test("Backend memory hook endpoints refuse non-JSON content types and browser origins", async () => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-code-hook-http-hardening-"));
+  const state = createBackendState("127.0.0.1", { sessionHome: root });
+  const server = createBackendServer(state);
+  const url = await listen(server);
+  const dshTurnStart = {
+    version: 1,
+    client: "dsh",
+    sessionId: "session-hook-hardening",
+    turnId: "dsh-0-1",
+    prompt: "Hardening prompt.",
+  };
+  try {
+    // Missing content type.
+    const untyped = await fetch(`${url}/memory/turn-start`, {
+      method: "POST",
+      body: JSON.stringify(dshTurnStart),
+    });
+    assert.equal(untyped.status, 415);
+    assert.deepEqual(await untyped.json(), { ok: false, error: "content-type must be application/json" });
+
+    // text/plain, the shape a cross-site HTML form can send.
+    const textPlain = await fetch(`${url}/memory/turn-start`, {
+      method: "POST",
+      headers: { "content-type": "text/plain" },
+      body: JSON.stringify(dshTurnStart),
+    });
+    assert.equal(textPlain.status, 415);
+
+    // A browser-style Origin header, even with the correct content type.
+    const withOrigin = await fetch(`${url}/memory/turn-start`, {
+      method: "POST",
+      headers: { "content-type": "application/json", origin: "http://127.0.0.1:8787" },
+      body: JSON.stringify(dshTurnStart),
+    });
+    assert.equal(withOrigin.status, 403);
+    assert.deepEqual(await withOrigin.json(), { ok: false, error: "cross-origin hook requests are not accepted" });
+
+    // Same guard applies to the writeback and discard endpoints.
+    const originWriteback = await fetch(`${url}/memory/writeback`, {
+      method: "POST",
+      headers: { "content-type": "application/json", origin: "https://evil.example" },
+      body: JSON.stringify({
+        version: 1,
+        client: "dsh",
+        sessionId: "session-hook-hardening",
+        turnId: "dsh-0-1",
+        userText: "poison",
+        assistantText: "poison",
+      }),
+    });
+    assert.equal(originWriteback.status, 403);
+
+    // The normal native-client shape (JSON content type, no Origin) is unaffected.
+    const native = await fetch(`${url}/memory/turn-start`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ...dshTurnStart, cwd: TEST_WORKSPACE }),
+    });
+    assert.equal(native.status, 200);
+
+    // Charset parameters on the JSON media type are still accepted.
+    const charset = await fetch(`${url}/memory/turn-start`, {
+      method: "POST",
+      headers: { "content-type": "application/json; charset=utf-8" },
+      body: JSON.stringify({ ...dshTurnStart, turnId: "dsh-0-2", cwd: TEST_WORKSPACE }),
+    });
+    assert.equal(charset.status, 200);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+    await rm(root, { recursive: true, force: true });
   }
 });
 

--- a/packages/ts/memorax-code-backend/test/transport/http/memory-hook.test.mjs
+++ b/packages/ts/memorax-code-backend/test/transport/http/memory-hook.test.mjs
@@ -83,6 +83,65 @@ test("Backend memory hook endpoints record and write back a turn", async () => {
   }
 });
 
+test("Backend DSH turn-discard endpoint discards turn metadata", async () => {
+  const sessionHome = await mkdtemp(join(tmpdir(), "memorax-code-hook-http-dsh-discard-"));
+  const restoreEnv = withEnv({
+    ...WRITEBACK_ENV,
+    MEMORAX_CODE_HOME: undefined,
+    MEMORAX_CODE_MEMORY_RETRIEVAL_ENABLED: "false",
+    MEMORAX_CODE_DSH_TRACE_ENABLED: "false",
+  });
+  const originalFetch = globalThis.fetch;
+  const state = createBackendState("127.0.0.1", { sessionHome });
+  const server = createBackendServer(state);
+  const url = await listen(server);
+  try {
+    const start = await originalFetch(`${url}/memory/turn-start`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        version: 1,
+        client: "dsh",
+        sessionId: "session-dsh-discard",
+        turnId: "dsh-0-1",
+        prompt: "Interrupted prompt.",
+        cwd: TEST_WORKSPACE,
+      }),
+    });
+    assert.equal(start.status, 200);
+
+    const discard = await originalFetch(`${url}/memory/turn-discard`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        version: 1,
+        client: "dsh",
+        sessionId: "session-dsh-discard",
+        turnId: "dsh-0-1",
+      }),
+    });
+    assert.equal(discard.status, 200);
+    assert.deepEqual(await discard.json(), { ok: true, discarded: true });
+
+    const replayDiscard = await originalFetch(`${url}/memory/turn-discard`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        version: 1,
+        client: "dsh",
+        sessionId: "session-dsh-discard",
+        turnId: "dsh-0-1",
+      }),
+    });
+    assert.equal(replayDiscard.status, 200);
+    assert.deepEqual(await replayDiscard.json(), { ok: true, discarded: false });
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+    restoreEnv();
+    await rm(sessionHome, { recursive: true, force: true });
+  }
+});
+
 test("Backend memory hook endpoints reject commands outside the closed schema", async () => {
   const root = await mkdtemp(join(tmpdir(), "memorax-code-hook-http-contract-"));
   const state = createBackendState("127.0.0.1", { sessionHome: root });

--- a/packages/ts/memorax-code-backend/test/viewer/history/memory-viewer-client-history.test.mjs
+++ b/packages/ts/memorax-code-backend/test/viewer/history/memory-viewer-client-history.test.mjs
@@ -390,6 +390,61 @@ test("memory viewer tags DSH events as their own client and excludes them from t
   assert.equal(claude.events.some((event) => event.client === "dsh"), false);
 });
 
+test("memory viewer loads persisted DSH trace history into the DSH view", async (t) => {
+  // Round 10 #4: the DSH filter used to fall through to the codex+claude
+  // sweep, so live DSH events showed but on-disk DSH trace history never
+  // loaded. The DSH view must read the DSH sessions root, and the DSH
+  // projection key must be its own directory (not the codex one).
+  const memoraxCodeHome = await mkdtemp(join(tmpdir(), "memorax-code-viewer-dsh-history-"));
+  t.after(() => rm(memoraxCodeHome, { recursive: true, force: true }));
+  const projectId = `repo:${"d".repeat(32)}`;
+  await writeTraceEvents(memoraxCodeHome, "dsh", "dsh-history-session", [{
+    type: "memory_retrieve",
+    event_id: "dsh-history-event",
+    timestamp: "2026-07-28T00:02:00.000Z",
+    trace: {
+      session_id: "dsh-history-session",
+      memory_project: { project_id: projectId, project_label: "DSH Project" },
+    },
+    source: "dsh_hook_retrieval",
+    operation: "retrieve",
+    ok: true,
+    response: { items: [{ memory: "Persisted DSH memory." }] },
+  }]);
+  // A codex event with the SAME native ids must stay out of the DSH view and
+  // must not collide with it (identity is client-scoped).
+  await writeTraceEvents(memoraxCodeHome, "codex", "dsh-history-session", [{
+    type: "memory_retrieve",
+    event_id: "dsh-history-event",
+    timestamp: "2026-07-28T00:03:00.000Z",
+    trace: {
+      session_id: "dsh-history-session",
+      memory_project: { project_id: projectId, project_label: "DSH Project" },
+    },
+    source: "direct_overlay",
+    operation: "retrieve",
+    ok: true,
+    response: { items: [{ memory: "Codex memory." }] },
+  }]);
+
+  const dsh = await listMemoryViewerDataWithHistory(memoraxCodeHome, { client: "dsh" });
+  assert.deepEqual(dsh.events.map(({ client, id, content }) => ({ client, id, content })), [{
+    client: "dsh",
+    id: "dsh-trace:dsh-history-event",
+    content: "Persisted DSH memory.",
+  }]);
+  assert.deepEqual(dsh.projectSessions.map((entry) => entry.client), ["dsh"]);
+
+  const all = await listMemoryViewerDataWithHistory(memoraxCodeHome);
+  assert.deepEqual(
+    all.events.map((event) => `${event.client}:${event.id}`).sort(),
+    ["codex:trace:dsh-history-event", "dsh:dsh-trace:dsh-history-event"],
+  );
+
+  const codex = await listMemoryViewerDataWithHistory(memoraxCodeHome, { client: "codex" });
+  assert.equal(codex.events.some((event) => event.client === "dsh"), false);
+});
+
 async function writeTraceEvents(memoraxCodeHome, client, sessionDir, events) {
   const directory = join(memoraxCodeHome, "debug", "traces", client, "sessions", sessionDir);
   const path = join(directory, "events.jsonl");

--- a/packages/ts/memorax-code-backend/test/viewer/history/memory-viewer-client-history.test.mjs
+++ b/packages/ts/memorax-code-backend/test/viewer/history/memory-viewer-client-history.test.mjs
@@ -355,6 +355,41 @@ test("memory viewer assigns a client to live events and preserves Codex identiti
   assert.equal(new Set(live.map((event) => event.eventKey)).size, 3);
 });
 
+test("memory viewer tags DSH events as their own client and excludes them from the Codex view", async (t) => {
+  const memoraxCodeHome = await mkdtemp(join(tmpdir(), "memorax-code-viewer-dsh-"));
+  t.after(() => rm(memoraxCodeHome, { recursive: true, force: true }));
+  const dshContext = (sessionId) => ({
+    schemaVersion: "1",
+    client: "dsh",
+    sessionId,
+    contextOrigin: "dsh-hook-body",
+    capturedAt: "2026-07-28T00:00:00.000Z",
+  });
+  recordMemoryViewerEvent({
+    eventId: "dsh-live-event",
+    source: "dsh_hook_writeback",
+    operation: "writeback",
+    ok: true,
+    traceContext: dshContext("dsh-session"),
+  });
+  recordMemoryViewerEvent({
+    source: "dsh_hook_retrieval",
+    operation: "retrieve",
+    ok: true,
+    traceContext: dshContext("dsh-session-2"),
+  });
+
+  const live = listMemoryViewerEvents();
+  assert.deepEqual(live.map((event) => event.client), ["dsh", "dsh"]);
+  assert.equal(live[0].id, "dsh-trace:dsh-live-event");
+  assert.match(live[1].id, /^dsh-memory-viewer:/);
+
+  const codex = await listMemoryViewerDataWithHistory(memoraxCodeHome, { client: "codex" });
+  assert.equal(codex.events.some((event) => event.client === "dsh"), false);
+  const claude = await listMemoryViewerDataWithHistory(memoraxCodeHome, { client: "claude" });
+  assert.equal(claude.events.some((event) => event.client === "dsh"), false);
+});
+
 async function writeTraceEvents(memoraxCodeHome, client, sessionDir, events) {
   const directory = join(memoraxCodeHome, "debug", "traces", client, "sessions", sessionDir);
   const path = join(directory, "events.jsonl");

--- a/packages/ts/memorax-code-codex-adapter/test/config-utils-lock.test.mjs
+++ b/packages/ts/memorax-code-codex-adapter/test/config-utils-lock.test.mjs
@@ -7,6 +7,7 @@ import {
   mkdir,
   mkdtemp,
   readFile,
+  readdir,
   rm,
   stat,
   utimes,
@@ -16,6 +17,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import {
+  atomicWriteJson,
+  atomicWriteText,
   withJsonFileLock,
   withJsonFileLockAsync,
 } from "../../memorax-code-adapter-common/src/config-utils.mjs";
@@ -253,3 +256,34 @@ function runWorker(path, args) {
     child.on("close", (code) => resolve({ code, stderr }));
   });
 }
+
+test("atomicWriteText writes private, atomically replaced files with no temp residue", async () => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-code-atomic-write-text-"));
+  const directory = join(root, "nested");
+  const path = join(directory, "state.json");
+  try {
+    atomicWriteText(path, "first\n");
+    atomicWriteText(path, "second\n");
+    assert.equal(await readFile(path, "utf8"), "second\n");
+    if (process.platform !== "win32") {
+      assert.equal((await stat(path)).mode & 0o777, 0o600);
+    }
+    assert.deepEqual((await readdir(directory)).sort(), ["state.json"]);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("atomicWriteJson serializes and replaces the target atomically", async () => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-code-atomic-write-json-"));
+  const path = join(root, "state.json");
+  try {
+    atomicWriteJson(path, { version: 1, enabled: true });
+    assert.deepEqual(JSON.parse(await readFile(path, "utf8")), { version: 1, enabled: true });
+    atomicWriteJson(path, { version: 2 });
+    assert.deepEqual(JSON.parse(await readFile(path, "utf8")), { version: 2 });
+    assert.deepEqual((await readdir(root)).sort(), ["state.json"]);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/packages/ts/memorax-code-dsh-adapter/cordis.patch.yml
+++ b/packages/ts/memorax-code-dsh-adapter/cordis.patch.yml
@@ -4,10 +4,11 @@
     - id: memorax-dsh
       name: '@memorax/memorax-code-dsh-adapter'
       config:
-        # Defaults are resolved per-process in the adapter; environment
-        # variables (MEMORAX_CODE_BACKEND_URL, MEMORAX_CODE_BACKEND_TOKEN,
-        # MEMORAX_CODE_DSH_HOOK_TIMEOUT_MS, MEMORAX_CODE_DSH_RETRIEVAL_INJECT)
-        # take precedence over these neutral defaults.
+        # Neutral bundle defaults. Environment variables
+        # (MEMORAX_CODE_DSH_HOOK_TIMEOUT_MS, MEMORAX_CODE_DSH_RETRIEVAL_INJECT,
+        # MEMORAX_CODE_DSH_HOOK_DEBUG) override these per-process defaults;
+        # the Backend URL and token are resolved config-first with environment
+        # fallback (MEMORAX_CODE_BACKEND_URL, MEMORAX_CODE_BACKEND_TOKEN).
         timeoutMs: 5000
         injectRetrieval: false
         debug: false

--- a/packages/ts/memorax-code-dsh-adapter/cordis.patch.yml
+++ b/packages/ts/memorax-code-dsh-adapter/cordis.patch.yml
@@ -1,0 +1,13 @@
+# MemoraX Code DSH adapter bundle patch. Applied as a single insert over the
+# composed profile; later layers address the row by id `memorax-dsh`.
+- insert:
+    - id: memorax-dsh
+      name: '@memorax/memorax-code-dsh-adapter'
+      config:
+        # Defaults are resolved per-process in the adapter; environment
+        # variables (MEMORAX_CODE_BACKEND_URL, MEMORAX_CODE_BACKEND_TOKEN,
+        # MEMORAX_CODE_DSH_HOOK_TIMEOUT_MS, MEMORAX_CODE_DSH_RETRIEVAL_INJECT)
+        # take precedence over these neutral defaults.
+        timeoutMs: 5000
+        injectRetrieval: false
+        debug: false

--- a/packages/ts/memorax-code-dsh-adapter/package.json
+++ b/packages/ts/memorax-code-dsh-adapter/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@memorax/memorax-code-dsh-adapter",
+  "version": "0.1.2",
+  "private": true,
+  "type": "module",
+  "description": "DeepSeek Harness (DSH) cordis plugin and session bridge for MemoraX Code memory.",
+  "main": "src/index.mjs",
+  "exports": {
+    ".": "./src/index.mjs",
+    "./cordis.patch.yml": "./cordis.patch.yml",
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "src",
+    "cordis.patch.yml"
+  ],
+  "dsh": {
+    "bundle": {
+      "patch": "./cordis.patch.yml"
+    }
+  },
+  "scripts": {
+    "test": "node --test test/*.test.mjs"
+  },
+  "peerDependencies": {
+    "@deepseek-ai/cordis": "^4.0.1"
+  },
+  "engines": {
+    "node": ">=24"
+  },
+  "license": "MIT"
+}

--- a/packages/ts/memorax-code-dsh-adapter/src/backend-forwarder.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/src/backend-forwarder.mjs
@@ -46,6 +46,17 @@ export async function postBackend(path, body, options = {}) {
       { status: response.status },
     );
   }
+  if (parsed === undefined || parsed === null || typeof parsed !== "object") {
+    // A 2xx without a parseable JSON object is not a success: the session
+    // bridge reads body.ok/scheduled/reason/discarded from this payload, and
+    // swallowing a malformed body here would report every skip/rejection as
+    // an accepted dispatch with zero visibility.
+    throw new DshBackendError(
+      `Backend answered ${path} with HTTP ${response.status} but no JSON body`,
+      DSH_BACKEND_HTTP_ERROR,
+      { status: response.status },
+    );
+  }
   return { ok: true, status: response.status, body: parsed };
 }
 

--- a/packages/ts/memorax-code-dsh-adapter/src/backend-forwarder.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/src/backend-forwarder.mjs
@@ -30,6 +30,9 @@ export async function postBackend(path, body, options = {}) {
       method: "POST",
       headers,
       body: JSON.stringify(body),
+      // Never follow redirects: a 307/308 would silently forward the Backend
+      // token header and the command body to whatever the redirect targets.
+      redirect: "error",
       signal: AbortSignal.timeout(timeoutMs),
     });
   } catch (error) {

--- a/packages/ts/memorax-code-dsh-adapter/src/backend-forwarder.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/src/backend-forwarder.mjs
@@ -1,0 +1,34 @@
+import { DEFAULT_TIMEOUT_MS } from "./config.mjs";
+
+export async function postBackend(path, body, options = {}) {
+  const backendUrl = options.backendUrl;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  if (!backendUrl) return { ok: false, error: "backend URL is not configured" };
+  try {
+    const headers = { "content-type": "application/json", connection: "close" };
+    if (options.token) headers["x-memorax-code-backend-token"] = options.token;
+    const url = new URL(path, backendUrl.endsWith("/") ? backendUrl : `${backendUrl}/`);
+    const response = await fetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    const parsed = await response.json().catch(() => undefined);
+    return { ok: response.ok, status: response.status, body: parsed };
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+export function createBackendForwarder(connection) {
+  return {
+    async forward(path, body) {
+      return await postBackend(path, body, {
+        backendUrl: connection.backendUrl,
+        token: connection.token,
+        timeoutMs: connection.timeoutMs,
+      });
+    },
+  };
+}

--- a/packages/ts/memorax-code-dsh-adapter/src/backend-forwarder.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/src/backend-forwarder.mjs
@@ -1,24 +1,49 @@
 import { DEFAULT_TIMEOUT_MS } from "./config.mjs";
 
+export const DSH_BACKEND_UNREACHABLE = "DSH_BACKEND_UNREACHABLE";
+export const DSH_BACKEND_TIMEOUT = "DSH_BACKEND_TIMEOUT";
+export const DSH_BACKEND_HTTP_ERROR = "DSH_BACKEND_HTTP_ERROR";
+export const DSH_BACKEND_NOT_CONFIGURED = "DSH_BACKEND_NOT_CONFIGURED";
+
+export class DshBackendError extends Error {
+  constructor(message, code, options = {}) {
+    super(message);
+    this.name = "DshBackendError";
+    this.code = code;
+    if (options.status !== undefined) this.status = options.status;
+    if (options.cause !== undefined) this.cause = options.cause;
+  }
+}
+
 export async function postBackend(path, body, options = {}) {
   const backendUrl = options.backendUrl;
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-  if (!backendUrl) return { ok: false, error: "backend URL is not configured" };
+  if (!backendUrl) {
+    throw new DshBackendError("backend URL is not configured", DSH_BACKEND_NOT_CONFIGURED);
+  }
+  let response;
   try {
     const headers = { "content-type": "application/json", connection: "close" };
     if (options.token) headers["x-memorax-code-backend-token"] = options.token;
     const url = new URL(path, backendUrl.endsWith("/") ? backendUrl : `${backendUrl}/`);
-    const response = await fetch(url, {
+    response = await fetch(url, {
       method: "POST",
       headers,
       body: JSON.stringify(body),
       signal: AbortSignal.timeout(timeoutMs),
     });
-    const parsed = await response.json().catch(() => undefined);
-    return { ok: response.ok, status: response.status, body: parsed };
   } catch (error) {
-    return { ok: false, error: error instanceof Error ? error.message : String(error) };
+    throw dshBackendNetworkError(error);
   }
+  const parsed = await response.json().catch(() => undefined);
+  if (!response.ok) {
+    throw new DshBackendError(
+      `Backend rejected ${path} with HTTP ${response.status}`,
+      DSH_BACKEND_HTTP_ERROR,
+      { status: response.status },
+    );
+  }
+  return { ok: true, status: response.status, body: parsed };
 }
 
 export function createBackendForwarder(connection) {
@@ -31,4 +56,13 @@ export function createBackendForwarder(connection) {
       });
     },
   };
+}
+
+function dshBackendNetworkError(error) {
+  const timedOut = error?.name === "TimeoutError" || error?.name === "AbortError";
+  return new DshBackendError(
+    timedOut ? "Backend request timed out" : "Backend is unreachable",
+    timedOut ? DSH_BACKEND_TIMEOUT : DSH_BACKEND_UNREACHABLE,
+    { cause: error },
+  );
 }

--- a/packages/ts/memorax-code-dsh-adapter/src/config.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/src/config.mjs
@@ -1,15 +1,70 @@
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { isAbsolute, join, resolve } from "node:path";
+
 export const DEFAULT_BACKEND_URL = "http://127.0.0.1:8787";
 export const DEFAULT_TIMEOUT_MS = 5000;
 
 export const MEMORY_HOOK_COMMAND_VERSION = 1;
 
-export function resolveBackendConnection(config = {}, env = process.env) {
-  const backendUrl = normalizeHttpUrl(config.backendUrl)
-    ?? normalizeHttpUrl(env.MEMORAX_CODE_BACKEND_URL)
-    ?? backendUrlFromHostPort(env)
-    ?? DEFAULT_BACKEND_URL;
-  const token = stringValue(config.backendToken)
+// The managed Backend announces its URL (and, in server mode, its token file)
+// through an authority record under the MemoraX Code home directory. The
+// canonical reader lives in memorax-code-adapter-common
+// (backend-connection.mjs); this adapter is a standalone cordis plugin and
+// cannot import that package, so the validation rules are mirrored here and
+// pinned by the backend contract test. Differences are deliberate: a broken
+// authority record must NOT throw inside a fail-silent plugin — it warns and
+// falls back, while adapter-common fails fast in CLI contexts.
+const BACKEND_CONNECTION_VERSION = 1;
+const BACKEND_TOKEN_VERSION = 1;
+const BACKEND_CONNECTION_KEYS = new Set(["version", "url", "tokenPath"]);
+const BACKEND_TOKEN_KEYS = new Set(["version", "token", "createdAt", "rotatedAt"]);
+
+export function resolveBackendConnection(config = {}, env = process.env, options = {}) {
+  const onInvalidBackendUrl = typeof options.onInvalidBackendUrl === "function"
+    ? options.onInvalidBackendUrl
+    : undefined;
+  const onAuthorityIssue = typeof options.onAuthorityIssue === "function"
+    ? options.onAuthorityIssue
+    : undefined;
+  const memoraxCodeHome = stringValue(env.MEMORAX_CODE_HOME)
+    ?? join(homedir(), ".memorax-code");
+  const authority = readBackendConnectionAuthority(memoraxCodeHome, onAuthorityIssue);
+
+  const configUrl = stringValue(config.backendUrl);
+  const envUrl = stringValue(env.MEMORAX_CODE_BACKEND_URL);
+  let selected;
+  if (normalizeHttpUrl(configUrl)) {
+    selected = { url: normalizeHttpUrl(configUrl), source: "config" };
+  } else if (configUrl) {
+    warnInvalidUrl(configUrl, "config backendUrl");
+    selected = undefined;
+  }
+  if (!selected && normalizeHttpUrl(envUrl)) {
+    selected = { url: normalizeHttpUrl(envUrl), source: "environment" };
+  } else if (!selected && envUrl) {
+    warnInvalidUrl(envUrl, "MEMORAX_CODE_BACKEND_URL");
+  }
+  if (!selected) {
+    const hostPortUrl = backendUrlFromHostPort(env);
+    if (hostPortUrl) selected = { url: hostPortUrl, source: "environment" };
+  }
+  if (!selected && authority) {
+    selected = { url: authority.url, source: "authority" };
+  }
+  if (!selected) selected = { url: DEFAULT_BACKEND_URL, source: "default" };
+
+  const envToken = stringValue(config.backendToken)
     ?? stringValue(env.MEMORAX_CODE_BACKEND_TOKEN);
+  // The persisted token is only trusted when the selected URL really came
+  // from the authority record: sending the managed token to a user-supplied
+  // URL would leak it to an arbitrary destination.
+  const persistedToken = !envToken
+    && selected.source === "authority"
+    && authority?.tokenPath
+    ? readBackendToken(authority.tokenPath, memoraxCodeHome, onAuthorityIssue)
+    : undefined;
+  const token = envToken ?? persistedToken;
   const timeoutMs = positiveInteger(
     env.MEMORAX_CODE_DSH_HOOK_TIMEOUT_MS,
     config.timeoutMs,
@@ -25,7 +80,133 @@ export function resolveBackendConnection(config = {}, env = process.env) {
     config.debug,
     false,
   );
-  return { backendUrl, token, timeoutMs, injectRetrieval, debug };
+  return {
+    backendUrl: selected.url,
+    urlSource: selected.source,
+    token,
+    tokenSource: envToken ? "environment" : persistedToken ? "authority-file" : "none",
+    timeoutMs,
+    injectRetrieval,
+    debug,
+  };
+
+  function warnInvalidUrl(value, source) {
+    // An explicitly configured URL that cannot be normalized (missing
+    // scheme, wrong scheme, typo) is a misconfiguration: surface it instead
+    // of silently falling back to the default loopback URL.
+    onInvalidBackendUrl?.(value, source);
+  }
+}
+
+export function backendConnectionPath(memoraxCodeHome) {
+  return join(memoraxCodeHome, "runtime", "backend", "backend-connection.json");
+}
+
+export function backendTokenPath(memoraxCodeHome) {
+  return join(memoraxCodeHome, "runtime", "backend", "backend-token.json");
+}
+
+function readBackendConnectionAuthority(memoraxCodeHome, onAuthorityIssue) {
+  const path = backendConnectionPath(memoraxCodeHome);
+  let value;
+  try {
+    value = JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    // Absent or unreadable: the managed Backend may simply not have written
+    // it yet. Nothing to announce for the common absent case.
+    if (!authorityRecordExists(path)) return undefined;
+    onAuthorityIssue?.("backend connection record is unreadable", path);
+    return undefined;
+  }
+  if (!isRecord(value)) {
+    onAuthorityIssue?.("backend connection record is not an object", path);
+    return undefined;
+  }
+  if (value.version !== BACKEND_CONNECTION_VERSION) {
+    onAuthorityIssue?.(`backend connection record version ${String(value.version)} is unsupported`, path);
+    return undefined;
+  }
+  if (Object.keys(value).some((key) => !BACKEND_CONNECTION_KEYS.has(key))) {
+    onAuthorityIssue?.("backend connection record has unknown fields", path);
+    return undefined;
+  }
+  const url = normalizedManagedBackendUrl(value.url);
+  if (!url) {
+    onAuthorityIssue?.("backend connection record URL is invalid", path);
+    return undefined;
+  }
+  let tokenPath;
+  if (Object.prototype.hasOwnProperty.call(value, "tokenPath")) {
+    tokenPath = canonicalTokenPath(value.tokenPath, memoraxCodeHome);
+    if (!tokenPath) {
+      onAuthorityIssue?.("backend connection record tokenPath is invalid", path);
+      return undefined;
+    }
+  }
+  return { url, ...(tokenPath ? { tokenPath } : {}) };
+}
+
+function readBackendToken(expectedPath, memoraxCodeHome, onAuthorityIssue) {
+  const path = backendTokenPath(memoraxCodeHome);
+  if (resolve(path) !== resolve(expectedPath)) return undefined;
+  let value;
+  try {
+    value = JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return undefined;
+  }
+  if (!isRecord(value)) {
+    onAuthorityIssue?.("backend token record is not an object", path);
+    return undefined;
+  }
+  if (value.version !== BACKEND_TOKEN_VERSION) {
+    onAuthorityIssue?.(`backend token record version ${String(value.version)} is unsupported`, path);
+    return undefined;
+  }
+  if (Object.keys(value).some((key) => !BACKEND_TOKEN_KEYS.has(key))) {
+    onAuthorityIssue?.("backend token record has unknown fields", path);
+    return undefined;
+  }
+  const token = stringValue(value.token);
+  if (!token) {
+    onAuthorityIssue?.("backend token record has no token", path);
+    return undefined;
+  }
+  const createdAt = stringValue(value.createdAt);
+  if (!createdAt || !Number.isFinite(Date.parse(createdAt))) {
+    onAuthorityIssue?.("backend token record createdAt is invalid", path);
+    return undefined;
+  }
+  return token;
+}
+
+function authorityRecordExists(path) {
+  try {
+    readFileSync(path, "utf8");
+    return true;
+  } catch (error) {
+    return error?.code !== "ENOENT";
+  }
+}
+
+function canonicalTokenPath(value, memoraxCodeHome) {
+  const candidate = stringValue(value);
+  if (!candidate || !isAbsolute(candidate)) return undefined;
+  const expected = resolve(backendTokenPath(memoraxCodeHome));
+  return resolve(candidate) === expected ? expected : undefined;
+}
+
+function normalizedManagedBackendUrl(value) {
+  const url = normalizeHttpUrl(value);
+  if (!url) return undefined;
+  const parsed = new URL(url);
+  if (parsed.protocol !== "http:"
+    || parsed.username
+    || parsed.password
+    || parsed.pathname !== "/"
+    || parsed.search
+    || parsed.hash) return undefined;
+  return url;
 }
 
 export function normalizeHttpUrl(value) {
@@ -72,4 +253,8 @@ function booleanValue(...values) {
     if (["0", "false", "no", "off"].includes(normalized)) return false;
   }
   return false;
+}
+
+function isRecord(value) {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
 }

--- a/packages/ts/memorax-code-dsh-adapter/src/config.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/src/config.mjs
@@ -11,18 +11,18 @@ export function resolveBackendConnection(config = {}, env = process.env) {
   const token = stringValue(config.backendToken)
     ?? stringValue(env.MEMORAX_CODE_BACKEND_TOKEN);
   const timeoutMs = positiveInteger(
-    config.timeoutMs,
     env.MEMORAX_CODE_DSH_HOOK_TIMEOUT_MS,
+    config.timeoutMs,
     DEFAULT_TIMEOUT_MS,
   );
   const injectRetrieval = booleanValue(
-    config.injectRetrieval,
     env.MEMORAX_CODE_DSH_RETRIEVAL_INJECT,
+    config.injectRetrieval,
     false,
   );
   const debug = booleanValue(
-    config.debug,
     env.MEMORAX_CODE_DSH_HOOK_DEBUG,
+    config.debug,
     false,
   );
   return { backendUrl, token, timeoutMs, injectRetrieval, debug };

--- a/packages/ts/memorax-code-dsh-adapter/src/config.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/src/config.mjs
@@ -1,0 +1,75 @@
+export const DEFAULT_BACKEND_URL = "http://127.0.0.1:8787";
+export const DEFAULT_TIMEOUT_MS = 5000;
+
+export const MEMORY_HOOK_COMMAND_VERSION = 1;
+
+export function resolveBackendConnection(config = {}, env = process.env) {
+  const backendUrl = normalizeHttpUrl(config.backendUrl)
+    ?? normalizeHttpUrl(env.MEMORAX_CODE_BACKEND_URL)
+    ?? backendUrlFromHostPort(env)
+    ?? DEFAULT_BACKEND_URL;
+  const token = stringValue(config.backendToken)
+    ?? stringValue(env.MEMORAX_CODE_BACKEND_TOKEN);
+  const timeoutMs = positiveInteger(
+    config.timeoutMs,
+    env.MEMORAX_CODE_DSH_HOOK_TIMEOUT_MS,
+    DEFAULT_TIMEOUT_MS,
+  );
+  const injectRetrieval = booleanValue(
+    config.injectRetrieval,
+    env.MEMORAX_CODE_DSH_RETRIEVAL_INJECT,
+    false,
+  );
+  const debug = booleanValue(
+    config.debug,
+    env.MEMORAX_CODE_DSH_HOOK_DEBUG,
+    false,
+  );
+  return { backendUrl, token, timeoutMs, injectRetrieval, debug };
+}
+
+export function normalizeHttpUrl(value) {
+  const candidate = stringValue(value);
+  if (!candidate) return undefined;
+  try {
+    const parsed = new URL(candidate);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return undefined;
+    return parsed.toString().replace(/\/+$/, "");
+  } catch {
+    return undefined;
+  }
+}
+
+export function backendUrlFromHostPort(env) {
+  const rawHost = stringValue(env.MEMORAX_CODE_BACKEND_HOST);
+  const rawPort = stringValue(env.MEMORAX_CODE_BACKEND_PORT);
+  if (!rawHost && !rawPort) return undefined;
+  const host = rawHost ?? "127.0.0.1";
+  const port = rawPort ?? "8787";
+  const formattedHost = host.includes(":") && !host.startsWith("[") ? `[${host}]` : host;
+  return normalizeHttpUrl(`http://${formattedHost}:${port}`);
+}
+
+export function stringValue(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function positiveInteger(...values) {
+  for (const value of values) {
+    if (typeof value === "number" && Number.isInteger(value) && value > 0) return value;
+    const parsed = typeof value === "string" ? Number(value) : NaN;
+    if (Number.isInteger(parsed) && parsed > 0) return parsed;
+  }
+  return DEFAULT_TIMEOUT_MS;
+}
+
+function booleanValue(...values) {
+  for (const value of values) {
+    if (typeof value === "boolean") return value;
+    if (typeof value !== "string") continue;
+    const normalized = value.trim().toLowerCase();
+    if (["1", "true", "yes", "on"].includes(normalized)) return true;
+    if (["0", "false", "no", "off"].includes(normalized)) return false;
+  }
+  return false;
+}

--- a/packages/ts/memorax-code-dsh-adapter/src/config.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/src/config.mjs
@@ -58,10 +58,14 @@ export function resolveBackendConnection(config = {}, env = process.env, options
     ?? stringValue(env.MEMORAX_CODE_BACKEND_TOKEN);
   // The persisted token is only trusted when the selected URL really came
   // from the authority record: sending the managed token to a user-supplied
-  // URL would leak it to an arbitrary destination.
-  const persistedToken = !envToken
-    && selected.source === "authority"
-    && authority?.tokenPath
+  // URL would leak it to an arbitrary destination. Canonical form (adapter-
+  // common): the token follows the URL when the SELECTED url equals the
+  // authority url, regardless of which source produced it. A user-configured
+  // URL that is byte-identical to the managed Backend URL is that Backend, so
+  // attaching the token leaks nothing — and gating on `source === "authority"`
+  // instead would drop the token and 401 every request in exactly that setup.
+  const authorityMatches = authority?.url === selected.url;
+  const persistedToken = !envToken && authorityMatches && authority?.tokenPath
     ? readBackendToken(authority.tokenPath, memoraxCodeHome, onAuthorityIssue)
     : undefined;
   const token = envToken ?? persistedToken;
@@ -123,7 +127,7 @@ function readBackendConnectionAuthority(memoraxCodeHome, onAuthorityIssue) {
     return undefined;
   }
   if (value.version !== BACKEND_CONNECTION_VERSION) {
-    onAuthorityIssue?.(`backend connection record version ${String(value.version)} is unsupported`, path);
+    onAuthorityIssue?.("backend connection record version is unsupported", path);
     return undefined;
   }
   if (Object.keys(value).some((key) => !BACKEND_CONNECTION_KEYS.has(key))) {
@@ -153,6 +157,10 @@ function readBackendToken(expectedPath, memoraxCodeHome, onAuthorityIssue) {
   try {
     value = JSON.parse(readFileSync(path, "utf8"));
   } catch {
+    // Every other failure mode of this record reports through onAuthorityIssue;
+    // an unreadable/corrupt token file must too, or the adapter silently runs
+    // token-less and 401s forever with no diagnostic trail.
+    onAuthorityIssue?.("backend token record is unreadable or not valid JSON", path);
     return undefined;
   }
   if (!isRecord(value)) {
@@ -160,7 +168,7 @@ function readBackendToken(expectedPath, memoraxCodeHome, onAuthorityIssue) {
     return undefined;
   }
   if (value.version !== BACKEND_TOKEN_VERSION) {
-    onAuthorityIssue?.(`backend token record version ${String(value.version)} is unsupported`, path);
+    onAuthorityIssue?.("backend token record version is unsupported", path);
     return undefined;
   }
   if (Object.keys(value).some((key) => !BACKEND_TOKEN_KEYS.has(key))) {
@@ -176,6 +184,16 @@ function readBackendToken(expectedPath, memoraxCodeHome, onAuthorityIssue) {
   if (!createdAt || !Number.isFinite(Date.parse(createdAt))) {
     onAuthorityIssue?.("backend token record createdAt is invalid", path);
     return undefined;
+  }
+  // Mirrors adapter-common's readBackendTokenRecord: a present-but-invalid
+  // rotatedAt rejects the record. Accepting it here would make this mirror
+  // trust a token file the canonical reader refuses.
+  if (Object.prototype.hasOwnProperty.call(value, "rotatedAt")) {
+    const rotatedAt = stringValue(value.rotatedAt);
+    if (!rotatedAt || !Number.isFinite(Date.parse(rotatedAt))) {
+      onAuthorityIssue?.("backend token record rotatedAt is invalid", path);
+      return undefined;
+    }
   }
   return token;
 }

--- a/packages/ts/memorax-code-dsh-adapter/src/index.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/src/index.mjs
@@ -1,0 +1,60 @@
+import { createBackendForwarder } from "./backend-forwarder.mjs";
+import { resolveBackendConnection } from "./config.mjs";
+import { createSessionBridge } from "./session-bridge.mjs";
+
+export const name = "memorax-dsh";
+
+export const inject = [];
+
+export function apply(ctx, config = {}) {
+  const connection = resolveBackendConnection(config, process.env);
+  const debug = connection.debug
+    ? (message, detail) => console.error(`[memorax-dsh] ${message}`, detail ?? "")
+    : () => {};
+  const bridge = createSessionBridge({
+    dispatch: createBackendForwarder(connection).forward,
+    debug,
+  });
+
+  ctx.on("session/created", (session) => {
+    try {
+      bridge.onSessionCreated(session);
+    } catch (error) {
+      debug("session/created handler failed", errorMessage(error));
+    }
+  });
+
+  ctx.on("session/event", (session, event) => {
+    try {
+      bridge.onSessionEvent(session, event);
+    } catch (error) {
+      debug("session/event handler failed", errorMessage(error));
+    }
+  });
+
+  ctx.on("session/disposed", (session) => {
+    try {
+      bridge.onSessionDisposed(session);
+    } catch (error) {
+      debug("session/disposed handler failed", errorMessage(error));
+    }
+  });
+
+  if (connection.injectRetrieval) {
+    ctx.on("llm/stream", async function* (options, next) {
+      try {
+        const context = bridge.takePendingContext(options?.sessionId);
+        if (context) {
+          options.system = options.system ? `${options.system}\n\n${context}` : context;
+        }
+      } catch (error) {
+        debug("llm/stream injection failed", errorMessage(error));
+      }
+      yield* next();
+    });
+  }
+}
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/ts/memorax-code-dsh-adapter/src/index.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/src/index.mjs
@@ -10,19 +10,37 @@ const RETRIEVAL_WAIT_MS = 300;
 
 export function apply(ctx, config) {
   const resolvedConfig = config ?? {};
-  const connection = resolveBackendConnection(resolvedConfig, process.env, {
-    onInvalidBackendUrl: (value, source) => console.error(
-      `[memorax-dsh] ignoring invalid ${source} "${value}"; falling back to the next configured Backend URL`,
-    ),
-    onAuthorityIssue: (reason, path) => console.error(
-      `[memorax-dsh] ignoring Backend connection record (${reason}: ${path}); falling back to the default Backend URL`,
-    ),
-  });
-  const debug = connection.debug
+  const initial = resolveBackendConnection(resolvedConfig, process.env);
+  const debug = initial.debug
     ? (message, detail) => console.error(`[memorax-dsh] ${message}`, detail ?? "")
     : () => {};
+
+  // The managed Backend may start AFTER this plugin loads, and its token can
+  // rotate while DSH keeps running. Freezing the connection at apply() time
+  // would strand the adapter on a stale URL/token until the plugin is
+  // reloaded, so every hook dispatch re-resolves the connection instead.
+  // Resolution reads at most two small JSON files at turn frequency; the
+  // invalid-config warnings are deduped so a broken record cannot spam stderr
+  // on every dispatch.
+  const reportedIssues = new Set();
+  const reportOnce = (message) => {
+    if (reportedIssues.has(message)) return;
+    reportedIssues.add(message);
+    console.error(message);
+  };
+  const dispatch = async (path, body) => {
+    const connection = resolveBackendConnection(resolvedConfig, process.env, {
+      onInvalidBackendUrl: (value, source) => reportOnce(
+        `[memorax-dsh] ignoring invalid ${source} "${value}"; falling back to the next configured Backend URL`,
+      ),
+      onAuthorityIssue: (reason, recordPath) => reportOnce(
+        `[memorax-dsh] ignoring Backend connection record (${reason}: ${recordPath}); falling back to the default Backend URL`,
+      ),
+    });
+    return await createBackendForwarder(connection).forward(path, body);
+  };
   const bridge = createSessionBridge({
-    dispatch: createBackendForwarder(connection).forward,
+    dispatch,
     debug,
   });
 
@@ -50,7 +68,10 @@ export function apply(ctx, config) {
     }
   });
 
-  if (connection.injectRetrieval) {
+  // Retrieval injection is decided once at apply(): it comes from static
+  // plugin config / environment (not from the rotating authority records), so
+  // per-dispatch re-resolution buys nothing here.
+  if (initial.injectRetrieval) {
     ctx.on("llm/stream", async function* (options, next) {
       try {
         const context = await bridge.waitForPendingContext(options?.sessionId, RETRIEVAL_WAIT_MS);

--- a/packages/ts/memorax-code-dsh-adapter/src/index.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/src/index.mjs
@@ -6,8 +6,9 @@ export const name = "memorax-dsh";
 
 export const inject = [];
 
-export function apply(ctx, config = {}) {
-  const connection = resolveBackendConnection(config, process.env);
+export function apply(ctx, config) {
+  const resolvedConfig = config ?? {};
+  const connection = resolveBackendConnection(resolvedConfig, process.env);
   const debug = connection.debug
     ? (message, detail) => console.error(`[memorax-dsh] ${message}`, detail ?? "")
     : () => {};

--- a/packages/ts/memorax-code-dsh-adapter/src/index.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/src/index.mjs
@@ -10,7 +10,14 @@ const RETRIEVAL_WAIT_MS = 300;
 
 export function apply(ctx, config) {
   const resolvedConfig = config ?? {};
-  const connection = resolveBackendConnection(resolvedConfig, process.env);
+  const connection = resolveBackendConnection(resolvedConfig, process.env, {
+    onInvalidBackendUrl: (value, source) => console.error(
+      `[memorax-dsh] ignoring invalid ${source} "${value}"; falling back to the next configured Backend URL`,
+    ),
+    onAuthorityIssue: (reason, path) => console.error(
+      `[memorax-dsh] ignoring Backend connection record (${reason}: ${path}); falling back to the default Backend URL`,
+    ),
+  });
   const debug = connection.debug
     ? (message, detail) => console.error(`[memorax-dsh] ${message}`, detail ?? "")
     : () => {};

--- a/packages/ts/memorax-code-dsh-adapter/src/index.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/src/index.mjs
@@ -6,6 +6,8 @@ export const name = "memorax-dsh";
 
 export const inject = [];
 
+const RETRIEVAL_WAIT_MS = 300;
+
 export function apply(ctx, config) {
   const resolvedConfig = config ?? {};
   const connection = resolveBackendConnection(resolvedConfig, process.env);
@@ -44,7 +46,7 @@ export function apply(ctx, config) {
   if (connection.injectRetrieval) {
     ctx.on("llm/stream", async function* (options, next) {
       try {
-        const context = bridge.takePendingContext(options?.sessionId);
+        const context = await bridge.waitForPendingContext(options?.sessionId, RETRIEVAL_WAIT_MS);
         if (context) {
           options.system = options.system ? `${options.system}\n\n${context}` : context;
         }

--- a/packages/ts/memorax-code-dsh-adapter/src/session-bridge.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/src/session-bridge.mjs
@@ -26,21 +26,31 @@ export function createSessionBridge({ dispatch, debug = () => {} }) {
       const state = sessionId ? sessions.get(sessionId) : undefined;
       if (!state || !isRecord(event)) return;
       switch (event.type) {
-        case "turn/start":
+        case "turn/start": {
+          const previousTurn = state.turn;
+          const previousTurnStarted = state.turnStarted;
           state.turn = nonNegativeInteger(event.data?.turn);
           state.userText = undefined;
           state.assistantText = undefined;
           state.turnStarted = false;
+          pendingContext.delete(state.sessionId);
+          if (previousTurn !== undefined && previousTurnStarted) {
+            dispatchTurnDiscard(state, previousTurn);
+          }
           break;
+        }
         case "user/message":
           handleUserMessage(state, event.data);
           break;
         case "assistant/message":
           handleAssistantMessage(state, event.data);
           break;
-        case "turn/end":
+        case "turn/end": {
+          const eventTurn = nonNegativeInteger(event.data?.turn, undefined);
+          if (eventTurn !== undefined && eventTurn !== state.turn) break;
           handleTurnEnd(state, event.data);
           break;
+        }
         default:
           break;
       }
@@ -49,7 +59,12 @@ export function createSessionBridge({ dispatch, debug = () => {} }) {
       const sessionId = stringValue(session?.id);
       if (!sessionId) return;
       const state = sessions.get(sessionId);
-      if (state) state.disposed = true;
+      if (state) {
+        state.disposed = true;
+        if (state.turn !== undefined && state.turnStarted) {
+          dispatchTurnDiscard(state, state.turn);
+        }
+      }
       sessions.delete(sessionId);
       pendingContext.delete(sessionId);
     },
@@ -94,7 +109,10 @@ export function createSessionBridge({ dispatch, debug = () => {} }) {
     state.turnStarted = false;
     if (turn === undefined) return;
     if (turnEndCompleted(data)) {
-      if (!userText || !assistantText) return;
+      if (!userText || !assistantText) {
+        if (turnStarted) dispatchTurnDiscard(state, turn);
+        return;
+      }
       dispatchWriteback(state, turn, userText, assistantText);
     } else if (turnStarted) {
       dispatchTurnDiscard(state, turn);

--- a/packages/ts/memorax-code-dsh-adapter/src/session-bridge.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/src/session-bridge.mjs
@@ -17,6 +17,8 @@ export function createSessionBridge({ dispatch, debug = () => {} }) {
         assistantText: undefined,
         turnStarted: false,
         dispatchTail: undefined,
+        generation: 0,
+        disposed: false,
       });
     },
     onSessionEvent(session, event) {
@@ -46,6 +48,8 @@ export function createSessionBridge({ dispatch, debug = () => {} }) {
     onSessionDisposed(session) {
       const sessionId = stringValue(session?.id);
       if (!sessionId) return;
+      const state = sessions.get(sessionId);
+      if (state) state.disposed = true;
       sessions.delete(sessionId);
       pendingContext.delete(sessionId);
     },
@@ -100,7 +104,9 @@ export function createSessionBridge({ dispatch, debug = () => {} }) {
   function dispatchTurnStart(state) {
     const body = buildTurnStartCommand(state);
     if (!body) return;
+    const generation = ++state.generation;
     void enqueue(state, () => dispatch("/memory/turn-start", body)).then((result) => {
+      if (state.disposed || state.generation !== generation) return;
       if (!result?.ok) {
         debug("turn-start dispatch rejected", resultFailureMessage(result));
         return;

--- a/packages/ts/memorax-code-dsh-adapter/src/session-bridge.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/src/session-bridge.mjs
@@ -3,6 +3,7 @@ import { MEMORY_HOOK_COMMAND_VERSION } from "./config.mjs";
 export function createSessionBridge({ dispatch, debug = () => {} }) {
   const sessions = new Map();
   const pendingContext = new Map();
+  const pendingRetrieval = new Map();
 
   return {
     onSessionCreated(session) {
@@ -34,6 +35,7 @@ export function createSessionBridge({ dispatch, debug = () => {} }) {
           state.assistantText = undefined;
           state.turnStarted = false;
           pendingContext.delete(state.sessionId);
+          pendingRetrieval.delete(state.sessionId);
           if (previousTurn !== undefined && previousTurnStarted) {
             dispatchTurnDiscard(state, previousTurn);
           }
@@ -47,7 +49,11 @@ export function createSessionBridge({ dispatch, debug = () => {} }) {
           break;
         case "turn/end": {
           const eventTurn = nonNegativeInteger(event.data?.turn, undefined);
-          if (eventTurn !== undefined && eventTurn !== state.turn) break;
+          if (eventTurn === undefined) {
+            if (state.turn !== undefined) break;
+          } else if (eventTurn !== state.turn) {
+            break;
+          }
           handleTurnEnd(state, event.data);
           break;
         }
@@ -67,6 +73,7 @@ export function createSessionBridge({ dispatch, debug = () => {} }) {
       }
       sessions.delete(sessionId);
       pendingContext.delete(sessionId);
+      pendingRetrieval.delete(sessionId);
     },
     takePendingContext(sessionId) {
       const key = stringValue(sessionId);
@@ -74,6 +81,25 @@ export function createSessionBridge({ dispatch, debug = () => {} }) {
       const context = pendingContext.get(key);
       pendingContext.delete(key);
       return context;
+    },
+    async waitForPendingContext(sessionId, timeoutMs) {
+      const key = stringValue(sessionId);
+      if (!key) return undefined;
+      const context = pendingContext.get(key);
+      if (context !== undefined) {
+        pendingContext.delete(key);
+        pendingRetrieval.delete(key);
+        return context;
+      }
+      const retrieval = pendingRetrieval.get(key);
+      if (!retrieval) return undefined;
+      pendingRetrieval.delete(key);
+      const additionalContext = await boundedWait(retrieval.promise, timeoutMs);
+      if (additionalContext) {
+        pendingContext.delete(key);
+        return additionalContext;
+      }
+      return undefined;
     },
     sessionCount() {
       return sessions.size;
@@ -123,16 +149,24 @@ export function createSessionBridge({ dispatch, debug = () => {} }) {
     const body = buildTurnStartCommand(state);
     if (!body) return;
     const generation = ++state.generation;
+    const deferred = createDeferred();
+    pendingRetrieval.set(state.sessionId, deferred);
     void enqueue(state, () => dispatch("/memory/turn-start", body)).then((result) => {
-      if (state.disposed || state.generation !== generation) return;
+      if (state.disposed || state.generation !== generation) {
+        deferred.resolve(undefined);
+        return;
+      }
       if (!result?.ok) {
         debug("turn-start dispatch rejected", resultFailureMessage(result));
+        deferred.resolve(undefined);
         return;
       }
       const additionalContext = stringValue(result?.body?.additionalContext);
       if (additionalContext) pendingContext.set(state.sessionId, additionalContext);
+      deferred.resolve(additionalContext);
     }).catch((error) => {
       debug("turn-start dispatch failed", errorMessage(error));
+      deferred.resolve(undefined);
     });
   }
 
@@ -233,6 +267,21 @@ export function turnEndCompleted(data) {
 
 function stringValue(value) {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function createDeferred() {
+  let resolve;
+  const promise = new Promise((res) => { resolve = res; });
+  return { promise, resolve };
+}
+
+function boundedWait(promise, timeoutMs) {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) return promise;
+  let timer;
+  const timeout = new Promise((resolve) => {
+    timer = setTimeout(() => resolve(undefined), timeoutMs);
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
 }
 
 function nonNegativeInteger(value, fallback) {

--- a/packages/ts/memorax-code-dsh-adapter/src/session-bridge.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/src/session-bridge.mjs
@@ -450,9 +450,16 @@ function resultFailureMessage(result) {
 
 function resultBodyError(result) {
   const body = result?.body;
-  if (!isRecord(body) || body.ok !== false) return undefined;
-  if (typeof body.error === "string" && body.error) return body.error;
-  return "unknown backend rejection";
+  if (!isRecord(body)) return "backend response has no JSON body";
+  // The Backend contract is an explicit ok:true on every accepted command. A
+  // 2xx body WITHOUT ok:true is not a success: a misconfigured proxy or a
+  // future Backend returning an unrelated JSON object would otherwise be
+  // treated as an accepted turn-start/writeback with zero visibility.
+  if (body.ok !== true) {
+    if (body.ok === false && typeof body.error === "string" && body.error) return body.error;
+    return "backend response body missing ok:true";
+  }
+  return undefined;
 }
 
 function writebackSkipReason(result) {

--- a/packages/ts/memorax-code-dsh-adapter/src/session-bridge.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/src/session-bridge.mjs
@@ -78,7 +78,7 @@ export function createSessionBridge({ dispatch, debug = () => {} }) {
     state.assistantText = state.assistantText ? `${state.assistantText}\n\n${text}` : text;
   }
 
-  function handleTurnEnd(state, _data) {
+  function handleTurnEnd(state, data) {
     const userText = state.userText;
     const assistantText = state.assistantText;
     const turn = state.turn;
@@ -87,6 +87,7 @@ export function createSessionBridge({ dispatch, debug = () => {} }) {
     state.assistantText = undefined;
     state.turnStarted = false;
     if (!userText || !assistantText || turn === undefined) return;
+    if (!turnEndCompleted(data)) return;
     dispatchWriteback(state, turn, userText, assistantText);
   }
 
@@ -156,6 +157,12 @@ export function extractMessageText(message) {
 
 export function isDirectUserMessage(message) {
   return isRecord(message) && isRecord(message.source) && message.source.kind === "user";
+}
+
+export function turnEndCompleted(data) {
+  const reason = isRecord(data) && isRecord(data.reason) ? data.reason : undefined;
+  if (!reason) return true;
+  return reason.kind === "completed";
 }
 
 function stringValue(value) {

--- a/packages/ts/memorax-code-dsh-adapter/src/session-bridge.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/src/session-bridge.mjs
@@ -1,0 +1,172 @@
+import { MEMORY_HOOK_COMMAND_VERSION } from "./config.mjs";
+
+export function createSessionBridge({ dispatch, debug = () => {} }) {
+  const sessions = new Map();
+  const pendingContext = new Map();
+
+  return {
+    onSessionCreated(session) {
+      const sessionId = stringValue(session?.id);
+      if (!sessionId) return;
+      sessions.set(sessionId, {
+        sessionId,
+        cwd: stringValue(session?.header?.cwd),
+        firstLiveSeq: nonNegativeInteger(session?.firstLiveSeq, 0),
+        turn: undefined,
+        userText: undefined,
+        assistantText: undefined,
+        turnStarted: false,
+      });
+    },
+    onSessionEvent(session, event) {
+      const sessionId = stringValue(session?.id);
+      const state = sessionId ? sessions.get(sessionId) : undefined;
+      if (!state || !isRecord(event)) return;
+      switch (event.type) {
+        case "turn/start":
+          state.turn = nonNegativeInteger(event.data?.turn);
+          state.userText = undefined;
+          state.assistantText = undefined;
+          state.turnStarted = false;
+          break;
+        case "user/message":
+          handleUserMessage(state, event.data);
+          break;
+        case "assistant/message":
+          handleAssistantMessage(state, event.data);
+          break;
+        case "turn/end":
+          handleTurnEnd(state, event.data);
+          break;
+        default:
+          break;
+      }
+    },
+    onSessionDisposed(session) {
+      const sessionId = stringValue(session?.id);
+      if (!sessionId) return;
+      sessions.delete(sessionId);
+      pendingContext.delete(sessionId);
+    },
+    takePendingContext(sessionId) {
+      const key = stringValue(sessionId);
+      if (!key) return undefined;
+      const context = pendingContext.get(key);
+      pendingContext.delete(key);
+      return context;
+    },
+    sessionCount() {
+      return sessions.size;
+    },
+  };
+
+  function handleUserMessage(state, data) {
+    if (!isDirectUserMessage(data)) return;
+    const text = extractMessageText(data);
+    if (!text) return;
+    state.userText = state.userText ? `${state.userText}\n\n${text}` : text;
+    if (!state.turnStarted && state.userText) {
+      state.turnStarted = true;
+      dispatchTurnStart(state);
+    }
+  }
+
+  function handleAssistantMessage(state, data) {
+    if (!isRecord(data) || !isRecord(data.message)) return;
+    const text = extractMessageText(data.message);
+    if (!text) return;
+    state.assistantText = state.assistantText ? `${state.assistantText}\n\n${text}` : text;
+  }
+
+  function handleTurnEnd(state, _data) {
+    const userText = state.userText;
+    const assistantText = state.assistantText;
+    const turn = state.turn;
+    state.turn = undefined;
+    state.userText = undefined;
+    state.assistantText = undefined;
+    state.turnStarted = false;
+    if (!userText || !assistantText || turn === undefined) return;
+    dispatchWriteback(state, turn, userText, assistantText);
+  }
+
+  function dispatchTurnStart(state) {
+    const body = buildTurnStartCommand(state);
+    if (!body) return;
+    void dispatch("/memory/turn-start", body).then((result) => {
+      const additionalContext = stringValue(result?.body?.additionalContext);
+      if (additionalContext) pendingContext.set(state.sessionId, additionalContext);
+    }).catch((error) => {
+      debug("turn-start dispatch failed", error instanceof Error ? error.message : String(error));
+    });
+  }
+
+  function dispatchWriteback(state, turn, userText, assistantText) {
+    const body = buildWritebackCommand(state, turn, userText, assistantText);
+    if (!body) return;
+    void dispatch("/memory/writeback", body).catch((error) => {
+      debug("writeback dispatch failed", error instanceof Error ? error.message : String(error));
+    });
+  }
+}
+
+export function buildTurnId(sessionId, firstLiveSeq, turn) {
+  return `dsh-${nonNegativeInteger(firstLiveSeq, 0)}-${nonNegativeInteger(turn, 0)}`;
+}
+
+export function buildTurnStartCommand(state) {
+  const sessionId = stringValue(state?.sessionId);
+  const prompt = stringValue(state?.userText);
+  if (!sessionId || !prompt || state?.turn === undefined) return undefined;
+  return {
+    version: MEMORY_HOOK_COMMAND_VERSION,
+    client: "dsh",
+    sessionId,
+    turnId: buildTurnId(sessionId, state.firstLiveSeq, state.turn),
+    prompt,
+    ...(stringValue(state?.cwd) ? { cwd: state.cwd } : {}),
+  };
+}
+
+export function buildWritebackCommand(state, turn, userText, assistantText) {
+  const sessionId = stringValue(state?.sessionId);
+  const prompt = stringValue(userText);
+  const reply = stringValue(assistantText);
+  if (!sessionId || !prompt || !reply || turn === undefined) return undefined;
+  return {
+    version: MEMORY_HOOK_COMMAND_VERSION,
+    client: "dsh",
+    sessionId,
+    turnId: buildTurnId(sessionId, state?.firstLiveSeq, turn),
+    userText: prompt,
+    assistantText: reply,
+    ...(stringValue(state?.cwd) ? { cwd: state.cwd } : {}),
+  };
+}
+
+export function extractMessageText(message) {
+  if (!isRecord(message)) return "";
+  const blocks = Array.isArray(message.content) ? message.content : [];
+  return blocks
+    .map((block) => isRecord(block) && block.type === "text" && typeof block.text === "string" ? block.text : "")
+    .filter(Boolean)
+    .join("\n")
+    .trim();
+}
+
+export function isDirectUserMessage(message) {
+  return isRecord(message) && isRecord(message.source) && message.source.kind === "user";
+}
+
+function stringValue(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function nonNegativeInteger(value, fallback) {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+function isRecord(value) {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}

--- a/packages/ts/memorax-code-dsh-adapter/src/session-bridge.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/src/session-bridge.mjs
@@ -1,24 +1,81 @@
 import { MEMORY_HOOK_COMMAND_VERSION } from "./config.mjs";
 
+// Single source of truth for the HTTP paths this adapter calls. The Backend
+// transport (transport/http/memory-hook.ts) routes the same strings, and
+// test/memory/dsh-adapter-contract.test.mjs fails when either side drifts.
+export const MEMORY_HOOK_PATHS = Object.freeze({
+  turnStart: "/memory/turn-start",
+  writeback: "/memory/writeback",
+  turnDiscard: "/memory/turn-discard",
+});
+
+// The adapter joins multiple user (or assistant) messages of one turn with
+// this delimiter. The Backend's DSH prompt matching mirrors the exact same
+// delimiter (PROMPT_DELIMITER in clients/dsh/memory-hook-runtime.ts); the
+// contract test pins the two together because a silent mismatch would make
+// every writeback fail prompt_mismatch.
+export const MESSAGE_JOIN_DELIMITER = "\n\n";
+
 export function createSessionBridge({ dispatch, debug = () => {} }) {
   const sessions = new Map();
   const pendingContext = new Map();
   const pendingRetrieval = new Map();
+  // Incarnation counter is PER SESSION, not global: a brand-new second session
+  // must keep plain turnIds (only genuinely re-created sessions get the -gN
+  // suffix), so "g>=2 means this session was rebuilt" stays diagnosable.
+  const sessionIncarnations = new Map();
 
   return {
     onSessionCreated(session) {
       const sessionId = stringValue(session?.id);
       if (!sessionId) return;
+      const firstLiveSeq = nonNegativeInteger(session?.firstLiveSeq, 0);
+      const cwd = stringValue(session?.header?.cwd);
+      const previous = sessions.get(sessionId);
+      if (
+        previous
+        && previous.firstLiveSeq === firstLiveSeq
+        && previous.cwd === cwd
+      ) {
+        // Duplicate session/created for the SAME live incarnation (event
+        // replay, reconnect, plugin reload). Ignoring it is safe and correct:
+        // in-flight dispatches stay guarded by the per-dispatch generation
+        // token, replayed turn events are already idempotent, and retiring the
+        // state here would wrongly discard a live turn and drop its writeback.
+        return;
+      }
+      let generation = 1;
+      if (previous) {
+        // Same session id re-created with a DIFFERENT identity payload: the
+        // old incarnation is dead. Retire it so its in-flight turn-start
+        // response cannot leak into the new incarnation, and best-effort
+        // discard its started turn on the Backend instead of leaving orphan
+        // metadata.
+        previous.disposed = true;
+        if (previous.turn !== undefined && previous.turnStarted) {
+          dispatchTurnDiscard(previous, previous.turn);
+        }
+        generation = nonNegativeInteger(sessionIncarnations.get(sessionId), 1) + 1;
+      } else if (sessionIncarnations.has(sessionId)) {
+        // Re-created after a dispose with a matching payload: still a new
+        // incarnation, so its turnIds must not reuse the disposed one's.
+        generation = nonNegativeInteger(sessionIncarnations.get(sessionId), 1) + 1;
+      }
+      // Stale pending retrieval/context belong to the previous incarnation.
+      pendingContext.delete(sessionId);
+      pendingRetrieval.delete(sessionId);
+      sessionIncarnations.set(sessionId, generation);
       sessions.set(sessionId, {
         sessionId,
-        cwd: stringValue(session?.header?.cwd),
-        firstLiveSeq: nonNegativeInteger(session?.firstLiveSeq, 0),
+        cwd,
+        firstLiveSeq,
         turn: undefined,
         userText: undefined,
         assistantText: undefined,
         turnStarted: false,
         dispatchTail: undefined,
         generation: 0,
+        sessionGeneration: generation,
         disposed: false,
       });
     },
@@ -31,7 +88,12 @@ export function createSessionBridge({ dispatch, debug = () => {} }) {
           const nextTurn = nonNegativeInteger(event.data?.turn);
           const previousTurn = state.turn;
           const previousTurnStarted = state.turnStarted;
-          if (nextTurn === undefined && previousTurn !== undefined && previousTurnStarted) {
+          if (previousTurn !== undefined && (nextTurn === undefined || nextTurn === previousTurn)) {
+            // A start without a turn id, or replaying the CURRENT turn's id,
+            // can never identify a NEW turn: it is a duplicate/replayed start
+            // (reconnect, event replay). Ignore it. Resetting here would clear
+            // the accumulated user text and discard the live turn on the
+            // Backend, permanently losing that turn's writeback.
             break;
           }
           state.turn = nextTurn;
@@ -75,6 +137,10 @@ export function createSessionBridge({ dispatch, debug = () => {} }) {
           dispatchTurnDiscard(state, state.turn);
         }
       }
+      // Keep the sessionIncarnations memory: a session re-created after a
+      // dispose must get a fresh incarnation suffix even when its identity
+      // payload is identical, so its turnIds can never collide with the
+      // disposed incarnation's.
       sessions.delete(sessionId);
       pendingContext.delete(sessionId);
       pendingRetrieval.delete(sessionId);
@@ -114,7 +180,9 @@ export function createSessionBridge({ dispatch, debug = () => {} }) {
     if (!isDirectUserMessage(data)) return;
     const text = extractMessageText(data);
     if (!text) return;
-    state.userText = state.userText ? `${state.userText}\n\n${text}` : text;
+    state.userText = state.userText
+      ? `${state.userText}${MESSAGE_JOIN_DELIMITER}${text}`
+      : text;
     if (!state.turnStarted && state.userText) {
       state.turnStarted = true;
       dispatchTurnStart(state);
@@ -125,7 +193,9 @@ export function createSessionBridge({ dispatch, debug = () => {} }) {
     if (!isRecord(data) || !isRecord(data.message)) return;
     const text = extractMessageText(data.message);
     if (!text) return;
-    state.assistantText = state.assistantText ? `${state.assistantText}\n\n${text}` : text;
+    state.assistantText = state.assistantText
+      ? `${state.assistantText}${MESSAGE_JOIN_DELIMITER}${text}`
+      : text;
   }
 
   function handleTurnEnd(state, data) {
@@ -155,13 +225,24 @@ export function createSessionBridge({ dispatch, debug = () => {} }) {
     const generation = ++state.generation;
     const deferred = createDeferred();
     pendingRetrieval.set(state.sessionId, deferred);
-    void enqueue(state, () => dispatch("/memory/turn-start", body)).then((result) => {
+    void enqueue(state, () => dispatch(MEMORY_HOOK_PATHS.turnStart, body)).then((result) => {
       if (state.disposed || state.generation !== generation) {
         deferred.resolve(undefined);
         return;
       }
       if (!result?.ok) {
         debug("turn-start dispatch rejected", resultFailureMessage(result));
+        deferred.resolve(undefined);
+        return;
+      }
+      const bodyError = resultBodyError(result);
+      if (bodyError) {
+        // HTTP 2xx with a body-level rejection. The current Backend answers
+        // turn-start with ok:true (conflicts self-heal server-side), so this
+        // branch is contract-drift defense: if a future Backend starts
+        // rejecting in the body, the turn must be treated as NOT started
+        // instead of silently proceeding to a writeback it would then skip.
+        debug("turn-start dispatch rejected", bodyError);
         deferred.resolve(undefined);
         return;
       }
@@ -177,8 +258,23 @@ export function createSessionBridge({ dispatch, debug = () => {} }) {
   function dispatchWriteback(state, turn, userText, assistantText) {
     const body = buildWritebackCommand(state, turn, userText, assistantText);
     if (!body) return;
-    void enqueue(state, () => dispatch("/memory/writeback", body)).then((result) => {
-      if (!result?.ok) debug("writeback dispatch rejected", resultFailureMessage(result));
+    void enqueue(state, () => dispatch(MEMORY_HOOK_PATHS.writeback, body)).then((result) => {
+      if (!result?.ok) {
+        debug("writeback dispatch rejected", resultFailureMessage(result));
+        return;
+      }
+      // The Backend accepts writeback commands with HTTP 200 and reports
+      // skipped scheduling in the body: { ok: true, scheduled: false,
+      // reason }. Without reading the body, "accepted" and "silently
+      // dropped" (turn_metadata_missing, prompt_mismatch, config_missing)
+      // look identical from here, which made every skip invisible.
+      const bodyError = resultBodyError(result);
+      if (bodyError) {
+        debug("writeback dispatch rejected", bodyError);
+        return;
+      }
+      const skip = writebackSkipReason(result);
+      if (skip) debug("writeback skipped by backend", skip);
     }).catch((error) => {
       debug("writeback dispatch failed", errorMessage(error));
     });
@@ -187,8 +283,22 @@ export function createSessionBridge({ dispatch, debug = () => {} }) {
   function dispatchTurnDiscard(state, turn) {
     const body = buildTurnDiscardCommand(state, turn);
     if (!body) return;
-    void enqueue(state, () => dispatch("/memory/turn-discard", body)).then((result) => {
-      if (!result?.ok) debug("turn-discard dispatch rejected", resultFailureMessage(result));
+    void enqueue(state, () => dispatch(MEMORY_HOOK_PATHS.turnDiscard, body)).then((result) => {
+      if (!result?.ok) {
+        debug("turn-discard dispatch rejected", resultFailureMessage(result));
+        return;
+      }
+      const bodyError = resultBodyError(result);
+      if (bodyError) {
+        debug("turn-discard dispatch rejected", bodyError);
+        return;
+      }
+      // discarded:false means the Backend found no live metadata for the
+      // turn (already discarded, evicted, or restarted). Usually benign —
+      // discard is best-effort — but still worth a debug line.
+      if (result?.body?.discarded === false) {
+        debug("turn-discard found no live turn metadata", body.turnId);
+      }
     }).catch((error) => {
       debug("turn-discard dispatch failed", errorMessage(error));
     });
@@ -204,8 +314,11 @@ export function createSessionBridge({ dispatch, debug = () => {} }) {
   }
 }
 
-export function buildTurnId(sessionId, firstLiveSeq, turn) {
-  return `dsh-${nonNegativeInteger(firstLiveSeq, 0)}-${nonNegativeInteger(turn, 0)}`;
+export function buildTurnId(sessionId, firstLiveSeq, sessionGeneration, turn) {
+  const incarnation = nonNegativeInteger(sessionGeneration, 1) >= 2
+    ? `-g${nonNegativeInteger(sessionGeneration, 1)}`
+    : "";
+  return `dsh-${nonNegativeInteger(firstLiveSeq, 0)}${incarnation}-${nonNegativeInteger(turn, 0)}`;
 }
 
 export function buildTurnStartCommand(state) {
@@ -216,7 +329,7 @@ export function buildTurnStartCommand(state) {
     version: MEMORY_HOOK_COMMAND_VERSION,
     client: "dsh",
     sessionId,
-    turnId: buildTurnId(sessionId, state.firstLiveSeq, state.turn),
+    turnId: buildTurnId(sessionId, state.firstLiveSeq, state.sessionGeneration, state.turn),
     prompt,
     ...(stringValue(state?.cwd) ? { cwd: state.cwd } : {}),
   };
@@ -231,7 +344,7 @@ export function buildWritebackCommand(state, turn, userText, assistantText) {
     version: MEMORY_HOOK_COMMAND_VERSION,
     client: "dsh",
     sessionId,
-    turnId: buildTurnId(sessionId, state?.firstLiveSeq, turn),
+    turnId: buildTurnId(sessionId, state?.firstLiveSeq, state?.sessionGeneration, turn),
     userText: prompt,
     assistantText: reply,
     ...(stringValue(state?.cwd) ? { cwd: state.cwd } : {}),
@@ -245,7 +358,7 @@ export function buildTurnDiscardCommand(state, turn) {
     version: MEMORY_HOOK_COMMAND_VERSION,
     client: "dsh",
     sessionId,
-    turnId: buildTurnId(sessionId, state?.firstLiveSeq, turn),
+    turnId: buildTurnId(sessionId, state?.firstLiveSeq, state?.sessionGeneration, turn),
   };
 }
 
@@ -297,6 +410,21 @@ function resultFailureMessage(result) {
   if (typeof result?.error === "string" && result.error) return result.error;
   if (typeof result?.status === "number") return `status ${result.status}`;
   return "unknown backend failure";
+}
+
+function resultBodyError(result) {
+  const body = result?.body;
+  if (!isRecord(body) || body.ok !== false) return undefined;
+  if (typeof body.error === "string" && body.error) return body.error;
+  return "unknown backend rejection";
+}
+
+function writebackSkipReason(result) {
+  const body = result?.body;
+  if (!isRecord(body) || body.ok !== true) return undefined;
+  if (body.scheduled !== false) return undefined;
+  if (typeof body.reason === "string" && body.reason) return body.reason;
+  return "unknown reason";
 }
 
 function errorMessage(error) {

--- a/packages/ts/memorax-code-dsh-adapter/src/session-bridge.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/src/session-bridge.mjs
@@ -65,6 +65,13 @@ export function createSessionBridge({ dispatch, debug = () => {} }) {
       pendingContext.delete(sessionId);
       pendingRetrieval.delete(sessionId);
       sessionIncarnations.set(sessionId, generation);
+      // Long-lived DSH processes see one session per task; keep the
+      // incarnation table bounded or it grows without limit.
+      while (sessionIncarnations.size > 512) {
+        const oldest = sessionIncarnations.keys().next().value;
+        if (oldest === undefined) break;
+        sessionIncarnations.delete(oldest);
+      }
       sessions.set(sessionId, {
         sessionId,
         cwd,
@@ -96,14 +103,30 @@ export function createSessionBridge({ dispatch, debug = () => {} }) {
             // Backend, permanently losing that turn's writeback.
             break;
           }
+          // Any turn-start response still in flight belongs to a turn that is
+          // no longer current; bump the generation so it cannot resolve into
+          // pendingContext for whatever turn comes next.
+          state.generation += 1;
+          // Out-of-order events: the first user/message arrived BEFORE this
+          // turn/start, accumulated text, and could not dispatch (no turn id
+          // yet). Keep that text instead of dropping the turn's first prompt.
+          const carryUndispatchedText = previousTurn === undefined
+            && previousTurnStarted
+            && state.userText !== undefined;
           state.turn = nextTurn;
-          state.userText = undefined;
-          state.assistantText = undefined;
-          state.turnStarted = false;
+          if (!carryUndispatchedText) {
+            state.userText = undefined;
+            state.assistantText = undefined;
+            state.turnStarted = false;
+          }
           pendingContext.delete(state.sessionId);
           pendingRetrieval.delete(state.sessionId);
           if (previousTurn !== undefined && previousTurnStarted) {
             dispatchTurnDiscard(state, previousTurn);
+          }
+          if (carryUndispatchedText) {
+            state.turnStarted = false;
+            dispatchTurnStart(state);
           }
           break;
         }
@@ -207,6 +230,10 @@ export function createSessionBridge({ dispatch, debug = () => {} }) {
     state.userText = undefined;
     state.assistantText = undefined;
     state.turnStarted = false;
+    // The turn is over: a turn-start response still in flight for it must not
+    // resolve into pendingContext afterwards (it would leak the finished
+    // turn's retrieval context into an unrelated later LLM call).
+    state.generation += 1;
     if (turn === undefined) return;
     if (turnEndCompleted(data)) {
       if (!userText || !assistantText) {
@@ -226,12 +253,15 @@ export function createSessionBridge({ dispatch, debug = () => {} }) {
     const deferred = createDeferred();
     pendingRetrieval.set(state.sessionId, deferred);
     void enqueue(state, () => dispatch(MEMORY_HOOK_PATHS.turnStart, body)).then((result) => {
-      if (state.disposed || state.generation !== generation) {
+      // Transport failures are always reported, even when the turn already
+      // ended: swallowing them behind the generation guard would hide real
+      // Backend outages behind ordinary fast-failing turns.
+      if (!result?.ok) {
+        debug("turn-start dispatch rejected", resultFailureMessage(result));
         deferred.resolve(undefined);
         return;
       }
-      if (!result?.ok) {
-        debug("turn-start dispatch rejected", resultFailureMessage(result));
+      if (state.disposed || state.generation !== generation) {
         deferred.resolve(undefined);
         return;
       }
@@ -402,6 +432,12 @@ function boundedWait(promise, timeoutMs) {
 }
 
 function nonNegativeInteger(value, fallback) {
+  // Number(null), Number("") and Number([]) all coerce to 0, which would
+  // alias a malformed turn id / firstLiveSeq to turn 0; only genuine numbers
+  // or non-empty numeric strings may coerce.
+  if (value === null || value === "" || typeof value === "boolean" || typeof value === "object") {
+    return fallback;
+  }
   const parsed = Number(value);
   return Number.isInteger(parsed) && parsed >= 0 ? parsed : fallback;
 }

--- a/packages/ts/memorax-code-dsh-adapter/src/session-bridge.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/src/session-bridge.mjs
@@ -16,6 +16,7 @@ export function createSessionBridge({ dispatch, debug = () => {} }) {
         userText: undefined,
         assistantText: undefined,
         turnStarted: false,
+        dispatchTail: undefined,
       });
     },
     onSessionEvent(session, event) {
@@ -82,32 +83,62 @@ export function createSessionBridge({ dispatch, debug = () => {} }) {
     const userText = state.userText;
     const assistantText = state.assistantText;
     const turn = state.turn;
+    const turnStarted = state.turnStarted;
     state.turn = undefined;
     state.userText = undefined;
     state.assistantText = undefined;
     state.turnStarted = false;
-    if (!userText || !assistantText || turn === undefined) return;
-    if (!turnEndCompleted(data)) return;
-    dispatchWriteback(state, turn, userText, assistantText);
+    if (turn === undefined) return;
+    if (turnEndCompleted(data)) {
+      if (!userText || !assistantText) return;
+      dispatchWriteback(state, turn, userText, assistantText);
+    } else if (turnStarted) {
+      dispatchTurnDiscard(state, turn);
+    }
   }
 
   function dispatchTurnStart(state) {
     const body = buildTurnStartCommand(state);
     if (!body) return;
-    void dispatch("/memory/turn-start", body).then((result) => {
+    void enqueue(state, () => dispatch("/memory/turn-start", body)).then((result) => {
+      if (!result?.ok) {
+        debug("turn-start dispatch rejected", resultFailureMessage(result));
+        return;
+      }
       const additionalContext = stringValue(result?.body?.additionalContext);
       if (additionalContext) pendingContext.set(state.sessionId, additionalContext);
     }).catch((error) => {
-      debug("turn-start dispatch failed", error instanceof Error ? error.message : String(error));
+      debug("turn-start dispatch failed", errorMessage(error));
     });
   }
 
   function dispatchWriteback(state, turn, userText, assistantText) {
     const body = buildWritebackCommand(state, turn, userText, assistantText);
     if (!body) return;
-    void dispatch("/memory/writeback", body).catch((error) => {
-      debug("writeback dispatch failed", error instanceof Error ? error.message : String(error));
+    void enqueue(state, () => dispatch("/memory/writeback", body)).then((result) => {
+      if (!result?.ok) debug("writeback dispatch rejected", resultFailureMessage(result));
+    }).catch((error) => {
+      debug("writeback dispatch failed", errorMessage(error));
     });
+  }
+
+  function dispatchTurnDiscard(state, turn) {
+    const body = buildTurnDiscardCommand(state, turn);
+    if (!body) return;
+    void enqueue(state, () => dispatch("/memory/turn-discard", body)).then((result) => {
+      if (!result?.ok) debug("turn-discard dispatch rejected", resultFailureMessage(result));
+    }).catch((error) => {
+      debug("turn-discard dispatch failed", errorMessage(error));
+    });
+  }
+
+  function enqueue(state, operation) {
+    const previous = state.dispatchTail
+      ? state.dispatchTail.catch(() => undefined)
+      : Promise.resolve();
+    const current = previous.then(operation);
+    state.dispatchTail = current;
+    return current;
   }
 }
 
@@ -145,6 +176,17 @@ export function buildWritebackCommand(state, turn, userText, assistantText) {
   };
 }
 
+export function buildTurnDiscardCommand(state, turn) {
+  const sessionId = stringValue(state?.sessionId);
+  if (!sessionId || turn === undefined) return undefined;
+  return {
+    version: MEMORY_HOOK_COMMAND_VERSION,
+    client: "dsh",
+    sessionId,
+    turnId: buildTurnId(sessionId, state?.firstLiveSeq, turn),
+  };
+}
+
 export function extractMessageText(message) {
   if (!isRecord(message)) return "";
   const blocks = Array.isArray(message.content) ? message.content : [];
@@ -172,6 +214,16 @@ function stringValue(value) {
 function nonNegativeInteger(value, fallback) {
   const parsed = Number(value);
   return Number.isInteger(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+function resultFailureMessage(result) {
+  if (typeof result?.error === "string" && result.error) return result.error;
+  if (typeof result?.status === "number") return `status ${result.status}`;
+  return "unknown backend failure";
+}
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
 }
 
 function isRecord(value) {

--- a/packages/ts/memorax-code-dsh-adapter/src/session-bridge.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/src/session-bridge.mjs
@@ -28,9 +28,13 @@ export function createSessionBridge({ dispatch, debug = () => {} }) {
       if (!state || !isRecord(event)) return;
       switch (event.type) {
         case "turn/start": {
+          const nextTurn = nonNegativeInteger(event.data?.turn);
           const previousTurn = state.turn;
           const previousTurnStarted = state.turnStarted;
-          state.turn = nonNegativeInteger(event.data?.turn);
+          if (nextTurn === undefined && previousTurn !== undefined && previousTurnStarted) {
+            break;
+          }
+          state.turn = nextTurn;
           state.userText = undefined;
           state.assistantText = undefined;
           state.turnStarted = false;

--- a/packages/ts/memorax-code-dsh-adapter/test/backend-forwarder.test.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/test/backend-forwarder.test.mjs
@@ -110,6 +110,34 @@ test("postBackend throws DshBackendError when the backend URL is missing", async
   );
 });
 
+test("postBackend refuses to follow redirects", async (t) => {
+  const redirects = [];
+  const server = createServer((req, res) => {
+    redirects.push(req.url);
+    res.writeHead(307, { location: "http://127.0.0.1:1/evil" });
+    res.end();
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address();
+  t.after(() => new Promise((resolve) => server.close(resolve)));
+
+  await assert.rejects(
+    () => postBackend("/memory/turn-start", { version: 1 }, {
+      backendUrl: `http://127.0.0.1:${port}`,
+      token: "secret",
+      timeoutMs: 1000,
+    }),
+    (error) => {
+      // The redirect must abort the request instead of forwarding the token
+      // header and command body to the redirect target.
+      assert.ok(error instanceof DshBackendError);
+      assert.equal(error.code, DSH_BACKEND_UNREACHABLE);
+      return true;
+    },
+  );
+  assert.deepEqual(redirects, ["/memory/turn-start"]);
+});
+
 test("createBackendForwarder returns a forward function bound to the connection", async (t) => {
   const received = [];
   const server = createServer((req, res) => {

--- a/packages/ts/memorax-code-dsh-adapter/test/backend-forwarder.test.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/test/backend-forwarder.test.mjs
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import { test } from "node:test";
+import { createBackendForwarder, postBackend } from "../src/backend-forwarder.mjs";
+
+test("postBackend posts the command and returns the parsed response", async (t) => {
+  const received = [];
+  const server = createServer((req, res) => {
+    let body = "";
+    req.on("data", (chunk) => { body += chunk; });
+    req.on("end", () => {
+      received.push({ url: req.url, headers: req.headers, body: JSON.parse(body) });
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true }));
+    });
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address();
+  t.after(() => new Promise((resolve) => server.close(resolve)));
+
+  const result = await postBackend("/memory/turn-start", {
+    version: 1,
+    client: "dsh",
+    sessionId: "s",
+    turnId: "dsh-0-1",
+    prompt: "hello",
+  }, { backendUrl: `http://127.0.0.1:${port}`, token: "secret" });
+
+  assert.equal(result.ok, true);
+  assert.equal(received.length, 1);
+  assert.equal(received[0].url, "/memory/turn-start");
+  assert.equal(received[0].headers["x-memorax-code-backend-token"], "secret");
+  assert.equal(received[0].body.client, "dsh");
+});
+
+test("postBackend swallows connection failures and returns an error result", async () => {
+  const result = await postBackend("/memory/writeback", { version: 1 }, {
+    backendUrl: "http://127.0.0.1:1",
+    timeoutMs: 200,
+  });
+  assert.equal(result.ok, false);
+  assert.equal(typeof result.error, "string");
+});
+
+test("postBackend returns an error when the backend URL is missing", async () => {
+  const result = await postBackend("/memory/turn-start", { version: 1 }, {});
+  assert.equal(result.ok, false);
+  assert.equal(result.error, "backend URL is not configured");
+});
+
+test("createBackendForwarder returns a forward function bound to the connection", async (t) => {
+  const received = [];
+  const server = createServer((req, res) => {
+    let body = "";
+    req.on("data", (chunk) => { body += chunk; });
+    req.on("end", () => {
+      received.push(JSON.parse(body));
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true, additionalContext: "ctx" }));
+    });
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address();
+  t.after(() => new Promise((resolve) => server.close(resolve)));
+
+  const forwarder = createBackendForwarder({
+    backendUrl: `http://127.0.0.1:${port}`,
+    token: undefined,
+    timeoutMs: 1000,
+  });
+  const result = await forwarder.forward("/memory/turn-start", { version: 1, client: "dsh" });
+  assert.equal(result.ok, true);
+  assert.equal(result.body.additionalContext, "ctx");
+  assert.equal(received[0].client, "dsh");
+});

--- a/packages/ts/memorax-code-dsh-adapter/test/backend-forwarder.test.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/test/backend-forwarder.test.mjs
@@ -1,7 +1,15 @@
 import assert from "node:assert/strict";
 import { createServer } from "node:http";
 import { test } from "node:test";
-import { createBackendForwarder, postBackend } from "../src/backend-forwarder.mjs";
+import {
+  DSH_BACKEND_HTTP_ERROR,
+  DSH_BACKEND_NOT_CONFIGURED,
+  DSH_BACKEND_TIMEOUT,
+  DSH_BACKEND_UNREACHABLE,
+  DshBackendError,
+  createBackendForwarder,
+  postBackend,
+} from "../src/backend-forwarder.mjs";
 
 test("postBackend posts the command and returns the parsed response", async (t) => {
   const received = [];
@@ -33,19 +41,73 @@ test("postBackend posts the command and returns the parsed response", async (t) 
   assert.equal(received[0].body.client, "dsh");
 });
 
-test("postBackend swallows connection failures and returns an error result", async () => {
-  const result = await postBackend("/memory/writeback", { version: 1 }, {
-    backendUrl: "http://127.0.0.1:1",
-    timeoutMs: 200,
-  });
-  assert.equal(result.ok, false);
-  assert.equal(typeof result.error, "string");
+test("postBackend throws DshBackendError with unreachable code on connection failures", async () => {
+  await assert.rejects(
+    () => postBackend("/memory/writeback", { version: 1 }, {
+      backendUrl: "http://127.0.0.1:59999",
+      timeoutMs: 200,
+    }),
+    (error) => {
+      assert.ok(error instanceof DshBackendError);
+      assert.equal(error.code, DSH_BACKEND_UNREACHABLE);
+      assert.equal(error.name, "DshBackendError");
+      return true;
+    },
+  );
 });
 
-test("postBackend returns an error when the backend URL is missing", async () => {
-  const result = await postBackend("/memory/turn-start", { version: 1 }, {});
-  assert.equal(result.ok, false);
-  assert.equal(result.error, "backend URL is not configured");
+test("postBackend throws DshBackendError with timeout code when the backend stalls", async (t) => {
+  const server = createServer(() => {});
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address();
+  t.after(() => new Promise((resolve) => server.close(resolve)));
+
+  await assert.rejects(
+    () => postBackend("/memory/turn-start", { version: 1 }, {
+      backendUrl: `http://127.0.0.1:${port}`,
+      timeoutMs: 100,
+    }),
+    (error) => {
+      assert.ok(error instanceof DshBackendError);
+      assert.equal(error.code, DSH_BACKEND_TIMEOUT);
+      return true;
+    },
+  );
+});
+
+test("postBackend throws DshBackendError with http_error code on non-2xx responses", async (t) => {
+  const server = createServer((req, res) => {
+    res.writeHead(503, { "content-type": "application/json" });
+    res.end(JSON.stringify({ error: "unavailable" }));
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address();
+  t.after(() => new Promise((resolve) => server.close(resolve)));
+
+  await assert.rejects(
+    () => postBackend("/memory/writeback", { version: 1 }, {
+      backendUrl: `http://127.0.0.1:${port}`,
+      timeoutMs: 1000,
+    }),
+    (error) => {
+      assert.ok(error instanceof DshBackendError);
+      assert.equal(error.code, DSH_BACKEND_HTTP_ERROR);
+      assert.equal(error.status, 503);
+      return true;
+    },
+  );
+});
+
+test("postBackend throws DshBackendError when the backend URL is missing", async () => {
+  await assert.rejects(
+    () => postBackend("/memory/turn-start", { version: 1 }, {}),
+    (error) => {
+      assert.ok(error instanceof DshBackendError);
+      assert.equal(error.code, DSH_BACKEND_NOT_CONFIGURED);
+      assert.equal(error.message, "backend URL is not configured");
+      return true;
+    },
+  );
 });
 
 test("createBackendForwarder returns a forward function bound to the connection", async (t) => {

--- a/packages/ts/memorax-code-dsh-adapter/test/backend-forwarder.test.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/test/backend-forwarder.test.mjs
@@ -163,3 +163,28 @@ test("createBackendForwarder returns a forward function bound to the connection"
   assert.equal(result.body.additionalContext, "ctx");
   assert.equal(received[0].client, "dsh");
 });
+
+test("a 2xx without a JSON body is a failure, not a silent success", async (t) => {
+  // The session bridge reads body.ok/scheduled/reason from the parsed payload;
+  // an empty or malformed body must surface as a dispatch failure instead of
+  // being reported as an accepted turn-start/writeback.
+  for (const raw of ["", "not json at all", "\"just a string\"", "42"]) {
+    const server = createServer((req, res) => {
+      req.resume();
+      req.on("end", () => {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(raw);
+      });
+    });
+    await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address();
+    t.after(() => new Promise((resolve) => server.close(resolve)));
+
+    await assert.rejects(
+      postBackend("/memory/turn-start", { version: 1 }, {
+        backendUrl: `http://127.0.0.1:${port}`,
+      }),
+      (error) => error instanceof DshBackendError && error.code === DSH_BACKEND_HTTP_ERROR,
+    );
+  }
+});

--- a/packages/ts/memorax-code-dsh-adapter/test/config.test.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/test/config.test.mjs
@@ -263,6 +263,44 @@ test("an invalid token record warns, yields no token, and keeps the authority UR
   }
 });
 
+test("an invalid rotatedAt rejects the token record like the canonical reader", () => {
+  const home = tempHome();
+  try {
+    writeAuthority(home, { version: 1, url: "http://127.0.0.1:9001", tokenPath: backendTokenPath(home) });
+
+    // Codex round 8, config.mjs:180 — a present-but-invalid rotatedAt must
+    // reject the whole record. Accepting it here would make this mirror trust
+    // a token file adapter-common's readBackendTokenRecord refuses.
+    writeToken(home, { version: 1, token: "t", createdAt: "2026-01-01T00:00:00.000Z", rotatedAt: "not-a-date" });
+    const issues = [];
+    const rejected = resolveBackendConnection({}, { MEMORAX_CODE_HOME: home }, {
+      onAuthorityIssue: (reason) => issues.push(reason),
+    });
+    assert.equal(rejected.backendUrl, "http://127.0.0.1:9001");
+    assert.equal(rejected.token, undefined);
+    assert.equal(rejected.tokenSource, "none");
+    assert.equal(issues.length, 1);
+    assert.match(issues[0], /rotatedAt/);
+
+    // A well-formed rotatedAt (token rotation happened) keeps the record valid.
+    writeToken(home, {
+      version: 1,
+      token: "rotated",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      rotatedAt: "2026-02-01T00:00:00.000Z",
+    });
+    const rotated = resolveBackendConnection({}, { MEMORAX_CODE_HOME: home }, {
+      onAuthorityIssue: (reason) => issues.push(reason),
+    });
+    assert.equal(rotated.backendUrl, "http://127.0.0.1:9001");
+    assert.equal(rotated.token, "rotated");
+    assert.equal(rotated.tokenSource, "authority-file");
+    assert.equal(issues.length, 1, "a valid rotatedAt must not report an issue");
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
 test("an environment token overrides the authority token", () => {
   const home = tempHome();
   try {
@@ -285,4 +323,33 @@ test("cordis bundle patch timeoutMs matches the adapter default", () => {
   const match = /^\s*timeoutMs:\s*(\d+)\s*$/m.exec(patch);
   assert.ok(match, "cordis.patch.yml must declare a timeoutMs config default");
   assert.equal(Number(match[1]), DEFAULT_TIMEOUT_MS);
+});
+
+test("the persisted token follows a configured URL that equals the authority URL", () => {
+  const home = tempHome();
+  try {
+    // Canonical adapter-common semantics: the managed token is attached when
+    // the SELECTED url equals the authority url, regardless of which source
+    // (config/env/authority) produced it. Gating on the source would drop the
+    // token and 401 every request for a user who configured the identical URL.
+    writeAuthority(home, { version: 1, url: "http://127.0.0.1:9001", tokenPath: backendTokenPath(home) });
+    writeToken(home, { version: 1, token: "managed-token", createdAt: "2026-01-01T00:00:00.000Z" });
+
+    const connection = resolveBackendConnection({ backendUrl: "http://127.0.0.1:9001" }, {
+      MEMORAX_CODE_HOME: home,
+    });
+    assert.equal(connection.backendUrl, "http://127.0.0.1:9001");
+    assert.equal(connection.urlSource, "config");
+    assert.equal(connection.token, "managed-token");
+    assert.equal(connection.tokenSource, "authority-file");
+
+    // A configured URL that is NOT the authority URL still gets no token.
+    const other = resolveBackendConnection({ backendUrl: "http://127.0.0.1:9999" }, {
+      MEMORAX_CODE_HOME: home,
+    });
+    assert.equal(other.token, undefined);
+    assert.equal(other.tokenSource, "none");
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
 });

--- a/packages/ts/memorax-code-dsh-adapter/test/config.test.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/test/config.test.mjs
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  DEFAULT_BACKEND_URL,
+  DEFAULT_TIMEOUT_MS,
+  backendUrlFromHostPort,
+  normalizeHttpUrl,
+  resolveBackendConnection,
+} from "../src/config.mjs";
+
+test("resolveBackendConnection defaults to the loopback Backend", () => {
+  const connection = resolveBackendConnection({}, {});
+  assert.equal(connection.backendUrl, DEFAULT_BACKEND_URL);
+  assert.equal(connection.token, undefined);
+  assert.equal(connection.timeoutMs, DEFAULT_TIMEOUT_MS);
+  assert.equal(connection.injectRetrieval, false);
+  assert.equal(connection.debug, false);
+});
+
+test("resolveBackendConnection prefers config over environment", () => {
+  const connection = resolveBackendConnection(
+    { backendUrl: "http://127.0.0.1:9999", backendToken: "config-token", timeoutMs: 1234, injectRetrieval: true },
+    { MEMORAX_CODE_BACKEND_URL: "http://env.test", MEMORAX_CODE_BACKEND_TOKEN: "env-token" },
+  );
+  assert.equal(connection.backendUrl, "http://127.0.0.1:9999");
+  assert.equal(connection.token, "config-token");
+  assert.equal(connection.timeoutMs, 1234);
+  assert.equal(connection.injectRetrieval, true);
+});
+
+test("resolveBackendConnection reads the environment overrides", () => {
+  const connection = resolveBackendConnection({}, {
+    MEMORAX_CODE_BACKEND_URL: "http://127.0.0.1:8788",
+    MEMORAX_CODE_BACKEND_TOKEN: "env-token",
+    MEMORAX_CODE_DSH_HOOK_TIMEOUT_MS: "3210",
+    MEMORAX_CODE_DSH_RETRIEVAL_INJECT: "1",
+    MEMORAX_CODE_DSH_HOOK_DEBUG: "true",
+  });
+  assert.equal(connection.backendUrl, "http://127.0.0.1:8788");
+  assert.equal(connection.token, "env-token");
+  assert.equal(connection.timeoutMs, 3210);
+  assert.equal(connection.injectRetrieval, true);
+  assert.equal(connection.debug, true);
+});
+
+test("resolveBackendConnection builds a URL from host and port environment", () => {
+  const connection = resolveBackendConnection({}, {
+    MEMORAX_CODE_BACKEND_HOST: "127.0.0.1",
+    MEMORAX_CODE_BACKEND_PORT: "9000",
+  });
+  assert.equal(connection.backendUrl, "http://127.0.0.1:9000");
+});
+
+test("normalizeHttpUrl rejects non-http URLs and trims trailing slashes", () => {
+  assert.equal(normalizeHttpUrl("http://127.0.0.1:8787/"), "http://127.0.0.1:8787");
+  assert.equal(normalizeHttpUrl("file:///tmp/x"), undefined);
+  assert.equal(normalizeHttpUrl("not-a-url"), undefined);
+  assert.equal(normalizeHttpUrl(""), undefined);
+});
+
+test("backendUrlFromHostPort returns undefined without host or port", () => {
+  assert.equal(backendUrlFromHostPort({}), undefined);
+});

--- a/packages/ts/memorax-code-dsh-adapter/test/config.test.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/test/config.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import { test } from "node:test";
 import {
   DEFAULT_BACKEND_URL,
@@ -74,4 +75,12 @@ test("normalizeHttpUrl rejects non-http URLs and trims trailing slashes", () => 
 
 test("backendUrlFromHostPort returns undefined without host or port", () => {
   assert.equal(backendUrlFromHostPort({}), undefined);
+});
+
+test("cordis bundle patch timeoutMs matches the adapter default", () => {
+  const patchUrl = new URL("../cordis.patch.yml", import.meta.url);
+  const patch = readFileSync(patchUrl, "utf8");
+  const match = /^\s*timeoutMs:\s*(\d+)\s*$/m.exec(patch);
+  assert.ok(match, "cordis.patch.yml must declare a timeoutMs config default");
+  assert.equal(Number(match[1]), DEFAULT_TIMEOUT_MS);
 });

--- a/packages/ts/memorax-code-dsh-adapter/test/config.test.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/test/config.test.mjs
@@ -51,6 +51,20 @@ test("resolveBackendConnection builds a URL from host and port environment", () 
   assert.equal(connection.backendUrl, "http://127.0.0.1:9000");
 });
 
+test("environment overrides the bundle defaults for adapter toggles", () => {
+  const connection = resolveBackendConnection(
+    { timeoutMs: 5000, injectRetrieval: false, debug: false },
+    {
+      MEMORAX_CODE_DSH_HOOK_TIMEOUT_MS: "9000",
+      MEMORAX_CODE_DSH_RETRIEVAL_INJECT: "true",
+      MEMORAX_CODE_DSH_HOOK_DEBUG: "1",
+    },
+  );
+  assert.equal(connection.timeoutMs, 9000);
+  assert.equal(connection.injectRetrieval, true);
+  assert.equal(connection.debug, true);
+});
+
 test("normalizeHttpUrl rejects non-http URLs and trims trailing slashes", () => {
   assert.equal(normalizeHttpUrl("http://127.0.0.1:8787/"), "http://127.0.0.1:8787");
   assert.equal(normalizeHttpUrl("file:///tmp/x"), undefined);

--- a/packages/ts/memorax-code-dsh-adapter/test/config.test.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/test/config.test.mjs
@@ -1,69 +1,126 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { test } from "node:test";
 import {
   DEFAULT_BACKEND_URL,
   DEFAULT_TIMEOUT_MS,
+  backendConnectionPath,
+  backendTokenPath,
   backendUrlFromHostPort,
   normalizeHttpUrl,
   resolveBackendConnection,
 } from "../src/config.mjs";
 
+function tempHome() {
+  return mkdtempSync(join(tmpdir(), "memorax-dsh-config-"));
+}
+
+function writeAuthority(home, record) {
+  mkdirSync(join(home, "runtime", "backend"), { recursive: true });
+  writeFileSync(backendConnectionPath(home), JSON.stringify(record), "utf8");
+}
+
+function writeToken(home, record) {
+  mkdirSync(join(home, "runtime", "backend"), { recursive: true });
+  writeFileSync(backendTokenPath(home), JSON.stringify(record), "utf8");
+}
+
+test.afterEach?.(() => {});
+
 test("resolveBackendConnection defaults to the loopback Backend", () => {
-  const connection = resolveBackendConnection({}, {});
-  assert.equal(connection.backendUrl, DEFAULT_BACKEND_URL);
-  assert.equal(connection.token, undefined);
-  assert.equal(connection.timeoutMs, DEFAULT_TIMEOUT_MS);
-  assert.equal(connection.injectRetrieval, false);
-  assert.equal(connection.debug, false);
+  const home = tempHome();
+  try {
+    const connection = resolveBackendConnection({}, { MEMORAX_CODE_HOME: home });
+    assert.equal(connection.backendUrl, DEFAULT_BACKEND_URL);
+    assert.equal(connection.urlSource, "default");
+    assert.equal(connection.token, undefined);
+    assert.equal(connection.tokenSource, "none");
+    assert.equal(connection.timeoutMs, DEFAULT_TIMEOUT_MS);
+    assert.equal(connection.injectRetrieval, false);
+    assert.equal(connection.debug, false);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
 });
 
 test("resolveBackendConnection prefers config over environment", () => {
-  const connection = resolveBackendConnection(
-    { backendUrl: "http://127.0.0.1:9999", backendToken: "config-token", timeoutMs: 1234, injectRetrieval: true },
-    { MEMORAX_CODE_BACKEND_URL: "http://env.test", MEMORAX_CODE_BACKEND_TOKEN: "env-token" },
-  );
-  assert.equal(connection.backendUrl, "http://127.0.0.1:9999");
-  assert.equal(connection.token, "config-token");
-  assert.equal(connection.timeoutMs, 1234);
-  assert.equal(connection.injectRetrieval, true);
+  const home = tempHome();
+  try {
+    const connection = resolveBackendConnection(
+      { backendUrl: "http://127.0.0.1:9999", backendToken: "config-token", timeoutMs: 1234, injectRetrieval: true },
+      {
+        MEMORAX_CODE_HOME: home,
+        MEMORAX_CODE_BACKEND_URL: "http://env.test",
+        MEMORAX_CODE_BACKEND_TOKEN: "env-token",
+      },
+    );
+    assert.equal(connection.backendUrl, "http://127.0.0.1:9999");
+    assert.equal(connection.urlSource, "config");
+    assert.equal(connection.token, "config-token");
+    assert.equal(connection.tokenSource, "environment");
+    assert.equal(connection.timeoutMs, 1234);
+    assert.equal(connection.injectRetrieval, true);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
 });
 
 test("resolveBackendConnection reads the environment overrides", () => {
-  const connection = resolveBackendConnection({}, {
-    MEMORAX_CODE_BACKEND_URL: "http://127.0.0.1:8788",
-    MEMORAX_CODE_BACKEND_TOKEN: "env-token",
-    MEMORAX_CODE_DSH_HOOK_TIMEOUT_MS: "3210",
-    MEMORAX_CODE_DSH_RETRIEVAL_INJECT: "1",
-    MEMORAX_CODE_DSH_HOOK_DEBUG: "true",
-  });
-  assert.equal(connection.backendUrl, "http://127.0.0.1:8788");
-  assert.equal(connection.token, "env-token");
-  assert.equal(connection.timeoutMs, 3210);
-  assert.equal(connection.injectRetrieval, true);
-  assert.equal(connection.debug, true);
+  const home = tempHome();
+  try {
+    const connection = resolveBackendConnection({}, {
+      MEMORAX_CODE_HOME: home,
+      MEMORAX_CODE_BACKEND_URL: "http://127.0.0.1:8788",
+      MEMORAX_CODE_BACKEND_TOKEN: "env-token",
+      MEMORAX_CODE_DSH_HOOK_TIMEOUT_MS: "3210",
+      MEMORAX_CODE_DSH_RETRIEVAL_INJECT: "1",
+      MEMORAX_CODE_DSH_HOOK_DEBUG: "true",
+    });
+    assert.equal(connection.backendUrl, "http://127.0.0.1:8788");
+    assert.equal(connection.urlSource, "environment");
+    assert.equal(connection.token, "env-token");
+    assert.equal(connection.timeoutMs, 3210);
+    assert.equal(connection.injectRetrieval, true);
+    assert.equal(connection.debug, true);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
 });
 
 test("resolveBackendConnection builds a URL from host and port environment", () => {
-  const connection = resolveBackendConnection({}, {
-    MEMORAX_CODE_BACKEND_HOST: "127.0.0.1",
-    MEMORAX_CODE_BACKEND_PORT: "9000",
-  });
-  assert.equal(connection.backendUrl, "http://127.0.0.1:9000");
+  const home = tempHome();
+  try {
+    const connection = resolveBackendConnection({}, {
+      MEMORAX_CODE_HOME: home,
+      MEMORAX_CODE_BACKEND_HOST: "127.0.0.1",
+      MEMORAX_CODE_BACKEND_PORT: "9000",
+    });
+    assert.equal(connection.backendUrl, "http://127.0.0.1:9000");
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
 });
 
 test("environment overrides the bundle defaults for adapter toggles", () => {
-  const connection = resolveBackendConnection(
-    { timeoutMs: 5000, injectRetrieval: false, debug: false },
-    {
-      MEMORAX_CODE_DSH_HOOK_TIMEOUT_MS: "9000",
-      MEMORAX_CODE_DSH_RETRIEVAL_INJECT: "true",
-      MEMORAX_CODE_DSH_HOOK_DEBUG: "1",
-    },
-  );
-  assert.equal(connection.timeoutMs, 9000);
-  assert.equal(connection.injectRetrieval, true);
-  assert.equal(connection.debug, true);
+  const home = tempHome();
+  try {
+    const connection = resolveBackendConnection(
+      { timeoutMs: 5000, injectRetrieval: false, debug: false },
+      {
+        MEMORAX_CODE_HOME: home,
+        MEMORAX_CODE_DSH_HOOK_TIMEOUT_MS: "9000",
+        MEMORAX_CODE_DSH_RETRIEVAL_INJECT: "true",
+        MEMORAX_CODE_DSH_HOOK_DEBUG: "1",
+      },
+    );
+    assert.equal(connection.timeoutMs, 9000);
+    assert.equal(connection.injectRetrieval, true);
+    assert.equal(connection.debug, true);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
 });
 
 test("normalizeHttpUrl rejects non-http URLs and trims trailing slashes", () => {
@@ -75,6 +132,151 @@ test("normalizeHttpUrl rejects non-http URLs and trims trailing slashes", () => 
 
 test("backendUrlFromHostPort returns undefined without host or port", () => {
   assert.equal(backendUrlFromHostPort({}), undefined);
+});
+
+test("resolveBackendConnection reports invalid explicitly configured URLs", () => {
+  const home = tempHome();
+  try {
+    const warnings = [];
+    resolveBackendConnection(
+      { backendUrl: "127.0.0.1:8787" },
+      { MEMORAX_CODE_HOME: home },
+      { onInvalidBackendUrl: (value, source) => warnings.push({ value, source }) },
+    );
+    assert.deepEqual(warnings, [{ value: "127.0.0.1:8787", source: "config backendUrl" }]);
+
+    const envWarnings = [];
+    const connection = resolveBackendConnection(
+      {},
+      { MEMORAX_CODE_HOME: home, MEMORAX_CODE_BACKEND_URL: "localhost:8787" },
+      { onInvalidBackendUrl: (value, source) => envWarnings.push({ value, source }) },
+    );
+    assert.deepEqual(envWarnings, [{ value: "localhost:8787", source: "MEMORAX_CODE_BACKEND_URL" }]);
+    assert.equal(connection.backendUrl, DEFAULT_BACKEND_URL);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("resolveBackendConnection does not warn for valid or absent URLs", () => {
+  const home = tempHome();
+  try {
+    const warnings = [];
+    resolveBackendConnection(
+      { backendUrl: "http://127.0.0.1:9000" },
+      {
+        MEMORAX_CODE_HOME: home,
+        MEMORAX_CODE_BACKEND_URL: "http://env.test",
+      },
+      { onInvalidBackendUrl: (value) => warnings.push(value) },
+    );
+    resolveBackendConnection({}, { MEMORAX_CODE_HOME: home }, {
+      onInvalidBackendUrl: (value) => warnings.push(value),
+    });
+    assert.deepEqual(warnings, []);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("resolveBackendConnection resolves the managed authority record", () => {
+  const home = tempHome();
+  try {
+    writeAuthority(home, { version: 1, url: "http://127.0.0.1:9001", tokenPath: backendTokenPath(home) });
+    writeToken(home, { version: 1, token: "managed-token", createdAt: "2026-01-01T00:00:00.000Z" });
+    const connection = resolveBackendConnection({}, { MEMORAX_CODE_HOME: home });
+    assert.equal(connection.backendUrl, "http://127.0.0.1:9001");
+    assert.equal(connection.urlSource, "authority");
+    assert.equal(connection.token, "managed-token");
+    assert.equal(connection.tokenSource, "authority-file");
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("an explicit URL wins over the authority record and never receives its token", () => {
+  const home = tempHome();
+  try {
+    writeAuthority(home, { version: 1, url: "http://127.0.0.1:9001", tokenPath: backendTokenPath(home) });
+    writeToken(home, { version: 1, token: "managed-token", createdAt: "2026-01-01T00:00:00.000Z" });
+    const connection = resolveBackendConnection(
+      {},
+      { MEMORAX_CODE_HOME: home, MEMORAX_CODE_BACKEND_URL: "http://127.0.0.1:9999" },
+    );
+    assert.equal(connection.backendUrl, "http://127.0.0.1:9999");
+    assert.equal(connection.urlSource, "environment");
+    // The persisted managed token must not be sent to a user-supplied URL.
+    assert.equal(connection.token, undefined);
+    assert.equal(connection.tokenSource, "none");
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("an invalid authority record warns and falls back instead of throwing", () => {
+  const home = tempHome();
+  try {
+    for (const record of [
+      { version: 2, url: "http://127.0.0.1:9001" },
+      { version: 1, url: "http://127.0.0.1:9001", extra: "field" },
+      { version: 1, url: "ftp://127.0.0.1:9001" },
+      { version: 1, url: "http://user:pass@127.0.0.1:9001" },
+      { version: 1, url: "http://127.0.0.1:9001/path" },
+      { version: 1, url: "http://127.0.0.1:9001", tokenPath: "/elsewhere/token.json" },
+    ]) {
+      writeAuthority(home, record);
+      const issues = [];
+      const connection = resolveBackendConnection({}, { MEMORAX_CODE_HOME: home }, {
+        onAuthorityIssue: (reason) => issues.push(reason),
+      });
+      assert.equal(issues.length, 1, `expected one issue for ${JSON.stringify(record)}`);
+      assert.equal(connection.backendUrl, DEFAULT_BACKEND_URL);
+      assert.equal(connection.urlSource, "default");
+    }
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("an invalid token record warns, yields no token, and keeps the authority URL", () => {
+  const home = tempHome();
+  try {
+    writeAuthority(home, { version: 1, url: "http://127.0.0.1:9001", tokenPath: backendTokenPath(home) });
+    for (const record of [
+      { version: 2, token: "t", createdAt: "2026-01-01T00:00:00.000Z" },
+      { version: 1, token: "t", createdAt: "2026-01-01T00:00:00.000Z", extra: true },
+      { version: 1, token: "", createdAt: "2026-01-01T00:00:00.000Z" },
+      { version: 1, token: "t", createdAt: "not-a-date" },
+    ]) {
+      writeToken(home, record);
+      const issues = [];
+      const connection = resolveBackendConnection({}, { MEMORAX_CODE_HOME: home }, {
+        onAuthorityIssue: (reason) => issues.push(reason),
+      });
+      assert.equal(connection.backendUrl, "http://127.0.0.1:9001");
+      assert.equal(connection.token, undefined);
+      assert.equal(connection.tokenSource, "none");
+      assert.equal(issues.length, 1, `expected one issue for ${JSON.stringify(record)}`);
+    }
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("an environment token overrides the authority token", () => {
+  const home = tempHome();
+  try {
+    writeAuthority(home, { version: 1, url: "http://127.0.0.1:9001", tokenPath: backendTokenPath(home) });
+    writeToken(home, { version: 1, token: "managed-token", createdAt: "2026-01-01T00:00:00.000Z" });
+    const connection = resolveBackendConnection(
+      {},
+      { MEMORAX_CODE_HOME: home, MEMORAX_CODE_BACKEND_TOKEN: "env-token" },
+    );
+    assert.equal(connection.token, "env-token");
+    assert.equal(connection.tokenSource, "environment");
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
 });
 
 test("cordis bundle patch timeoutMs matches the adapter default", () => {

--- a/packages/ts/memorax-code-dsh-adapter/test/index.test.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/test/index.test.mjs
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { test } from "node:test";
+import { backendConnectionPath, backendTokenPath } from "../src/config.mjs";
 import { apply, name } from "../src/index.mjs";
 
 function recordingCtx() {
@@ -67,3 +71,81 @@ test("llm/stream waits for the pending turn-start retrieval before streaming", a
   assert.deepEqual(chunks, ["chunk"]);
   assert.equal(options.system, "recalled memory");
 });
+
+test("hook dispatches re-resolve the backend authority after apply", async (t) => {
+  // Codex round 8, index.mjs:13 — the managed Backend may start AFTER this
+  // plugin loads and its token can rotate mid-run. apply() must not freeze the
+  // connection: every dispatch re-reads the authority records.
+  const home = mkdtempSync(join(tmpdir(), "memorax-dsh-late-authority-"));
+  const previousHome = process.env.MEMORAX_CODE_HOME;
+  process.env.MEMORAX_CODE_HOME = home;
+  t.after(() => {
+    if (previousHome === undefined) delete process.env.MEMORAX_CODE_HOME;
+    else process.env.MEMORAX_CODE_HOME = previousHome;
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  const turnStarts = [];
+  const server = createServer((req, res) => {
+    let body = "";
+    req.on("data", (chunk) => { body += chunk; });
+    req.on("end", () => {
+      if (req.url === "/memory/turn-start") {
+        turnStarts.push({ token: req.headers["x-memorax-code-backend-token"] });
+      }
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true }));
+    });
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address();
+  t.after(() => new Promise((resolve) => server.close(resolve)));
+
+  const writeAuthority = (token) => {
+    mkdirSync(join(home, "runtime", "backend"), { recursive: true });
+    writeFileSync(backendConnectionPath(home), JSON.stringify({
+      version: 1,
+      url: `http://127.0.0.1:${port}`,
+      tokenPath: backendTokenPath(home),
+    }), "utf8");
+    writeFileSync(backendTokenPath(home), JSON.stringify({
+      version: 1,
+      token,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      ...(token === "token-2" ? { rotatedAt: "2026-02-01T00:00:00.000Z" } : {}),
+    }), "utf8");
+  };
+
+  // Load the plugin while NO authority record exists yet.
+  const ctx = recordingCtx();
+  apply(ctx, {});
+
+  const sess = { id: "session-late", header: { cwd: "/repo" }, firstLiveSeq: 1 };
+  const startTurn = (turn) => {
+    ctx.handlers["session/created"](sess);
+    ctx.handlers["session/event"](sess, { type: "turn/start", data: { turn } });
+    ctx.handlers["session/event"](sess, { type: "user/message", data: textMessage(`query ${turn}`) });
+  };
+
+  // The managed Backend starts late and writes its authority record now.
+  writeAuthority("token-1");
+  startTurn(0);
+  await waitFor(() => turnStarts.length >= 1, "turn-start never reached the late-started Backend");
+  assert.equal(turnStarts[0].token, "token-1");
+
+  // Token rotation while DSH keeps running: the next dispatch must pick up
+  // the rotated token without reloading the plugin.
+  writeAuthority("token-2");
+  startTurn(1);
+  await waitFor(() => turnStarts.length >= 2, "second turn-start never reached the Backend");
+  assert.equal(turnStarts[1].token, "token-2");
+});
+
+async function waitFor(predicate, message) {
+  const deadline = Date.now() + 2000;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(message);
+}

--- a/packages/ts/memorax-code-dsh-adapter/test/index.test.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/test/index.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createServer } from "node:http";
 import { test } from "node:test";
 import { apply, name } from "../src/index.mjs";
 
@@ -10,6 +11,10 @@ function recordingCtx() {
       handlers[event] = handler;
     },
   };
+}
+
+function textMessage(text) {
+  return { content: [{ type: "text", text }], source: { kind: "user" } };
 }
 
 test("apply tolerates a null or missing plugin config", () => {
@@ -24,4 +29,41 @@ test("apply tolerates a null or missing plugin config", () => {
 
 test("the DSH adapter exposes the memorax-dsh plugin name", () => {
   assert.equal(name, "memorax-dsh");
+});
+
+test("llm/stream waits for the pending turn-start retrieval before streaming", async (t) => {
+  const server = createServer((req, res) => {
+    let body = "";
+    req.on("data", (chunk) => { body += chunk; });
+    req.on("end", () => {
+      if (req.url === "/memory/turn-start") {
+        setTimeout(() => {
+          res.writeHead(200, { "content-type": "application/json" });
+          res.end(JSON.stringify({ ok: true, additionalContext: "recalled memory" }));
+        }, 40);
+      } else {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ ok: true }));
+      }
+    });
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address();
+  t.after(() => new Promise((resolve) => server.close(resolve)));
+
+  const ctx = recordingCtx();
+  apply(ctx, { injectRetrieval: true, backendUrl: `http://127.0.0.1:${port}` });
+
+  const sess = { id: "session-x", header: { cwd: "/repo" }, firstLiveSeq: 1 };
+  ctx.handlers["session/created"](sess);
+  ctx.handlers["session/event"](sess, { type: "turn/start", data: { turn: 0 } });
+  ctx.handlers["session/event"](sess, { type: "user/message", data: textMessage("query") });
+
+  const options = { sessionId: "session-x" };
+  const stream = ctx.handlers["llm/stream"](options, async function* () { yield "chunk"; });
+  const chunks = [];
+  for await (const chunk of stream) chunks.push(chunk);
+
+  assert.deepEqual(chunks, ["chunk"]);
+  assert.equal(options.system, "recalled memory");
 });

--- a/packages/ts/memorax-code-dsh-adapter/test/index.test.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/test/index.test.mjs
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { apply, name } from "../src/index.mjs";
+
+function recordingCtx() {
+  const handlers = {};
+  return {
+    handlers,
+    on(event, handler) {
+      handlers[event] = handler;
+    },
+  };
+}
+
+test("apply tolerates a null or missing plugin config", () => {
+  for (const config of [null, undefined, {}]) {
+    const ctx = recordingCtx();
+    assert.doesNotThrow(() => apply(ctx, config));
+    assert.equal(typeof ctx.handlers["session/created"], "function");
+    assert.equal(typeof ctx.handlers["session/event"], "function");
+    assert.equal(typeof ctx.handlers["session/disposed"], "function");
+  }
+});
+
+test("the DSH adapter exposes the memorax-dsh plugin name", () => {
+  assert.equal(name, "memorax-dsh");
+});

--- a/packages/ts/memorax-code-dsh-adapter/test/session-bridge.test.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/test/session-bridge.test.mjs
@@ -1,0 +1,201 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  buildTurnId,
+  buildTurnStartCommand,
+  buildWritebackCommand,
+  createSessionBridge,
+  extractMessageText,
+  isDirectUserMessage,
+} from "../src/session-bridge.mjs";
+
+function textMessage(text) {
+  return { content: [{ type: "text", text }], source: { kind: "user" } };
+}
+
+function assistantData(text) {
+  return { turn: 0, step: 1, message: { content: [{ type: "text", text }], source: { kind: "model" } } };
+}
+
+function session(id, extra = {}) {
+  return { id, header: { cwd: "/repo" }, firstLiveSeq: 3, ...extra };
+}
+
+test("extractMessageText joins text blocks and ignores non-text blocks", () => {
+  assert.equal(extractMessageText({ content: [{ type: "text", text: "hello" }] }), "hello");
+  assert.equal(extractMessageText({
+    content: [
+      { type: "text", text: "a" },
+      { type: "reasoning", text: "skip me" },
+      { type: "text", text: "b" },
+    ],
+  }), "a\nb");
+  assert.equal(extractMessageText(undefined), "");
+});
+
+test("isDirectUserMessage detects the human source kind", () => {
+  assert.equal(isDirectUserMessage({ source: { kind: "user" } }), true);
+  assert.equal(isDirectUserMessage({ source: { kind: "plugin" } }), false);
+  assert.equal(isDirectUserMessage(undefined), false);
+});
+
+test("buildTurnId combines session first live seq and turn number", () => {
+  assert.equal(buildTurnId("session-1", 7, 2), "dsh-7-2");
+  assert.equal(buildTurnId("session-1", undefined, "3"), "dsh-0-3");
+});
+
+test("a complete turn produces a turn-start and a writeback command", async () => {
+  const calls = [];
+  const bridge = createSessionBridge({
+    dispatch: async (path, body) => {
+      calls.push({ path, body });
+      return { ok: true, body: {} };
+    },
+  });
+
+  bridge.onSessionCreated(session("session-abc"));
+  bridge.onSessionEvent(session("session-abc"), { type: "turn/start", data: { turn: 1 } });
+  bridge.onSessionEvent(session("session-abc"), { type: "user/message", data: textMessage("fix the build") });
+  bridge.onSessionEvent(session("session-abc"), { type: "assistant/message", data: assistantData("done") });
+  bridge.onSessionEvent(session("session-abc"), { type: "turn/end", data: { turn: 1, reason: { kind: "completed" } } });
+
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(calls.length, 2);
+  assert.deepEqual(calls[0], {
+    path: "/memory/turn-start",
+    body: {
+      version: 1,
+      client: "dsh",
+      sessionId: "session-abc",
+      turnId: "dsh-3-1",
+      prompt: "fix the build",
+      cwd: "/repo",
+    },
+  });
+  assert.deepEqual(calls[1], {
+    path: "/memory/writeback",
+    body: {
+      version: 1,
+      client: "dsh",
+      sessionId: "session-abc",
+      turnId: "dsh-3-1",
+      userText: "fix the build",
+      assistantText: "done",
+      cwd: "/repo",
+    },
+  });
+});
+
+test("missing assistant message skips the turn writeback", async () => {
+  const calls = [];
+  const bridge = createSessionBridge({
+    dispatch: async (path, body) => {
+      calls.push({ path, body });
+      return { ok: true, body: {} };
+    },
+  });
+
+  bridge.onSessionCreated(session("session-skip"));
+  bridge.onSessionEvent(session("session-skip"), { type: "turn/start", data: { turn: 0 } });
+  bridge.onSessionEvent(session("session-skip"), { type: "user/message", data: textMessage("hello") });
+  bridge.onSessionEvent(session("session-skip"), { type: "turn/end", data: { turn: 0, reason: { kind: "error" } } });
+
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].path, "/memory/turn-start");
+});
+
+test("synthetic plugin messages do not start a turn", async () => {
+  const calls = [];
+  const bridge = createSessionBridge({
+    dispatch: async (path, body) => {
+      calls.push({ path, body });
+      return { ok: true, body: {} };
+    },
+  });
+
+  bridge.onSessionCreated(session("session-plugin"));
+  bridge.onSessionEvent(session("session-plugin"), { type: "turn/start", data: { turn: 2 } });
+  bridge.onSessionEvent(session("session-plugin"), {
+    type: "user/message",
+    data: { content: [{ type: "text", text: "injected" }], source: { kind: "plugin", plugin: "x" } },
+  });
+
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(calls.length, 0);
+});
+
+test("additionalContext from turn-start is captured as pending context", async () => {
+  const bridge = createSessionBridge({
+    dispatch: async (path) => {
+      assert.equal(path, "/memory/turn-start");
+      return { ok: true, body: { additionalContext: "recalled memory" } };
+    },
+  });
+
+  bridge.onSessionCreated(session("session-ctx"));
+  bridge.onSessionEvent(session("session-ctx"), { type: "turn/start", data: { turn: 4 } });
+  bridge.onSessionEvent(session("session-ctx"), { type: "user/message", data: textMessage("query") });
+
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(bridge.takePendingContext("session-ctx"), "recalled memory");
+  assert.equal(bridge.takePendingContext("session-ctx"), undefined);
+});
+
+test("dispatch failures are swallowed without throwing", async () => {
+  const errors = [];
+  const bridge = createSessionBridge({
+    dispatch: async () => {
+      throw new Error("backend down");
+    },
+    debug: (message, detail) => errors.push({ message, detail }),
+  });
+
+  bridge.onSessionCreated(session("session-err"));
+  bridge.onSessionEvent(session("session-err"), { type: "turn/start", data: { turn: 0 } });
+  bridge.onSessionEvent(session("session-err"), { type: "user/message", data: textMessage("query") });
+  bridge.onSessionEvent(session("session-err"), { type: "assistant/message", data: assistantData("reply") });
+  bridge.onSessionEvent(session("session-err"), { type: "turn/end", data: { turn: 0, reason: { kind: "completed" } } });
+
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(errors.length, 2);
+  const messages = errors.map((entry) => entry.message).sort();
+  assert.deepEqual(messages, ["turn-start dispatch failed", "writeback dispatch failed"]);
+});
+
+test("buildTurnStartCommand and buildWritebackCommand are pure", () => {
+  assert.equal(buildTurnStartCommand({}), undefined);
+  assert.equal(buildTurnStartCommand({ sessionId: "s", turn: 0 }), undefined);
+  assert.equal(buildTurnStartCommand({ sessionId: "s", turn: 0, userText: "p" }).turnId, "dsh-0-0");
+  assert.equal(buildWritebackCommand({ sessionId: "s" }, 1, "u", ""), undefined);
+  assert.deepEqual(buildWritebackCommand({ sessionId: "s", cwd: "/w" }, 2, "u", "a"), {
+    version: 1,
+    client: "dsh",
+    sessionId: "s",
+    turnId: "dsh-0-2",
+    userText: "u",
+    assistantText: "a",
+    cwd: "/w",
+  });
+});
+
+test("replaying the same turn events does not duplicate a writeback", async () => {
+  const calls = [];
+  const bridge = createSessionBridge({
+    dispatch: async (path, body) => {
+      calls.push({ path, body });
+      return { ok: true, body: {} };
+    },
+  });
+
+  bridge.onSessionCreated(session("session-idem"));
+  bridge.onSessionEvent(session("session-idem"), { type: "turn/start", data: { turn: 1 } });
+  bridge.onSessionEvent(session("session-idem"), { type: "user/message", data: textMessage("once") });
+  bridge.onSessionEvent(session("session-idem"), { type: "assistant/message", data: assistantData("reply") });
+  bridge.onSessionEvent(session("session-idem"), { type: "turn/end", data: { turn: 1, reason: { kind: "completed" } } });
+  bridge.onSessionEvent(session("session-idem"), { type: "turn/end", data: { turn: 1, reason: { kind: "completed" } } });
+
+  await new Promise((resolve) => setImmediate(resolve));
+  const writebacks = calls.filter((call) => call.path === "/memory/writeback");
+  assert.equal(writebacks.length, 1);
+});

--- a/packages/ts/memorax-code-dsh-adapter/test/session-bridge.test.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/test/session-bridge.test.mjs
@@ -530,6 +530,66 @@ test("disposing a session mid-turn discards the active turn", async () => {
   assert.equal(calls[1].body.turnId, "dsh-3-1");
 });
 
+test("a malformed turn/start without a turn id is rejected while a turn is active", async () => {
+  const calls = [];
+  const bridge = createSessionBridge({
+    dispatch: async (path, body) => {
+      calls.push({ path, body });
+      return { ok: true, body: {} };
+    },
+  });
+
+  bridge.onSessionCreated(session("session-malformed-start"));
+  bridge.onSessionEvent(session("session-malformed-start"), { type: "turn/start", data: { turn: 1 } });
+  bridge.onSessionEvent(session("session-malformed-start"), { type: "user/message", data: textMessage("first") });
+  bridge.onSessionEvent(session("session-malformed-start"), { type: "turn/start", data: {} });
+  bridge.onSessionEvent(session("session-malformed-start"), { type: "assistant/message", data: assistantData("reply") });
+  bridge.onSessionEvent(session("session-malformed-start"), { type: "turn/end", data: { turn: 1, reason: { kind: "completed" } } });
+
+  await flushMicrotasks();
+  assert.deepEqual(calls.map((call) => call.path), ["/memory/turn-start", "/memory/writeback"]);
+  assert.equal(calls[1].body.turnId, "dsh-3-1");
+  assert.equal(calls[1].body.userText, "first");
+  assert.equal(calls[1].body.assistantText, "reply");
+});
+
+test("a malformed turn/start with a non-integer turn id is rejected while a turn is active", async () => {
+  const calls = [];
+  const bridge = createSessionBridge({
+    dispatch: async (path, body) => {
+      calls.push({ path, body });
+      return { ok: true, body: {} };
+    },
+  });
+
+  bridge.onSessionCreated(session("session-malformed-turn-int"));
+  bridge.onSessionEvent(session("session-malformed-turn-int"), { type: "turn/start", data: { turn: 0 } });
+  bridge.onSessionEvent(session("session-malformed-turn-int"), { type: "user/message", data: textMessage("query") });
+  bridge.onSessionEvent(session("session-malformed-turn-int"), { type: "turn/start", data: { turn: "nope" } });
+
+  await flushMicrotasks();
+  assert.deepEqual(calls.map((call) => call.path), ["/memory/turn-start"]);
+});
+
+test("a malformed turn/start is tolerated when no turn is active", async () => {
+  const calls = [];
+  const bridge = createSessionBridge({
+    dispatch: async (path, body) => {
+      calls.push({ path, body });
+      return { ok: true, body: {} };
+    },
+  });
+
+  bridge.onSessionCreated(session("session-malformed-start-idle"));
+  bridge.onSessionEvent(session("session-malformed-start-idle"), { type: "turn/start", data: {} });
+  bridge.onSessionEvent(session("session-malformed-start-idle"), { type: "turn/start", data: { turn: 3 } });
+  bridge.onSessionEvent(session("session-malformed-start-idle"), { type: "user/message", data: textMessage("query") });
+
+  await flushMicrotasks();
+  assert.deepEqual(calls.map((call) => call.path), ["/memory/turn-start"]);
+  assert.equal(calls[0].body.turnId, "dsh-3-3");
+});
+
 test("a turn/end without a turn id does not clobber the active turn", async () => {
   const calls = [];
   const bridge = createSessionBridge({

--- a/packages/ts/memorax-code-dsh-adapter/test/session-bridge.test.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/test/session-bridge.test.mjs
@@ -53,7 +53,7 @@ test("a complete turn produces a turn-start and a writeback command", async () =
   const bridge = createSessionBridge({
     dispatch: async (path, body) => {
       calls.push({ path, body });
-      return { ok: true, body: {} };
+      return { ok: true, body: { ok: true } };
     },
   });
 
@@ -95,7 +95,7 @@ test("missing assistant message skips the turn writeback", async () => {
   const bridge = createSessionBridge({
     dispatch: async (path, body) => {
       calls.push({ path, body });
-      return { ok: true, body: {} };
+      return { ok: true, body: { ok: true } };
     },
   });
 
@@ -129,7 +129,7 @@ test("an errored turn with partial assistant output does not write back", async 
   const bridge = createSessionBridge({
     dispatch: async (path, body) => {
       calls.push({ path, body });
-      return { ok: true, body: {} };
+      return { ok: true, body: { ok: true } };
     },
   });
 
@@ -148,7 +148,7 @@ test("a cancelled turn with partial assistant output does not write back", async
   const bridge = createSessionBridge({
     dispatch: async (path, body) => {
       calls.push({ path, body });
-      return { ok: true, body: {} };
+      return { ok: true, body: { ok: true } };
     },
   });
 
@@ -167,7 +167,7 @@ test("synthetic plugin messages do not start a turn", async () => {
   const bridge = createSessionBridge({
     dispatch: async (path, body) => {
       calls.push({ path, body });
-      return { ok: true, body: {} };
+      return { ok: true, body: { ok: true } };
     },
   });
 
@@ -186,7 +186,7 @@ test("additionalContext from turn-start is captured as pending context", async (
   const bridge = createSessionBridge({
     dispatch: async (path) => {
       assert.equal(path, "/memory/turn-start");
-      return { ok: true, body: { additionalContext: "recalled memory" } };
+      return { ok: true, body: { ok: true, additionalContext: "recalled memory" } };
     },
   });
 
@@ -241,7 +241,7 @@ test("replaying the same turn events does not duplicate a writeback", async () =
   const bridge = createSessionBridge({
     dispatch: async (path, body) => {
       calls.push({ path, body });
-      return { ok: true, body: {} };
+      return { ok: true, body: { ok: true } };
     },
   });
 
@@ -267,7 +267,7 @@ test("writeback is serialized behind a slow turn-start and is not lost", async (
         await turnStartGate;
       }
       calls.push({ path, body });
-      return { ok: true, body: {} };
+      return { ok: true, body: { ok: true } };
     },
   });
 
@@ -299,7 +299,7 @@ test("an interrupted turn sends a discard command instead of a writeback", async
   const bridge = createSessionBridge({
     dispatch: async (path, body) => {
       calls.push({ path, body });
-      return { ok: true, body: {} };
+      return { ok: true, body: { ok: true } };
     },
   });
 
@@ -374,9 +374,9 @@ test("a superseded turn-start response is dropped when a newer turn has started"
       calls.push({ path, body });
       if (path === "/memory/turn-start" && body.turnId === "dsh-3-1") {
         await firstGate;
-        return { ok: true, body: { additionalContext: "stale context" } };
+        return { ok: true, body: { ok: true, additionalContext: "stale context" } };
       }
-      return { ok: true, body: {} };
+      return { ok: true, body: { ok: true } };
     },
   });
 
@@ -397,10 +397,10 @@ test("a turn-start completion for a disposed session does not clobber a recreate
   const release = {};
   const bridge = createSessionBridge({
     dispatch: async (path, body) => {
-      if (path === "/memory/turn-discard") return { ok: true, body: {} };
+      if (path === "/memory/turn-discard") return { ok: true, body: { ok: true } };
       assert.equal(path, "/memory/turn-start");
       await new Promise((resolve) => { release[body.prompt] = resolve; });
-      return { ok: true, body: { additionalContext: `context for ${body.prompt}` } };
+      return { ok: true, body: { ok: true, additionalContext: `context for ${body.prompt}` } };
     },
   });
 
@@ -429,7 +429,7 @@ test("a delayed turn/end for an older turn does not clear the newer turn state",
   const bridge = createSessionBridge({
     dispatch: async (path, body) => {
       calls.push({ path, body });
-      return { ok: true, body: {} };
+      return { ok: true, body: { ok: true } };
     },
   });
 
@@ -459,8 +459,8 @@ test("a delayed turn/end for an older turn does not clear the newer turn state",
 test("a new turn start clears stale pending context from the previous turn", async () => {
   const bridge = createSessionBridge({
     dispatch: async (path, body) => {
-      if (body.turnId === "dsh-3-1") return { ok: true, body: { additionalContext: "stale ctx" } };
-      return { ok: true, body: {} };
+      if (body.turnId === "dsh-3-1") return { ok: true, body: { ok: true, additionalContext: "stale ctx" } };
+      return { ok: true, body: { ok: true } };
     },
   });
 
@@ -481,7 +481,7 @@ test("a superseded turn queues a turn-discard for the previous turn", async () =
   const bridge = createSessionBridge({
     dispatch: async (path, body) => {
       calls.push({ path, body });
-      return { ok: true, body: {} };
+      return { ok: true, body: { ok: true } };
     },
   });
 
@@ -505,7 +505,7 @@ test("a completed turn with no assistant text discards its backend metadata", as
   const bridge = createSessionBridge({
     dispatch: async (path, body) => {
       calls.push({ path, body });
-      return { ok: true, body: {} };
+      return { ok: true, body: { ok: true } };
     },
   });
 
@@ -524,7 +524,7 @@ test("disposing a session mid-turn discards the active turn", async () => {
   const bridge = createSessionBridge({
     dispatch: async (path, body) => {
       calls.push({ path, body });
-      return { ok: true, body: {} };
+      return { ok: true, body: { ok: true } };
     },
   });
 
@@ -544,7 +544,7 @@ test("a malformed turn/start without a turn id is rejected while a turn is activ
   const bridge = createSessionBridge({
     dispatch: async (path, body) => {
       calls.push({ path, body });
-      return { ok: true, body: {} };
+      return { ok: true, body: { ok: true } };
     },
   });
 
@@ -567,7 +567,7 @@ test("a malformed turn/start with a non-integer turn id is rejected while a turn
   const bridge = createSessionBridge({
     dispatch: async (path, body) => {
       calls.push({ path, body });
-      return { ok: true, body: {} };
+      return { ok: true, body: { ok: true } };
     },
   });
 
@@ -585,7 +585,7 @@ test("a malformed turn/start is tolerated when no turn is active", async () => {
   const bridge = createSessionBridge({
     dispatch: async (path, body) => {
       calls.push({ path, body });
-      return { ok: true, body: {} };
+      return { ok: true, body: { ok: true } };
     },
   });
 
@@ -604,7 +604,7 @@ test("a turn/end without a turn id does not clobber the active turn", async () =
   const bridge = createSessionBridge({
     dispatch: async (path, body) => {
       calls.push({ path, body });
-      return { ok: true, body: {} };
+      return { ok: true, body: { ok: true } };
     },
   });
 
@@ -640,9 +640,9 @@ test("waitForPendingContext resolves once the turn-start retrieval settles in ti
     dispatch: async (path, body) => {
       if (path === "/memory/turn-start") {
         await new Promise((resolve) => { release[body.prompt] = resolve; });
-        return { ok: true, body: { additionalContext: `ctx:${body.prompt}` } };
+        return { ok: true, body: { ok: true, additionalContext: `ctx:${body.prompt}` } };
       }
-      return { ok: true, body: {} };
+      return { ok: true, body: { ok: true } };
     },
   });
 
@@ -662,9 +662,9 @@ test("waitForPendingContext times out and returns undefined when retrieval is sl
     dispatch: async (path, body) => {
       if (path === "/memory/turn-start") {
         await new Promise((resolve) => { release.resolve = resolve; });
-        return { ok: true, body: { additionalContext: "late ctx" } };
+        return { ok: true, body: { ok: true, additionalContext: "late ctx" } };
       }
-      return { ok: true, body: {} };
+      return { ok: true, body: { ok: true } };
     },
   });
 
@@ -686,9 +686,9 @@ test("re-creating a session without dispose retires the old incarnation", async 
       calls.push({ path, body });
       if (path === "/memory/turn-start" && body.prompt === "stale") {
         await new Promise((resolve) => { release.stale = resolve; });
-        return { ok: true, body: { additionalContext: "stale context" } };
+        return { ok: true, body: { ok: true, additionalContext: "stale context" } };
       }
-      return { ok: true, body: { additionalContext: `ctx:${body.prompt}` } };
+      return { ok: true, body: { ok: true, additionalContext: `ctx:${body.prompt}` } };
     },
   });
 
@@ -726,7 +726,7 @@ test("an identical session/created redelivery keeps the live incarnation", async
   const bridge = createSessionBridge({
     dispatch: async (path, body) => {
       calls.push({ path, body });
-      return { ok: true, body: {} };
+      return { ok: true, body: { ok: true } };
     },
   });
 
@@ -761,9 +761,9 @@ test("re-creating a session clears stale pending context from the previous incar
   const bridge = createSessionBridge({
     dispatch: async (path, body) => {
       if (path === "/memory/turn-start") {
-        return { ok: true, body: { additionalContext: `ctx:${body.prompt}` } };
+        return { ok: true, body: { ok: true, additionalContext: `ctx:${body.prompt}` } };
       }
-      return { ok: true, body: {} };
+      return { ok: true, body: { ok: true } };
     },
   });
 
@@ -782,7 +782,7 @@ test("a turn/start without a turn id does not reset a pending unstarted turn", a
   const bridge = createSessionBridge({
     dispatch: async (path, body) => {
       calls.push({ path, body });
-      return { ok: true, body: {} };
+      return { ok: true, body: { ok: true } };
     },
   });
 
@@ -818,7 +818,7 @@ test("a turn-start response with body.ok=false is treated as rejected (defensive
         // a writeback the Backend would then skip.
         return { ok: true, status: 200, body: { ok: false, error: "conflicting_turn_start" } };
       }
-      return { ok: true, body: {} };
+      return { ok: true, body: { ok: true } };
     },
     debug: (message, detail) => errors.push({ message, detail }),
   });
@@ -834,6 +834,41 @@ test("a turn-start response with body.ok=false is treated as rejected (defensive
   assert.equal(bridge.takePendingContext("session-body-reject"), undefined);
 });
 
+test("a 2xx body with no ok field is a failure, not a fake success", async () => {
+  // Round 10 #2: a misconfigured proxy or a wrong service on the Backend port
+  // can answer 200 with an unrelated JSON object ({ status: "ok" }, {}, ...).
+  // The Backend contract is an explicit ok:true on every accepted command;
+  // anything else must be treated as rejected so the bridge does not mark a
+  // turn as started (or a writeback as sent) that the Backend never accepted.
+  const errors = [];
+  const calls = [];
+  const bridge = createSessionBridge({
+    dispatch: async (path, body) => {
+      calls.push({ path, body });
+      if (path === "/memory/turn-start") {
+        return { ok: true, status: 200, body: { status: "accepted" } };
+      }
+      return { ok: true, status: 200, body: { ok: true } };
+    },
+    debug: (message, detail) => errors.push({ message, detail }),
+  });
+
+  bridge.onSessionCreated(session("session-no-ok"));
+  bridge.onSessionEvent(session("session-no-ok"), { type: "turn/start", data: { turn: 0 } });
+  bridge.onSessionEvent(session("session-no-ok"), { type: "user/message", data: textMessage("query") });
+  // No turn/end here: the generation guard would swallow the body check for a
+  // turn that already ended, and this test pins the response validation itself
+  // (same shape as the body.ok=false test above).
+
+  await flushMicrotasks();
+  assert.equal(errors.length, 1);
+  assert.equal(errors[0].message, "turn-start dispatch rejected");
+  assert.equal(errors[0].detail, "backend response body missing ok:true");
+  assert.equal(bridge.takePendingContext("session-no-ok"), undefined);
+  // The turn never started, so no writeback may be dispatched for it.
+  assert.deepEqual(calls.map((call) => call.path), ["/memory/turn-start"]);
+});
+
 test("a writeback body-level skip reason is surfaced through debug", async () => {
   // The Backend accepts writeback with HTTP 200 and reports skipped
   // scheduling only in the body ({ ok: true, scheduled: false, reason }).
@@ -845,7 +880,7 @@ test("a writeback body-level skip reason is surfaced through debug", async () =>
       if (path === "/memory/writeback") {
         return { ok: true, status: 200, body: { ok: true, scheduled: false, reason: "turn_metadata_missing" } };
       }
-      return { ok: true, body: {} };
+      return { ok: true, body: { ok: true } };
     },
     debug: (message, detail) => errors.push({ message, detail }),
   });
@@ -869,7 +904,7 @@ test("a turn-discard response with discarded=false is surfaced through debug", a
       if (path === "/memory/turn-discard") {
         return { ok: true, status: 200, body: { ok: true, discarded: false } };
       }
-      return { ok: true, body: {} };
+      return { ok: true, body: { ok: true } };
     },
     debug: (message, detail) => errors.push({ message, detail }),
   });
@@ -890,7 +925,7 @@ test("concurrent sessions keep independent turn state", async () => {
   const bridge = createSessionBridge({
     dispatch: async (path, body) => {
       calls.push({ path, body });
-      return { ok: true, body: {} };
+      return { ok: true, body: { ok: true } };
     },
   });
 

--- a/packages/ts/memorax-code-dsh-adapter/test/session-bridge.test.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/test/session-bridge.test.mjs
@@ -41,9 +41,11 @@ test("isDirectUserMessage detects the human source kind", () => {
   assert.equal(isDirectUserMessage(undefined), false);
 });
 
-test("buildTurnId combines session first live seq and turn number", () => {
-  assert.equal(buildTurnId("session-1", 7, 2), "dsh-7-2");
-  assert.equal(buildTurnId("session-1", undefined, "3"), "dsh-0-3");
+test("buildTurnId combines session first live seq, incarnation, and turn number", () => {
+  assert.equal(buildTurnId("session-1", 7, 1, 2), "dsh-7-2");
+  assert.equal(buildTurnId("session-1", 7, 2, 2), "dsh-7-g2-2");
+  assert.equal(buildTurnId("session-1", 7, 5, 2), "dsh-7-g5-2");
+  assert.equal(buildTurnId("session-1", undefined, 1, "3"), "dsh-0-3");
 });
 
 test("a complete turn produces a turn-start and a writeback command", async () => {
@@ -317,7 +319,14 @@ test("an interrupted turn sends a discard command instead of a writeback", async
   });
 });
 
-test("resolved backend failures are reported through debug", async () => {
+test("resolved failure envelopes still report through debug (defensive branch)", async () => {
+  // The real forwarder (createBackendForwarder) NEVER resolves { ok: false }:
+  // transport failures throw DshBackendError and successes resolve
+  // { ok: true, status, body }. The throw path is covered by "dispatch
+  // failures are swallowed without throwing" above. This test pins the
+  // bridge's defensive branch so a future forwarder that starts resolving
+  // failure envelopes instead of throwing still reports them instead of
+  // treating them as successes.
   const errors = [];
   const bridge = createSessionBridge({
     dispatch: async (path) => {
@@ -667,6 +676,239 @@ test("waitForPendingContext times out and returns undefined when retrieval is sl
   release.resolve();
   await flushMicrotasks();
   assert.equal(bridge.takePendingContext("session-slow-ctx"), "late ctx");
+});
+
+test("re-creating a session without dispose retires the old incarnation", async () => {
+  const release = {};
+  const calls = [];
+  const bridge = createSessionBridge({
+    dispatch: async (path, body) => {
+      calls.push({ path, body });
+      if (path === "/memory/turn-start" && body.prompt === "stale") {
+        await new Promise((resolve) => { release.stale = resolve; });
+        return { ok: true, body: { additionalContext: "stale context" } };
+      }
+      return { ok: true, body: { additionalContext: `ctx:${body.prompt}` } };
+    },
+  });
+
+  bridge.onSessionCreated(session("session-dirty-rebuild"));
+  bridge.onSessionEvent(session("session-dirty-rebuild"), { type: "turn/start", data: { turn: 1 } });
+  bridge.onSessionEvent(session("session-dirty-rebuild"), { type: "user/message", data: textMessage("stale") });
+  await flushMicrotasks();
+
+  // Same session id, no intervening session/disposed, but a DIFFERENT live
+  // window (firstLiveSeq 9): only a distinguishable payload proves a rebuild.
+  // An identical payload is indistinguishable from a redelivery of the same
+  // incarnation and is covered by the next test.
+  bridge.onSessionCreated(session("session-dirty-rebuild", { firstLiveSeq: 9 }));
+  bridge.onSessionEvent(session("session-dirty-rebuild"), { type: "turn/start", data: { turn: 1 } });
+  bridge.onSessionEvent(session("session-dirty-rebuild"), { type: "user/message", data: textMessage("fresh") });
+  await flushMicrotasks();
+
+  // The stale in-flight response must not leak into the new incarnation.
+  release.stale();
+  await flushMicrotasks();
+  assert.equal(bridge.takePendingContext("session-dirty-rebuild"), "ctx:fresh");
+
+  const paths = calls.map((call) => call.path);
+  assert.equal(paths.filter((path) => path === "/memory/turn-discard").length, 1);
+  const discard = calls.find((call) => call.path === "/memory/turn-discard");
+  // Old incarnation turnId (gen 1, no suffix) is discarded; new incarnation
+  // uses a distinct turnId (gen 2) so the two can never collide.
+  assert.equal(discard.body.turnId, "dsh-3-1");
+  const starts = calls.filter((call) => call.path === "/memory/turn-start");
+  assert.deepEqual(starts.map((call) => call.body.turnId), ["dsh-3-1", "dsh-9-g2-1"]);
+});
+
+test("an identical session/created redelivery keeps the live incarnation", async () => {
+  const calls = [];
+  const bridge = createSessionBridge({
+    dispatch: async (path, body) => {
+      calls.push({ path, body });
+      return { ok: true, body: {} };
+    },
+  });
+
+  bridge.onSessionCreated(session("session-replayed"));
+  bridge.onSessionEvent(session("session-replayed"), { type: "turn/start", data: { turn: 1 } });
+  bridge.onSessionEvent(session("session-replayed"), { type: "user/message", data: textMessage("live") });
+  await flushMicrotasks();
+
+  // Same id, same firstLiveSeq, same cwd: indistinguishable from a replay of
+  // the SAME live incarnation (reconnect, event redelivery, plugin reload).
+  // Retiring the state here would discard the live turn on the Backend and
+  // drop its writeback, so the redelivery must be ignored.
+  bridge.onSessionCreated(session("session-replayed"));
+  bridge.onSessionEvent(session("session-replayed"), { type: "user/message", data: textMessage("more") });
+  bridge.onSessionEvent(session("session-replayed"), { type: "assistant/message", data: assistantData("reply") });
+  bridge.onSessionEvent(session("session-replayed"), { type: "turn/end", data: { turn: 1, reason: { kind: "completed" } } });
+  await flushMicrotasks();
+
+  const starts = calls.filter((call) => call.path === "/memory/turn-start");
+  assert.deepEqual(starts.map((call) => call.body.turnId), ["dsh-3-1"]);
+  // The turn-start was already dispatched at the first message, so its
+  // prompt stays "live"; text that arrived later rides on the writeback,
+  // where the Backend accepts it via the delimiter prefix match.
+  assert.equal(starts[0].body.prompt, "live");
+  const writebacks = calls.filter((call) => call.path === "/memory/writeback");
+  assert.equal(writebacks.length, 1);
+  assert.equal(writebacks[0].body.userText, "live\n\nmore");
+  assert.equal(calls.some((call) => call.path === "/memory/turn-discard"), false);
+});
+
+test("re-creating a session clears stale pending context from the previous incarnation", async () => {
+  const bridge = createSessionBridge({
+    dispatch: async (path, body) => {
+      if (path === "/memory/turn-start") {
+        return { ok: true, body: { additionalContext: `ctx:${body.prompt}` } };
+      }
+      return { ok: true, body: {} };
+    },
+  });
+
+  bridge.onSessionCreated(session("session-stale-pending"));
+  bridge.onSessionEvent(session("session-stale-pending"), { type: "turn/start", data: { turn: 1 } });
+  bridge.onSessionEvent(session("session-stale-pending"), { type: "user/message", data: textMessage("old") });
+  await flushMicrotasks();
+  assert.equal(bridge.takePendingContext("session-stale-pending"), "ctx:old");
+
+  bridge.onSessionCreated(session("session-stale-pending"));
+  assert.equal(bridge.takePendingContext("session-stale-pending"), undefined);
+});
+
+test("a turn/start without a turn id does not reset a pending unstarted turn", async () => {
+  const calls = [];
+  const bridge = createSessionBridge({
+    dispatch: async (path, body) => {
+      calls.push({ path, body });
+      return { ok: true, body: {} };
+    },
+  });
+
+  bridge.onSessionCreated(session("session-pending-start"));
+  bridge.onSessionEvent(session("session-pending-start"), { type: "turn/start", data: { turn: 4 } });
+  // Second start arrives before any user/message: state.turn is set but the
+  // turn has not dispatched. The guard must still ignore this start.
+  bridge.onSessionEvent(session("session-pending-start"), { type: "turn/start", data: {} });
+  bridge.onSessionEvent(session("session-pending-start"), { type: "user/message", data: textMessage("query") });
+  bridge.onSessionEvent(session("session-pending-start"), { type: "assistant/message", data: assistantData("reply") });
+  bridge.onSessionEvent(session("session-pending-start"), { type: "turn/end", data: { turn: 4, reason: { kind: "completed" } } });
+
+  await flushMicrotasks();
+  assert.deepEqual(calls.map((call) => call.path), ["/memory/turn-start", "/memory/writeback"]);
+  assert.equal(calls[0].body.turnId, "dsh-3-4");
+  assert.equal(calls[1].body.turnId, "dsh-3-4");
+  assert.equal(calls[1].body.userText, "query");
+});
+
+test("a turn-start response with body.ok=false is treated as rejected (defensive branch)", async () => {
+  const errors = [];
+  const bridge = createSessionBridge({
+    dispatch: async (path) => {
+      if (path === "/memory/turn-start") {
+        // HTTP 2xx with a body-level rejection. The CURRENT Backend never
+        // sends this for turn-start: it answers { ok: true, ... } and
+        // self-heals turnId conflicts server-side (see
+        // dsh-memory-hook-runtime "turn_start_conflict_replaced"), and
+        // non-2xx statuses make the real forwarder throw before the body is
+        // inspected. This pins the bridge's contract-drift defense: if a
+        // future Backend starts rejecting turn-start in a 2xx body, the
+        // bridge must treat the turn as NOT started instead of proceeding to
+        // a writeback the Backend would then skip.
+        return { ok: true, status: 200, body: { ok: false, error: "conflicting_turn_start" } };
+      }
+      return { ok: true, body: {} };
+    },
+    debug: (message, detail) => errors.push({ message, detail }),
+  });
+
+  bridge.onSessionCreated(session("session-body-reject"));
+  bridge.onSessionEvent(session("session-body-reject"), { type: "turn/start", data: { turn: 0 } });
+  bridge.onSessionEvent(session("session-body-reject"), { type: "user/message", data: textMessage("query") });
+
+  await flushMicrotasks();
+  assert.equal(errors.length, 1);
+  assert.equal(errors[0].message, "turn-start dispatch rejected");
+  assert.equal(errors[0].detail, "conflicting_turn_start");
+  assert.equal(bridge.takePendingContext("session-body-reject"), undefined);
+});
+
+test("a writeback body-level skip reason is surfaced through debug", async () => {
+  // The Backend accepts writeback with HTTP 200 and reports skipped
+  // scheduling only in the body ({ ok: true, scheduled: false, reason }).
+  // Reading the body is what makes turn_metadata_missing / prompt_mismatch
+  // visible instead of silently dropped.
+  const errors = [];
+  const bridge = createSessionBridge({
+    dispatch: async (path) => {
+      if (path === "/memory/writeback") {
+        return { ok: true, status: 200, body: { ok: true, scheduled: false, reason: "turn_metadata_missing" } };
+      }
+      return { ok: true, body: {} };
+    },
+    debug: (message, detail) => errors.push({ message, detail }),
+  });
+
+  bridge.onSessionCreated(session("session-skip"));
+  bridge.onSessionEvent(session("session-skip"), { type: "turn/start", data: { turn: 0 } });
+  bridge.onSessionEvent(session("session-skip"), { type: "user/message", data: textMessage("query") });
+  bridge.onSessionEvent(session("session-skip"), { type: "assistant/message", data: assistantData("reply") });
+  bridge.onSessionEvent(session("session-skip"), { type: "turn/end", data: { turn: 0, reason: { kind: "completed" } } });
+
+  await flushMicrotasks();
+  assert.equal(errors.length, 1);
+  assert.equal(errors[0].message, "writeback skipped by backend");
+  assert.equal(errors[0].detail, "turn_metadata_missing");
+});
+
+test("a turn-discard response with discarded=false is surfaced through debug", async () => {
+  const errors = [];
+  const bridge = createSessionBridge({
+    dispatch: async (path) => {
+      if (path === "/memory/turn-discard") {
+        return { ok: true, status: 200, body: { ok: true, discarded: false } };
+      }
+      return { ok: true, body: {} };
+    },
+    debug: (message, detail) => errors.push({ message, detail }),
+  });
+
+  bridge.onSessionCreated(session("session-discard-miss"));
+  bridge.onSessionEvent(session("session-discard-miss"), { type: "turn/start", data: { turn: 0 } });
+  bridge.onSessionEvent(session("session-discard-miss"), { type: "user/message", data: textMessage("query") });
+  bridge.onSessionEvent(session("session-discard-miss"), { type: "turn/end", data: { turn: 0, reason: { kind: "interrupted" } } });
+
+  await flushMicrotasks();
+  assert.equal(errors.length, 1);
+  assert.equal(errors[0].message, "turn-discard found no live turn metadata");
+  assert.equal(errors[0].detail, "dsh-3-0");
+});
+
+test("concurrent sessions keep independent turn state", async () => {
+  const calls = [];
+  const bridge = createSessionBridge({
+    dispatch: async (path, body) => {
+      calls.push({ path, body });
+      return { ok: true, body: {} };
+    },
+  });
+
+  for (const id of ["session-a", "session-b"]) {
+    bridge.onSessionCreated(session(id));
+    bridge.onSessionEvent(session(id), { type: "turn/start", data: { turn: 0 } });
+    bridge.onSessionEvent(session(id), { type: "user/message", data: textMessage(`q:${id}`) });
+    bridge.onSessionEvent(session(id), { type: "assistant/message", data: assistantData(`a:${id}`) });
+    bridge.onSessionEvent(session(id), { type: "turn/end", data: { turn: 0, reason: { kind: "completed" } } });
+  }
+
+  await flushMicrotasks();
+  assert.equal(bridge.sessionCount(), 2);
+  const writebacks = calls.filter((call) => call.path === "/memory/writeback");
+  assert.deepEqual(
+    writebacks.map((call) => [call.body.sessionId, call.body.userText]).sort(),
+    [["session-a", "q:session-a"], ["session-b", "q:session-b"]],
+  );
 });
 
 async function flushMicrotasks() {

--- a/packages/ts/memorax-code-dsh-adapter/test/session-bridge.test.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/test/session-bridge.test.mjs
@@ -7,6 +7,7 @@ import {
   createSessionBridge,
   extractMessageText,
   isDirectUserMessage,
+  turnEndCompleted,
 } from "../src/session-bridge.mjs";
 
 function textMessage(text) {
@@ -103,6 +104,53 @@ test("missing assistant message skips the turn writeback", async () => {
   await new Promise((resolve) => setImmediate(resolve));
   assert.equal(calls.length, 1);
   assert.equal(calls[0].path, "/memory/turn-start");
+});
+
+test("turnEndCompleted only accepts a completed turn end reason", () => {
+  assert.equal(turnEndCompleted({ reason: { kind: "completed" } }), true);
+  assert.equal(turnEndCompleted({ reason: { kind: "error" } }), false);
+  assert.equal(turnEndCompleted({ reason: { kind: "cancelled" } }), false);
+  assert.equal(turnEndCompleted({ reason: { kind: "interrupted" } }), false);
+  assert.equal(turnEndCompleted(undefined), true);
+  assert.equal(turnEndCompleted({}), true);
+});
+
+test("an errored turn with partial assistant output does not write back", async () => {
+  const calls = [];
+  const bridge = createSessionBridge({
+    dispatch: async (path, body) => {
+      calls.push({ path, body });
+      return { ok: true, body: {} };
+    },
+  });
+
+  bridge.onSessionCreated(session("session-error"));
+  bridge.onSessionEvent(session("session-error"), { type: "turn/start", data: { turn: 0 } });
+  bridge.onSessionEvent(session("session-error"), { type: "user/message", data: textMessage("run the tests") });
+  bridge.onSessionEvent(session("session-error"), { type: "assistant/message", data: assistantData("partial reply") });
+  bridge.onSessionEvent(session("session-error"), { type: "turn/end", data: { turn: 0, reason: { kind: "error" } } });
+
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.deepEqual(calls.map((call) => call.path), ["/memory/turn-start"]);
+});
+
+test("a cancelled turn with partial assistant output does not write back", async () => {
+  const calls = [];
+  const bridge = createSessionBridge({
+    dispatch: async (path, body) => {
+      calls.push({ path, body });
+      return { ok: true, body: {} };
+    },
+  });
+
+  bridge.onSessionCreated(session("session-cancel"));
+  bridge.onSessionEvent(session("session-cancel"), { type: "turn/start", data: { turn: 0 } });
+  bridge.onSessionEvent(session("session-cancel"), { type: "user/message", data: textMessage("run the tests") });
+  bridge.onSessionEvent(session("session-cancel"), { type: "assistant/message", data: assistantData("partial reply") });
+  bridge.onSessionEvent(session("session-cancel"), { type: "turn/end", data: { turn: 0, reason: { kind: "cancelled" } } });
+
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.deepEqual(calls.map((call) => call.path), ["/memory/turn-start"]);
 });
 
 test("synthetic plugin messages do not start a turn", async () => {

--- a/packages/ts/memorax-code-dsh-adapter/test/session-bridge.test.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/test/session-bridge.test.mjs
@@ -359,10 +359,11 @@ test("buildTurnDiscardCommand builds a minimal discard command", () => {
 test("a superseded turn-start response is dropped when a newer turn has started", async () => {
   let releaseFirst;
   const firstGate = new Promise((resolve) => { releaseFirst = resolve; });
+  const calls = [];
   const bridge = createSessionBridge({
     dispatch: async (path, body) => {
-      assert.equal(path, "/memory/turn-start");
-      if (body.turnId === "dsh-3-1") {
+      calls.push({ path, body });
+      if (path === "/memory/turn-start" && body.turnId === "dsh-3-1") {
         await firstGate;
         return { ok: true, body: { additionalContext: "stale context" } };
       }
@@ -387,6 +388,7 @@ test("a turn-start completion for a disposed session does not clobber a recreate
   const release = {};
   const bridge = createSessionBridge({
     dispatch: async (path, body) => {
+      if (path === "/memory/turn-discard") return { ok: true, body: {} };
       assert.equal(path, "/memory/turn-start");
       await new Promise((resolve) => { release[body.prompt] = resolve; });
       return { ok: true, body: { additionalContext: `context for ${body.prompt}` } };
@@ -411,6 +413,121 @@ test("a turn-start completion for a disposed session does not clobber a recreate
   release.stale();
   await flushMicrotasks();
   assert.equal(bridge.takePendingContext("session-recreated"), undefined);
+});
+
+test("a delayed turn/end for an older turn does not clear the newer turn state", async () => {
+  const calls = [];
+  const bridge = createSessionBridge({
+    dispatch: async (path, body) => {
+      calls.push({ path, body });
+      return { ok: true, body: {} };
+    },
+  });
+
+  bridge.onSessionCreated(session("session-stale-end"));
+  bridge.onSessionEvent(session("session-stale-end"), { type: "turn/start", data: { turn: 1 } });
+  bridge.onSessionEvent(session("session-stale-end"), { type: "user/message", data: textMessage("first") });
+  bridge.onSessionEvent(session("session-stale-end"), { type: "turn/start", data: { turn: 2 } });
+  bridge.onSessionEvent(session("session-stale-end"), { type: "user/message", data: textMessage("second") });
+  bridge.onSessionEvent(session("session-stale-end"), { type: "turn/end", data: { turn: 1, reason: { kind: "completed" } } });
+  bridge.onSessionEvent(session("session-stale-end"), { type: "assistant/message", data: assistantData("second reply") });
+  bridge.onSessionEvent(session("session-stale-end"), { type: "turn/end", data: { turn: 2, reason: { kind: "completed" } } });
+
+  await flushMicrotasks();
+  const writebacks = calls.filter((call) => call.path === "/memory/writeback");
+  assert.equal(writebacks.length, 1);
+  assert.deepEqual(writebacks[0].body, {
+    version: 1,
+    client: "dsh",
+    sessionId: "session-stale-end",
+    turnId: "dsh-3-2",
+    userText: "second",
+    assistantText: "second reply",
+    cwd: "/repo",
+  });
+});
+
+test("a new turn start clears stale pending context from the previous turn", async () => {
+  const bridge = createSessionBridge({
+    dispatch: async (path, body) => {
+      if (body.turnId === "dsh-3-1") return { ok: true, body: { additionalContext: "stale ctx" } };
+      return { ok: true, body: {} };
+    },
+  });
+
+  bridge.onSessionCreated(session("session-context-stale"));
+  bridge.onSessionEvent(session("session-context-stale"), { type: "turn/start", data: { turn: 1 } });
+  bridge.onSessionEvent(session("session-context-stale"), { type: "user/message", data: textMessage("first") });
+  await flushMicrotasks();
+
+  bridge.onSessionEvent(session("session-context-stale"), { type: "turn/start", data: { turn: 2 } });
+  bridge.onSessionEvent(session("session-context-stale"), { type: "user/message", data: textMessage("second") });
+  await flushMicrotasks();
+
+  assert.equal(bridge.takePendingContext("session-context-stale"), undefined);
+});
+
+test("a superseded turn queues a turn-discard for the previous turn", async () => {
+  const calls = [];
+  const bridge = createSessionBridge({
+    dispatch: async (path, body) => {
+      calls.push({ path, body });
+      return { ok: true, body: {} };
+    },
+  });
+
+  bridge.onSessionCreated(session("session-supersede-discard"));
+  bridge.onSessionEvent(session("session-supersede-discard"), { type: "turn/start", data: { turn: 1 } });
+  bridge.onSessionEvent(session("session-supersede-discard"), { type: "user/message", data: textMessage("first") });
+  bridge.onSessionEvent(session("session-supersede-discard"), { type: "turn/start", data: { turn: 2 } });
+  bridge.onSessionEvent(session("session-supersede-discard"), { type: "user/message", data: textMessage("second") });
+
+  await flushMicrotasks();
+  assert.deepEqual(calls.map((call) => call.path), [
+    "/memory/turn-start",
+    "/memory/turn-discard",
+    "/memory/turn-start",
+  ]);
+  assert.equal(calls[1].body.turnId, "dsh-3-1");
+});
+
+test("a completed turn with no assistant text discards its backend metadata", async () => {
+  const calls = [];
+  const bridge = createSessionBridge({
+    dispatch: async (path, body) => {
+      calls.push({ path, body });
+      return { ok: true, body: {} };
+    },
+  });
+
+  bridge.onSessionCreated(session("session-tool-only"));
+  bridge.onSessionEvent(session("session-tool-only"), { type: "turn/start", data: { turn: 0 } });
+  bridge.onSessionEvent(session("session-tool-only"), { type: "user/message", data: textMessage("run tools") });
+  bridge.onSessionEvent(session("session-tool-only"), { type: "turn/end", data: { turn: 0, reason: { kind: "completed" } } });
+
+  await flushMicrotasks();
+  assert.deepEqual(calls.map((call) => call.path), ["/memory/turn-start", "/memory/turn-discard"]);
+  assert.equal(calls[1].body.turnId, "dsh-3-0");
+});
+
+test("disposing a session mid-turn discards the active turn", async () => {
+  const calls = [];
+  const bridge = createSessionBridge({
+    dispatch: async (path, body) => {
+      calls.push({ path, body });
+      return { ok: true, body: {} };
+    },
+  });
+
+  bridge.onSessionCreated(session("session-dispose-mid-turn"));
+  bridge.onSessionEvent(session("session-dispose-mid-turn"), { type: "turn/start", data: { turn: 1 } });
+  bridge.onSessionEvent(session("session-dispose-mid-turn"), { type: "user/message", data: textMessage("query") });
+  await flushMicrotasks();
+  bridge.onSessionDisposed(session("session-dispose-mid-turn"));
+  await flushMicrotasks();
+
+  assert.deepEqual(calls.map((call) => call.path), ["/memory/turn-start", "/memory/turn-discard"]);
+  assert.equal(calls[1].body.turnId, "dsh-3-1");
 });
 
 async function flushMicrotasks() {

--- a/packages/ts/memorax-code-dsh-adapter/test/session-bridge.test.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/test/session-bridge.test.mjs
@@ -916,3 +916,59 @@ async function flushMicrotasks() {
     await new Promise((resolve) => setImmediate(resolve));
   }
 }
+test("a late turn-start response cannot inject context after turn/end", async () => {
+  let releaseTurnStart;
+  const dispatched = [];
+  const bridge = createSessionBridge({
+    dispatch: (path, body) => {
+      dispatched.push({ path, body });
+      if (path === "/memory/turn-start") {
+        return new Promise((resolve) => { releaseTurnStart = resolve; });
+      }
+      return Promise.resolve({ ok: true, body: { ok: true } });
+    },
+    debug: () => {},
+  });
+
+  const sess = session("session-late-response");
+  bridge.onSessionCreated(sess);
+  bridge.onSessionEvent(sess, { type: "turn/start", data: { turn: 0 } });
+  bridge.onSessionEvent(sess, { type: "user/message", data: textMessage("query") });
+  bridge.onSessionEvent(sess, { type: "assistant/message", data: assistantData("reply") });
+  bridge.onSessionEvent(sess, { type: "turn/end", data: { turn: 0, reason: { kind: "completed" } } });
+
+  // The turn is over; only now does the turn-start response arrive carrying
+  // retrieval context for the finished turn.
+  await flushMicrotasks();
+  assert.equal(typeof releaseTurnStart, "function", "turn-start dispatch must have been issued");
+  releaseTurnStart({ ok: true, body: { ok: true, additionalContext: "stale context" } });
+  for (let i = 0; i < 10; i++) await Promise.resolve();
+  await flushMicrotasks();
+
+  assert.equal(bridge.takePendingContext("session-late-response"), undefined,
+    "a response for a finished turn must not land in pendingContext");
+});
+
+test("an out-of-order user message keeps its text when turn/start arrives late", async () => {
+  const dispatched = [];
+  const bridge = createSessionBridge({
+    dispatch: (path, body) => {
+      dispatched.push({ path, body });
+      return Promise.resolve({ ok: true, body: { ok: true } });
+    },
+    debug: () => {},
+  });
+
+  const sess = session("session-out-of-order");
+  bridge.onSessionCreated(sess);
+  // The first user message arrives BEFORE the turn/start event, so the bridge
+  // has text but no turn id to dispatch with.
+  bridge.onSessionEvent(sess, { type: "user/message", data: textMessage("early bird text") });
+  // Now the turn id arrives for the same turn.
+  bridge.onSessionEvent(sess, { type: "turn/start", data: { turn: 0 } });
+  await flushMicrotasks();
+
+  const turnStart = dispatched.find((entry) => entry.path === "/memory/turn-start");
+  assert.ok(turnStart, "the carried text must be dispatched once the turn id is known");
+  assert.equal(turnStart.body.prompt, "early bird text");
+});

--- a/packages/ts/memorax-code-dsh-adapter/test/session-bridge.test.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/test/session-bridge.test.mjs
@@ -356,6 +356,63 @@ test("buildTurnDiscardCommand builds a minimal discard command", () => {
   });
 });
 
+test("a superseded turn-start response is dropped when a newer turn has started", async () => {
+  let releaseFirst;
+  const firstGate = new Promise((resolve) => { releaseFirst = resolve; });
+  const bridge = createSessionBridge({
+    dispatch: async (path, body) => {
+      assert.equal(path, "/memory/turn-start");
+      if (body.turnId === "dsh-3-1") {
+        await firstGate;
+        return { ok: true, body: { additionalContext: "stale context" } };
+      }
+      return { ok: true, body: {} };
+    },
+  });
+
+  bridge.onSessionCreated(session("session-superseded"));
+  bridge.onSessionEvent(session("session-superseded"), { type: "turn/start", data: { turn: 1 } });
+  bridge.onSessionEvent(session("session-superseded"), { type: "user/message", data: textMessage("first") });
+  bridge.onSessionEvent(session("session-superseded"), { type: "turn/start", data: { turn: 2 } });
+  bridge.onSessionEvent(session("session-superseded"), { type: "user/message", data: textMessage("second") });
+
+  await flushMicrotasks();
+  releaseFirst();
+  await flushMicrotasks();
+
+  assert.equal(bridge.takePendingContext("session-superseded"), undefined);
+});
+
+test("a turn-start completion for a disposed session does not clobber a recreated session", async () => {
+  const release = {};
+  const bridge = createSessionBridge({
+    dispatch: async (path, body) => {
+      assert.equal(path, "/memory/turn-start");
+      await new Promise((resolve) => { release[body.prompt] = resolve; });
+      return { ok: true, body: { additionalContext: `context for ${body.prompt}` } };
+    },
+  });
+
+  bridge.onSessionCreated(session("session-recreated"));
+  bridge.onSessionEvent(session("session-recreated"), { type: "turn/start", data: { turn: 1 } });
+  bridge.onSessionEvent(session("session-recreated"), { type: "user/message", data: textMessage("stale") });
+  await flushMicrotasks();
+  bridge.onSessionDisposed(session("session-recreated"));
+
+  bridge.onSessionCreated(session("session-recreated"));
+  bridge.onSessionEvent(session("session-recreated"), { type: "turn/start", data: { turn: 2 } });
+  bridge.onSessionEvent(session("session-recreated"), { type: "user/message", data: textMessage("fresh") });
+  await flushMicrotasks();
+
+  release.fresh();
+  await flushMicrotasks();
+  assert.equal(bridge.takePendingContext("session-recreated"), "context for fresh");
+
+  release.stale();
+  await flushMicrotasks();
+  assert.equal(bridge.takePendingContext("session-recreated"), undefined);
+});
+
 async function flushMicrotasks() {
   for (let index = 0; index < 4; index += 1) {
     await new Promise((resolve) => setImmediate(resolve));

--- a/packages/ts/memorax-code-dsh-adapter/test/session-bridge.test.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/test/session-bridge.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import {
+  buildTurnDiscardCommand,
   buildTurnId,
   buildTurnStartCommand,
   buildWritebackCommand,
@@ -102,8 +103,14 @@ test("missing assistant message skips the turn writeback", async () => {
   bridge.onSessionEvent(session("session-skip"), { type: "turn/end", data: { turn: 0, reason: { kind: "error" } } });
 
   await new Promise((resolve) => setImmediate(resolve));
-  assert.equal(calls.length, 1);
-  assert.equal(calls[0].path, "/memory/turn-start");
+  assert.equal(calls.length, 2);
+  assert.deepEqual(calls.map((call) => call.path), ["/memory/turn-start", "/memory/turn-discard"]);
+  assert.deepEqual(calls[1].body, {
+    version: 1,
+    client: "dsh",
+    sessionId: "session-skip",
+    turnId: "dsh-3-0",
+  });
 });
 
 test("turnEndCompleted only accepts a completed turn end reason", () => {
@@ -131,7 +138,7 @@ test("an errored turn with partial assistant output does not write back", async 
   bridge.onSessionEvent(session("session-error"), { type: "turn/end", data: { turn: 0, reason: { kind: "error" } } });
 
   await new Promise((resolve) => setImmediate(resolve));
-  assert.deepEqual(calls.map((call) => call.path), ["/memory/turn-start"]);
+  assert.deepEqual(calls.map((call) => call.path), ["/memory/turn-start", "/memory/turn-discard"]);
 });
 
 test("a cancelled turn with partial assistant output does not write back", async () => {
@@ -150,7 +157,7 @@ test("a cancelled turn with partial assistant output does not write back", async
   bridge.onSessionEvent(session("session-cancel"), { type: "turn/end", data: { turn: 0, reason: { kind: "cancelled" } } });
 
   await new Promise((resolve) => setImmediate(resolve));
-  assert.deepEqual(calls.map((call) => call.path), ["/memory/turn-start"]);
+  assert.deepEqual(calls.map((call) => call.path), ["/memory/turn-start", "/memory/turn-discard"]);
 });
 
 test("synthetic plugin messages do not start a turn", async () => {
@@ -247,3 +254,110 @@ test("replaying the same turn events does not duplicate a writeback", async () =
   const writebacks = calls.filter((call) => call.path === "/memory/writeback");
   assert.equal(writebacks.length, 1);
 });
+
+test("writeback is serialized behind a slow turn-start and is not lost", async () => {
+  const calls = [];
+  let releaseTurnStart;
+  const turnStartGate = new Promise((resolve) => { releaseTurnStart = resolve; });
+  const bridge = createSessionBridge({
+    dispatch: async (path, body) => {
+      if (path === "/memory/turn-start") {
+        await turnStartGate;
+      }
+      calls.push({ path, body });
+      return { ok: true, body: {} };
+    },
+  });
+
+  bridge.onSessionCreated(session("session-slow"));
+  bridge.onSessionEvent(session("session-slow"), { type: "turn/start", data: { turn: 2 } });
+  bridge.onSessionEvent(session("session-slow"), { type: "user/message", data: textMessage("query") });
+  bridge.onSessionEvent(session("session-slow"), { type: "assistant/message", data: assistantData("reply") });
+  bridge.onSessionEvent(session("session-slow"), { type: "turn/end", data: { turn: 2, reason: { kind: "completed" } } });
+
+  await flushMicrotasks();
+  assert.deepEqual(calls.map((call) => call.path), []);
+
+  releaseTurnStart();
+  await flushMicrotasks();
+  assert.deepEqual(calls.map((call) => call.path), ["/memory/turn-start", "/memory/writeback"]);
+  assert.deepEqual(calls[1].body, {
+    version: 1,
+    client: "dsh",
+    sessionId: "session-slow",
+    turnId: "dsh-3-2",
+    userText: "query",
+    assistantText: "reply",
+    cwd: "/repo",
+  });
+});
+
+test("an interrupted turn sends a discard command instead of a writeback", async () => {
+  const calls = [];
+  const bridge = createSessionBridge({
+    dispatch: async (path, body) => {
+      calls.push({ path, body });
+      return { ok: true, body: {} };
+    },
+  });
+
+  bridge.onSessionCreated(session("session-discard"));
+  bridge.onSessionEvent(session("session-discard"), { type: "turn/start", data: { turn: 1 } });
+  bridge.onSessionEvent(session("session-discard"), { type: "user/message", data: textMessage("query") });
+  bridge.onSessionEvent(session("session-discard"), { type: "assistant/message", data: assistantData("partial") });
+  bridge.onSessionEvent(session("session-discard"), { type: "turn/end", data: { turn: 1, reason: { kind: "interrupted" } } });
+
+  await flushMicrotasks();
+  assert.deepEqual(calls.map((call) => call.path), ["/memory/turn-start", "/memory/turn-discard"]);
+  assert.deepEqual(calls[1].body, {
+    version: 1,
+    client: "dsh",
+    sessionId: "session-discard",
+    turnId: "dsh-3-1",
+  });
+});
+
+test("resolved backend failures are reported through debug", async () => {
+  const errors = [];
+  const bridge = createSessionBridge({
+    dispatch: async (path) => {
+      if (path === "/memory/turn-start") return { ok: false, status: 503 };
+      return { ok: false, error: "backend timeout" };
+    },
+    debug: (message, detail) => errors.push({ message, detail }),
+  });
+
+  bridge.onSessionCreated(session("session-reject"));
+  bridge.onSessionEvent(session("session-reject"), { type: "turn/start", data: { turn: 0 } });
+  bridge.onSessionEvent(session("session-reject"), { type: "user/message", data: textMessage("query") });
+  bridge.onSessionEvent(session("session-reject"), { type: "assistant/message", data: assistantData("reply") });
+  bridge.onSessionEvent(session("session-reject"), { type: "turn/end", data: { turn: 0, reason: { kind: "completed" } } });
+
+  await flushMicrotasks();
+  assert.equal(errors.length, 2);
+  assert.deepEqual(
+    errors.map((entry) => entry.message).sort(),
+    ["turn-start dispatch rejected", "writeback dispatch rejected"],
+  );
+  const turnStartFailure = errors.find((entry) => entry.message === "turn-start dispatch rejected");
+  const writebackFailure = errors.find((entry) => entry.message === "writeback dispatch rejected");
+  assert.equal(turnStartFailure.detail, "status 503");
+  assert.equal(writebackFailure.detail, "backend timeout");
+});
+
+test("buildTurnDiscardCommand builds a minimal discard command", () => {
+  assert.equal(buildTurnDiscardCommand({}, 0), undefined);
+  assert.equal(buildTurnDiscardCommand({ sessionId: "s" }, undefined), undefined);
+  assert.deepEqual(buildTurnDiscardCommand({ sessionId: "s", firstLiveSeq: 5 }, 3), {
+    version: 1,
+    client: "dsh",
+    sessionId: "s",
+    turnId: "dsh-5-3",
+  });
+});
+
+async function flushMicrotasks() {
+  for (let index = 0; index < 4; index += 1) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+}

--- a/packages/ts/memorax-code-dsh-adapter/test/session-bridge.test.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/test/session-bridge.test.mjs
@@ -530,6 +530,85 @@ test("disposing a session mid-turn discards the active turn", async () => {
   assert.equal(calls[1].body.turnId, "dsh-3-1");
 });
 
+test("a turn/end without a turn id does not clobber the active turn", async () => {
+  const calls = [];
+  const bridge = createSessionBridge({
+    dispatch: async (path, body) => {
+      calls.push({ path, body });
+      return { ok: true, body: {} };
+    },
+  });
+
+  bridge.onSessionCreated(session("session-unlabeled-end"));
+  bridge.onSessionEvent(session("session-unlabeled-end"), { type: "turn/start", data: { turn: 1 } });
+  bridge.onSessionEvent(session("session-unlabeled-end"), { type: "user/message", data: textMessage("first") });
+  bridge.onSessionEvent(session("session-unlabeled-end"), { type: "turn/start", data: { turn: 2 } });
+  bridge.onSessionEvent(session("session-unlabeled-end"), { type: "user/message", data: textMessage("second") });
+  bridge.onSessionEvent(session("session-unlabeled-end"), { type: "turn/end", data: { reason: { kind: "completed" } } });
+  bridge.onSessionEvent(session("session-unlabeled-end"), { type: "assistant/message", data: assistantData("second reply") });
+  bridge.onSessionEvent(session("session-unlabeled-end"), { type: "turn/end", data: { turn: 2, reason: { kind: "completed" } } });
+
+  await flushMicrotasks();
+  const writebacks = calls.filter((call) => call.path === "/memory/writeback");
+  assert.equal(writebacks.length, 1);
+  assert.deepEqual(writebacks[0].body, {
+    version: 1,
+    client: "dsh",
+    sessionId: "session-unlabeled-end",
+    turnId: "dsh-3-2",
+    userText: "second",
+    assistantText: "second reply",
+    cwd: "/repo",
+  });
+  const discards = calls.filter((call) => call.path === "/memory/turn-discard");
+  assert.equal(discards.length, 1);
+  assert.equal(discards[0].body.turnId, "dsh-3-1");
+});
+
+test("waitForPendingContext resolves once the turn-start retrieval settles in time", async () => {
+  const release = {};
+  const bridge = createSessionBridge({
+    dispatch: async (path, body) => {
+      if (path === "/memory/turn-start") {
+        await new Promise((resolve) => { release[body.prompt] = resolve; });
+        return { ok: true, body: { additionalContext: `ctx:${body.prompt}` } };
+      }
+      return { ok: true, body: {} };
+    },
+  });
+
+  bridge.onSessionCreated(session("session-wait-ctx"));
+  bridge.onSessionEvent(session("session-wait-ctx"), { type: "turn/start", data: { turn: 1 } });
+  bridge.onSessionEvent(session("session-wait-ctx"), { type: "user/message", data: textMessage("query") });
+
+  const pending = bridge.waitForPendingContext("session-wait-ctx", 200);
+  await flushMicrotasks();
+  release.query();
+  assert.equal(await pending, "ctx:query");
+});
+
+test("waitForPendingContext times out and returns undefined when retrieval is slow", async () => {
+  const release = {};
+  const bridge = createSessionBridge({
+    dispatch: async (path, body) => {
+      if (path === "/memory/turn-start") {
+        await new Promise((resolve) => { release.resolve = resolve; });
+        return { ok: true, body: { additionalContext: "late ctx" } };
+      }
+      return { ok: true, body: {} };
+    },
+  });
+
+  bridge.onSessionCreated(session("session-slow-ctx"));
+  bridge.onSessionEvent(session("session-slow-ctx"), { type: "turn/start", data: { turn: 1 } });
+  bridge.onSessionEvent(session("session-slow-ctx"), { type: "user/message", data: textMessage("query") });
+
+  assert.equal(await bridge.waitForPendingContext("session-slow-ctx", 20), undefined);
+  release.resolve();
+  await flushMicrotasks();
+  assert.equal(bridge.takePendingContext("session-slow-ctx"), "late ctx");
+});
+
 async function flushMicrotasks() {
   for (let index = 0; index < 4; index += 1) {
     await new Promise((resolve) => setImmediate(resolve));

--- a/scripts/check-local-trace-only.mjs
+++ b/scripts/check-local-trace-only.mjs
@@ -20,6 +20,7 @@ const productionRoots = [
   "packages/ts/memorax-code-claude-adapter/runtime-hooks/",
   "packages/ts/memorax-code-claude-adapter/scripts/",
   "packages/ts/memorax-code-claude-adapter/src/",
+  "packages/ts/memorax-code-dsh-adapter/src/",
 ];
 
 const reviewedNetworkSources = new Set([
@@ -27,6 +28,7 @@ const reviewedNetworkSources = new Set([
   "packages/ts/memorax-code-backend/src/app/backend-server.ts",
   "packages/ts/memorax-code-backend/src/clients/claude/memory-hook-runtime.ts",
   "packages/ts/memorax-code-backend/src/clients/codex/memory-hook-runtime.ts",
+  "packages/ts/memorax-code-backend/src/clients/dsh/memory-hook-runtime.ts",
   "packages/ts/memorax-code-backend/src/lifecycle/backend/service.ts",
   "packages/ts/memorax-code-backend/src/lifecycle/backend/status.ts",
   "packages/ts/memorax-code-backend/src/memory/automatic-retrieval.ts",
@@ -49,6 +51,7 @@ const reviewedNetworkSources = new Set([
   "packages/ts/memorax-code-codex-adapter/runtime-hooks/memory-writeback.mjs",
   "packages/ts/memorax-code-codex-adapter/src/cli.mjs",
   "packages/ts/memorax-code-codex-adapter/skills/memorax-code/scripts/detect_updates.py",
+  "packages/ts/memorax-code-dsh-adapter/src/backend-forwarder.mjs",
 ]);
 
 const localTraceCoreSources = new Set([

--- a/scripts/npm-package-check.sh
+++ b/scripts/npm-package-check.sh
@@ -350,6 +350,7 @@ assert config_sections == {
     "memory.writeback",
     "trace.claude",
     "trace.codex",
+    "trace.dsh",
 }
 assert 'output_language = "zh"' in config_text
 assert memorax_code_config.stat().st_mode & 0o777 == 0o600

--- a/scripts/sync-release-version.mjs
+++ b/scripts/sync-release-version.mjs
@@ -13,6 +13,7 @@ export const RELEASE_VERSION_TARGETS = Object.freeze([
   { file: "packages/ts/memorax-code-backend/package-lock.json", field: ["version"] },
   { file: "packages/ts/memorax-code-backend/package-lock.json", field: ["packages", "", "version"] },
   { file: "packages/ts/memorax-code-codex-adapter/package.json", field: ["version"] },
+  { file: "packages/ts/memorax-code-dsh-adapter/package.json", field: ["version"] },
   { file: "packages/ts/memorax-code-codex-adapter/.codex-plugin/plugin.json", field: ["version"] },
   { file: "packages/ts/memorax-code-codex-adapter/hooks/runtime-shell.json", field: ["shellVersion"] },
   { file: "packages/ts/memorax-code-claude-adapter/package.json", field: ["version"] },


### PR DESCRIPTION
# feat: add DeepSeek Harness (DSH) support

Closes #42 — a user asked for DSH support and offered to help with the adaptation. This PR adds it: a new `client: dsh` path in the backend plus a cordis plugin that bridges DSH session events to the Memorax backend over HTTP.

## What's in this PR

- **New package `packages/ts/memorax-code-dsh-adapter`** — cordis plugin (`dsh.bundle.patch`):
  - listens to DSH `session/event` (turn/start, turn/end) and `agent/error`
  - translates events → Memorax hook commands inside the plugin (isolates DSH's internal ABI)
  - forwards to the local backend via HTTP, fails silent when backend is unreachable (never blocks the DSH conversation)
  - zero-dependency (only `fetch` + `node:crypto`)
- **Backend changes** (`client: "dsh"`):
  - `hook-command.ts`: `DshWritebackCommand` — inline `userText`/`assistantText`, `transcriptPath` optional (DSH has no transcript file)
  - `service.ts` / `automatic-writeback.ts` / `turn-coordinator.ts`: dispatch + client union
  - `clients/dsh/memory-hook-runtime.ts`: turn-start via `recordTurnStart` + `retrieveAutomaticMemoryContext`; writeback via `turnCoordinator.completeMaterializedTurn`
  - `trace/config.ts` + `trace/store.ts`: DSH trace records + `DshTurnTokenUsage`
- **Identity rules**: `sessionId` = DSH `session.id`, `turnId` = `dsh-<firstLiveSeq>-<turn>` (monotonic, unique), `client: "dsh"` — same-id isolation across clients is unit-tested.
- **Docs**: README / README.zh.md, docs/configuration.md (DSH install), ARCHITECTURE.md client matrix.

## Verification

- `npm test` (backend): **521 pass / 0 fail** (incl. 11 new DSH tests)
- adapter: **20 pass / 0 fail**
- codex adapter 202 pass, claude adapter 65 pass (no regressions)
- `npm run typecheck` (backend) + `make docs-check` + `sync-release-version --check` all pass
- **E2E on real dsh v0.1.0-rc.6**: isolated backend + adapter installed into a headless profile + mock LLM → backend logs `memory_hook.turn_start` and `memory_hook.writeback`; replay of the same turn is deduped (`skipReason="duplicate_pending"`, MemoraX received 1 record not 2).

## Notes / follow-up

- Retrieval injection is optional and off by default (`injectRetrieval=false`): turn-start retrieval is async, so injection only affects the next turn — documented as best-effort.
- DSH has no skill-reminder concept; `parseSkillReminderCommand` fails closed for `dsh`.

## Updates (addressing Codex review)

All 6 review suggestions are addressed in f5c4d81:

- **P1** skip writeback for interrupted/cancelled turns (reason-aware)
- **P1** reject writeback without matching turn metadata (`turn_metadata_missing`)
- **P1** npm publish of the adapter package is a maintainer action — docs now use local-checkout install until then
- **P2** env vars can override the bundle default (`injectRetrieval` / `timeoutMs` / `debug`)
- **P2** DSH activity isolated from the Codex viewer projection (client-tagged)
- **P2** DSH adapter suite included in `make test`

Test suites: backend 523, dsh adapter 24, codex 202, claude 65 — all green. (One pre-existing `make test` failure in npm-package postinstall is environment-sensitive and fails on base too.)

## Updates 2 (addressing the four-perspective review)

All DSH-specific findings and the high-value repo-level items are addressed in 60ef4bc:

**A — DSH-specific:**
- generation-tracked `pendingContext` (stale retrieval from older turns is dropped, not just overwritten)
- `disposed` guard: in-flight dispatch completions are skipped after session dispose (no leaked map entries)
- `automaticRetrievalTurns` cleared on session close (bounded growth, not just FIFO cap)
- null-safe `config` in `apply()`; dead `dsh` entry removed from `SKILL_REMINDER_KEYS`; patch defaults asserted against `config.mjs`
- adapter errors unified to `DshBackendError` (Error subclass + `code`), fail-silent semantics preserved

**B — repo-level (low-risk, done here since this PR is the CI-less repo's first big external surface):**
- `sync-release-version` now tracks the dsh-adapter package version
- added `.github/workflows/ci.yml`: `make test` + `make docs-check` on ubuntu/windows; `npm-package-check` in a separate non-blocking job (known issue: needs claude/codex CLIs, also red on base)
- `/health` no longer leaks `sessionHome` to unauthenticated clients
- `atomicWriteText` now uses `randomUUID()` + `openSync("wx", 0o600)` (matches `runtime-record` pattern)

**Verification:** backend 532, dsh adapter 35, codex 204, claude 65, `make docs-check` — all green on Linux Node 24. CI matrix includes windows (not runnable here).

**Left for maintainers (existing-code debt, not introduced by this PR):** `Atomics.wait` sync blocking (3 sites), adapter-common standalone test suite, unified error API across adapter-common modules, shared base for the three client runtimes. Happy to pick these up in follow-ups if useful.


## Updates 3 (addressing fifth Codex review)

cad588d addresses both suggestions from the latest pass:

- **P1** `dshPromptMatches` now requires equality or the exact bridge delimiter `\n\n` — dropped the broad `\s/\p{P}` boundary that still let `"Fix the build.evil"` slip through a `.` suffix. The adapter only ever joins continuations with `\n\n` (session-bridge.mjs:113), so the check now mirrors the actual protocol.
- **P2** `turn/start` without a valid native turn id while another turn is active now fails closed — the malformed event is rejected, active messages/retrieval state preserved, no discard dispatched for the previous valid turn. Falls back to tolerance only when no turn is active.

**Verification:** backend typecheck ✅, backend DSH suites ✅ (25 cases), dsh-adapter 47/47 ✅ (3 new tests), codex 204 ✅, claude 65 ✅, `make docs-check` ✅. Unrelated suite failures (codex-plugin-hooks/install etc.) reproduce on base — pre-existing environment issues.


## Updates 3 (addressing the external adversarial review — P0s, P1s, contract honesty)

Full pass over the four-perspective adversarial report (6 P0 / 15 P1 / test-honesty audit) landed in 5c75c00:

**P0:**
- Session-rebuild guard hardened: per-session **incarnation counter** (`-gN` suffix prevents turnId collisions across rebuilds; same-generation redelivery ignored; distinct payload treated as rebuild with best-effort discard)
- Writeback now falls back to **current-turn trace attestation** when metadata is missing (session+turn double match) — mitigates the pure-in-memory state machine for DSH
- Hook endpoints enforce `application/json` and **reject Origin-bearing requests** (415/403) — closes the cross-site poisoning vector on default loopback
- `npm-package-check` now asserts `trace.dsh` config (no more silently-red CI)
- Capacity boundary (shared 256 pool) disclosed in docs with saturation tests

**P1 (high-value):**
- Conflicting turn-start **self-healing** (latest wins, diagnostic recorded)
- Invalid URL explicit warning instead of silent fallback
- `redirect: "error"` — no token header/body forwarding on 307/308
- Adapter reads backend skip reasons (`turn_metadata_missing`/`prompt_mismatch` now visible in debug)
- Connection parsing authority-mirror with validation; no more silent 401 loop on token rotate

**Contract & test honesty:**
- New `dsh-adapter-contract.test.mjs` (builder↔parser bidirectional, delimiters, paths, authority mirror vs adapter-common)
- Fake-coverage tests renamed and honestly labeled; real throw paths covered
- P2s from the last Codex pass also landed (no-ID second turn-start no longer resets state; retrieval double-toggle documented; `body.ok=false` honored)

**Corrections to earlier claims (honest):**
- The adapter does **not** register a cordis `agent/error` listener; dispatch failures are contained in the promise chain and only visible via `MEMORAX_CODE_DSH_HOOK_DEBUG`. Earlier description text claiming an `agent/error` integration was wrong.
- DSH turnIds are deterministic (`dsh-<firstLiveSeq>[-gN]-<turn>`), not crypto-derived: the adapter intentionally imports no crypto. Uniqueness comes from the per-session incarnation counter + server-side self-healing. Earlier text claiming crypto-derived IDs was wrong.

**Verification:** dsh adapter 63/63, backend DSH suites 51/51 (one env-only failure — no .git in unpacked tree), claude 65/65, codex 203/204 (root-user env-only), docs-check green.

Left for maintainers (existing-code debt, unchanged by this PR): loopback auth architecture, 256-pool bucketing, Atomics.wait, adapter-common standalone suite, redactor gaps, CSP, backend test isolation.
## Updates 4 (codex round 7 + self-adversarial pass)

**Codex round 7 (3 P1 + 5 P2) — all addressed in 18d2819:**
- recovery writeback gated by attested prompt sha256 (exact hash or hash of prefix+\n\n delimiter); no bare userText
- attestation cwd/workspaceKind authoritative over request cwd (no cross-repo binding)
- attestation stays OPEN until scheduled:true — transient failures can retry
- backend authority re-resolved per dispatch (late-start backend / token rotate no longer require reload)
- conflict self-heal releases the retrieval claim; interrupted turns close their attestation (no replay穿透)
- rotatedAt present-but-invalid rejects the whole token record (mirrors adapter-common)
- transcriptPath removed from DSH command keys, parse-rejected

**Self-adversarial pass (1 P1 + 5 P2 + 9 P3), highlights:** prompt no longer lands in plaintext in events.jsonl (sha256 only, same source as the attestation — the hash gate was self-defeating otherwise); trace writes serialized; in-process tombstone (512 LRU) blocks replayed recovery; 2xx with a non-JSON body now raises instead of faking ok:true; 24h recovery window; no attested cwd => reject; generation advances on turn/end (stale turn-start responses can't inject); out-of-order user→turn/start retains the first prompt; bounded LRUs throughout.

**Verification:** dsh adapter 69/69, backend DSH suites 42/42, full 515 pass (2 env-only failures unchanged: Node>=24 guard, root-readable chmod 000).