### PR TITLE
docs: add Trendshift badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
   </picture>
 </h1>
 
+<p align="center">
+  <a href="https://trendshift.io/repositories/105791?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-105791" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/105791/daily?language=JavaScript" alt="memorax-ai/memorax-code | Trendshift" width="250" height="55" /></a>
+</p>
+
 <h2 align="center">Never lose context. Never start over.</h2>
 
 <p align="center">

--- a/README.zh.md
+++ b/README.zh.md
@@ -6,6 +6,10 @@
   </picture>
 </h1>
 
+<p align="center">
+  <a href="https://trendshift.io/repositories/105791?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-105791" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/105791/daily?language=JavaScript" alt="memorax-ai/memorax-code | Trendshift" width="250" height="55" /></a>
+</p>
+
 <h2 align="center">上下文不断档，开发无需重来</h2>
 
 <p align="center">


### PR DESCRIPTION
## Summary

- Add a linked Trendshift repository badge beneath the MemoraX Code lockup.
- Keep the English and Simplified Chinese README layouts synchronized.

## Why

Make the project's Trendshift page and ranking badge discoverable from the repository landing page.

## User impact

Visitors can open the MemoraX Code Trendshift page directly from either README.

## Validation

- `make docs-check`
- `git diff --check`
- Verified the Trendshift page and badge image URLs return HTTP 200