### PR TITLE
feat: package the initial OpenCode adapter artifact

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,9 +76,9 @@ same change, then run the matching verification profile in Section 5.
   local.
 - Memory Viewer is a content-free local projection, not memory, transcript,
   session, or lifecycle authority.
-- `memorax-code` is the shared user-facing skill. Changes must work in both
-  Codex and Claude Code packaging and must keep triggers, metadata, references,
-  and resource paths valid.
+- `memorax-code` is the shared user-facing skill. Changes must work in Codex,
+  Claude Code, and OpenCode packaging and must keep triggers, metadata,
+  references, and resource paths valid.
 - Packaged skills must address product users. Do not include maintainer
   runbooks, private paths, unpublished plans, secrets, internal fixtures, or
   local diagnostic artifacts.
@@ -98,9 +98,11 @@ boundaries:
 - **Codex**: `npm test --prefix packages/ts/memorax-code-codex-adapter`.
 - **Claude Code**:
   `npm test --prefix packages/ts/memorax-code-claude-adapter`.
+- **OpenCode**:
+  `npm test --prefix packages/ts/memorax-code-opencode-adapter`.
 - **Adapter-common/shared Hook**: `adapter-common` has no standalone suite. Run
-  affected Backend tests and both adapter suites; add `make npm-package-check`
-  when staged runtime or package layout changes.
+  affected Backend tests and all three adapter suites; add
+  `make npm-package-check` when staged runtime or package layout changes.
 - **Trace/local-only boundary**: for trace, provider, or outbound transport,
   run `make test-npm-package` in addition to affected package tests.
 - **Documentation**: `make docs-check`.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -24,14 +24,14 @@ authoritative.
 
 ## 2. System Shape and Package Ownership
 
-MemoraX Code integrates Codex and Claude Code with one local Backend. The
-Backend is a capability-oriented modular monolith. The clients retain
-ownership of models, model-provider credentials, native tools, model-provider
-traffic, and native transcript creation.
+MemoraX Code integrates Codex, Claude Code, and OpenCode with one local
+Backend. The Backend is a capability-oriented modular monolith. The clients
+retain ownership of models, model-provider credentials, native tools,
+model-provider traffic, and native transcript or message creation.
 
 Around the Backend are:
 
-- two client deployment adapters;
+- three client deployment adapters;
 - one lower-level shared runtime source layer;
 - one npm assembly and installed-CLI layer; and
 - repository automation that builds, validates, stages, and tests artifacts.
@@ -41,11 +41,13 @@ flowchart LR
   subgraph Clients["Client-owned runtimes"]
     Codex["Codex"]
     Claude["Claude Code"]
+    OpenCode["OpenCode"]
   end
 
   subgraph Adapters["Client deployment adapters"]
     CodexAdapter["Codex adapter<br/>plugin, Hooks, canonical skill"]
     ClaudeAdapter["Claude adapter<br/>plugin, Hooks, installer"]
+    OpenCodeAdapter["OpenCode adapter<br/>plugin and skill artifact"]
   end
 
   Common["adapter-common<br/>records, locks, Hook and Repo Memory helpers"]
@@ -61,15 +63,18 @@ flowchart LR
   Common -. "runtime source" .-> Build
   CodexAdapter -. "artifact source" .-> Build
   ClaudeAdapter -. "artifact source" .-> Build
+  OpenCodeAdapter -. "artifact source" .-> Build
   Build -->|"assembles"| Artifact
   Artifact -->|"launches"| Backend
 
   Backend --> Common
   CodexAdapter --> Common
   ClaudeAdapter --> Common
+  OpenCodeAdapter --> Common
 
   Codex --> CodexAdapter
   Claude --> ClaudeAdapter
+  OpenCode --> OpenCodeAdapter
   CodexAdapter -. "versioned local Hook HTTP" .-> Backend
   ClaudeAdapter -. "versioned local Hook HTTP" .-> Backend
 
@@ -88,18 +93,19 @@ relationships; the arrow labels distinguish them. It is not an import graph.
 | `packages/ts/memorax-code-adapter-common` | Shared source for Backend connection authority, private runtime records, cross-process locking and configuration, Hook generations, Hook launch helpers, and Repo/Personal Memory helpers | Backend composition, native transcript interpretation, MemoraX request execution, or client plugin policy | `packages/ts/memorax-code-adapter-common/src/backend-connection.mjs`, `src/runtime-record.mjs`, `src/hooks`, and `src/repo-memory` |
 | `packages/ts/memorax-code-codex-adapter` | Codex plugin artifact, Hook shells and runtimes, session/workspace observation, diagnostics, and the canonical shared skill | Codex rollout semantics or Backend-side writeback authority | `.codex-plugin`, `hooks`, `runtime-hooks`, `src`, and `skills/memorax-code` |
 | `packages/ts/memorax-code-claude-adapter` | Claude Code plugin artifact, Hook shells and runtimes, configuration, installer, marketplace source, and diagnostics | Claude transcript semantics or Backend memory orchestration | `.claude-plugin`, `hooks`, `runtime-hooks`, `scripts`, and `src/plugin-install.mjs` |
+| `packages/ts/memorax-code-opencode-adapter` | OpenCode plugin runtime, shell-session identity, and a materialized shared skill | OpenCode message interpretation inside the Backend, installation lifecycle, or model-provider configuration | `src/plugin.mjs` and the OpenCode materialization mapping in `scripts/npm-source-files.mjs` |
 | `packages/npm/memorax-code` | Installed executable wrappers, update, preinstall/postinstall, npm manifest, and release-package source | Backend lifecycle semantics, uninstall orchestration, or artifact staging | `bin`, `lib/run-entrypoint.mjs`, and `package.json` |
 | `scripts` | Backend build orchestration, staging/materialization, package layout, documentation, and local-only data gates | Product runtime authority | Package-build/check scripts and executable contract scripts |
 | `.github` | Issue and pull-request contribution templates | Product runtime behavior | `.github/ISSUE_TEMPLATE` and `.github/pull_request_template.md` |
 
-`memorax-code-adapter-common` is a source layer consumed by the Backend and
-both adapters; it is not an independently deployed service. The npm artifact
+`memorax-code-adapter-common` is a source layer consumed by the Backend and all
+three adapters; it is not an independently deployed service. The npm artifact
 assembles all runtime trees, but package assembly does not make the npm wrapper
 the owner of their behavior.
 
 ### 2.2 Physical dependency directions
 
-- The Backend and both adapters may import adapter-common. Adapter-common must
+- The Backend and all three adapters may import adapter-common. Adapter-common must
   not import those higher-level components back.
 - Adapter Hook runtimes do not import Backend implementation. They communicate
   through versioned, client-qualified local HTTP commands.
@@ -109,8 +115,8 @@ the owner of their behavior.
 - The npm layer locates staged entrypoints. `scripts` owns how source is
   materialized into that staged layout.
 - The canonical user-facing `memorax-code` skill lives in the Codex adapter.
-  Packaging materializes the Claude artifact from that source; do not maintain
-  a second independent skill copy.
+  Packaging materializes the Claude Code and OpenCode artifacts from that
+  source; do not maintain independent skill copies.
 
 Client integration is deliberately not physically symmetric. Codex plugin
 material belongs to the Codex adapter, while current install, activation, and
@@ -528,6 +534,7 @@ flowchart TD
   CommonSource["adapter-common runtime source"]
   CodexSource["Codex adapter and canonical skill"]
   ClaudeSource["Claude adapter"]
+  OpenCodeSource["OpenCode adapter"]
   Stage["npm staging tree"]
   Materialize["skill and marketplace materialization"]
   Gates["layout, source, symlink, and local-only gates"]
@@ -540,6 +547,7 @@ flowchart TD
   CommonSource --> Stage
   CodexSource --> Stage
   ClaudeSource --> Stage
+  OpenCodeSource --> Stage
   Stage --> Materialize
   Materialize --> Gates
   Gates --> Pack
@@ -550,8 +558,9 @@ flowchart TD
   committed.
 - Adapter-common and adapter `.mjs` runtime trees are staged from declared,
   tracked source.
-- The Claude skill and marketplace are materialized from canonical sources;
-  packaging may rewrite contained relative imports for the staged topology.
+- The Claude Code skill and marketplace and the OpenCode skill artifact are
+  materialized from canonical sources; packaging may rewrite contained
+  relative imports for the staged topology.
 - The npm wrappers use `packages/npm/memorax-code/lib/run-entrypoint.mjs` to
   locate staged Backend or adapter entrypoints.
 - Artifact gates reject undeclared paths, unsafe symlinks, cache/build debris,
@@ -594,12 +603,12 @@ Placement rules:
   root-surface, public-route, delegation, and dependency-cycle contracts.
 - Backend behavior tests build and exercise `dist`; architecture tests inspect
   `src` directly.
-- The Backend suite discovers nested tests recursively. Codex and Claude Code
-  adapter suites currently discover only flat `test/*.test.mjs`; their package
-  scripts must change before tests are nested.
+- The Backend suite discovers nested tests recursively. Codex, Claude Code, and
+  OpenCode adapter suites currently discover only flat `test/*.test.mjs`; their
+  package scripts must change before tests are nested.
 - Adapter-common has no standalone suite. Its changes are verified through all
-  affected consumers: Backend, both adapters, and package checks when staged
-  runtime layout is involved.
+  affected consumers: Backend, all three adapters, and package checks when
+  staged runtime layout is involved.
 - Before moving, splitting, or renaming tests, search `scripts` and `.github`
   for explicit paths and test-name patterns.
 
@@ -614,8 +623,8 @@ uses those named profiles rather than copying commands here.
 | Hook HTTP or adapter-visible command schema | `test/transport/http` and affected adapter suites | Backend source boundaries and package shape when staged | Backend + Adapter-common/shared Hook; add Install/artifacts when staged package shape changes |
 | Backend root entrypoint or compatibility facade | Entrypoint, architecture, and npm package tests | Source boundaries and package shape | Backend + Install/artifacts |
 | Client-native parsing or identity | `test/clients/<client>` | Source boundaries | Backend |
-| Client adapter plugin or Hook deployment | Matching adapter suite and affected Backend contract tests | Package shape when staged | Codex or Claude Code; add Adapter-common/shared Hook for shared Hook source and Install/artifacts for staged package shape |
-| Adapter-common | Affected Backend tests and both adapter suites | Package shape when staged layout changes | Adapter-common/shared Hook; add Install/artifacts when staged runtime or package layout changes |
+| Client adapter plugin or Hook deployment | Matching adapter suite and affected Backend contract tests | Package shape when staged | Codex, Claude Code, or OpenCode; add Adapter-common/shared Hook for shared Hook source and Install/artifacts for staged package shape |
+| Adapter-common | Affected Backend tests and all three adapter suites | Package shape when staged layout changes | Adapter-common/shared Hook; add Install/artifacts when staged runtime or package layout changes |
 | MemoraX provider, trace, or outbound transport | Matching Backend tests | Local-only trace boundary | Backend + Trace/local-only boundary |
 | Test relocation | Moved owning suite | Platform-specific consumers | Matching named profile |
 | Packaging/materialization | npm package tests and artifact gates | Package shape and local-only trace boundary | Install/artifacts |

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-ts test-codex-adapter test-claude-adapter test-npm-package docs-check npm-package-build npm-package-check npm-publish-dry-run release-version-check clean
+.PHONY: test test-ts test-codex-adapter test-claude-adapter test-opencode-adapter test-npm-package docs-check npm-package-build npm-package-check npm-publish-dry-run release-version-check clean
 
 NPM ?= npm
 
@@ -10,12 +10,16 @@ test-ts:
 	$(NPM) test --prefix packages/ts/memorax-code-backend
 	$(MAKE) test-codex-adapter
 	$(MAKE) test-claude-adapter
+	$(MAKE) test-opencode-adapter
 
 test-codex-adapter:
 	$(NPM) test --prefix packages/ts/memorax-code-codex-adapter
 
 test-claude-adapter:
 	$(NPM) test --prefix packages/ts/memorax-code-claude-adapter
+
+test-opencode-adapter:
+	$(NPM) test --prefix packages/ts/memorax-code-opencode-adapter
 
 test-npm-package:
 	$(NPM) ci --prefix packages/ts/memorax-code-backend

--- a/packages/npm/memorax-code/package.json
+++ b/packages/npm/memorax-code/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@memorax/memorax-code",
   "version": "0.1.2",
-  "description": "MemoraX Code CLI, local memory backend, Codex and Claude Code adapters, skills, and Memory Viewer.",
+  "description": "MemoraX Code CLI, local memory backend, Codex, Claude Code, and OpenCode adapters, skills, and Memory Viewer.",
   "license": "MIT",
   "type": "module",
   "homepage": "https://github.com/memorax-ai/memorax-code#readme",
@@ -15,6 +15,7 @@
   "keywords": [
     "agent",
     "codex",
+    "opencode",
     "memory",
     "memorax"
   ],

--- a/packages/npm/memorax-code/test/npm-package-layout.test.mjs
+++ b/packages/npm/memorax-code/test/npm-package-layout.test.mjs
@@ -19,6 +19,11 @@ test("single npm package layout accepts declared paths and rejects unknown trees
     isAllowedNpmPackPath("lib/memorax-code-codex-adapter/skills/memorax-code/SKILL.md"),
     true,
   );
+  assert.equal(isAllowedNpmPackPath("lib/memorax-code-opencode-adapter/src/plugin.mjs"), true);
+  assert.equal(
+    isAllowedNpmPackPath("lib/memorax-code-opencode-adapter/skills/memorax-code/SKILL.md"),
+    true,
+  );
   assert.equal(isAllowedNpmPackPath("lib/temporary-build/output.js"), false);
   assert.equal(isAllowedNpmPackPath("lib/unknown-runtime.mjs"), false);
   assert.equal(isAllowedNpmPackPath("bin/unknown-command.mjs"), false);

--- a/packages/npm/memorax-code/test/npm-source-files.test.mjs
+++ b/packages/npm/memorax-code/test/npm-source-files.test.mjs
@@ -52,6 +52,24 @@ test("Claude shared skill stages directly from tracked Codex skill sources", () 
   );
 });
 
+test("OpenCode shared skill stages directly from tracked Codex skill sources", () => {
+  assert.ok(npmMainSourceTrees.some((mapping) => (
+    mapping.source === "packages/ts/memorax-code-codex-adapter/skills/memorax-code"
+    && mapping.destination === "lib/memorax-code-opencode-adapter/skills/memorax-code"
+  )));
+  assert.equal(
+    npmMainSourceTrees.some((mapping) => mapping.source === "packages/ts/memorax-code-opencode-adapter/skills"),
+    false,
+  );
+});
+
+test("OpenCode adapter runtime is a declared npm source tree", () => {
+  assert.ok(npmMainSourceTrees.some((mapping) => (
+    mapping.source === "packages/ts/memorax-code-opencode-adapter/src"
+    && mapping.destination === "lib/memorax-code-opencode-adapter/src"
+  )));
+});
+
 test("Codex plugin assets are declared npm source trees", () => {
   assert.ok(npmMainSourceTrees.some((mapping) => (
     mapping.source === "packages/ts/memorax-code-codex-adapter/assets"

--- a/packages/ts/memorax-code-opencode-adapter/package.json
+++ b/packages/ts/memorax-code-opencode-adapter/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@memorax-code/opencode-adapter",
+  "version": "0.1.2",
+  "private": true,
+  "type": "module",
+  "description": "OpenCode plugin adapter for MemoraX Code memory services.",
+  "scripts": {
+    "test": "node --test test/*.test.mjs"
+  }
+}

--- a/packages/ts/memorax-code-opencode-adapter/src/plugin.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/src/plugin.mjs
@@ -1,0 +1,42 @@
+import { delimiter } from "node:path";
+import { readAdapterState } from "../../memorax-code-adapter-common/src/config-utils.mjs";
+
+export function createMemoraxOpenCodePlugin(options = {}) {
+  return async () => ({
+    "shell.env": async (input, output) => {
+      if (!pluginEnabled(options)) return;
+      output.env.MEMORAX_CODE_MEMORY_CLI_TRACE_CLIENT = "opencode";
+      const sessionId = stringValue(input?.sessionID);
+      if (sessionId) {
+        output.env.MEMORAX_CODE_MEMORY_CLI_TRACE_SESSION_ID = sessionId;
+        output.env.MEMORAX_CODE_MEMORY_CLI_SESSION_ID = sessionId;
+      }
+      const cliBinDir = stringValue(options.cliBinDir);
+      if (cliBinDir) {
+        const currentPath = output.env.PATH ?? process.env.PATH ?? "";
+        const pathEntries = currentPath.split(delimiter).filter(Boolean);
+        output.env.PATH = pathEntries.includes(cliBinDir)
+          ? currentPath
+          : [cliBinDir, ...pathEntries].join(delimiter);
+      }
+    },
+  });
+}
+
+export const MemoraxOpenCodePlugin = createMemoraxOpenCodePlugin();
+export default MemoraxOpenCodePlugin;
+
+function stringValue(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function pluginEnabled(options) {
+  const statePath = stringValue(options.statePath);
+  if (!statePath) return true;
+  const state = readAdapterState(statePath);
+  return state?.unreadable !== true
+    && state?.version === 1
+    && state?.runtime === "opencode"
+    && state?.integration === "plugin"
+    && state?.enabled === true;
+}

--- a/packages/ts/memorax-code-opencode-adapter/src/plugin.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/src/plugin.mjs
@@ -7,6 +7,8 @@ export function createMemoraxOpenCodePlugin(options = {}) {
       if (!pluginEnabled(options)) return;
       output.env.MEMORAX_CODE_MEMORY_CLI_TRACE_CLIENT = "opencode";
       const sessionId = stringValue(input?.sessionID);
+      delete output.env.MEMORAX_CODE_MEMORY_CLI_TRACE_SESSION_ID;
+      delete output.env.MEMORAX_CODE_MEMORY_CLI_SESSION_ID;
       if (sessionId) {
         output.env.MEMORAX_CODE_MEMORY_CLI_TRACE_SESSION_ID = sessionId;
         output.env.MEMORAX_CODE_MEMORY_CLI_SESSION_ID = sessionId;

--- a/packages/ts/memorax-code-opencode-adapter/test/plugin.test.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/test/plugin.test.mjs
@@ -1,0 +1,25 @@
+import { strict as assert } from "node:assert";
+import { delimiter } from "node:path";
+import { test } from "node:test";
+import { createMemoraxOpenCodePlugin } from "../src/plugin.mjs";
+
+test("shell.env overwrites the OpenCode session identity and prepends the managed CLI path", async () => {
+  const cliBinDir = "/memorax/bin";
+  const plugin = createMemoraxOpenCodePlugin({ cliBinDir });
+  const hooks = await plugin({});
+  const output = {
+    env: {
+      MEMORAX_CODE_MEMORY_CLI_TRACE_CLIENT: "codex",
+      MEMORAX_CODE_MEMORY_CLI_TRACE_SESSION_ID: "old-session",
+      MEMORAX_CODE_MEMORY_CLI_SESSION_ID: "old-session",
+      PATH: ["/usr/bin", "/bin"].join(delimiter),
+    },
+  };
+
+  await hooks["shell.env"]({ sessionID: "session-2" }, output);
+
+  assert.equal(output.env.MEMORAX_CODE_MEMORY_CLI_TRACE_CLIENT, "opencode");
+  assert.equal(output.env.MEMORAX_CODE_MEMORY_CLI_TRACE_SESSION_ID, "session-2");
+  assert.equal(output.env.MEMORAX_CODE_MEMORY_CLI_SESSION_ID, "session-2");
+  assert.equal(output.env.PATH, [cliBinDir, "/usr/bin", "/bin"].join(delimiter));
+});

--- a/packages/ts/memorax-code-opencode-adapter/test/plugin.test.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/test/plugin.test.mjs
@@ -23,3 +23,21 @@ test("shell.env overwrites the OpenCode session identity and prepends the manage
   assert.equal(output.env.MEMORAX_CODE_MEMORY_CLI_SESSION_ID, "session-2");
   assert.equal(output.env.PATH, [cliBinDir, "/usr/bin", "/bin"].join(delimiter));
 });
+
+test("shell.env clears inherited session identity without an OpenCode session", async () => {
+  const plugin = createMemoraxOpenCodePlugin();
+  const hooks = await plugin({});
+  const output = {
+    env: {
+      MEMORAX_CODE_MEMORY_CLI_TRACE_CLIENT: "codex",
+      MEMORAX_CODE_MEMORY_CLI_TRACE_SESSION_ID: "old-session",
+      MEMORAX_CODE_MEMORY_CLI_SESSION_ID: "old-session",
+    },
+  };
+
+  await hooks["shell.env"]({}, output);
+
+  assert.equal(output.env.MEMORAX_CODE_MEMORY_CLI_TRACE_CLIENT, "opencode");
+  assert.equal(Object.hasOwn(output.env, "MEMORAX_CODE_MEMORY_CLI_TRACE_SESSION_ID"), false);
+  assert.equal(Object.hasOwn(output.env, "MEMORAX_CODE_MEMORY_CLI_SESSION_ID"), false);
+});

--- a/scripts/build-npm-packages.mjs
+++ b/scripts/build-npm-packages.mjs
@@ -68,6 +68,7 @@ async function stageMainPackage(destination) {
     "lib/memorax-code-adapter-common",
     "lib/memorax-code-codex-adapter",
     "lib/memorax-code-claude-adapter",
+    "lib/memorax-code-opencode-adapter",
   ]) {
     await mkdir(join(destination, path), { recursive: true });
   }
@@ -96,6 +97,10 @@ async function stageMainPackage(destination) {
   await copyFile(
     "packages/ts/memorax-code-claude-adapter/package.json",
     join(destination, "lib/memorax-code-claude-adapter/package.json"),
+  );
+  await copyFile(
+    "packages/ts/memorax-code-opencode-adapter/package.json",
+    join(destination, "lib/memorax-code-opencode-adapter/package.json"),
   );
 
   await buildClaudeMarketplace({
@@ -171,6 +176,8 @@ async function validateStaging(packageRoot) {
     "lib/memorax-code-claude-marketplace/plugins/memorax-code-claude-adapter/memorax-code-adapter-common/src/backend-connection.mjs",
     "lib/memorax-code-claude-marketplace/plugins/memorax-code-claude-adapter/memorax-code-adapter-common/src/runtime-record.mjs",
     "lib/memorax-code-claude-marketplace/plugins/memorax-code-claude-adapter/memorax-code-adapter-common/src/hooks/ensure-backend-runner.mjs",
+    "lib/memorax-code-opencode-adapter/src/plugin.mjs",
+    "lib/memorax-code-opencode-adapter/skills/memorax-code/SKILL.md",
   ]) {
     if (!(await stat(join(packageRoot, requiredPath)).catch(() => undefined))?.isFile()) {
       throw new Error(`staged npm package is missing required runtime entrypoint: ${requiredPath}`);

--- a/scripts/check-local-trace-only.mjs
+++ b/scripts/check-local-trace-only.mjs
@@ -20,6 +20,7 @@ const productionRoots = [
   "packages/ts/memorax-code-claude-adapter/runtime-hooks/",
   "packages/ts/memorax-code-claude-adapter/scripts/",
   "packages/ts/memorax-code-claude-adapter/src/",
+  "packages/ts/memorax-code-opencode-adapter/src/",
 ];
 
 const reviewedNetworkSources = new Set([
@@ -298,6 +299,12 @@ function sourcePathForArtifact(rawPath) {
       return `packages/ts/memorax-code-codex-adapter/skills/memorax-code/${pluginPath.slice("skills/memorax-code/".length)}`;
     }
     return `packages/ts/memorax-code-claude-adapter/${pluginPath}`;
+  }
+  if (path.startsWith("lib/memorax-code-opencode-adapter/skills/memorax-code/")) {
+    return `packages/ts/memorax-code-codex-adapter/skills/memorax-code/${path.slice("lib/memorax-code-opencode-adapter/skills/memorax-code/".length)}`;
+  }
+  if (path.startsWith("lib/memorax-code-opencode-adapter/")) {
+    return `packages/ts/memorax-code-opencode-adapter/${path.slice("lib/memorax-code-opencode-adapter/".length)}`;
   }
   if (path.startsWith("lib/") && !path.slice("lib/".length).includes("/")) {
     return `packages/npm/memorax-code/${path}`;

--- a/scripts/check-local-trace-only.test.mjs
+++ b/scripts/check-local-trace-only.test.mjs
@@ -177,6 +177,8 @@ test("local-only trace gate checks every shipped runtime tree in staged artifact
     ["package/lib/memorax-code-claude-adapter/hooks/undeclared-claude-hook.mjs", "undeclared-claude-hook.mjs"],
     ["package/lib/memorax-code-claude-adapter/scripts/undeclared-claude-script.mjs", "undeclared-claude-script.mjs"],
     ["package/lib/memorax-code-claude-adapter/skills/memorax-code/scripts/undeclared-claude-skill.py", "undeclared-claude-skill.py"],
+    ["package/lib/memorax-code-opencode-adapter/src/undeclared-opencode-plugin.mjs", "undeclared-opencode-plugin.mjs"],
+    ["package/lib/memorax-code-opencode-adapter/skills/memorax-code/scripts/undeclared-opencode-skill.py", "undeclared-opencode-skill.py"],
     ["package/lib/memorax-code-claude-marketplace/plugins/memorax-code-claude-adapter/hooks/undeclared-marketplace-hook.mjs", "undeclared-marketplace-hook.mjs"],
   ];
   try {

--- a/scripts/npm-package-check.sh
+++ b/scripts/npm-package-check.sh
@@ -67,6 +67,7 @@ expected_library_dirs = {
     "memorax-code-claude-adapter",
     "memorax-code-claude-marketplace",
     "memorax-code-codex-adapter",
+    "memorax-code-opencode-adapter",
 }
 actual_library_dirs = {
     path.name
@@ -149,6 +150,8 @@ for relative in [
     "lib/memorax-code-claude-marketplace/plugins/memorax-code-claude-adapter/memorax-code-adapter-common/src/repo-memory/repo-procedure-memory-context.mjs",
     "lib/memorax-code-claude-marketplace/plugins/memorax-code-claude-adapter/memorax-code-adapter-common/src/repo-memory/repo-user-profile-context.mjs",
     "lib/memorax-code-claude-marketplace/plugins/memorax-code-claude-adapter/skills/memorax-code/SKILL.md",
+    "lib/memorax-code-opencode-adapter/src/plugin.mjs",
+    "lib/memorax-code-opencode-adapter/skills/memorax-code/SKILL.md",
     "lib/memorax-code-backend/dist/service-entrypoint.js",
     "lib/memorax-code-backend/dist/memorax-cli.js",
     "lib/memorax-code-backend/dist/jsonl-append.js",
@@ -311,7 +314,9 @@ for relative in \
   lib/memorax-code-claude-marketplace/plugins/memorax-code-claude-adapter/memorax-code-adapter-common/src/repo-memory/repo-memory-auto-build.mjs \
   lib/memorax-code-claude-marketplace/plugins/memorax-code-claude-adapter/memorax-code-adapter-common/src/repo-memory/repo-procedure-memory-context.mjs \
   lib/memorax-code-claude-marketplace/plugins/memorax-code-claude-adapter/memorax-code-adapter-common/src/repo-memory/repo-user-profile-context.mjs \
-  lib/memorax-code-claude-marketplace/plugins/memorax-code-claude-adapter/skills/memorax-code/SKILL.md
+  lib/memorax-code-claude-marketplace/plugins/memorax-code-claude-adapter/skills/memorax-code/SKILL.md \
+  lib/memorax-code-opencode-adapter/src/plugin.mjs \
+  lib/memorax-code-opencode-adapter/skills/memorax-code/SKILL.md
 do
   test -f "$package_install_root/$relative"
 done

--- a/scripts/npm-package-layout.mjs
+++ b/scripts/npm-package-layout.mjs
@@ -7,6 +7,7 @@ const packagePrefixes = [
   "lib/memorax-code-claude-adapter/",
   "lib/memorax-code-claude-marketplace/",
   "lib/memorax-code-codex-adapter/",
+  "lib/memorax-code-opencode-adapter/",
 ];
 const packageFiles = new Set([
   "bin",

--- a/scripts/npm-source-files.mjs
+++ b/scripts/npm-source-files.mjs
@@ -15,8 +15,16 @@ export const npmMainSourceTrees = Object.freeze([
     destination: `lib/memorax-code-claude-adapter/${name}`,
   })),
   {
+    source: "packages/ts/memorax-code-opencode-adapter/src",
+    destination: "lib/memorax-code-opencode-adapter/src",
+  },
+  {
     source: "packages/ts/memorax-code-codex-adapter/skills/memorax-code",
     destination: "lib/memorax-code-claude-adapter/skills/memorax-code",
+  },
+  {
+    source: "packages/ts/memorax-code-codex-adapter/skills/memorax-code",
+    destination: "lib/memorax-code-opencode-adapter/skills/memorax-code",
   },
 ]);
 

--- a/scripts/sync-release-version.mjs
+++ b/scripts/sync-release-version.mjs
@@ -18,6 +18,7 @@ export const RELEASE_VERSION_TARGETS = Object.freeze([
   { file: "packages/ts/memorax-code-claude-adapter/package.json", field: ["version"] },
   { file: "packages/ts/memorax-code-claude-adapter/.claude-plugin/plugin.json", field: ["version"] },
   { file: "packages/ts/memorax-code-claude-adapter/hooks/runtime-shell.json", field: ["shellVersion"] },
+  { file: "packages/ts/memorax-code-opencode-adapter/package.json", field: ["version"] },
 ]);
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");


### PR DESCRIPTION
## Change Summary

Add the initial OpenCode adapter artifact and package it with the canonical `memorax-code` skill. This PR establishes the package and session-environment foundation only; managed installation, automatic retrieval/writeback, and the remaining lifecycle behavior are intentionally deferred to follow-up PRs.

## Implementation Highlights

- Add a minimal OpenCode plugin that exports the OpenCode client/session identity, prepends the managed CLI path, and honors managed adapter state.
- Stage the plugin and the existing canonical skill in the npm package without introducing a second skill authority.
- Extend build, version, source, package-layout, allowlist, and local-only boundary checks for the new adapter artifact.

## Validation

Validated at commit `8ca6f42` on macOS and in a Linux Docker container. Windows was not tested. Full OpenCode memory behavior was not exercised because this PR deliberately stops at the artifact and packaging boundary.

## Full End-to-End Validation Results

- Environment: macOS 26.5.1 arm64; Node.js 24.15.0; npm 11.12.1.
- Scenario or matrix: OpenCode adapter unit coverage, documentation contracts, and the complete local npm package harness.
- Command or workflow: `make test-opencode-adapter`, `make docs-check`, and `make npm-package-check`.
- Result: Passed: adapter 1/1, documentation 10/10, and npm package tests 167/167. The local-only gate, 314-file npm pack allowlist, installation checks, and lifecycle checks also passed.
- Evidence or artifacts: macOS validation screenshot attached below.
- Reason not run / remaining risk: No remaining macOS risk within this PR's artifact and packaging scope.

- Environment: `node:24-bookworm` Docker image; Debian 12 aarch64; Node.js 24.19.0; npm 11.17.0.
- Scenario or matrix: Portable adapter, documentation, build, staging, package-layout, local-only, install, and plugin-load checks.
- Command or workflow: Ran the adapter and documentation targets, Backend build and staging, release-alignment checks, package source/layout/local-only tests, the local-only gate, npm pack allowlist validation, and an `npm install --ignore-scripts` artifact smoke test.
- Result: Passed: adapter 1/1, documentation 10/10, and package source/layout/local-only tests 19/19. Backend build, staging, release alignment, the local-only gate, the 314-file npm pack allowlist, packaged plugin and canonical skill presence, and plugin loading all passed.
- Evidence or artifacts: Linux Docker validation screenshot attached below.
- Reason not run / remaining risk: The unqualified Linux `make npm-package-check` harness is not reported as passing because of the pre-existing host assumptions described below.

- Environment: The same Debian 12 Docker container, compared with `origin/main`.
- Scenario or matrix: Full Linux `make npm-package-check` portability audit.
- Command or workflow: Ran the full harness on this branch and reproduced its environment-dependent failures on `origin/main`.
- Result: The full harness is limited by two existing host dependencies: a Codex App bundled-runtime fixture uses a macOS path assumption on Linux, and a later check expects desktop clients to be installed on the host before asserting automatic installation and enablement. These limitations reproduce on `origin/main`; this PR does not change those behaviors.
- Evidence or artifacts: The Linux screenshot is explicitly scoped and does not claim an unqualified full-harness pass.
- Reason not run / remaining risk: The baseline Linux full-harness portability limitation remains; the portable PR-specific package checks listed above passed.

- Environment: Windows.
- Scenario or matrix: Package staging, installation, and plugin loading.
- Command or workflow: Not run.
- Result: Not verified.
- Evidence or artifacts: None.
- Reason not run / remaining risk: Windows-specific path and package-install behavior remains unverified for this PR.
-
<img width="1800" height="1080" alt="image" src="https://github.com/user-attachments/assets/a4c0610c-e573-44bb-a7a8-0ff518a79079" />
<img width="1800" height="1080" alt="image" src="https://github.com/user-attachments/assets/77299f8f-457f-4bd2-a3f9-08d1633186af" />

