### PR TITLE
feat: add managed OpenCode installation lifecycle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,8 +17,9 @@ precedence over generated memory or historical context.
   user-facing changes.
 - Treat `.repo_memory/` as local retrieval guidance, not current-code
   authority. It is Git-ignored and must not leak into public artifacts.
-- Use isolated `MEMORAX_CODE_HOME`, `CODEX_HOME`, and `CLAUDE_CONFIG_DIR`
-  locations for lifecycle, install, migration, or destructive tests.
+- Use isolated `MEMORAX_CODE_HOME`, `CODEX_HOME`, `CLAUDE_CONFIG_DIR`, and
+  `OPENCODE_CONFIG_DIR` locations for lifecycle, install, migration, or
+  destructive tests.
 
 ## 2. Architecture Routing
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -47,7 +47,7 @@ flowchart LR
   subgraph Adapters["Client deployment adapters"]
     CodexAdapter["Codex adapter<br/>plugin, Hooks, canonical skill"]
     ClaudeAdapter["Claude adapter<br/>plugin, Hooks, installer"]
-    OpenCodeAdapter["OpenCode adapter<br/>plugin and skill artifact"]
+    OpenCodeAdapter["OpenCode adapter<br/>plugin, installer, skill artifact"]
   end
 
   Common["adapter-common<br/>records, locks, Hook and Repo Memory helpers"]
@@ -93,7 +93,7 @@ relationships; the arrow labels distinguish them. It is not an import graph.
 | `packages/ts/memorax-code-adapter-common` | Shared source for Backend connection authority, private runtime records, cross-process locking and configuration, Hook generations, Hook launch helpers, and Repo/Personal Memory helpers | Backend composition, native transcript interpretation, MemoraX request execution, or client plugin policy | `packages/ts/memorax-code-adapter-common/src/backend-connection.mjs`, `src/runtime-record.mjs`, `src/hooks`, and `src/repo-memory` |
 | `packages/ts/memorax-code-codex-adapter` | Codex plugin artifact, Hook shells and runtimes, session/workspace observation, diagnostics, and the canonical shared skill | Codex rollout semantics or Backend-side writeback authority | `.codex-plugin`, `hooks`, `runtime-hooks`, `src`, and `skills/memorax-code` |
 | `packages/ts/memorax-code-claude-adapter` | Claude Code plugin artifact, Hook shells and runtimes, configuration, installer, marketplace source, and diagnostics | Claude transcript semantics or Backend memory orchestration | `.claude-plugin`, `hooks`, `runtime-hooks`, `scripts`, and `src/plugin-install.mjs` |
-| `packages/ts/memorax-code-opencode-adapter` | OpenCode plugin runtime, shell-session identity, and a materialized shared skill | OpenCode message interpretation inside the Backend, installation lifecycle, or model-provider configuration | `src/plugin.mjs` and the OpenCode materialization mapping in `scripts/npm-source-files.mjs` |
+| `packages/ts/memorax-code-opencode-adapter` | OpenCode plugin runtime, managed thin-loader installation, shell-session identity, and a materialized shared skill | OpenCode message interpretation inside the Backend or model-provider configuration | `src/plugin.mjs`, `src/plugin-install.mjs`, and the OpenCode materialization mapping in `scripts/npm-source-files.mjs` |
 | `packages/npm/memorax-code` | Installed executable wrappers, update, preinstall/postinstall, npm manifest, and release-package source | Backend lifecycle semantics, uninstall orchestration, or artifact staging | `bin`, `lib/run-entrypoint.mjs`, and `package.json` |
 | `scripts` | Backend build orchestration, staging/materialization, package layout, documentation, and local-only data gates | Product runtime authority | Package-build/check scripts and executable contract scripts |
 | `.github` | Issue and pull-request contribution templates | Product runtime behavior | `.github/ISSUE_TEMPLATE` and `.github/pull_request_template.md` |
@@ -121,9 +121,11 @@ the owner of their behavior.
 Client integration is deliberately not physically symmetric. Codex plugin
 material belongs to the Codex adapter, while current install, activation, and
 Hook-trust glue lives in Backend `clients/codex`. The Claude Code installer
-lives in the Claude adapter and is loaded by its Backend lifecycle
-participant. Preserve the participant contract and each client's actual
-authority instead of forcing matching directory shapes.
+lives in the Claude adapter. The OpenCode adapter installs an auto-discovered
+thin loader and shared skill without editing OpenCode provider configuration.
+Both installers are loaded by their Backend lifecycle participants. Preserve
+the participant contract and each client's actual authority instead of forcing
+matching directory shapes.
 
 ## 3. Runtime Flows
 
@@ -160,14 +162,24 @@ The principal control-plane locations are:
 - `packages/ts/memorax-code-backend/src/lifecycle` for start, stop, restart,
   status, uninstall, client selection, participants, and locks;
 - `packages/ts/memorax-code-backend/src/lifecycle/backend` for Backend process,
-  PID/token/connection records, cleanup, status probing, and shutdown; and
+  PID/token/connection records, cleanup, status probing, and shutdown;
 - `packages/ts/memorax-code-adapter-common/src/hooks` for immutable Hook
-  generation and launch selection.
+  generation and launch selection; and
+- each adapter lifecycle participant for client-specific preparation, status,
+  disablement, and removal. OpenCode's participant delegates plugin and skill
+  materialization to `memorax-code-opencode-adapter/src/plugin-install.mjs`.
 
 Staging and activation are separate decisions. A failed Backend start must not
 replace the currently authoritative Hook generation. Cross-process lifecycle
 decisions use durable records and bounded locks rather than relying on one
 process's in-memory serialization.
+
+OpenCode lifecycle discovery accepts either its configuration directory or an
+`opencode` executable on `PATH`, so Desktop-only, CLI-only, and combined
+installations are supported. The installer records managed ownership under
+`$MEMORAX_CODE_HOME/adapters/opencode`, writes the auto-discovered plugin and
+skill artifacts under the OpenCode configuration directory, and leaves model
+and provider configuration untouched.
 
 ### 3.2 Hook and retrieval data flow
 
@@ -305,6 +317,7 @@ src/
   clients/
     codex/                Codex native interpretation and lifecycle adapters
     claude/               Claude native interpretation and lifecycle participant
+    opencode/             OpenCode lifecycle participant
   config/                 Backend and proxy/config interpretation
   entrypoints/            process and management-CLI orchestration
   lifecycle/
@@ -340,6 +353,7 @@ entrypoints and compatibility facades. It is not another implementation area.
 | `src/lifecycle/backend` | Managed process, PID/token/connection records, status probing, cleanup, and shutdown requests | Helper contracts do not depend back on the full service implementation |
 | `src/clients/codex` | Codex rollout, prompt, turn-index, and workspace interpretation; Hook memory runtime; plugin integration glue; and lifecycle participant | No Claude format fallback; request runtime remains HTTP-composition independent |
 | `src/clients/claude` | Claude transcript/turn interpretation, Hook memory runtime, and lifecycle participant | No Codex format fallback; request runtime remains HTTP-composition independent |
+| `src/clients/opencode` | OpenCode lifecycle participant | Request-time memory flow remains independent from plugin installation |
 | `src/memory` | Memory commands, retrieval, writeback, turn coordination, repository session pinning, manual CLI, buffering/chunking, task projection, and reconciliation | Client-neutral modules do not parse native transcript formats |
 | `src/repository` | Read-only repository identity and Repo Memory readiness | Scope derivation does not execute Git or use synchronous filesystem reads |
 | `src/provider/memorax` | MemoraX config interpretation, query/add/status payloads, HTTP transport, and normalized results | Independent from server routing and plugin lifecycle |
@@ -442,7 +456,7 @@ and
 
 | Concern | Authority | Derived or non-authoritative views |
 | --- | --- | --- |
-| Models, model-provider credentials, native tools, and model-provider traffic | Codex or Claude Code | Backend and adapters must not proxy or persist this authority |
+| Models, model-provider credentials, native tools, and model-provider traffic | Codex, Claude Code, or OpenCode | Backend and adapters must not proxy or persist this authority |
 | Hook command identity | Versioned, client-qualified command plus validated required session/turn fields | Parsed HTTP request objects |
 | Automatic writeback content | Codex rollout JSONL or Claude Code transcript JSONL for the matching client | Hook text, trace, latest-Turn guesses, and the other client's format are not fallbacks |
 | Workspace and repository identity | Backend read-only resolution held by the live repository-session runtime; its only permitted scope transition is the same-root degraded-direct-`.git` to verified-Git upgrade | Project labels, Viewer catalog entries, and Hook `cwd` |
@@ -561,13 +575,17 @@ flowchart TD
 - The Claude Code skill and marketplace and the OpenCode skill artifact are
   materialized from canonical sources; packaging may rewrite contained
   relative imports for the staged topology.
+- OpenCode lifecycle installation writes only a managed thin loader and the
+  materialized skill into the client's auto-discovery directories. It does not
+  edit `opencode.json` or `opencode.jsonc`. Desktop discovery does not require
+  a standalone `opencode` command in `PATH`; CLI-only discovery does.
 - The npm wrappers use `packages/npm/memorax-code/lib/run-entrypoint.mjs` to
   locate staged Backend or adapter entrypoints.
 - Artifact gates reject undeclared paths, unsafe symlinks, cache/build debris,
   and local-only data-boundary violations.
-- Installed-package tests isolate `MEMORAX_CODE_HOME`, `CODEX_HOME`, and
-  `CLAUDE_CONFIG_DIR` so lifecycle and client integration checks do not reuse
-  developer state.
+- Installed-package tests isolate `MEMORAX_CODE_HOME`, `CODEX_HOME`,
+  `CLAUDE_CONFIG_DIR`, and `OPENCODE_CONFIG_DIR` so lifecycle and client
+  integration checks do not reuse developer state.
 
 Root architecture and contributor guidance are repository documents, while
 `shipped-docs.json` remains the authority for user documentation included in

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -8,8 +8,8 @@ installation. For a source checkout and contributor setup, see
 ## Requirements
 
 - Node.js 24 or newer and npm.
-- At least one of Codex or Claude Code installed in the environment where
-  MemoraX Code will run.
+- At least one of Codex, Claude Code, OpenCode Desktop, or the OpenCode CLI
+  installed in the environment where MemoraX Code will run.
 - Python 3 only when using Repo Memory operations.
 
 MemoraX-backed search, retrieval, and writeback additionally require a MemoraX
@@ -48,7 +48,8 @@ Backend status, and client guidance visible.
 
 The installer:
 
-1. Detects runnable Codex and Claude Code clients independently.
+1. Detects runnable Codex and Claude Code clients, plus OpenCode through its
+   configuration directory or CLI.
 2. Enables every detected client without asking for a client selector.
 3. Prompts for the MemoraX connection and preferred language when at least one
    client was detected.
@@ -57,7 +58,7 @@ The installer:
 
 Read the final summary. npm can finish installing the package even when a
 client integration or MemoraX configuration still needs attention.
-MemoraX Code does not read or change either client's model-provider URL,
+MemoraX Code does not read or change the clients' model-provider URL,
 credentials, model, or login mode.
 
 Do not use `--ignore-scripts` for a normal install or update. It skips the
@@ -72,6 +73,9 @@ opening a new MemoraX Code session.
 For Codex, enable **MemoraX Code Codex Adapter** from Plugins or `/plugins` if
 it is not already enabled. Claude Code registration is handled by the
 installer.
+
+OpenCode registration uses its plugin and skill auto-discovery. Restart or
+refresh OpenCode after installation so the managed integration is loaded.
 
 Open the client in a real project directory and submit at least one prompt
 before using the client doctor as the final verification. Until the Hooks have
@@ -88,7 +92,7 @@ memorax-code status
 memorax-cli status
 ```
 
-Then run the doctor command for each installed client:
+Codex and Claude Code also provide client-specific doctor commands:
 
 ```bash
 memorax-code-codex doctor
@@ -96,7 +100,7 @@ memorax-code-claude doctor
 ```
 
 `memorax-code status` checks the local Backend and selected client
-integrations. `memorax-cli status` checks whether the local MemoraX
+integrations, including OpenCode. `memorax-cli status` checks whether the local MemoraX
 configuration, workspace scope, and memory switches resolve without printing
 the API key. It does not send a test request to MemoraX; the first real search
 or write verifies remote connectivity and credentials.
@@ -151,7 +155,8 @@ memorax-code uninstall
 ```
 
 Do not start with `npm uninstall -g`. npm does not provide MemoraX Code with an
-uninstall lifecycle in which to disable managed Hooks and stop the Backend.
+uninstall lifecycle in which to remove managed client integrations and stop
+the Backend.
 The product command removes the managed integrations and global package while
 retaining `$MEMORAX_CODE_HOME` configuration and local traces, Claude plugin
 data, client provider configuration, and memories stored in MemoraX. Review

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,12 +38,12 @@ are not a compatibility contract.
 
 ## New configuration
 
-The generated template selects both clients, disables automatic retrieval,
+The generated template selects all three clients, disables automatic retrieval,
 enables automatic writeback, sets the preferred language to Chinese (`zh`),
 uses a five-turn skill reminder and the adaptive repository-update policy, and
-enables content-bearing local traces for both clients. npm installation may
-narrow `[clients]` to clients detected on the host. The tables below list all
-fallbacks, including tuning fields omitted from the generated file.
+enables content-bearing local traces for Codex and Claude Code. npm installation
+may narrow `[clients]` to clients detected on the host. The tables below list
+all fallbacks, including tuning fields omitted from the generated file.
 
 On POSIX systems MemoraX Code creates `$MEMORAX_CODE_HOME` with mode `0700`
 and a new `config.toml` with mode `0600`. Windows relies on the current user's
@@ -51,16 +51,19 @@ filesystem ACLs.
 
 ## Client selection
 
-If `[clients]` is absent, lifecycle commands select both clients. If it is
-present, `codex` and `claude` are boolean fields and an omitted client is
-disabled. The command-line override is:
+If `[clients]` is absent, lifecycle commands select Codex, Claude Code, and
+OpenCode. If it is present, `codex`, `claude`, and `opencode` are boolean fields
+and an omitted client is disabled. The command-line override accepts a
+comma-separated subset:
 
 ```text
---clients codex|claude|codex,claude|all|none
+--clients codex|claude|opencode|<comma-separated subset>|all|none
 ```
 
-A normal npm install or reinstall refreshes `[clients]` from the runnable
-clients detected at that time. Update-mode postinstall runs preserve enabled
+A normal npm install or reinstall refreshes `[clients]` from the available
+clients detected at that time. OpenCode is available when its explicit, XDG,
+or default configuration directory exists, or when `opencode` is on `PATH`.
+Update-mode postinstall runs preserve enabled
 clients and also probe each disabled client. An interactive update offers each
 runnable disabled integration for activation with a default of yes. Declining
 the prompt, or running non-interactively, keeps that integration disabled. A
@@ -69,9 +72,27 @@ configuration instead of being permanently disabled. When an update newly
 enables Codex, it requests initial Hook activation after the client-selection
 prompt.
 
-Client selection controls plugin and Hook lifecycle only. It does not change
-Codex or Claude Code provider settings. `--clients none` runs the Backend
-without managing either client integration.
+Client selection controls managed client-integration lifecycle only. It does
+not change Codex, Claude Code, or OpenCode provider settings. `--clients none`
+runs the Backend without managing a client integration.
+
+## OpenCode integration paths
+
+The managed OpenCode plugin loader and shared skill use OpenCode's automatic
+discovery directories:
+
+```text
+~/.config/opencode/plugins/memorax-code.js
+~/.config/opencode/skills/memorax-code/
+```
+
+Set `OPENCODE_CONFIG_DIR` to override the complete OpenCode configuration root.
+Otherwise, `XDG_CONFIG_HOME` replaces `~/.config` when set. The managed adapter
+record lives at `$MEMORAX_CODE_HOME/adapters/opencode/state.json`.
+
+MemoraX Code does not add entries to or otherwise modify `opencode.json` or
+`opencode.jsonc`. Restart or refresh OpenCode after installation or after these
+managed assets change.
 
 ## MemoraX connection
 
@@ -190,8 +211,8 @@ entered and do not pass through this detector.
 
 `[memory.skill_reminder].interval_turns` defaults to `5`; its environment
 override is `MEMORAX_CODE_MEMORY_SKILL_REMINDER_INTERVAL_TURNS`. A positive
-value controls the reminder cadence for both clients, beginning with the first
-eligible prompt.
+value controls the reminder cadence for Codex and Claude Code, beginning with
+the first eligible prompt.
 
 | Field | Environment override | Fallback |
 | --- | --- | --- |
@@ -203,10 +224,15 @@ Supported policies are `every-commit`, `commit-count`, `daily`,
 `pull-request`, `pull-request-or-daily`, and `adaptive`. Invalid policy values
 fall back to `adaptive`.
 
-The first eligible prompt starts a background build only when the Backend has
-authorized a Git worktree and that worktree has no `.repo_memory/PROFILE.md`.
-If the Backend or workspace authority is unavailable, the Hook skips the
-initial build instead of falling back to its local `cwd`.
+In Codex and Claude Code, the first eligible prompt starts a background build
+only when the Backend has authorized a Git worktree and that worktree has no
+`.repo_memory/PROFILE.md`. If the Backend or workspace authority is
+unavailable, the Hook skips the initial build instead of falling back to its
+local `cwd`.
+
+OpenCode supports active Repo Memory operations through the installed skill;
+background Repo Memory maintenance is added separately from its installation
+lifecycle.
 
 ## Local traces
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -10,9 +10,10 @@ memorax-code-claude doctor
 memorax-code logs
 ```
 
-`status` checks the Backend and client integrations. `memory status` checks
-credentials, scope, and memory switches without printing secrets. Each client
-`doctor` checks its plugin, skill, workspace, and Backend connection.
+`memorax-code status` checks the Backend and selected client integrations,
+including OpenCode. `memorax-cli status` checks credentials, scope, and memory
+switches without printing secrets. Codex and Claude Code additionally provide
+client-specific `doctor` commands.
 
 ## Installed, but memory is unavailable
 
@@ -102,6 +103,18 @@ memorax-code-claude doctor
 This reconciles the Claude Code marketplace plugin and Hooks. If the plugin is
 still missing or stale, restart or refresh Claude Code. Do not manually copy
 Hooks into Claude settings.
+
+## OpenCode plugin or skill is inactive
+
+```sh
+memorax-code start --clients opencode
+memorax-code status --clients opencode
+```
+
+Rerun the start command to reconcile the managed plugin and skill, then restart
+or refresh OpenCode. The configuration root follows `OPENCODE_CONFIG_DIR`, then
+`XDG_CONFIG_HOME`, and otherwise defaults to `~/.config/opencode`. MemoraX Code
+does not add plugin entries to `opencode.json` or `opencode.jsonc`.
 
 An already-open client may keep its loaded plugin shell while a later prompt
 uses the updated Hook runtime. Restart or refresh the client to load a changed

--- a/packages/npm/memorax-code/bin/memorax-code-plugin-postinstall.mjs
+++ b/packages/npm/memorax-code/bin/memorax-code-plugin-postinstall.mjs
@@ -20,6 +20,7 @@ import {
 import { stagePackagedClientHookRuntime } from "../lib/client-hook-runtime.mjs";
 import { ensureClaudeCommandEnv } from "../lib/resolve-claude-command.mjs";
 import { ensureCodexCommandEnv } from "../lib/resolve-codex-command.mjs";
+import { commandOnPath } from "../lib/vscode-extension-command.mjs";
 import { resolveWindowsCliInvocation } from "../lib/windows-cli-invocation.mjs";
 
 const PLUGIN_NAME = "memorax-code-codex-adapter";
@@ -38,6 +39,7 @@ const RESET = "\x1b[0m";
 if (truthyEnv(process.env.MEMORAX_CODE_SKIP_POSTINSTALL)) process.exit(0);
 const skipCodexPluginInstall = truthyEnv(process.env.MEMORAX_CODE_SKIP_CODEX_PLUGIN_INSTALL);
 const skipClaudeAdapterInstall = truthyEnv(process.env.MEMORAX_CODE_SKIP_CLAUDE_ADAPTER_INSTALL);
+const skipOpenCodeAdapterInstall = truthyEnv(process.env.MEMORAX_CODE_SKIP_OPENCODE_ADAPTER_INSTALL);
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const memoraxCodeBin = join(scriptDir, "memorax-code.mjs");
@@ -70,7 +72,7 @@ try {
   process.exit(0);
 }
 runCommonPreflight();
-const requestedClients = ["codex", "claude"];
+const requestedClients = ["codex", "claude", "opencode"];
 const codexPreflight = requestedClients.includes("codex") && !skipCodexPluginInstall
   ? runCodexPreflight({
       integrationSelected: !updatePostinstall
@@ -85,9 +87,17 @@ const claudePreflight = requestedClients.includes("claude") && !skipClaudeAdapte
         || previousClients.includes("claude"),
     })
   : { ok: true };
+const opencodePreflight = requestedClients.includes("opencode") && !skipOpenCodeAdapterInstall
+  ? runOpenCodePreflight({
+      integrationSelected: !updatePostinstall
+        || previousClients === undefined
+        || previousClients.includes("opencode"),
+    })
+  : { ok: true };
 const detectedClients = requestedClients.filter((client) => {
   if (client === "codex") return !skipCodexPluginInstall && codexPreflight.ok;
-  return !skipClaudeAdapterInstall && claudePreflight.ok;
+  if (client === "claude") return !skipClaudeAdapterInstall && claudePreflight.ok;
+  return !skipOpenCodeAdapterInstall && opencodePreflight.ok;
 });
 const selectedClients = updatePostinstall && previousClients !== undefined
   ? await chooseUpdateClients(previousClients, detectedClients, scriptedAnswers)
@@ -103,6 +113,9 @@ if (requestedClients.includes("codex") && !skipCodexPluginInstall && !codexPrefl
 }
 if (requestedClients.includes("claude") && !skipClaudeAdapterInstall && !claudePreflight.ok) {
   log("Claude Code runtime was not detected; skipping its adapter setup.");
+}
+if (requestedClients.includes("opencode") && !skipOpenCodeAdapterInstall && !opencodePreflight.ok) {
+  log("OpenCode runtime or configuration was not detected; skipping its adapter setup.");
 }
 if (writeClientSelectionConfig(selectedClients) === "failed") {
   printPostinstallSummary("not-verified");
@@ -121,6 +134,7 @@ if (memoraxConfigResult === "configured") {
 }
 const codexClientEnabled = installClients.includes("codex");
 const claudeClientEnabled = installClients.includes("claude");
+const opencodeClientEnabled = installClients.includes("opencode");
 const codexClientNewlyEnabled = codexClientEnabled
   && updatePostinstall
   && previousClients !== undefined
@@ -147,6 +161,7 @@ if (codexClientEnabled && result.status === 0) {
 }
 const skipCodexAdapter = !codexClientEnabled;
 const skipClaudeAdapter = !claudeClientEnabled;
+const skipOpenCodeAdapter = !opencodeClientEnabled;
 const codexSkipReason = postinstallClientSkipReason({
   explicitlySkipped: skipCodexPluginInstall,
   selected: selectedClients.includes("codex"),
@@ -157,6 +172,11 @@ const claudeSkipReason = postinstallClientSkipReason({
   selected: selectedClients.includes("claude"),
   enabled: claudeClientEnabled,
 });
+const opencodeSkipReason = postinstallClientSkipReason({
+  explicitlySkipped: skipOpenCodeAdapterInstall,
+  selected: selectedClients.includes("opencode"),
+  enabled: opencodeClientEnabled,
+});
 
 let backendAndAdaptersStatus = startBackendAndCheck({
   skipCodexAdapter,
@@ -165,13 +185,24 @@ let backendAndAdaptersStatus = startBackendAndCheck({
   skipClaudeAdapter,
   claudeAdapterRequired: !skipClaudeAdapter,
   claudeSkipReason,
+  skipOpenCodeAdapter,
+  opencodeAdapterRequired: !skipOpenCodeAdapter,
+  opencodeSkipReason,
 });
 if (backendAndAdaptersStatus === "enabled") {
   logGreen(`Client Hook runtime ${stagedHookRuntime.generationId} activated.`);
 }
 if (backendAndAdaptersStatus === "enabled") {
-  printNextSteps({ codexAdapterEnabled: !skipCodexAdapter, claudeAdapterEnabled: !skipClaudeAdapter });
-  printCommonCommands({ codexAdapterEnabled: !skipCodexAdapter, claudeAdapterEnabled: !skipClaudeAdapter });
+  printNextSteps({
+    codexAdapterEnabled: !skipCodexAdapter,
+    claudeAdapterEnabled: !skipClaudeAdapter,
+    opencodeAdapterEnabled: !skipOpenCodeAdapter,
+  });
+  printCommonCommands({
+    codexAdapterEnabled: !skipCodexAdapter,
+    claudeAdapterEnabled: !skipClaudeAdapter,
+    opencodeAdapterEnabled: !skipOpenCodeAdapter,
+  });
 }
 printPostinstallSummary(backendAndAdaptersStatus);
 if (backendAndAdaptersStatus === "enabled") {
@@ -221,7 +252,7 @@ async function chooseUpdateClients(previousClients, detectedClients, scriptedAns
 
   if (!canPromptForUpdate()) {
     for (const client of availableDisabledClients) {
-      const label = client === "codex" ? "Codex" : "Claude Code";
+      const label = clientLabel(client);
       log(`${label} runtime is available, but its integration remains disabled because this update cannot prompt. Rerun \`memorax-code update\` from an interactive terminal to choose whether to enable it.`);
     }
     return [...previousClients];
@@ -230,7 +261,7 @@ async function chooseUpdateClients(previousClients, detectedClients, scriptedAns
   let rl;
   try {
     for (const client of availableDisabledClients) {
-      const label = client === "codex" ? "Codex" : "Claude Code";
+      const label = clientLabel(client);
       const question = `${label} runtime is available, but its integration is disabled in [clients]. Enable it now? [Y/n]`;
       let answer;
       if (scriptedAnswers) {
@@ -250,7 +281,7 @@ async function chooseUpdateClients(previousClients, detectedClients, scriptedAns
   } finally {
     rl?.close();
   }
-  return ["codex", "claude"].filter((client) => selected.has(client));
+  return ["codex", "claude", "opencode"].filter((client) => selected.has(client));
 }
 
 async function configureMemoraxMemoryFromAnswers(answers) {
@@ -602,7 +633,11 @@ function readPersistedClientSelection() {
   try {
     const clients = parse(readFileSync(path, "utf8"))?.clients;
     if (!clients || typeof clients !== "object" || typeof clients.codex !== "boolean" || typeof clients.claude !== "boolean") return undefined;
-    return [clients.codex ? "codex" : undefined, clients.claude ? "claude" : undefined].filter(Boolean);
+    return [
+      clients.codex ? "codex" : undefined,
+      clients.claude ? "claude" : undefined,
+      clients.opencode === true ? "opencode" : undefined,
+    ].filter(Boolean);
   } catch {
     return undefined;
   }
@@ -620,7 +655,8 @@ function writeClientSelectionConfig(clients) {
 }
 
 function setManagedClientSelection(text, clients) {
-  const withClaude = setTomlField(text, "clients", "claude", String(clients.includes("claude")));
+  const withOpenCode = setTomlField(text, "clients", "opencode", String(clients.includes("opencode")));
+  const withClaude = setTomlField(withOpenCode, "clients", "claude", String(clients.includes("claude")));
   return setTomlField(withClaude, "clients", "codex", String(clients.includes("codex")));
 }
 
@@ -668,6 +704,7 @@ function defaultMemoraxCodeConfig() {
     "[clients]",
     "codex = true # Manage the Codex adapter.",
     "claude = true # Manage the Claude adapter.",
+    "opencode = true # Manage the OpenCode adapter.",
     "",
     "# MemoraX remote-memory connection. Credentials may also come from the environment.",
     "[memorax]",
@@ -769,10 +806,13 @@ function runCommonPreflight() {
   const memoraxCodeVersion = runNodeMemoraxCodeCommand(["--version"], { print: false });
   log(`MemoraX Code backend package: ${commandSummary(memoraxCodeVersion) ?? packageVersionSummary()}`);
   if (skipCodexPluginInstall) {
-    log("Codex plugin registration is disabled for this npm postinstall; backend and Claude Code setup can still continue.");
+    log("Codex plugin registration is disabled for this npm postinstall; other client setup can still continue.");
   }
   if (skipClaudeAdapterInstall) {
-    log("Claude Code adapter setup is disabled for this npm postinstall; backend and Codex setup can still continue.");
+    log("Claude Code adapter setup is disabled for this npm postinstall; other client setup can still continue.");
+  }
+  if (skipOpenCodeAdapterInstall) {
+    log("OpenCode adapter setup is disabled for this npm postinstall; other client setup can still continue.");
   }
   return {};
 }
@@ -812,6 +852,27 @@ function runClaudePreflight({ integrationSelected = true } = {}) {
   return { ok: true };
 }
 
+function runOpenCodePreflight({ integrationSelected = true } = {}) {
+  const explicitConfigDir = stringOption(process.env.OPENCODE_CONFIG_DIR);
+  const configHome = stringOption(process.env.XDG_CONFIG_HOME) ?? join(homedir(), ".config");
+  const configDir = resolve(explicitConfigDir ?? join(configHome, "opencode"));
+  const configDetected = explicitConfigDir !== undefined || existsSync(configDir);
+  const cliDetected = commandOnPath(
+    "opencode",
+    process.env.PATH,
+    process.platform,
+    process.env.PATHEXT,
+  );
+  const detected = configDetected || cliDetected;
+  log(`OpenCode configuration: ${configDetected ? `found (${configDir})` : "not detected"}`);
+  log(`OpenCode CLI: ${cliDetected ? "found in PATH" : "not detected"}`);
+  if (!detected) return { ok: false };
+  log(integrationSelected
+    ? "Keeping OpenCode provider config unchanged and enabling the shared memory plugin integration."
+    : "Keeping OpenCode provider config unchanged while checking whether to enable its integration.");
+  return { ok: true };
+}
+
 function installedPluginCache() {
   for (const marketplaceName of [CLI_MARKETPLACE_NAME, PERSONAL_MARKETPLACE_NAME]) {
     const versions = installedPluginCacheVersions(marketplaceName);
@@ -835,7 +896,17 @@ function installedPluginCacheVersions(marketplaceName) {
   }
 }
 
-function startBackendAndCheck({ skipCodexAdapter = false, clientMode = "all", codexSkipReason, skipClaudeAdapter = false, claudeAdapterRequired = !skipClaudeAdapter, claudeSkipReason } = {}) {
+function startBackendAndCheck({
+  skipCodexAdapter = false,
+  clientMode = "all",
+  codexSkipReason,
+  skipClaudeAdapter = false,
+  claudeAdapterRequired = !skipClaudeAdapter,
+  claudeSkipReason,
+  skipOpenCodeAdapter = false,
+  opencodeAdapterRequired = !skipOpenCodeAdapter,
+  opencodeSkipReason,
+} = {}) {
   logGreen("Starting backend with `memorax-code start`...");
   const adapterFlags = clientLifecycleFlags({ clientMode });
   const startArgs = ["start", ...adapterFlags];
@@ -884,10 +955,10 @@ function startBackendAndCheck({ skipCodexAdapter = false, clientMode = "all", co
   const enabled = memoraxCodeEnabled(checked, {
     codexAdapterRequired: !skipCodexAdapter,
     claudeAdapterRequired,
+    opencodeAdapterRequired,
   });
   if (!enabled) {
-    if (skipCodexAdapter || skipClaudeAdapter) printSkippedAdapterDiagnostics({ codexSkipReason, claudeSkipReason });
-    else printUnavailableDiagnostics();
+    printUnavailableDiagnostics({ codexSkipReason, claudeSkipReason, opencodeSkipReason });
     return "unavailable";
   }
   return "enabled";
@@ -930,12 +1001,9 @@ function clientLifecycleFlags({ clientMode = "all" } = {}) {
 }
 
 function clientModeFor(clients) {
-  const hasCodex = clients.includes("codex");
-  const hasClaude = clients.includes("claude");
-  if (hasCodex && hasClaude) return "all";
-  if (hasCodex) return "codex";
-  if (hasClaude) return "claude";
-  return "none";
+  const selected = ["codex", "claude", "opencode"].filter((client) => clients.includes(client));
+  if (selected.length === 3) return "all";
+  return selected.length > 0 ? selected.join(",") : "none";
 }
 
 function postinstallClientSkipReason({ explicitlySkipped, selected, enabled }) {
@@ -947,10 +1015,21 @@ function postinstallClientSkipReason({ explicitlySkipped, selected, enabled }) {
 function clientSelectionMessage(clients) {
   const hasCodex = clients.includes("codex");
   const hasClaude = clients.includes("claude");
+  const hasOpenCode = clients.includes("opencode");
+  if (hasCodex && hasClaude && hasOpenCode) return "Configuring MemoraX Code for Codex, Claude Code, and OpenCode.";
   if (hasCodex && hasClaude) return "Configuring MemoraX Code for Codex and Claude Code.";
+  if (hasCodex && hasOpenCode) return "Configuring MemoraX Code for Codex and OpenCode.";
+  if (hasClaude && hasOpenCode) return "Configuring MemoraX Code for Claude Code and OpenCode.";
   if (hasCodex) return "Configuring MemoraX Code for Codex only.";
   if (hasClaude) return "Configuring MemoraX Code for Claude Code only.";
+  if (hasOpenCode) return "Configuring MemoraX Code for OpenCode only.";
   return "Skipping client adapter setup for this npm postinstall.";
+}
+
+function clientLabel(client) {
+  if (client === "codex") return "Codex";
+  if (client === "claude") return "Claude Code";
+  return "OpenCode";
 }
 
 function detectedClientMessage(clients) {
@@ -1087,8 +1166,8 @@ function codexClientRunning() {
   });
 }
 
-function printNextSteps({ codexAdapterEnabled = true, claudeAdapterEnabled = true } = {}) {
-  const clientText = enabledClientText({ codexAdapterEnabled, claudeAdapterEnabled });
+function printNextSteps({ codexAdapterEnabled = true, claudeAdapterEnabled = true, opencodeAdapterEnabled = true } = {}) {
+  const clientText = enabledClientText({ codexAdapterEnabled, claudeAdapterEnabled, opencodeAdapterEnabled });
   if (clientText && updatePostinstall) {
     logGreen(`${bold("The new Hook runtime is active")}; existing sessions with the stable shell select it on their next user prompt.`);
     log(`Restart or refresh ${clientText} only if its plugin shell was installed, changed, or newly enabled, or if MemoraX Code is not active on the next prompt.`);
@@ -1100,16 +1179,20 @@ function printNextSteps({ codexAdapterEnabled = true, claudeAdapterEnabled = tru
   if (codexAdapterEnabled && !updatePostinstall) {
     logGreen(`After restart, ${bold("enable the MemoraX Code Codex Adapter plugin")} from Codex Plugins or CLI \`/plugins\` if it is not already enabled.`);
   }
-  const statusCommands = statusCommandText({ codexAdapterEnabled, claudeAdapterEnabled });
+  const statusCommands = statusCommandText({ codexAdapterEnabled, claudeAdapterEnabled, opencodeAdapterEnabled });
   log(`If MemoraX Code is not active ${updatePostinstall ? "on the next prompt" : "in new sessions"}, run ${statusCommands}.`);
   log("If npm hides install details, reinstall with `--foreground-scripts`.");
 }
 
-function enabledClientText({ codexAdapterEnabled = true, claudeAdapterEnabled = true } = {}) {
-  if (codexAdapterEnabled && claudeAdapterEnabled) return "Codex or Claude Code";
-  if (codexAdapterEnabled) return "Codex";
-  if (claudeAdapterEnabled) return "Claude Code";
-  return "";
+function enabledClientText({ codexAdapterEnabled = true, claudeAdapterEnabled = true, opencodeAdapterEnabled = true } = {}) {
+  const labels = [
+    codexAdapterEnabled ? "Codex" : undefined,
+    claudeAdapterEnabled ? "Claude Code" : undefined,
+    opencodeAdapterEnabled ? "OpenCode" : undefined,
+  ].filter(Boolean);
+  if (labels.length < 2) return labels[0] ?? "";
+  if (labels.length === 2) return `${labels[0]} or ${labels[1]}`;
+  return `${labels.slice(0, -1).join(", ")}, or ${labels.at(-1)}`;
 }
 
 function statusCommandText({ codexAdapterEnabled = true, claudeAdapterEnabled = true } = {}) {
@@ -1195,19 +1278,17 @@ function readMemoraxInstallStatus() {
   }
 }
 
-function printUnavailableDiagnostics() {
+function printUnavailableDiagnostics({ codexSkipReason, claudeSkipReason, opencodeSkipReason } = {}) {
   logRed("MemoraX Code is not enabled for new client sessions.");
   logRed("Check `memorax-code status`, `memorax-code-codex status`, and `memorax-code-claude status` for Backend and adapter details.");
-  logRed("If Codex or Claude Code is open, restart or refresh it after fixing the reported status.");
-  printCommonCommands();
-}
-
-function printSkippedAdapterDiagnostics({ codexSkipReason, claudeSkipReason } = {}) {
+  logRed("If Codex, Claude Code, or OpenCode is open, restart or refresh it after fixing the reported status.");
   if (codexSkipReason) printCodexSkippedDiagnostics(codexSkipReason);
   if (claudeSkipReason) printClaudeSkippedDiagnostics(claudeSkipReason);
+  if (opencodeSkipReason) printOpenCodeSkippedDiagnostics(opencodeSkipReason);
   printCommonCommands({
     codexAdapterEnabled: !codexSkipReason,
     claudeAdapterEnabled: !claudeSkipReason,
+    opencodeAdapterEnabled: !opencodeSkipReason,
   });
 }
 
@@ -1223,10 +1304,15 @@ function printClaudeSkippedDiagnostics() {
   log("Run `memorax-code start` after installing Claude Code, then restart or refresh Claude Code.");
 }
 
+function printOpenCodeSkippedDiagnostics() {
+  logRed("OpenCode adapter setup was skipped for this npm postinstall, so MemoraX Code left the OpenCode integration unchanged.");
+  log("Run `memorax-code start --clients opencode` after installing OpenCode, then restart or refresh OpenCode.");
+}
+
 function printFailureSuggestions() {
   logRed("Suggested recovery: run `memorax-code stop`, then `memorax-code start`, then `memorax-code status`.");
   logRed("If the Backend port is busy, stop the process using 127.0.0.1:8787 and retry `memorax-code start`.");
-  logRed("If client sessions still bypass MemoraX Code, restart or refresh Codex or Claude Code and verify the relevant adapter status.");
+  logRed("If client sessions still bypass MemoraX Code, restart or refresh the affected client and verify the relevant adapter status.");
   printCommonCommands();
 }
 
@@ -1258,7 +1344,11 @@ function printCommonCommands({ codexAdapterEnabled = true, claudeAdapterEnabled 
   if (claudeAdapterEnabled) log("- `memorax-code-claude sessions`: verify recent native Claude Code session registration.");
 }
 
-function memoraxCodeEnabled(statusResult, { codexAdapterRequired = true, claudeAdapterRequired = true } = {}) {
+function memoraxCodeEnabled(statusResult, {
+  codexAdapterRequired = true,
+  claudeAdapterRequired = true,
+  opencodeAdapterRequired = true,
+} = {}) {
   const output = `${statusResult.stdout ?? ""}\n${statusResult.stderr ?? ""}`;
   const normalized = stripAnsi(output);
   const backendOk = /MemoraX Code Backend status:\s*Enabled\b/im.test(normalized)
@@ -1268,10 +1358,12 @@ function memoraxCodeEnabled(statusResult, { codexAdapterRequired = true, claudeA
     || /Backend:\s*(?:running|ok)\b/im.test(normalized);
   const codexAdapterOk = /Codex adapter:\s*ok\b/im.test(normalized);
   const claudeAdapterOk = /Claude adapter:\s*ok\b/im.test(normalized);
+  const opencodeAdapterOk = /OpenCode adapter:\s*ok\b/im.test(normalized);
   return backendOk
     && serviceOk
     && (!codexAdapterRequired || codexAdapterOk)
-    && (!claudeAdapterRequired || claudeAdapterOk);
+    && (!claudeAdapterRequired || claudeAdapterOk)
+    && (!opencodeAdapterRequired || opencodeAdapterOk);
 }
 
 function log(message) {

--- a/packages/npm/memorax-code/test/postinstall.test.mjs
+++ b/packages/npm/memorax-code/test/postinstall.test.mjs
@@ -6,6 +6,7 @@ import { tmpdir } from "node:os";
 import { delimiter, dirname, join } from "node:path";
 import test from "node:test";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { commandOnPath } from "../lib/vscode-extension-command.mjs";
 
 const postinstallPath = fileURLToPath(new URL("../bin/memorax-code-plugin-postinstall.mjs", import.meta.url));
 const adapterCommonSourceRoot = fileURLToPath(new URL(
@@ -27,6 +28,13 @@ const vscodeExtensionCommandPath = fileURLToPath(new URL("../lib/vscode-extensio
 const windowsCliInvocationPath = fileURLToPath(new URL("../lib/windows-cli-invocation.mjs", import.meta.url));
 const smolTomlPath = fileURLToPath(new URL("../../../ts/memorax-code-backend/node_modules/smol-toml", import.meta.url));
 const memoraxCodePluginId = "memorax-code-codex-adapter@memorax-code";
+
+function pathWithoutCommand(command, pathValue) {
+  return String(pathValue ?? "")
+    .split(delimiter)
+    .filter((root) => root && !commandOnPath(command, root, process.platform, process.env.PATHEXT))
+    .join(delimiter);
+}
 
 function codexHook(name, currentHash, overrides = {}) {
   return {
@@ -88,11 +96,13 @@ async function startMockMemorax({ status = 200, body = { success: true, data: { 
   };
 }
 
-async function runPostinstall({ existingCache = false, explicitCache = false, hookRuntimeFailure, failStartOnce = false, connectionAuthorityFailure = false, runtimeAuthorityFailureCode, officialMode = false, codexConfig, memoraxCodeConfig, memoraxCodeConfigMode, emptyClaudeSettings = false, claudeAvailable = true, claudeVersionFails = false, claudeSettingsText, codexAvailable = true, codexAppOnly = false, vscodeOnly = false, skipCodexPluginInstall = false, skipClaudeAdapterInstall = false, unavailableStatus = false, prefixedStatus = false, input = "", interactive = false, npmCommand = "install", memoraxVerify, memoraxEnv = {}, memoryStatusFixture, hookSnapshot = [], hookUpdatePlan = [], hookFullReview = false, hookFullReviewMissing = false, hookSnapshotFails = false, hookCheckFails = false, hookTrustFails = false, ttyOverride } = {}) {
+async function runPostinstall({ existingCache = false, explicitCache = false, hookRuntimeFailure, failStartOnce = false, connectionAuthorityFailure = false, runtimeAuthorityFailureCode, officialMode = false, codexConfig, memoraxCodeConfig, memoraxCodeConfigMode, emptyClaudeSettings = false, claudeAvailable = true, claudeVersionFails = false, claudeSettingsText, codexAvailable = true, codexAppOnly = false, vscodeOnly = false, opencodeAvailable = false, opencodeXdgAvailable = false, opencodeCliAvailable = false, skipCodexPluginInstall = false, skipClaudeAdapterInstall = false, skipOpenCodeAdapterInstall = false, unavailableStatus = false, prefixedStatus = false, input = "", interactive = false, npmCommand = "install", memoraxVerify, memoraxEnv = {}, memoryStatusFixture, hookSnapshot = [], hookUpdatePlan = [], hookFullReview = false, hookFullReviewMissing = false, hookSnapshotFails = false, hookCheckFails = false, hookTrustFails = false, ttyOverride } = {}) {
   const root = await mkdtemp(join(tmpdir(), "memorax-code-postinstall-"));
   const binDir = join(root, "bin");
   const codexHome = join(root, "codex-home");
   const claudeHome = join(root, "claude-home");
+  const opencodeConfigDir = join(root, "opencode-config");
+  const xdgConfigHome = join(root, "xdg-config");
   const memoraxCodeHome = join(root, "memorax-code-home");
   const home = join(root, "home");
   const fakeBin = join(root, "fake-bin");
@@ -102,6 +112,7 @@ async function runPostinstall({ existingCache = false, explicitCache = false, ho
   const memoraxServer = memoraxVerify ? await startMockMemorax(memoraxVerify) : undefined;
   await mkdir(binDir, { recursive: true });
   await mkdir(fakeBin, { recursive: true });
+  if (process.platform !== "win32") await symlink(process.execPath, join(fakeBin, "node"));
   await mkdir(libDir, { recursive: true });
   await mkdir(nodeModulesDir, { recursive: true });
   await copyFile(postinstallPath, join(binDir, "memorax-code-plugin-postinstall.mjs"));
@@ -259,8 +270,10 @@ async function runPostinstall({ existingCache = false, explicitCache = false, ho
     "if (process.argv[2] === 'stop') console.error('fake memorax-code stop output');",
     "const clientsIndex = process.argv.indexOf('--clients');",
     "const clientMode = clientsIndex >= 0 ? process.argv[clientsIndex + 1] : 'all';",
-    "const codexEnabled = clientMode === 'all' || clientMode === 'codex' || clientMode === 'codex,claude';",
-    "const claudeEnabled = clientMode === 'all' || clientMode === 'claude' || clientMode === 'codex,claude';",
+    "const selectedClients = new Set(clientMode === 'all' ? ['codex', 'claude', 'opencode'] : clientMode.split(','));",
+    "const codexEnabled = selectedClients.has('codex');",
+    "const claudeEnabled = selectedClients.has('claude');",
+    "const opencodeEnabled = selectedClients.has('opencode');",
     "if (process.argv[2] === 'status' && process.env.MEMORAX_CODE_TEST_UNAVAILABLE_STATUS === '1') {",
     "  console.error('memorax-code: ok');",
     "  console.error('backend: ok http://127.0.0.1:8787 status=200');",
@@ -274,12 +287,14 @@ async function runPostinstall({ existingCache = false, explicitCache = false, ho
     "    console.error('[MemoraX Code Backend]: Backend status: \\x1b[34m\\x1b[1mEnabled\\x1b[0m http://127.0.0.1:8787 status=200');",
     "    if (codexEnabled) console.error('[MemoraX Code Backend]: Codex adapter: \\x1b[32mok\\x1b[0m integration=hooks skills=plugin-managed');",
     "    if (claudeEnabled) console.error('[MemoraX Code Backend]: Claude adapter: \\x1b[32mok\\x1b[0m integration=hooks skills=ok');",
+    "    if (opencodeEnabled) console.error('[MemoraX Code Backend]: OpenCode adapter: \\x1b[32mok\\x1b[0m integration=plugin skills=ok');",
     "    process.exit(0);",
     "  }",
     "  console.error('memorax-code: ok');",
     "  console.error('backend: ok http://127.0.0.1:8787 status=200');",
     "  if (codexEnabled) console.error('codex adapter: ok integration=hooks skills=plugin-managed');",
     "  if (claudeEnabled) console.error('claude adapter: ok integration=hooks skills=ok');",
+    "  if (opencodeEnabled) console.error('opencode adapter: ok integration=plugin skills=ok');",
     "}",
     "process.exit(0);",
     "",
@@ -343,14 +358,10 @@ async function runPostinstall({ existingCache = false, explicitCache = false, ho
         "",
       ].join("\n"), { mode: 0o755 });
       await chmod(appCodex, 0o755);
-      await symlink(process.execPath, join(fakeBin, "node"));
     }
   }
   if (vscodeOnly) {
     await writeMockVsCodeRuntimes({ home, logPath });
-    if (process.platform !== "win32") {
-      await symlink(process.execPath, join(fakeBin, "node"));
-    }
   }
   if (claudeAvailable) {
     await writeFile(join(fakeBin, "claude"), [
@@ -362,6 +373,11 @@ async function runPostinstall({ existingCache = false, explicitCache = false, ho
       "",
     ].join("\n"), { mode: 0o755 });
     await chmod(join(fakeBin, "claude"), 0o755);
+  }
+  if (opencodeCliAvailable) {
+    const executable = join(fakeBin, process.platform === "win32" ? "opencode.cmd" : "opencode");
+    await writeFile(executable, "#!/usr/bin/env node\nprocess.exit(0);\n", { mode: 0o755 });
+    await chmod(executable, 0o755);
   }
   const cacheMarketplace = existingCache ? "personal" : explicitCache ? "memorax-code" : undefined;
   if (cacheMarketplace) {
@@ -386,6 +402,8 @@ async function runPostinstall({ existingCache = false, explicitCache = false, ho
     ? {}
     : { env: { ANTHROPIC_BASE_URL: "https://api.anthropic.com", ANTHROPIC_API_KEY: "test-key" } };
   await writeFile(join(claudeHome, "settings.json"), claudeSettingsText ?? `${JSON.stringify(claudeSettings, null, 2)}\n`);
+  if (opencodeAvailable) await mkdir(opencodeConfigDir, { recursive: true });
+  if (opencodeXdgAvailable) await mkdir(join(xdgConfigHome, "opencode"), { recursive: true });
 
   let activeHookRuntimeBefore;
   if (hookRuntimeFailure) {
@@ -440,13 +458,18 @@ async function runPostinstall({ existingCache = false, explicitCache = false, ho
     CODEX_HOME: codexHome,
     HOME: home,
     CLAUDE_CONFIG_DIR: claudeHome,
+    OPENCODE_CONFIG_DIR: opencodeAvailable ? opencodeConfigDir : "",
+    XDG_CONFIG_HOME: opencodeXdgAvailable ? xdgConfigHome : "",
     MEMORAX_CODE_HOME: memoraxCodeHome,
-    PATH: codexAppOnly || vscodeOnly ? fakeBin : `${fakeBin}${delimiter}${process.env.PATH ?? ""}`,
+    PATH: codexAppOnly || vscodeOnly
+      ? fakeBin
+      : `${fakeBin}${delimiter}${pathWithoutCommand("opencode", process.env.PATH)}`,
     npm_command: npmCommand,
     MEMORAX_CODE_NPM_POSTINSTALL_VERBOSE: "1",
     MEMORAX_CODE_NPM_POSTINSTALL_ASSUME_INTERACTIVE: interactive ? "1" : "0",
     MEMORAX_CODE_SKIP_CODEX_PLUGIN_INSTALL: skipCodexPluginInstall ? "1" : "0",
     MEMORAX_CODE_SKIP_CLAUDE_ADAPTER_INSTALL: skipClaudeAdapterInstall ? "1" : "0",
+    MEMORAX_CODE_SKIP_OPENCODE_ADAPTER_INSTALL: skipOpenCodeAdapterInstall ? "1" : "0",
     MEMORAX_CODE_TEST_FAIL_START_ONCE: failStartOnce ? "1" : "0",
     MEMORAX_CODE_TEST_RUNTIME_AUTHORITY_FAILURE: runtimeAuthorityFailureCode
       ?? (connectionAuthorityFailure ? "BACKEND_CONNECTION_AUTHORITY_INVALID" : ""),
@@ -498,6 +521,7 @@ async function runPostinstall({ existingCache = false, explicitCache = false, ho
     memoraxCodeHome,
     codexHome,
     claudeHome,
+    opencodeConfigDir,
     memoraxEndpoint: memoraxServer?.url,
     memoraxRequests: memoraxServer?.requests ?? [],
     activeHookRuntimeBefore,
@@ -573,8 +597,8 @@ test("postinstall updates an installed Codex plugin without remove/add", async (
     assert.match(run.log, /^memorax-code codex-plugin install --json$/m);
     assert.equal((run.log.match(/^memorax-code codex-plugin install --json$/gm) ?? []).length, 1);
     assert.doesNotMatch(run.log, /^codex plugin (?:remove|add) /m);
-    assert.match(run.log, /^memorax-code start --clients all$/m);
-    assert.match(run.log, /^memorax-code status --clients all$/m);
+    assert.match(run.log, /^memorax-code start --clients codex,claude$/m);
+    assert.match(run.log, /^memorax-code status --clients codex,claude$/m);
     assert.match(run.result.stderr, /\[MemoraX Code Install\]: Checking local install state/);
     assert.match(run.result.stderr, /\[MemoraX Code Install\]: MemoraX Code backend package: memorax-code 0\.1\.1-test/);
     assert.match(run.result.stderr, /\[MemoraX Code Install\]: Existing Codex plugin cache: found \(0\.1\.0\)/);
@@ -658,8 +682,8 @@ test("postinstall generation activation failure preserves the active runtime", a
   });
   try {
     assert.equal(run.result.code, 0, run.result.stderr);
-    assert.match(run.log, /^memorax-code start --clients all$/m);
-    assert.doesNotMatch(run.log, /^memorax-code (?:stop|status) --clients all$/m);
+    assert.match(run.log, /^memorax-code start --clients codex,claude$/m);
+    assert.doesNotMatch(run.log, /^memorax-code (?:stop|status) --clients codex,claude$/m);
     assert.match(run.result.stderr, /Client Hook runtime activation failed:/);
     assert.match(run.result.stderr, /previously active runtime remains authoritative/);
     assert.match(run.result.stderr, /Backend and selected adapters: .*Not verified/);
@@ -1006,10 +1030,10 @@ test("postinstall update defaults to enabling a detected Codex runtime on Enter"
     assert.match(run.log, /^memorax-code codex-plugin install --json$/m);
     assert.match(run.result.stderr, /Activate and trust MemoraX Code Codex Adapter hooks now\? \[Y\/n\]/);
     assert.match(run.log, /^memorax-code codex-plugin activate --yes$/m);
-    assert.match(run.log, /^memorax-code start --clients all$/m);
-    assert.match(run.log, /^memorax-code status --clients all$/m);
+    assert.match(run.log, /^memorax-code start --clients codex,claude$/m);
+    assert.match(run.log, /^memorax-code status --clients codex,claude$/m);
     const config = await readFile(join(run.memoraxCodeHome, "config.toml"), "utf8");
-    assert.match(config, /\[clients\]\ncodex = true\nclaude = true/);
+    assert.match(config, /\[clients\]\nopencode = false\ncodex = true\nclaude = true/);
   } finally {
     await rm(run.root, { recursive: true, force: true });
   }
@@ -1034,7 +1058,7 @@ test("postinstall update keeps a detected disabled client unchanged when non-int
     assert.match(run.log, /^memorax-code start --clients claude$/m);
     assert.match(run.log, /^memorax-code status --clients claude$/m);
     const config = await readFile(join(run.memoraxCodeHome, "config.toml"), "utf8");
-    assert.match(config, /\[clients\]\ncodex = false\nclaude = true/);
+    assert.match(config, /\[clients\]\nopencode = false\ncodex = false\nclaude = true/);
   } finally {
     await rm(run.root, { recursive: true, force: true });
   }
@@ -1062,7 +1086,7 @@ test("postinstall update lets each detected disabled client be selected independ
     assert.match(run.log, /^memorax-code start --clients claude$/m);
     assert.match(run.log, /^memorax-code status --clients claude$/m);
     const config = await readFile(join(run.memoraxCodeHome, "config.toml"), "utf8");
-    assert.match(config, /\[clients\]\ncodex = false\nclaude = true/);
+    assert.match(config, /\[clients\]\nopencode = false\ncodex = false\nclaude = true/);
   } finally {
     await rm(run.root, { recursive: true, force: true });
   }
@@ -1082,7 +1106,50 @@ test("postinstall fresh install auto-detects Codex and skips an unavailable Clau
     assert.match(run.log, /^memorax-code status --clients codex$/m);
     assert.match(run.result.stderr, /Backend and selected adapters: .*Enabled/);
     const config = await readFile(join(run.memoraxCodeHome, "config.toml"), "utf8");
-    assert.match(config, /\[clients\][^\r\n]*\r?\ncodex = true[^\r\n]*\r?\nclaude = false/m);
+    assert.match(config, /\[clients\][^\r\n]*\r?\ncodex = true[^\r\n]*\r?\nclaude = false[^\r\n]*\r?\nopencode = false/m);
+  } finally {
+    await rm(run.root, { recursive: true, force: true });
+  }
+});
+
+test("postinstall detects OpenCode Desktop from its XDG config directory", async () => {
+  const run = await runPostinstall({ opencodeXdgAvailable: true });
+  try {
+    assert.equal(run.result.code, 0, run.result.stderr);
+    assert.match(run.result.stderr, /OpenCode configuration: found/);
+    assert.match(run.result.stderr, /OpenCode CLI: not detected/);
+    assert.match(run.log, /^memorax-code start --clients all$/m);
+    assert.match(run.log, /^memorax-code status --clients all$/m);
+    const config = await readFile(join(run.memoraxCodeHome, "config.toml"), "utf8");
+    assert.match(tomlSectionText(config, "clients"), /^opencode = true(?:\s+#.*)?$/m);
+  } finally {
+    await rm(run.root, { recursive: true, force: true });
+  }
+});
+
+test("postinstall detects OpenCode CLI without an existing config directory", async () => {
+  const run = await runPostinstall({ opencodeCliAvailable: true });
+  try {
+    assert.equal(run.result.code, 0, run.result.stderr);
+    assert.match(run.result.stderr, /OpenCode configuration: not detected/);
+    assert.match(run.result.stderr, /OpenCode CLI: found in PATH/);
+    assert.match(run.log, /^memorax-code start --clients all$/m);
+    const config = await readFile(join(run.memoraxCodeHome, "config.toml"), "utf8");
+    assert.match(tomlSectionText(config, "clients"), /^opencode = true(?:\s+#.*)?$/m);
+  } finally {
+    await rm(run.root, { recursive: true, force: true });
+  }
+});
+
+test("postinstall detects OpenCode when Desktop configuration and CLI are both available", async () => {
+  const run = await runPostinstall({ opencodeXdgAvailable: true, opencodeCliAvailable: true });
+  try {
+    assert.equal(run.result.code, 0, run.result.stderr);
+    assert.match(run.result.stderr, /OpenCode configuration: found/);
+    assert.match(run.result.stderr, /OpenCode CLI: found in PATH/);
+    assert.match(run.log, /^memorax-code start --clients all$/m);
+    const config = await readFile(join(run.memoraxCodeHome, "config.toml"), "utf8");
+    assert.match(tomlSectionText(config, "clients"), /^opencode = true(?:\s+#.*)?$/m);
   } finally {
     await rm(run.root, { recursive: true, force: true });
   }
@@ -1102,10 +1169,10 @@ test("postinstall reinstall re-detects a newly available Claude runtime", async 
     assert.match(run.log, /^codex --version$/m);
     assert.match(run.log, /^claude --version$/m);
     assert.match(run.result.stderr, /Detected supported client runtimes\. Configuring MemoraX Code for Codex and Claude Code\./);
-    assert.match(run.log, /^memorax-code start --clients all$/m);
-    assert.match(run.log, /^memorax-code status --clients all$/m);
+    assert.match(run.log, /^memorax-code start --clients codex,claude$/m);
+    assert.match(run.log, /^memorax-code status --clients codex,claude$/m);
     const config = await readFile(join(run.memoraxCodeHome, "config.toml"), "utf8");
-    assert.match(config, /\[clients\]\ncodex = true\nclaude = true/);
+    assert.match(config, /\[clients\]\nopencode = false\ncodex = true\nclaude = true/);
   } finally {
     await rm(run.root, { recursive: true, force: true });
   }
@@ -1138,7 +1205,7 @@ test("postinstall update re-detects a legacy empty client selection", async () =
     assert.match(run.log, /^memorax-code start --clients codex$/m);
     assert.match(run.log, /^memorax-code status --clients codex$/m);
     const config = await readFile(join(run.memoraxCodeHome, "config.toml"), "utf8");
-    assert.match(config, /\[clients\]\ncodex = true\nclaude = false/);
+    assert.match(config, /\[clients\]\nopencode = false\ncodex = true\nclaude = false/);
   } finally {
     await rm(run.root, { recursive: true, force: true });
   }
@@ -1162,7 +1229,7 @@ test("postinstall update preserves client intent while skipping an uninstalled C
     assert.match(run.log, /^memorax-code status --clients codex$/m);
     assert.doesNotMatch(run.result.stderr, /Backend and selected adapters: Not verified/);
     const config = await readFile(join(run.memoraxCodeHome, "config.toml"), "utf8");
-    assert.match(config, /\[clients\]\ncodex = true\nclaude = true/);
+    assert.match(config, /\[clients\]\nopencode = false\ncodex = true\nclaude = true/);
   } finally {
     await rm(run.root, { recursive: true, force: true });
   }
@@ -1172,7 +1239,7 @@ test("postinstall recognizes prefixed human-readable memorax-code status output"
   const run = await runPostinstall({ prefixedStatus: true });
   try {
     assert.equal(run.result.code, 0, run.result.stderr);
-    assert.match(run.log, /^memorax-code status --clients all$/m);
+    assert.match(run.log, /^memorax-code status --clients codex,claude$/m);
     assert.match(run.result.stderr, /\[MemoraX Code Backend\]: Codex adapter: .*ok.* integration=hooks skills=plugin-managed/);
     assert.match(run.result.stderr, /Backend and selected adapters: .*Enabled/);
     assert.doesNotMatch(run.result.stderr, /\[MemoraX Code Backend\]: Backend and selected adapters:/);
@@ -1223,7 +1290,7 @@ test("postinstall skip for Codex plugin still starts backend for Claude Code", a
     assert.doesNotMatch(run.result.stderr, /enable the MemoraX Code Codex Adapter plugin/);
     assert.doesNotMatch(run.log, /^codex /m);
     const config = await readFile(join(run.memoraxCodeHome, "config.toml"), "utf8");
-    assert.match(config, /\[clients\][^\r\n]*\r?\ncodex = false[^\r\n]*\r?\nclaude = true/m);
+    assert.match(config, /\[clients\][^\r\n]*\r?\ncodex = false[^\r\n]*\r?\nclaude = true[^\r\n]*\r?\nopencode = false/m);
   } finally {
     await rm(run.root, { recursive: true, force: true });
   }
@@ -1236,8 +1303,8 @@ test("postinstall uses the same Claude Hook lifecycle without explicit provider 
     assert.doesNotMatch(run.result.stderr, /Claude Code login mode:|official login|provider\/API key mode/);
     assert.match(run.result.stderr, /Keeping Claude Code provider config unchanged and enabling the shared memory Hook integration/);
     assert.match(run.log, /^memorax-code codex-plugin install --json$/m);
-    assert.match(run.log, /^memorax-code start --clients all$/m);
-    assert.match(run.log, /^memorax-code status --clients all$/m);
+    assert.match(run.log, /^memorax-code start --clients codex,claude$/m);
+    assert.match(run.log, /^memorax-code status --clients codex,claude$/m);
     assert.match(run.result.stderr, /\[MemoraX Code Backend\]: codex adapter: ok integration=hooks skills=plugin-managed/);
     assert.match(run.result.stderr, /\[MemoraX Code Backend\]: claude adapter: ok integration=hooks skills=ok/);
     assert.match(run.result.stderr, /Backend and selected adapters: .*Enabled/);
@@ -1263,7 +1330,7 @@ test("postinstall env can explicitly skip Claude Code adapter setup", async () =
     assert.match(run.result.stderr, /Restart or refresh Codex/);
     assert.match(run.result.stderr, /run `memorax-code status` and `memorax-code-codex status`/);
     const config = await readFile(join(run.memoraxCodeHome, "config.toml"), "utf8");
-    assert.match(config, /\[clients\][^\r\n]*\r?\ncodex = true[^\r\n]*\r?\nclaude = false/m);
+    assert.match(config, /\[clients\][^\r\n]*\r?\ncodex = true[^\r\n]*\r?\nclaude = false[^\r\n]*\r?\nopencode = false/m);
   } finally {
     await rm(run.root, { recursive: true, force: true });
   }
@@ -1351,8 +1418,8 @@ test("postinstall does not auto-install Codex plugin when no cache exists yet", 
     assert.match(run.log, /^memorax-code codex-plugin install --json$/m);
     assert.doesNotMatch(run.log, /^codex plugin remove memorax-code-codex-adapter@personal$/m);
     assert.doesNotMatch(run.log, /^codex plugin add memorax-code-codex-adapter@personal$/m);
-    assert.match(run.log, /^memorax-code start --clients all$/m);
-    assert.match(run.log, /^memorax-code status --clients all$/m);
+    assert.match(run.log, /^memorax-code start --clients codex,claude$/m);
+    assert.match(run.log, /^memorax-code status --clients codex,claude$/m);
     assert.match(run.result.stderr, /\[MemoraX Code Install\]: Existing Codex plugin cache: not installed/i);
     assert.match(run.result.stderr, /Restart or refresh Codex or Claude Code/i);
     assert.match(run.result.stderr, /--foreground-scripts/i);
@@ -1403,8 +1470,8 @@ test("postinstall accepts VS Code bundled runtimes when no standalone CLI is ins
     assert.match(run.result.stderr, /Claude VS Code runtime: /);
     assert.doesNotMatch(run.result.stderr, /setup was selected but no .* runtime is runnable/);
     assert.match(run.log, /^memorax-code codex-plugin install --json$/m);
-    assert.match(run.log, /^memorax-code start --clients all$/m);
-    assert.match(run.log, /^memorax-code status --clients all$/m);
+    assert.match(run.log, /^memorax-code start --clients codex,claude$/m);
+    assert.match(run.log, /^memorax-code status --clients codex,claude$/m);
     if (process.platform !== "win32") {
       assert.match(run.log, /^vscode-claude --version$/m);
       if (/Codex VS Code runtime: /.test(run.result.stderr)) {
@@ -1515,7 +1582,7 @@ test("postinstall can configure only Codex", async () => {
     assert.doesNotMatch(run.log, /^claude /m);
     assert.equal(await readFile(join(run.claudeHome, "settings.json"), "utf8"), claudeSettingsText);
     const config = await readFile(join(run.memoraxCodeHome, "config.toml"), "utf8");
-    assert.match(config, /\[clients\][^\r\n]*\r?\ncodex = true[^\r\n]*\r?\nclaude = false/m);
+    assert.match(config, /\[clients\][^\r\n]*\r?\ncodex = true[^\r\n]*\r?\nclaude = false[^\r\n]*\r?\nopencode = false/m);
   } finally {
     await rm(run.root, { recursive: true, force: true });
   }
@@ -1544,7 +1611,7 @@ test("postinstall can write MemoraX memory config before backend start", async (
     assert.match(run.result.stderr, /first workspace-scoped memory request from a trusted workspace/);
     assert.match(run.result.stderr, /MemoraX memory: .*Configured/);
     assert.match(run.result.stderr, /Automatic writeback: .*Enabled/);
-    assert.match(run.log, /^memorax-code start --clients all$/m);
+    assert.match(run.log, /^memorax-code start --clients codex,claude$/m);
     assert.match(run.log, /^memorax-cli status --json --config-only$/m);
     assert.equal(run.memoraxRequests.length, 0);
     const config = await readFile(join(run.memoraxCodeHome, "config.toml"), "utf8");
@@ -1899,7 +1966,7 @@ test("postinstall starts only the common Backend when no supported client is det
     assert.match(run.result.stderr, /Backend and selected adapters: .*Enabled/);
     assert.doesNotMatch(run.result.stderr, /Restart or refresh Codex/);
     const config = await readFile(join(run.memoraxCodeHome, "config.toml"), "utf8");
-    assert.match(config, /\[clients\][^\r\n]*\r?\ncodex = false[^\r\n]*\r?\nclaude = false/m);
+    assert.match(config, /\[clients\][^\r\n]*\r?\ncodex = false[^\r\n]*\r?\nclaude = false[^\r\n]*\r?\nopencode = false/m);
   } finally {
     await rm(run.root, { recursive: true, force: true });
   }
@@ -1909,10 +1976,10 @@ test("postinstall recovers from a failed backend start and prints red diagnostic
   const run = await runPostinstall({ failStartOnce: true });
   try {
     assert.equal(run.result.code, 0, run.result.stderr);
-    assert.match(run.log, /^memorax-code start --clients all$/m);
-    assert.match(run.log, /^memorax-code stop --clients all$/m);
-    assert.match(run.log, /^memorax-code start --clients all$/m);
-    assert.match(run.log, /^memorax-code status --clients all$/m);
+    assert.match(run.log, /^memorax-code start --clients codex,claude$/m);
+    assert.match(run.log, /^memorax-code stop --clients codex,claude$/m);
+    assert.match(run.log, /^memorax-code start --clients codex,claude$/m);
+    assert.match(run.log, /^memorax-code status --clients codex,claude$/m);
     assert.match(run.result.stderr, /Backend start failed during npm postinstall/);
     assert.match(run.result.stderr, /\[MemoraX Code Backend\]: fake memorax-code start failure/);
     assert.match(run.result.stderr, /Attempting automatic recovery: `memorax-code stop` then `memorax-code start`/);
@@ -1928,7 +1995,7 @@ test("postinstall does not stop adapters after a deterministic connection author
   const run = await runPostinstall({ connectionAuthorityFailure: true });
   try {
     assert.equal(run.result.code, 0, run.result.stderr);
-    assert.equal((run.log.match(/^memorax-code start --clients all$/gm) ?? []).length, 1);
+    assert.equal((run.log.match(/^memorax-code start --clients codex,claude$/gm) ?? []).length, 1);
     assert.doesNotMatch(run.log, /^memorax-code stop(?: |$)/m);
     assert.doesNotMatch(run.log, /^memorax-code status(?: |$)/m);
     assert.match(run.result.stderr, /BACKEND_CONNECTION_AUTHORITY_INVALID/);
@@ -1956,7 +2023,7 @@ test("postinstall does not retry deterministic token or service-state failures",
       const run = await runPostinstall({ runtimeAuthorityFailureCode: code });
       try {
         assert.equal(run.result.code, 0, run.result.stderr);
-        assert.equal((run.log.match(/^memorax-code start --clients all$/gm) ?? []).length, 1);
+        assert.equal((run.log.match(/^memorax-code start --clients codex,claude$/gm) ?? []).length, 1);
         assert.doesNotMatch(run.log, /^memorax-code stop(?: |$)/m);
         assert.doesNotMatch(run.log, /^memorax-code status(?: |$)/m);
         assert.match(run.result.stderr, new RegExp(code));
@@ -1974,7 +2041,7 @@ test("postinstall does not stop a Backend after lifecycle lock contention", asyn
   });
   try {
     assert.equal(run.result.code, 0, run.result.stderr);
-    assert.equal((run.log.match(/^memorax-code start --clients all$/gm) ?? []).length, 1);
+    assert.equal((run.log.match(/^memorax-code start --clients codex,claude$/gm) ?? []).length, 1);
     assert.doesNotMatch(run.log, /^memorax-code stop(?: |$)/m);
     assert.doesNotMatch(run.log, /^memorax-code status(?: |$)/m);
     assert.match(run.result.stderr, /BACKEND_LIFECYCLE_LOCK_TIMEOUT/);
@@ -1992,7 +2059,7 @@ test("postinstall reports unavailable status and prints red diagnostics instead 
   const run = await runPostinstall({ unavailableStatus: true });
   try {
     assert.equal(run.result.code, 0, run.result.stderr);
-    assert.match(run.log, /^memorax-code status --clients all$/m);
+    assert.match(run.log, /^memorax-code status --clients codex,claude$/m);
     assert.match(run.result.stderr, /\[MemoraX Code Backend\]: codex adapter: not enabled integration=hooks/);
     assert.match(run.result.stderr, /\[MemoraX Code Backend\]: claude adapter: ok integration=hooks skills=ok/);
     assert.match(run.result.stderr, /Backend and selected adapters: .*Unavailable/);

--- a/packages/ts/memorax-code-backend/src/clients/opencode/lifecycle.ts
+++ b/packages/ts/memorax-code-backend/src/clients/opencode/lifecycle.ts
@@ -1,0 +1,76 @@
+import type {
+  AdapterLifecycleParticipant,
+  AdapterPluginLifecycleReport,
+  AdapterReport,
+} from "../../lifecycle/participant.js";
+
+export const openCodeAdapterLifecycle = {
+  async status({ argv, serviceOptions, backendUrl }) {
+    try {
+      return (await loadOpenCodePluginInstaller()).readOpenCodePluginStatus(
+        openCodeAdapterOptions(argv, serviceOptions.home, backendUrl),
+      );
+    } catch (error) {
+      return { ok: false, action: "status", error: error instanceof Error ? error.message : String(error) };
+    }
+  },
+  async prepareEnable({ argv, serviceOptions, backendUrl }) {
+    try {
+      return (await loadOpenCodePluginInstaller()).ensureOpenCodePluginInstalled(
+        openCodeAdapterOptions(argv, serviceOptions.home, backendUrl),
+      );
+    } catch (error) {
+      return { ok: false, action: "enable", error: error instanceof Error ? error.message : String(error) };
+    }
+  },
+  async disable({ argv, serviceOptions }) {
+    try {
+      return (await loadOpenCodePluginInstaller()).disableOpenCodePlugin(
+        openCodeAdapterOptions(argv, serviceOptions.home),
+      );
+    } catch (error) {
+      return { ok: false, action: "disable", error: error instanceof Error ? error.message : String(error) };
+    }
+  },
+  async remove({ argv, serviceOptions }) {
+    try {
+      return (await loadOpenCodePluginInstaller()).removeOpenCodePluginInstallation(
+        openCodeAdapterOptions(argv, serviceOptions.home),
+      );
+    } catch (error) {
+      return {
+        ok: false,
+        action: "opencode-plugin-remove",
+        reason: "plugin_remove_failed",
+        message: error instanceof Error ? error.message : String(error),
+      };
+    }
+  },
+} satisfies AdapterLifecycleParticipant<AdapterPluginLifecycleReport>;
+
+function openCodeAdapterOptions(
+  argv: string[],
+  memoraxCodeHome: string | undefined,
+  backendUrl?: string,
+): Record<string, unknown> {
+  const openCodeConfigDir = argValue(argv, "--opencode-config-dir");
+  return {
+    ...(openCodeConfigDir ? { openCodeConfigDir } : {}),
+    memoraxCodeHome,
+    ...(backendUrl ? { backendUrl } : {}),
+  };
+}
+
+async function loadOpenCodePluginInstaller(): Promise<{
+  ensureOpenCodePluginInstalled: (options: Record<string, unknown>) => AdapterReport;
+  disableOpenCodePlugin: (options: Record<string, unknown>) => AdapterReport;
+  removeOpenCodePluginInstallation: (options: Record<string, unknown>) => AdapterPluginLifecycleReport;
+  readOpenCodePluginStatus: (options: Record<string, unknown>) => AdapterReport;
+}> {
+  return await import(new URL("../../../../memorax-code-opencode-adapter/src/plugin-install.mjs", import.meta.url).href);
+}
+
+function argValue(argv: string[], name: string): string | undefined {
+  const index = argv.indexOf(name);
+  return index >= 0 ? argv[index + 1] : undefined;
+}

--- a/packages/ts/memorax-code-backend/src/config/memorax-code.ts
+++ b/packages/ts/memorax-code-backend/src/config/memorax-code.ts
@@ -14,6 +14,7 @@ export type MemoraxCodeConfig = Readonly<{
   clients?: Readonly<{
     codex?: boolean;
     claude?: boolean;
+    opencode?: boolean;
   }>;
   memorax?: Readonly<{
     endpoint?: string;
@@ -106,6 +107,7 @@ export function renderDefaultMemoraxCodeConfig(): string {
     "[clients]",
     "codex = true",
     "claude = true",
+    "opencode = true",
     "",
     "# MemoraX remote-memory connection. Credentials may also come from the environment.",
     "[memorax]",
@@ -228,6 +230,7 @@ function normalizeMemoraxCodeConfig(value: unknown): MemoraxCodeConfig {
     clients: prune({
       codex: booleanField(clients, "codex"),
       claude: booleanField(clients, "claude"),
+      opencode: booleanField(clients, "opencode"),
     }),
     memorax: prune({
       endpoint: stringField(memorax, "endpoint"),
@@ -304,7 +307,7 @@ function validateRawLifecycleConfig(value: unknown, path: string): void {
   if (rawClients !== undefined) {
     const clients = tableValue(rawClients);
     if (!clients) throw invalidLifecycleConfig(path, "clients must be a table");
-    for (const field of ["codex", "claude"] as const) {
+    for (const field of ["codex", "claude", "opencode"] as const) {
       if (clients[field] !== undefined && typeof clients[field] !== "boolean") {
         throw invalidLifecycleConfig(path, `clients.${field} must be a boolean`);
       }

--- a/packages/ts/memorax-code-backend/src/entrypoints/backend-cli.ts
+++ b/packages/ts/memorax-code-backend/src/entrypoints/backend-cli.ts
@@ -70,8 +70,8 @@ export function runBackendCli(argv = process.argv): void {
       `Usage: ${usageName} [${commands}] [--backend-url URL] [--backend-token TOKEN] [--home DIR]`,
       "[--host HOST] [--port PORT] [--rotate] [--show]",
       "[--codex-command CMD]",
-      "[--codex-home DIR] [--claude-home DIR]",
-      "[--clients codex|claude|codex,claude|all|none]",
+      "[--codex-home DIR] [--claude-home DIR] [--opencode-config-dir DIR]",
+      "[--clients codex|claude|opencode|CLIENT,...|all|none]",
       "[--json]",
       "[--marketplace-path FILE] [--plugin-source-path DIR] [--claude-command CMD] [--help]",
       "[--yes]",
@@ -226,6 +226,7 @@ async function startRawBackendServer(
         memoraxCodeHome: state.sessionHome,
         codexHome: argValue(argv, "--codex-home"),
         claudeHome: argValue(argv, "--claude-home"),
+        openCodeConfigDir: argValue(argv, "--opencode-config-dir"),
         codexCommand: argValue(argv, "--codex-command"),
         claudeCommand: argValue(argv, "--claude-command"),
       })
@@ -246,6 +247,8 @@ async function startRawBackendServer(
         codexReason: "reason" in cleanup.codexPlugin ? cleanup.codexPlugin.reason : undefined,
         claudeOk: cleanup.claudePlugin.ok,
         claudeReason: cleanup.claudePlugin.reason,
+        opencodeOk: cleanup.opencodePlugin.ok,
+        opencodeReason: cleanup.opencodePlugin.reason,
       });
     }
     server.close(() => {
@@ -517,6 +520,7 @@ function printMemoraxCodeStatus(report: MemoraxCodeStatusReport): void {
     backendLog(`Codex adapter: ${adapterStatusLine(report.codexAdapter)}`);
   }
   if (report.claudeAdapter) backendLog(`Claude adapter: ${claudeAdapterStatusLine(report.claudeAdapter, report.codexAdapter)}`);
+  if (report.opencodeAdapter) backendLog(`OpenCode adapter: ${adapterStatusLine(report.opencodeAdapter)}`);
   if (!suppressBackendGuidance()) {
     for (const line of statusGuidance(report)) backendLog(line);
   }
@@ -623,6 +627,7 @@ function printLifecycleResult(report: MemoraxCodeLifecycleReport): void {
   }
   if (report.codexAdapter) backendLog(`Codex adapter: ${adapterStatusLine(report.codexAdapter)}`);
   if (report.claudeAdapter) backendLog(`Claude adapter: ${adapterStatusLine(report.claudeAdapter)}`);
+  if (report.opencodeAdapter) backendLog(`OpenCode adapter: ${adapterStatusLine(report.opencodeAdapter)}`);
   if (report.codexPlugin) {
     const removed = report.codexPlugin.removedPaths.length;
     const marketplace = report.codexPlugin.marketplaceChanged ? " marketplace=updated" : " marketplace=unchanged";
@@ -681,13 +686,15 @@ function lifecycleGuidance(report: MemoraxCodeLifecycleReport): string[] {
         "Run `memorax-code logs` for details, then retry `memorax-code start`.",
       ];
     }
-    if (!report.codexAdapter && !report.claudeAdapter) {
+    if (!report.codexAdapter && !report.claudeAdapter && !report.opencodeAdapter) {
       return [
         green("Backend is running."),
         "Adapters were not changed for this command.",
       ];
     }
-    if ((!report.codexAdapter || isAdapterReady(report.codexAdapter)) && (!report.claudeAdapter || isAdapterReady(report.claudeAdapter))) {
+    if ((!report.codexAdapter || isAdapterReady(report.codexAdapter))
+      && (!report.claudeAdapter || isAdapterReady(report.claudeAdapter))
+      && (!report.opencodeAdapter || isAdapterReady(report.opencodeAdapter))) {
       return [
         green("Backend is running and adapters are enabled."),
         green("Existing sessions with the stable plugin shell select the active Hook runtime on their next user prompt."),
@@ -705,6 +712,7 @@ function lifecycleGuidance(report: MemoraxCodeLifecycleReport): string[] {
         green("Backend is stopped."),
         ...(report.codexAdapter ? [green("Codex Hook integration is stopped; provider config was not changed.")] : []),
         ...(report.claudeAdapter ? [green("Claude Code Hook integration is stopped; provider config was not changed.")] : []),
+        ...(report.opencodeAdapter ? [green("OpenCode plugin integration is stopped; provider config was not changed.")] : []),
       ]
       : [
         red("Backend did not stop cleanly."),
@@ -730,13 +738,7 @@ function lifecycleGuidance(report: MemoraxCodeLifecycleReport): string[] {
         "Run `memorax-code status` and `memorax-code logs` before retrying.",
       ];
     }
-    const clientName = report.codexAdapter && report.claudeAdapter
-      ? "Codex and Claude Code"
-      : report.codexAdapter
-        ? "Codex"
-        : report.claudeAdapter
-          ? "Claude Code"
-          : undefined;
+    const clientName = lifecycleClientName(report);
     const npmPackageRemoved = report.npmPackageRemoval?.ok === true
       && report.npmPackageRemoval.skipped !== true;
     return [
@@ -746,9 +748,7 @@ function lifecycleGuidance(report: MemoraxCodeLifecycleReport): string[] {
           ? [green(`MemoraX Code has been uninstalled from ${clientName}.`)]
           : []),
       ...(clientName
-        ? [green(report.codexAdapter && report.claudeAdapter
-          ? "Restart or refresh Codex and Claude Code so they drop the removed adapter plugins."
-          : `Restart or refresh ${clientName} so it drops the removed adapter plugin.`)]
+        ? [green(`Restart or refresh ${clientName} so it drops the removed adapter plugin${selectedLifecycleClientNames(report).length === 1 ? "" : "s"}.`)]
         : []),
     ];
   }
@@ -790,6 +790,12 @@ function statusGuidance(report: MemoraxCodeStatusReport): string[] {
       "Run `memorax-code start`, then restart or refresh Claude Code.",
     ];
   }
+  if (report.opencodeAdapter && !isAdapterReady(report.opencodeAdapter)) {
+    return [
+      red("OpenCode adapter is not enabled."),
+      "Run `memorax-code start`, then restart or refresh OpenCode.",
+    ];
+  }
   return [
     red("MemoraX Code needs attention."),
     "Run `memorax-code status` and `memorax-code logs` for details.",
@@ -826,10 +832,28 @@ function adapterStatusLine(report: AdapterReport): string {
     return `not ok endpoint_mismatch configured=${report.configuredBackendUrl ?? "missing"} expected=${report.expectedBackendUrl ?? "unknown"}`;
   }
   const enabled = isAdapterReady(report);
-  const skillStatus = report.codexSkills?.status ?? report.claudeSkills?.status;
+  const skillStatus = report.codexSkills?.status
+    ?? report.claudeSkills?.status
+    ?? report.opencodeSkills?.status;
   const skills = skillStatus ? ` skills=${skillStatus}` : "";
   const changed = report.changed === true ? " changed" : "";
-  return `${enabled ? "ok" : "not enabled"} integration=hooks${skills}${changed}`;
+  const integration = report.integration ?? report.state?.integration ?? "hooks";
+  return `${enabled ? "ok" : "not enabled"} integration=${integration}${skills}${changed}`;
+}
+
+function selectedLifecycleClientNames(report: MemoraxCodeLifecycleReport): string[] {
+  return [
+    report.codexAdapter ? "Codex" : undefined,
+    report.claudeAdapter ? "Claude Code" : undefined,
+    report.opencodeAdapter ? "OpenCode" : undefined,
+  ].filter((name): name is string => name !== undefined);
+}
+
+function lifecycleClientName(report: MemoraxCodeLifecycleReport): string | undefined {
+  const names = selectedLifecycleClientNames(report);
+  if (names.length < 2) return names[0];
+  if (names.length === 2) return `${names[0]} and ${names[1]}`;
+  return `${names.slice(0, -1).join(", ")}, and ${names.at(-1)}`;
 }
 
 function claudeAdapterStatusLine(report: AdapterReport, codexAdapter?: AdapterReport): string {

--- a/packages/ts/memorax-code-backend/src/lifecycle/active-clients.ts
+++ b/packages/ts/memorax-code-backend/src/lifecycle/active-clients.ts
@@ -8,7 +8,12 @@ export function readActiveManagedClients(memoraxCodeHome: string): ManagedClient
   try {
     const value = JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>;
     if (typeof value.codex !== "boolean" || typeof value.claude !== "boolean") return undefined;
-    return { codex: value.codex, claude: value.claude };
+    if (value.opencode !== undefined && typeof value.opencode !== "boolean") return undefined;
+    return {
+      codex: value.codex,
+      claude: value.claude,
+      opencode: value.opencode === true,
+    };
   } catch {
     return undefined;
   }

--- a/packages/ts/memorax-code-backend/src/lifecycle/client-plugin-removal.ts
+++ b/packages/ts/memorax-code-backend/src/lifecycle/client-plugin-removal.ts
@@ -18,11 +18,23 @@ type ClaudePluginInstaller = {
   removeClaudePluginInstallation: (options: Record<string, unknown>) => ClaudePluginRemovalReport;
 };
 
+type OpenCodePluginRemovalReport = {
+  ok: boolean;
+  action: string;
+  reason?: string;
+  message?: string;
+};
+
+type OpenCodePluginInstaller = {
+  removeOpenCodePluginInstallation: (options: Record<string, unknown>) => OpenCodePluginRemovalReport;
+};
+
 export type ClientPluginRemovalOptions = {
   memoraxCodeHome?: string;
   homeDir?: string;
   codexHome?: string;
   claudeHome?: string;
+  openCodeConfigDir?: string;
   codexCommand?: string;
   claudeCommand?: string;
 };
@@ -32,6 +44,7 @@ export type ClientPluginRemovalReport = {
   action: "client-plugin-removal-cleanup";
   codexPlugin: BackendRemovalCleanupReport | ClientPluginRemovalFailure;
   claudePlugin: ClaudePluginRemovalReport | ClientPluginRemovalFailure;
+  opencodePlugin: OpenCodePluginRemovalReport | ClientPluginRemovalFailure;
 };
 
 type ClientPluginRemovalFailure = {
@@ -45,13 +58,14 @@ export async function prepareClientPluginRemovalCleanup(
   options: ClientPluginRemovalOptions = {},
 ): Promise<() => Promise<ClientPluginRemovalReport>> {
   const claudePluginInstaller = await loadClaudePluginInstaller();
+  const openCodePluginInstaller = await loadOpenCodePluginInstaller();
   const home = resolveHome(options.homeDir);
   const memoraxCodeHome = resolve(options.memoraxCodeHome ?? process.env.MEMORAX_CODE_HOME ?? join(home, ".memorax-code"));
   const claudeState = await readJsonRecord(join(memoraxCodeHome, "adapters", "claude-code", "state.json"));
   const claudeHome = options.claudeHome ?? stringField(claudeState, "claudeHome");
 
   return async () => {
-    const [codexPlugin, claudePlugin] = await Promise.all([
+    const [codexPlugin, claudePlugin, opencodePlugin] = await Promise.all([
       cleanupCodexAfterBackendRemoval({
         memoraxCodeHome,
         homeDir: home,
@@ -65,18 +79,31 @@ export async function prepareClientPluginRemovalCleanup(
           ...(options.claudeCommand ? { claudeCommand: options.claudeCommand } : {}),
         }))
         .catch((error) => removalFailure("claude-plugin-remove", error)),
+      Promise.resolve()
+        .then(() => openCodePluginInstaller.removeOpenCodePluginInstallation({
+          memoraxCodeHome,
+          ...(options.openCodeConfigDir
+            ? { openCodeConfigDir: options.openCodeConfigDir }
+            : {}),
+        }))
+        .catch((error) => removalFailure("opencode-plugin-remove", error)),
     ]);
     return {
-      ok: codexPlugin.ok && claudePlugin.ok,
+      ok: codexPlugin.ok && claudePlugin.ok && opencodePlugin.ok,
       action: "client-plugin-removal-cleanup",
       codexPlugin,
       claudePlugin,
+      opencodePlugin,
     };
   };
 }
 
 async function loadClaudePluginInstaller(): Promise<ClaudePluginInstaller> {
   return await import(new URL("../../../memorax-code-claude-adapter/src/plugin-install.mjs", import.meta.url).href);
+}
+
+async function loadOpenCodePluginInstaller(): Promise<OpenCodePluginInstaller> {
+  return await import(new URL("../../../memorax-code-opencode-adapter/src/plugin-install.mjs", import.meta.url).href);
 }
 
 async function readJsonRecord(path: string): Promise<Record<string, unknown> | undefined> {

--- a/packages/ts/memorax-code-backend/src/lifecycle/client-selection.ts
+++ b/packages/ts/memorax-code-backend/src/lifecycle/client-selection.ts
@@ -3,9 +3,10 @@ import { loadLifecycleMemoraxCodeConfig, type MemoraxCodeConfig } from "../confi
 export type ManagedClients = Readonly<{
   codex: boolean;
   claude: boolean;
+  opencode: boolean;
 }>;
 
-const allClients: ManagedClients = Object.freeze({ codex: true, claude: true });
+const allClients: ManagedClients = Object.freeze({ codex: true, claude: true, opencode: true });
 
 export function resolveManagedClients(argv: readonly string[], config: MemoraxCodeConfig = {}): ManagedClients {
   const explicit = argValue(argv, "--clients");
@@ -15,6 +16,7 @@ export function resolveManagedClients(argv: readonly string[], config: MemoraxCo
     return {
       codex: config.clients.codex === true,
       claude: config.clients.claude === true,
+      opencode: config.clients.opencode === true,
     };
   }
 
@@ -24,15 +26,18 @@ export function resolveManagedClients(argv: readonly string[], config: MemoraxCo
 export function parseManagedClients(value: string): ManagedClients {
   const normalized = value.trim().toLowerCase();
   if (normalized === "all") return allClients;
-  if (normalized === "none") return { codex: false, claude: false };
+  if (normalized === "none") return { codex: false, claude: false, opencode: false };
 
   const names = normalized.split(",").map((name) => name.trim()).filter(Boolean);
-  if (names.length === 0 || names.some((name) => name !== "codex" && name !== "claude")) {
-    throw new Error(`invalid --clients value: ${value}; expected codex, claude, codex,claude, all, or none`);
+  if (names.length === 0 || names.some((name) => (
+    name !== "codex" && name !== "claude" && name !== "opencode"
+  ))) {
+    throw new Error(`invalid --clients value: ${value}; expected a comma-separated subset of codex, claude, opencode, or all or none`);
   }
   return {
     codex: names.includes("codex"),
     claude: names.includes("claude"),
+    opencode: names.includes("opencode"),
   };
 }
 

--- a/packages/ts/memorax-code-backend/src/lifecycle/orchestrator.ts
+++ b/packages/ts/memorax-code-backend/src/lifecycle/orchestrator.ts
@@ -24,6 +24,7 @@ import { loadManagedClientsConfig, resolveManagedClients, type ManagedClients } 
 import { clearActiveManagedClients, readActiveManagedClients, writeActiveManagedClients } from "./active-clients.js";
 import { codexAdapterLifecycle } from "../clients/codex/lifecycle.js";
 import { claudeAdapterLifecycle } from "../clients/claude/lifecycle.js";
+import { openCodeAdapterLifecycle } from "../clients/opencode/lifecycle.js";
 import type {
   AdapterReport,
 } from "./participant.js";
@@ -38,6 +39,7 @@ export type MemoraxCodeStatusReport = {
   backend: Awaited<ReturnType<typeof runBackendStatus>>;
   codexAdapter?: AdapterReport;
   claudeAdapter?: AdapterReport;
+  opencodeAdapter?: AdapterReport;
 };
 
 export type MemoraxCodeLifecycleReport = {
@@ -48,6 +50,7 @@ export type MemoraxCodeLifecycleReport = {
   backend?: Awaited<ReturnType<typeof startBackendService | typeof stopBackendService>>;
   codexAdapter?: AdapterReport;
   claudeAdapter?: AdapterReport;
+  opencodeAdapter?: AdapterReport;
   codexPlugin?: Awaited<ReturnType<typeof codexAdapterLifecycle.remove>>;
   npmPackageRemoval?: NpmPackageRemovalReport;
   removesPlugin?: boolean;
@@ -118,16 +121,22 @@ export async function collectMemoraxCodeStatus(
   const claudeAdapter = clients.claude
     ? await claudeAdapterLifecycle.status({ argv, serviceOptions, backendUrl })
     : undefined;
+  const opencodeAdapter = clients.opencode
+    ? await openCodeAdapterLifecycle.status({ argv, serviceOptions, backendUrl })
+    : undefined;
   const codexReady = codexAdapter ? isAdapterReady(codexAdapter) : true;
   const claudeReady = claudeAdapter ? isAdapterReady(claudeAdapter) : true;
+  const opencodeReady = opencodeAdapter ? isAdapterReady(opencodeAdapter) : true;
   return {
     ok: backend.ok
       && codexReady
+      && opencodeReady
       && (isOptionalUnconfiguredClaudeAdapter(claudeAdapter, codexAdapter) || claudeReady),
     action: "status",
     backend,
     ...(codexAdapter ? { codexAdapter } : {}),
     ...(claudeAdapter ? { claudeAdapter } : {}),
+    ...(opencodeAdapter ? { opencodeAdapter } : {}),
   };
 }
 
@@ -186,7 +195,10 @@ async function startMemoraxCodeServiceLocked(
   const deselectedClaude = previousClients?.claude && !clients.claude
     ? await claudeAdapterLifecycle.disable({ argv, serviceOptions })
     : undefined;
-  if (deselectedCodex?.ok === false || deselectedClaude?.ok === false) {
+  const deselectedOpenCode = previousClients?.opencode && !clients.opencode
+    ? await openCodeAdapterLifecycle.disable({ argv, serviceOptions })
+    : undefined;
+  if (deselectedCodex?.ok === false || deselectedClaude?.ok === false || deselectedOpenCode?.ok === false) {
     return {
       ok: false,
       action: "start",
@@ -196,6 +208,7 @@ async function startMemoraxCodeServiceLocked(
       ),
       ...(deselectedCodex ? { codexAdapter: deselectedCodex } : {}),
       ...(deselectedClaude ? { claudeAdapter: deselectedClaude } : {}),
+      ...(deselectedOpenCode ? { opencodeAdapter: deselectedOpenCode } : {}),
     };
   }
   // The marker is a conservative cleanup scope, not a readiness signal. Persist
@@ -233,21 +246,41 @@ async function startMemoraxCodeServiceLocked(
   const claudeAdapter = clients.claude
     ? await claudeAdapterLifecycle.prepareEnable({ argv, serviceOptions, backendUrl })
     : undefined;
+  const opencodeAdapter = clients.opencode
+    ? await openCodeAdapterLifecycle.prepareEnable({ argv, serviceOptions, backendUrl })
+    : undefined;
+  if (opencodeAdapter?.ok === false) {
+    return {
+      ok: false,
+      action: "start",
+      backend: await recoverBackendAfterStartPreparationFailure(
+        serviceOptions,
+        "opencode_adapter_enable_failed",
+      ),
+      ...(codexAdapter ? { codexAdapter } : {}),
+      ...(claudeAdapter ? { claudeAdapter } : {}),
+      opencodeAdapter,
+    };
+  }
   const backendStartOptions: BackendServiceOptions = {
     ...serviceOptions,
     claudeProjectsRoot: claudeProjectsRootForStart(argv, claudeAdapter),
   };
   const backend = await startBackendService(backendStartOptions);
   if (!backend.ok) {
-    const disabled = codexAdapter
+    const disabledCodex = codexAdapter
       ? await codexAdapterLifecycle.disable({ argv, serviceOptions })
+      : undefined;
+    const disabledOpenCode = opencodeAdapter
+      ? await openCodeAdapterLifecycle.disable({ argv, serviceOptions })
       : undefined;
     return {
       ok: false,
       action: "start",
       backend,
-      ...(disabled ? { codexAdapter: disabled } : {}),
+      ...(disabledCodex ? { codexAdapter: disabledCodex } : {}),
       ...(claudeAdapter ? { claudeAdapter } : {}),
+      ...(disabledOpenCode ? { opencodeAdapter: disabledOpenCode } : {}),
     };
   }
   return {
@@ -256,6 +289,7 @@ async function startMemoraxCodeServiceLocked(
     backend,
     ...(codexAdapter ? { codexAdapter } : {}),
     ...(claudeAdapter ? { claudeAdapter } : {}),
+    ...(opencodeAdapter ? { opencodeAdapter } : {}),
   };
 }
 
@@ -314,10 +348,13 @@ async function executeMemoraxCodeStop(
     ? {
       codex: activeClients.codex && !clients.codex,
       claude: activeClients.claude && !clients.claude,
+      opencode: activeClients.opencode && !clients.opencode,
     }
     : undefined;
-  const hasRemainingClients = remaining?.codex === true || remaining?.claude === true;
-  const backendOnlyStop = !clients.codex && !clients.claude;
+  const hasRemainingClients = remaining?.codex === true
+    || remaining?.claude === true
+    || remaining?.opencode === true;
+  const backendOnlyStop = !clients.codex && !clients.claude && !clients.opencode;
   const needsBackendStop = backendOnlyStop || !hasRemainingClients;
   // A true partial stop keeps the shared Backend for remaining clients. Every
   // other stop establishes Backend shutdown before mutating client state.
@@ -340,12 +377,20 @@ async function executeMemoraxCodeStop(
   const claudeAdapter = clients.claude
     ? await claudeAdapterLifecycle.disable({ argv, serviceOptions })
     : undefined;
-  const adaptersOk = codexAdapter?.ok !== false && claudeAdapter?.ok !== false;
+  const opencodeAdapter = clients.opencode
+    ? await openCodeAdapterLifecycle.disable({ argv, serviceOptions })
+    : undefined;
+  const adaptersOk = codexAdapter?.ok !== false
+    && claudeAdapter?.ok !== false
+    && opencodeAdapter?.ok !== false;
   const backend = stoppedBackend
     ?? (adaptersOk
       ? preservedBackendResult(serviceOptions, "active_clients_remaining")
       : preservedBackendResult(serviceOptions, "adapter_disable_failed"));
-  const ok = backend.ok && codexAdapter?.ok !== false && claudeAdapter?.ok !== false;
+  const ok = backend.ok
+    && codexAdapter?.ok !== false
+    && claudeAdapter?.ok !== false
+    && opencodeAdapter?.ok !== false;
   return {
     report: {
       ok,
@@ -353,6 +398,7 @@ async function executeMemoraxCodeStop(
       backend,
       ...(codexAdapter ? { codexAdapter } : {}),
       ...(claudeAdapter ? { claudeAdapter } : {}),
+      ...(opencodeAdapter ? { opencodeAdapter } : {}),
     },
     remainingClients: remaining && hasRemainingClients ? remaining : undefined,
   };
@@ -426,8 +472,12 @@ async function uninstallMemoraxCodeServiceLocked(
   const claudePlugin = clients.claude
     ? await claudeAdapterLifecycle.remove({ argv, serviceOptions })
     : undefined;
+  const opencodePlugin = clients.opencode
+    ? await openCodeAdapterLifecycle.remove({ argv, serviceOptions })
+    : undefined;
   const pluginCleanupOk = codexPlugin?.ok !== false
-    && claudePlugin?.ok !== false;
+    && claudePlugin?.ok !== false
+    && opencodePlugin?.ok !== false;
   const npmPackageRemoval = !pluginCleanupOk
     ? skippedNpmPackageRemoval("plugin_cleanup_failed")
     : canRemoveSharedPackage
@@ -436,6 +486,9 @@ async function uninstallMemoraxCodeServiceLocked(
   const claudeAdapter = stopped.claudeAdapter && claudePlugin
     ? { ...stopped.claudeAdapter, pluginRemove: claudePlugin }
     : stopped.claudeAdapter;
+  const opencodeAdapter = stopped.opencodeAdapter && opencodePlugin
+    ? { ...stopped.opencodeAdapter, pluginRemove: opencodePlugin }
+    : stopped.opencodeAdapter;
   const ok = pluginCleanupOk && npmPackageRemoval.ok !== false;
   if (ok) commitActiveManagedClients(memoraxCodeHome, stopExecution.remainingClients);
   return {
@@ -444,8 +497,9 @@ async function uninstallMemoraxCodeServiceLocked(
     action: "uninstall",
     ...(codexPlugin ? { codexPlugin } : {}),
     ...(claudeAdapter ? { claudeAdapter } : {}),
+    ...(opencodeAdapter ? { opencodeAdapter } : {}),
     npmPackageRemoval,
-    removesPlugin: codexPlugin?.ok === true || claudePlugin?.ok === true,
+    removesPlugin: codexPlugin?.ok === true || claudePlugin?.ok === true || opencodePlugin?.ok === true,
     removesUserState: false,
   };
 }
@@ -560,7 +614,9 @@ function argValue(argv: string[], name: string): string | undefined {
 }
 
 function includesManagedClients(selection: ManagedClients, required: ManagedClients): boolean {
-  return (!required.codex || selection.codex) && (!required.claude || selection.claude);
+  return (!required.codex || selection.codex)
+    && (!required.claude || selection.claude)
+    && (!required.opencode || selection.opencode);
 }
 
 function preservedBackendResult(
@@ -653,14 +709,15 @@ async function withMemoraxCodeLifecycleLock(
 }
 
 export function isAdapterReady(report: AdapterReport): boolean {
-  const hookIntegration = report.integration === "hooks" || report.state?.integration === "hooks";
-  return hookIntegration
+  const integration = report.integration ?? report.state?.integration;
+  return (integration === "hooks" || integration === "plugin")
     && report.ok !== false
     && report.installed === true
     && report.enabled === true
     && report.backendUrlMatches !== false
     && report.codexSkills?.ok !== false
-    && report.claudeSkills?.ok !== false;
+    && report.claudeSkills?.ok !== false
+    && report.opencodeSkills?.ok !== false;
 }
 
 

--- a/packages/ts/memorax-code-backend/src/lifecycle/participant.ts
+++ b/packages/ts/memorax-code-backend/src/lifecycle/participant.ts
@@ -15,7 +15,10 @@ export type AdapterReport = {
   error?: string;
   memoraxCodeHome?: string;
   codexHome?: string;
+  openCodeConfigDir?: string;
   installPath?: string;
+  pluginPath?: string;
+  skillPath?: string;
   state?: {
     version?: number;
     enabled?: boolean;
@@ -27,6 +30,7 @@ export type AdapterReport = {
   backendUrlMatches?: boolean;
   codexSkills?: { ok?: boolean; status?: string };
   claudeSkills?: { ok?: boolean; status?: string };
+  opencodeSkills?: { ok?: boolean; status?: string };
   pluginInstall?: AdapterPluginLifecycleReport;
   pluginRemove?: AdapterPluginLifecycleReport;
   pluginStatus?: AdapterReport;

--- a/packages/ts/memorax-code-backend/test/lifecycle/backend/service-integration.test.mjs
+++ b/packages/ts/memorax-code-backend/test/lifecycle/backend/service-integration.test.mjs
@@ -139,7 +139,7 @@ test("Backend service keeps Claude native Viewer enrichment behind the live mana
       operation: "query",
       request: { prompt: "Hook managed Claude prompt." },
     })}\n`, "utf8");
-    writeActiveManagedClients(home, { codex: false, claude: true });
+    writeActiveManagedClients(home, { codex: false, claude: true, opencode: false });
     const started = await startBackendService({
       home,
       port,
@@ -152,12 +152,12 @@ test("Backend service keeps Claude native Viewer enrichment behind the live mana
     assert.equal(enabled.summary.searchOperationCount, 1);
     assert.doesNotMatch(JSON.stringify(enabled), /private managed/);
 
-    writeActiveManagedClients(home, { codex: false, claude: false });
+    writeActiveManagedClients(home, { codex: false, claude: false, opencode: false });
     const disabled = await fetch(endpoint).then((response) => response.json());
     assert.equal(disabled.summary.searchOperationCount, 0);
     assert.doesNotMatch(JSON.stringify(disabled), /private managed/);
 
-    writeActiveManagedClients(home, { codex: false, claude: true });
+    writeActiveManagedClients(home, { codex: false, claude: true, opencode: false });
     const reenabled = await fetch(endpoint).then((response) => response.json());
     assert.equal(reenabled.summary.searchOperationCount, 1);
     assert.doesNotMatch(JSON.stringify(reenabled), /private managed/);

--- a/packages/ts/memorax-code-backend/test/lifecycle/client-plugin-removal.test.mjs
+++ b/packages/ts/memorax-code-backend/test/lifecycle/client-plugin-removal.test.mjs
@@ -5,12 +5,13 @@ import { dirname, join } from "node:path";
 import { test } from "node:test";
 import { prepareClientPluginRemovalCleanup } from "../../dist/lifecycle/client-plugin-removal.js";
 
-test("package-removal cleanup is prepared before shutdown and removes both client plugins", async () => {
+test("package-removal cleanup is prepared before shutdown and removes all client plugins", async () => {
   const root = await mkdtemp(join(tmpdir(), "memorax-code-client-plugin-removal-"));
   const home = join(root, "home");
   const memoraxCodeHome = join(home, "memorax-code-home");
   const codexHome = join(home, "codex-home");
   const claudeHome = join(home, "claude-home");
+  const openCodeConfigDir = join(home, "opencode-config");
   const codexPluginManifest = join(
     codexHome,
     ".memorax-code",
@@ -21,11 +22,17 @@ test("package-removal cleanup is prepared before shutdown and removes both clien
   );
   const claudeCommand = join(root, "fake-claude.mjs");
   const claudeCalls = join(root, "claude-calls.jsonl");
+  const openCodePlugin = join(openCodeConfigDir, "plugins", "memorax-code.js");
+  const openCodeSkill = join(openCodeConfigDir, "skills", "memorax-code");
+  const openCodeState = join(memoraxCodeHome, "adapters", "opencode", "state.json");
 
   try {
     await mkdir(dirname(codexPluginManifest), { recursive: true });
     await mkdir(join(memoraxCodeHome, "adapters", "codex"), { recursive: true });
     await mkdir(join(memoraxCodeHome, "adapters", "claude-code"), { recursive: true });
+    await mkdir(dirname(openCodeState), { recursive: true });
+    await mkdir(dirname(openCodePlugin), { recursive: true });
+    await mkdir(openCodeSkill, { recursive: true });
     await mkdir(claudeHome, { recursive: true });
     await writeFile(codexPluginManifest, '{"name":"memorax-code-codex-adapter"}\n');
     await writeFile(join(memoraxCodeHome, "adapters", "codex", "state.json"), `${JSON.stringify({
@@ -44,6 +51,17 @@ test("package-removal cleanup is prepared before shutdown and removes both clien
         "memorax-code-claude-adapter@memorax-code-local": true,
       },
     })}\n`);
+    await writeFile(openCodePlugin, "// Managed by MemoraX Code. Do not edit.\n");
+    await writeFile(join(openCodeSkill, "SKILL.md"), "# MemoraX Code\n");
+    await writeFile(openCodeState, `${JSON.stringify({
+      version: 1,
+      runtime: "opencode",
+      integration: "plugin",
+      enabled: true,
+      openCodeConfigDir,
+      pluginPath: openCodePlugin,
+      skillPath: openCodeSkill,
+    })}\n`);
     await writeFile(claudeCommand, `#!/usr/bin/env node
 import { appendFileSync } from "node:fs";
 appendFileSync(${JSON.stringify(claudeCalls)}, JSON.stringify(process.argv.slice(2)) + "\\n");
@@ -55,13 +73,18 @@ appendFileSync(${JSON.stringify(claudeCalls)}, JSON.stringify(process.argv.slice
       homeDir: home,
       codexCommand: join(root, "missing-codex"),
       claudeCommand,
+      openCodeConfigDir,
     });
     const report = await cleanup();
 
     assert.equal(report.ok, true);
     assert.equal(report.codexPlugin?.ok, true);
     assert.equal(report.claudePlugin?.ok, true);
+    assert.equal(report.opencodePlugin?.ok, true);
     await assert.rejects(stat(codexPluginManifest), /ENOENT/);
+    await assert.rejects(stat(openCodePlugin), /ENOENT/);
+    await assert.rejects(stat(openCodeSkill), /ENOENT/);
+    await assert.rejects(stat(openCodeState), /ENOENT/);
     const calls = (await readFile(claudeCalls, "utf8")).trim().split("\n").map(JSON.parse);
     assert.deepEqual(calls, [
       [

--- a/packages/ts/memorax-code-backend/test/lifecycle/client-selection.test.mjs
+++ b/packages/ts/memorax-code-backend/test/lifecycle/client-selection.test.mjs
@@ -14,18 +14,20 @@ import {
   resolveManagedClients,
 } from "../../dist/lifecycle/client-selection.js";
 
-test("managed clients default to both integrations", () => {
-  assert.deepEqual(resolveManagedClients([], {}), { codex: true, claude: true });
+test("managed clients default to all integrations", () => {
+  assert.deepEqual(resolveManagedClients([], {}), { codex: true, claude: true, opencode: true });
 });
 
 test("managed clients use persisted config", () => {
   assert.deepEqual(resolveManagedClients([], { clients: { codex: true, claude: false } }), {
     codex: true,
     claude: false,
+    opencode: false,
   });
-  assert.deepEqual(resolveManagedClients([], { clients: { codex: false, claude: true } }), {
+  assert.deepEqual(resolveManagedClients([], { clients: { codex: false, claude: true, opencode: true } }), {
     codex: false,
     claude: true,
+    opencode: true,
   });
 });
 
@@ -35,15 +37,18 @@ test("--clients overrides persisted config", () => {
   ], { clients: { codex: true, claude: false } }), {
     codex: false,
     claude: true,
+    opencode: false,
   });
 });
 
 test("--clients accepts exact client sets", () => {
-  assert.deepEqual(parseManagedClients("codex"), { codex: true, claude: false });
-  assert.deepEqual(parseManagedClients("claude"), { codex: false, claude: true });
-  assert.deepEqual(parseManagedClients("codex,claude"), { codex: true, claude: true });
-  assert.deepEqual(parseManagedClients("all"), { codex: true, claude: true });
-  assert.deepEqual(parseManagedClients("none"), { codex: false, claude: false });
+  assert.deepEqual(parseManagedClients("codex"), { codex: true, claude: false, opencode: false });
+  assert.deepEqual(parseManagedClients("claude"), { codex: false, claude: true, opencode: false });
+  assert.deepEqual(parseManagedClients("opencode"), { codex: false, claude: false, opencode: true });
+  assert.deepEqual(parseManagedClients("codex,opencode"), { codex: true, claude: false, opencode: true });
+  assert.deepEqual(parseManagedClients("codex,claude,opencode"), { codex: true, claude: true, opencode: true });
+  assert.deepEqual(parseManagedClients("all"), { codex: true, claude: true, opencode: true });
+  assert.deepEqual(parseManagedClients("none"), { codex: false, claude: false, opencode: false });
 });
 
 test("--clients rejects missing and unknown values", () => {
@@ -107,14 +112,33 @@ test("active managed clients persist and clear independently of config", async (
   const home = await mkdtemp(join(tmpdir(), "memorax-code-active-client-selection-"));
   try {
     assert.equal(readActiveManagedClients(home), undefined);
-    writeActiveManagedClients(home, { codex: false, claude: true });
-    assert.deepEqual(readActiveManagedClients(home), { codex: false, claude: true });
+    writeActiveManagedClients(home, { codex: false, claude: true, opencode: true });
+    assert.deepEqual(readActiveManagedClients(home), { codex: false, claude: true, opencode: true });
     assert.deepEqual(
       JSON.parse(await readFile(join(home, "runtime", "backend", "managed-clients.json"), "utf8")),
-      { codex: false, claude: true },
+      { codex: false, claude: true, opencode: true },
     );
     clearActiveManagedClients(home);
     assert.equal(readActiveManagedClients(home), undefined);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("active managed clients migrate legacy state without OpenCode to disabled", async () => {
+  const home = await mkdtemp(join(tmpdir(), "memorax-code-active-client-selection-legacy-"));
+  try {
+    const stateDir = join(home, "runtime", "backend");
+    await mkdir(stateDir, { recursive: true });
+    await writeFile(join(stateDir, "managed-clients.json"), JSON.stringify({
+      codex: true,
+      claude: false,
+    }));
+    assert.deepEqual(readActiveManagedClients(home), {
+      codex: true,
+      claude: false,
+      opencode: false,
+    });
   } finally {
     await rm(home, { recursive: true, force: true });
   }

--- a/packages/ts/memorax-code-backend/test/lifecycle/management-cli.test.mjs
+++ b/packages/ts/memorax-code-backend/test/lifecycle/management-cli.test.mjs
@@ -503,6 +503,7 @@ test("unqualified Backend recovery preserves both configured client integrations
     assert.deepEqual(JSON.parse(await readFile(activeClientsPath, "utf8")), {
       codex: true,
       claude: true,
+      opencode: false,
     });
 
     const backendOnlyStop = await runCli(cliPath, [
@@ -513,6 +514,7 @@ test("unqualified Backend recovery preserves both configured client integrations
     assert.deepEqual(JSON.parse(await readFile(activeClientsPath, "utf8")), {
       codex: true,
       claude: true,
+      opencode: false,
     });
 
     const recovered = await runCli(cliPath, ["start", "--json", ...commonArgs], { env });
@@ -523,9 +525,10 @@ test("unqualified Backend recovery preserves both configured client integrations
     assert.deepEqual(JSON.parse(await readFile(activeClientsPath, "utf8")), {
       codex: true,
       claude: true,
+      opencode: false,
     });
   } finally {
-    await runCli(cliPath, ["stop", "--json", ...commonArgs, "--clients", "all"], { env });
+    await runCli(cliPath, ["stop", "--json", ...commonArgs, "--clients", "codex,claude"], { env });
     await rm(home, { recursive: true, force: true });
     await rm(codexHome, { recursive: true, force: true });
     await rm(claudeHome, { recursive: true, force: true });
@@ -570,6 +573,7 @@ test("partial client stop preserves Backend until an explicit Backend-only stop"
     assert.deepEqual(JSON.parse(await readFile(join(home, "runtime", "backend", "managed-clients.json"), "utf8")), {
       codex: false,
       claude: true,
+      opencode: false,
     });
 
     const backendOnlyStopped = await runCli(cliPath, ["stop", "--json", ...commonArgs, "--clients", "none"]);
@@ -580,6 +584,7 @@ test("partial client stop preserves Backend until an explicit Backend-only stop"
     assert.deepEqual(JSON.parse(await readFile(join(home, "runtime", "backend", "managed-clients.json"), "utf8")), {
       codex: false,
       claude: true,
+      opencode: false,
     });
   } finally {
     await runCli(cliPath, ["stop", "--json", ...commonArgs, "--clients", "none"]);
@@ -715,6 +720,7 @@ test("failed Backend start preserves selected clients and direct Claude settings
     assert.deepEqual(JSON.parse(await readFile(join(home, "runtime", "backend", "managed-clients.json"), "utf8")), {
       codex: false,
       claude: true,
+      opencode: false,
     });
     assert.equal(await readFile(join(claudeHome, "settings.json"), "utf8"), originalSettings);
 

--- a/packages/ts/memorax-code-backend/test/lifecycle/opencode-lifecycle.test.mjs
+++ b/packages/ts/memorax-code-backend/test/lifecycle/opencode-lifecycle.test.mjs
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+import { freePort } from "../support/helpers.mjs";
+import { pathExists, runCli } from "./support/backend-service-fixtures.mjs";
+
+test("OpenCode participates in lifecycle selection and status reporting", { timeout: 30_000 }, async () => {
+  const home = await mkdtemp(join(tmpdir(), "memorax-code-opencode-lifecycle-home-"));
+  const openCodeConfigDir = await mkdtemp(join(tmpdir(), "memorax-code-opencode-lifecycle-config-"));
+  const port = await freePort();
+  const cliPath = fileURLToPath(new URL("../../dist/memorax-code.js", import.meta.url));
+  const commonArgs = [
+    "--home", home,
+    "--port", String(port),
+    "--opencode-config-dir", openCodeConfigDir,
+  ];
+  const statePath = join(home, "adapters", "opencode", "state.json");
+  const activeClientsPath = join(home, "runtime", "backend", "managed-clients.json");
+  const pluginPath = join(openCodeConfigDir, "plugins", "memorax-code.js");
+  const skillPath = join(openCodeConfigDir, "skills", "memorax-code", "SKILL.md");
+  try {
+    const started = await runCli(cliPath, [
+      "start", "--json", ...commonArgs, "--clients", "opencode",
+    ]);
+    assert.equal(started.code, 0, `${started.stdout}\n${started.stderr}`);
+    const startReport = JSON.parse(started.stdout);
+    assert.equal(startReport.action, "start");
+    assert.equal(startReport.opencodeAdapter.installed, true);
+    assert.equal(startReport.opencodeAdapter.enabled, true);
+    assert.equal(startReport.opencodeAdapter.integration, "plugin");
+    assert.equal(startReport.opencodeAdapter.backendUrlMatches, true);
+    assert.equal(startReport.opencodeAdapter.opencodeSkills.ok, true);
+    assert.equal(await pathExists(pluginPath), true);
+    assert.equal(await pathExists(skillPath), true);
+    assert.deepEqual(JSON.parse(await readFile(activeClientsPath, "utf8")), {
+      codex: false,
+      claude: false,
+      opencode: true,
+    });
+
+    const status = await runCli(cliPath, [
+      "status", "--json", ...commonArgs, "--clients", "opencode",
+    ]);
+    assert.equal(status.code, 0, `${status.stdout}\n${status.stderr}`);
+    const statusReport = JSON.parse(status.stdout);
+    assert.equal(statusReport.ok, true);
+    assert.equal(statusReport.opencodeAdapter.integration, "plugin");
+    assert.equal(statusReport.opencodeAdapter.enabled, true);
+
+    const humanStatus = await runCli(cliPath, [
+      "status", ...commonArgs, "--clients", "opencode",
+    ]);
+    assert.equal(humanStatus.code, 0, `${humanStatus.stdout}\n${humanStatus.stderr}`);
+    assert.match(humanStatus.stdout, /OpenCode adapter: ok integration=plugin skills=installed/);
+
+    await writeFile(activeClientsPath, `${JSON.stringify({
+      codex: false,
+      claude: true,
+      opencode: true,
+    }, null, 2)}\n`);
+    const partiallyStopped = await runCli(cliPath, [
+      "stop", "--json", ...commonArgs, "--clients", "opencode",
+    ]);
+    assert.equal(partiallyStopped.code, 0, `${partiallyStopped.stdout}\n${partiallyStopped.stderr}`);
+    const stopReport = JSON.parse(partiallyStopped.stdout);
+    assert.equal(stopReport.backend.skipped, true);
+    assert.equal(stopReport.backend.reason, "active_clients_remaining");
+    assert.equal(stopReport.opencodeAdapter.enabled, false);
+    assert.deepEqual(JSON.parse(await readFile(activeClientsPath, "utf8")), {
+      codex: false,
+      claude: true,
+      opencode: false,
+    });
+
+    const restarted = await runCli(cliPath, [
+      "restart", "--json", ...commonArgs, "--clients", "opencode",
+    ]);
+    assert.equal(restarted.code, 0, `${restarted.stdout}\n${restarted.stderr}`);
+    const restartReport = JSON.parse(restarted.stdout);
+    assert.equal(restartReport.action, "restart");
+    assert.equal(restartReport.opencodeAdapter.enabled, true);
+
+    const uninstalled = await runCli(cliPath, [
+      "uninstall", "--json", ...commonArgs,
+      "--clients", "opencode",
+      "--no-npm-uninstall",
+    ]);
+    assert.equal(uninstalled.code, 0, `${uninstalled.stdout}\n${uninstalled.stderr}`);
+    const uninstallReport = JSON.parse(uninstalled.stdout);
+    assert.equal(uninstallReport.action, "uninstall");
+    assert.equal(uninstallReport.opencodeAdapter.pluginRemove.ok, true);
+    assert.equal(await pathExists(pluginPath), false);
+    assert.equal(await pathExists(skillPath), false);
+    assert.equal(await pathExists(statePath), false);
+    assert.equal(await pathExists(activeClientsPath), false);
+  } finally {
+    await runCli(cliPath, ["stop", "--json", ...commonArgs, "--clients", "none"]);
+    await rm(home, { recursive: true, force: true });
+    await rm(openCodeConfigDir, { recursive: true, force: true });
+  }
+});

--- a/packages/ts/memorax-code-backend/test/lifecycle/orchestrator.test.mjs
+++ b/packages/ts/memorax-code-backend/test/lifecycle/orchestrator.test.mjs
@@ -307,7 +307,7 @@ test("memorax-code keeps Codex and Backend healthy after a managed Claude runtim
     "--port", String(port),
     "--codex-home", codexHome,
     "--claude-home", claudeHome,
-    "--clients", "all",
+    "--clients", "codex,claude",
   ];
   try {
     await Promise.all([
@@ -396,6 +396,7 @@ test("memorax-code uninstall preserves temporary Claude cleanup scope after plug
     assert.deepEqual(JSON.parse(await readFile(activeClientsPath, "utf8")), {
       codex: false,
       claude: true,
+      opencode: false,
     });
 
     const retried = await runCli(cliPath, [

--- a/packages/ts/memorax-code-backend/test/lifecycle/support/backend-service-fixtures.mjs
+++ b/packages/ts/memorax-code-backend/test/lifecycle/support/backend-service-fixtures.mjs
@@ -68,12 +68,13 @@ export async function pathExists(path) {
   }
 }
 
-export async function writeManagedClientsConfig(home, { codex, claude }) {
+export async function writeManagedClientsConfig(home, { codex, claude, opencode = false }) {
   await mkdir(home, { recursive: true });
   await writeFile(join(home, "config.toml"), [
     "[clients]",
     `codex = ${codex}`,
     `claude = ${claude}`,
+    `opencode = ${opencode}`,
     "",
   ].join("\n"));
 }

--- a/packages/ts/memorax-code-codex-adapter/skills/memorax-code/SKILL.md
+++ b/packages/ts/memorax-code-codex-adapter/skills/memorax-code/SKILL.md
@@ -72,7 +72,7 @@ Repo memory and personal memory remain local `.repo_memory` authorities. Resolve
 
 Apply instructions in this order: system and developer instructions, `AGENTS.md`, the current user request, then stored memory. Memory is guidance or historical context, not proof of current repository behavior.
 
-For MemoraX Code coding memory, use `memorax-cli` exactly as described by the selected reference. Invoke this skill as `$memorax-code` in Codex or `/memorax-code` in Claude Code; neither invocation is a shell command. `memorax-code` is the lifecycle CLI and must not be used for memory search or add. Do not call MemoraX HTTP endpoints directly.
+For MemoraX Code coding memory, use `memorax-cli` exactly as described by the selected reference. Invoke this skill as `$memorax-code` in Codex or `/memorax-code` in Claude Code. In OpenCode, ask the agent to use the `memorax-code` skill by name. These invocation forms are not shell commands. `memorax-code` is the lifecycle CLI and must not be used for memory search or add. Do not call MemoraX HTTP endpoints directly.
 
 When explaining Memory Viewer, describe only `/memory-viewer`. It is a
 content-free local summary and must not expose conversation or memory text,

--- a/packages/ts/memorax-code-codex-adapter/skills/memorax-code/references/memorax-add.md
+++ b/packages/ts/memorax-code-codex-adapter/skills/memorax-code/references/memorax-add.md
@@ -1,6 +1,6 @@
 # MemoraX Code Coding Memory Add
 
-Use these instructions only to add reusable coding knowledge through `memorax-cli`. Invoke the skill as `$memorax-code` in Codex or `/memorax-code` in Claude Code; do not route memory operations through the lifecycle-only `memorax-code` CLI. Do not use this authority for personal procedures, interaction preferences, generated repository facts, or one-off task details.
+Use these instructions only to add reusable coding knowledge through `memorax-cli`. Invoke the skill as `$memorax-code` in Codex or `/memorax-code` in Claude Code. In OpenCode, ask the agent to use the `memorax-code` skill by name. Do not route memory operations through the lifecycle-only `memorax-code` CLI. Do not use this authority for personal procedures, interaction preferences, generated repository facts, or one-off task details.
 
 ## Eligible Knowledge
 

--- a/packages/ts/memorax-code-codex-adapter/skills/memorax-code/references/memorax-search.md
+++ b/packages/ts/memorax-code-codex-adapter/skills/memorax-code/references/memorax-search.md
@@ -1,6 +1,6 @@
 # MemoraX Code Coding Memory Search
 
-Use these instructions only to search reusable coding memory through `memorax-cli`. Invoke the skill as `$memorax-code` in Codex or `/memorax-code` in Claude Code; do not route memory operations through the lifecycle-only `memorax-code` CLI. Do not call MemoraX HTTP endpoints directly, print credentials, or edit memory storage by hand.
+Use these instructions only to search reusable coding memory through `memorax-cli`. Invoke the skill as `$memorax-code` in Codex or `/memorax-code` in Claude Code. In OpenCode, ask the agent to use the `memorax-code` skill by name. Do not route memory operations through the lifecycle-only `memorax-code` CLI. Do not call MemoraX HTTP endpoints directly, print credentials, or edit memory storage by hand.
 
 ## Scope
 

--- a/packages/ts/memorax-code-codex-adapter/skills/memorax-code/references/personal-read.md
+++ b/packages/ts/memorax-code-codex-adapter/skills/memorax-code/references/personal-read.md
@@ -39,7 +39,7 @@ python3 <skill-dir>/scripts/user_profile_memory.py list --repo <repo>
 
 Use only active preferences returned by the script. If the preferences file does not exist, report that no user-profile memory is available; the list operation does not create it.
 
-Mention only preferences relevant to the current request unless the user explicitly asks to list all of them. Stored preferences describe how Codex should interact with the user; they are not repository facts.
+Mention only preferences relevant to the current request unless the user explicitly asks to list all of them. Stored preferences describe how the coding agent should interact with the user; they are not repository facts.
 
 ## Priority
 

--- a/packages/ts/memorax-code-codex-adapter/test/memorax-code-skill.test.mjs
+++ b/packages/ts/memorax-code-codex-adapter/test/memorax-code-skill.test.mjs
@@ -26,6 +26,7 @@ test("memorax-code is the single progressive router for all memory authorities",
   assert.match(skill, /current-task instructions and temporary plans/);
   assert.match(skill, /Do not call MemoraX HTTP endpoints directly/);
   assert.match(skill, /Invoke this skill as `\$memorax-code` in Codex or `\/memorax-code` in Claude Code/);
+  assert.match(skill, /In OpenCode, ask the agent to use the `memorax-code` skill by name/);
   assert.match(skill, /`memorax-code` is the lifecycle CLI and must not be used for memory search or add/);
 
   for (const reference of [
@@ -62,6 +63,7 @@ test("memorax-code references keep authority and operation boundaries explicit",
   const personalWrite = readSkillFile("references/personal-write.md");
 
   assert.match(memoraxSearch, /memorax-cli search/);
+  assert.match(memoraxSearch, /In OpenCode, ask the agent to use the `memorax-code` skill by name/);
   assert.match(memoraxSearch, /at most one focused search/);
   assert.match(memoraxSearch, /Do not call MemoraX HTTP endpoints directly/);
   assert.match(memoraxSearch, /memorax-cli search --query '/);
@@ -77,6 +79,7 @@ test("memorax-code references keep authority and operation boundaries explicit",
   assert.match(memoraxSearch, /Present its `userNotice` once without pausing the current task/);
   assert.doesNotMatch(memoraxSearch, /--query-file/);
   assert.match(memoraxAdd, /CODE_AGENT_MEMORY/);
+  assert.match(memoraxAdd, /In OpenCode, ask the agent to use the `memorax-code` skill by name/);
   assert.match(memoraxAdd, /Route user-owned ordered actions/);
   assert.match(memoraxAdd, /For a proactive add, write all generated prose/);
   assert.match(memoraxAdd, /language of the user's current request/);
@@ -97,6 +100,7 @@ test("memorax-code references keep authority and operation boundaries explicit",
   assert.match(repoUpdate, /Update existing repo memory from a delta/);
   assert.match(repoUpdate, /scripts\/detect_updates\.py/);
   assert.match(personalRead, /Do not write, normalize, migrate, repair, or delete memory/);
+  assert.match(personalRead, /how the coding agent should interact with the user/);
   assert.match(personalWrite, /Require the user to explicitly ask/);
   assert.match(personalWrite, /may be saved implicitly/);
 });

--- a/packages/ts/memorax-code-opencode-adapter/src/adapter-paths.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/src/adapter-paths.mjs
@@ -1,0 +1,29 @@
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+
+export function defaultOpenCodeConfigDir(env = process.env, home = homedir()) {
+  const explicit = stringOption(env.OPENCODE_CONFIG_DIR);
+  if (explicit) return resolve(explicit);
+  const configHome = stringOption(env.XDG_CONFIG_HOME) ?? join(home, ".config");
+  return resolve(configHome, "opencode");
+}
+
+export function defaultMemoraxCodeHome(env = process.env, home = homedir()) {
+  return resolve(stringOption(env.MEMORAX_CODE_HOME) ?? join(home, ".memorax-code"));
+}
+
+export function adapterStatePath(memoraxCodeHome = defaultMemoraxCodeHome()) {
+  return join(memoraxCodeHome, "adapters", "opencode", "state.json");
+}
+
+export function openCodePluginPath(configDir = defaultOpenCodeConfigDir()) {
+  return join(configDir, "plugins", "memorax-code.js");
+}
+
+export function openCodeSkillPath(configDir = defaultOpenCodeConfigDir()) {
+  return join(configDir, "skills", "memorax-code");
+}
+
+function stringOption(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}

--- a/packages/ts/memorax-code-opencode-adapter/src/plugin-install.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/src/plugin-install.mjs
@@ -39,9 +39,11 @@ export function ensureOpenCodePluginInstalled(options = {}) {
   const sourceProblem = validateSources(paths);
   if (sourceProblem) return { ...sourceProblem, action: "opencode-plugin-install" };
 
-  const pluginIsManaged = previousState?.pluginPath === paths.pluginPath;
+  const pluginExists = existsSync(paths.pluginPath);
+  const pluginIsManaged = previousState?.pluginPath === paths.pluginPath
+    && (!pluginExists || isManagedLoader(paths.pluginPath));
   const skillIsManaged = previousState?.skillPath === paths.skillPath;
-  if (existsSync(paths.pluginPath) && !pluginIsManaged) {
+  if (pluginExists && !pluginIsManaged) {
     return conflict("plugin_conflict", paths, paths.pluginPath);
   }
   if (existsSync(paths.skillPath) && !skillIsManaged) {
@@ -61,11 +63,6 @@ export function ensureOpenCodePluginInstalled(options = {}) {
     && previousState?.enabled === true
     && normalizeOptionalBackendUrl(previousState.backendUrl) === backendUrl;
 
-  if (!artifactsCurrent) {
-    materializeSkill(paths.skillSourcePath, paths.skillPath);
-    atomicWriteText(paths.pluginPath, loader);
-  }
-
   const now = new Date().toISOString();
   const state = {
     version: STATE_VERSION,
@@ -83,7 +80,19 @@ export function ensureOpenCodePluginInstalled(options = {}) {
     installedAt: stringOption(previousState?.installedAt) ?? now,
     updatedAt: now,
   };
-  atomicWriteJson(paths.statePath, state);
+  const pluginExisted = existsSync(paths.pluginPath);
+  const skillExisted = existsSync(paths.skillPath);
+  try {
+    if (!artifactsCurrent) {
+      materializeSkill(paths.skillSourcePath, paths.skillPath);
+      atomicWriteText(paths.pluginPath, loader);
+    }
+    atomicWriteJson(paths.statePath, state);
+  } catch (error) {
+    removeNewArtifact(paths.pluginPath, pluginExisted);
+    removeNewArtifact(paths.skillPath, skillExisted, true);
+    throw error;
+  }
   removePreviousInstallation(previousState, paths);
 
   return {
@@ -414,6 +423,15 @@ function removePreviousInstallation(previousState, paths) {
   }
   if (previousState.skillPath !== paths.skillPath) {
     rmSync(previousState.skillPath, { recursive: true, force: true });
+  }
+}
+
+function removeNewArtifact(path, existed, recursive = false) {
+  if (existed) return;
+  try {
+    rmSync(path, { recursive, force: true });
+  } catch {
+    // Preserve the original installation failure.
   }
 }
 

--- a/packages/ts/memorax-code-opencode-adapter/src/plugin-install.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/src/plugin-install.mjs
@@ -1,0 +1,505 @@
+import { createHash, randomUUID } from "node:crypto";
+import {
+  cpSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  readlinkSync,
+  renameSync,
+  rmSync,
+} from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { pathToFileURL, fileURLToPath } from "node:url";
+import {
+  atomicWriteJson,
+  atomicWriteText,
+  readAdapterState,
+  stringOption,
+} from "../../memorax-code-adapter-common/src/config-utils.mjs";
+import { DEFAULT_BACKEND_URL as BACKEND_DEFAULT } from "../../memorax-code-adapter-common/src/backend-connection.mjs";
+import {
+  adapterStatePath,
+  defaultMemoraxCodeHome,
+  defaultOpenCodeConfigDir,
+  openCodePluginPath,
+  openCodeSkillPath,
+} from "./adapter-paths.mjs";
+
+const STATE_VERSION = 1;
+const MANAGED_LOADER_HEADER = "// Managed by MemoraX Code. Do not edit.";
+const ADAPTER_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+export function ensureOpenCodePluginInstalled(options = {}) {
+  const paths = resolvePaths(options);
+  const previousState = readAdapterState(paths.statePath);
+  const stateProblem = validateState(previousState, paths.statePath);
+  if (stateProblem) return { ...stateProblem, action: "opencode-plugin-install" };
+  const sourceProblem = validateSources(paths);
+  if (sourceProblem) return { ...sourceProblem, action: "opencode-plugin-install" };
+
+  const pluginIsManaged = previousState?.pluginPath === paths.pluginPath;
+  const skillIsManaged = previousState?.skillPath === paths.skillPath;
+  if (existsSync(paths.pluginPath) && !pluginIsManaged) {
+    return conflict("plugin_conflict", paths, paths.pluginPath);
+  }
+  if (existsSync(paths.skillPath) && !skillIsManaged) {
+    return conflict("skill_conflict", paths, paths.skillPath);
+  }
+
+  const backendUrl = normalizeBackendUrl(
+    options.backendUrl ?? previousState?.backendUrl ?? BACKEND_DEFAULT,
+  );
+  const pluginSourceSha256 = fileSha256(paths.pluginSourcePath);
+  const loader = createManagedLoader(paths, pluginSourceSha256);
+  const artifactsCurrent = pluginIsManaged
+    && skillIsManaged
+    && fileContentsEqual(paths.pluginPath, loader)
+    && directoriesEqual(paths.skillSourcePath, paths.skillPath);
+  const current = artifactsCurrent
+    && previousState?.enabled === true
+    && normalizeOptionalBackendUrl(previousState.backendUrl) === backendUrl;
+
+  if (!artifactsCurrent) {
+    materializeSkill(paths.skillSourcePath, paths.skillPath);
+    atomicWriteText(paths.pluginPath, loader);
+  }
+
+  const now = new Date().toISOString();
+  const state = {
+    version: STATE_VERSION,
+    runtime: "opencode",
+    integration: "plugin",
+    enabled: true,
+    backendUrl,
+    openCodeConfigDir: paths.openCodeConfigDir,
+    pluginPath: paths.pluginPath,
+    pluginSourcePath: paths.pluginSourcePath,
+    pluginSourceSha256,
+    skillPath: paths.skillPath,
+    skillSourcePath: paths.skillSourcePath,
+    ...(paths.cliBinDir ? { cliBinDir: paths.cliBinDir } : {}),
+    installedAt: stringOption(previousState?.installedAt) ?? now,
+    updatedAt: now,
+  };
+  atomicWriteJson(paths.statePath, state);
+  removePreviousInstallation(previousState, paths);
+
+  return {
+    ok: true,
+    action: "opencode-plugin-install",
+    installed: true,
+    enabled: true,
+    managed: true,
+    integration: "plugin",
+    configuredBackendUrl: backendUrl,
+    expectedBackendUrl: backendUrl,
+    backendUrlMatches: true,
+    opencodeSkills: skillSummary(paths.skillPath, true),
+    changed: !current,
+    restartRequired: !artifactsCurrent,
+    statePath: paths.statePath,
+    pluginPath: paths.pluginPath,
+    skillPath: paths.skillPath,
+    state,
+  };
+}
+
+export function readOpenCodePluginStatus(options = {}) {
+  const paths = resolvePaths(options);
+  const state = readAdapterState(paths.statePath);
+  const stateProblem = validateState(state, paths.statePath);
+  if (stateProblem) return { ...stateProblem, action: "opencode-plugin-status", installed: false, enabled: false };
+  if (!state) {
+    return {
+      ok: true,
+      action: "opencode-plugin-status",
+      installed: false,
+      enabled: false,
+      managed: false,
+      integration: "plugin",
+      configuredBackendUrl: undefined,
+      expectedBackendUrl: normalizeOptionalBackendUrl(options.backendUrl),
+      backendUrlMatches: true,
+      opencodeSkills: skillSummary(paths.skillPath, false),
+      statePath: paths.statePath,
+      pluginPath: paths.pluginPath,
+      skillPath: paths.skillPath,
+      skipped: true,
+      reason: "not_managed",
+    };
+  }
+
+  const configuredPaths = resolvePaths({
+    ...options,
+    openCodeConfigDir: state.openCodeConfigDir,
+    pluginSourcePath: options.pluginSourcePath ?? state.pluginSourcePath,
+    skillSourcePath: options.skillSourcePath ?? state.skillSourcePath,
+    cliBinDir: options.cliBinDir ?? state.cliBinDir,
+  });
+  if (state.pluginPath !== configuredPaths.pluginPath || state.skillPath !== configuredPaths.skillPath) {
+    return {
+      ok: false,
+      action: "opencode-plugin-status",
+      installed: false,
+      enabled: false,
+      managed: true,
+      reason: "state_paths_invalid",
+      statePath: paths.statePath,
+    };
+  }
+
+  const pluginExists = existsSync(configuredPaths.pluginPath);
+  const skillExists = existsSync(join(configuredPaths.skillPath, "SKILL.md"));
+  const sourcesReady = !validateSources(configuredPaths);
+  const pluginSourceSha256 = sourcesReady ? fileSha256(configuredPaths.pluginSourcePath) : undefined;
+  const pluginCurrent = sourcesReady && fileContentsEqual(
+    configuredPaths.pluginPath,
+    createManagedLoader(configuredPaths, pluginSourceSha256),
+  );
+  const skillCurrent = sourcesReady
+    && directoriesEqual(configuredPaths.skillSourcePath, configuredPaths.skillPath);
+  const installed = pluginExists && skillExists;
+  const enabled = state.enabled === true && installed && pluginCurrent && skillCurrent;
+  const configuredBackendUrl = normalizeOptionalBackendUrl(state.backendUrl);
+  const expectedBackendUrl = normalizeOptionalBackendUrl(options.backendUrl);
+  const backendUrlMatches = !expectedBackendUrl || configuredBackendUrl === expectedBackendUrl;
+  return {
+    ok: true,
+    action: "opencode-plugin-status",
+    installed,
+    enabled,
+    managed: true,
+    integration: "plugin",
+    current: pluginCurrent && skillCurrent,
+    pluginExists,
+    pluginCurrent,
+    skillExists,
+    skillCurrent,
+    configuredBackendUrl,
+    expectedBackendUrl,
+    backendUrlMatches,
+    opencodeSkills: skillSummary(configuredPaths.skillPath, skillCurrent),
+    statePath: paths.statePath,
+    pluginPath: configuredPaths.pluginPath,
+    skillPath: configuredPaths.skillPath,
+    state,
+    ...(!backendUrlMatches
+      ? { reason: "backend_url_mismatch" }
+      : !enabled
+        ? { reason: statusReason({ sourcesReady, pluginExists, pluginCurrent, skillExists, skillCurrent }) }
+        : {}),
+  };
+}
+
+export function disableOpenCodePlugin(options = {}) {
+  const paths = resolvePaths(options);
+  const state = readAdapterState(paths.statePath);
+  const stateProblem = validateState(state, paths.statePath);
+  if (stateProblem) return { ...stateProblem, action: "opencode-plugin-disable" };
+  if (!state) {
+    return {
+      ok: true,
+      action: "opencode-plugin-disable",
+      installed: false,
+      enabled: false,
+      managed: false,
+      integration: "plugin",
+      skipped: true,
+      reason: "not_managed",
+      statePath: paths.statePath,
+    };
+  }
+
+  const nextState = {
+    ...state,
+    enabled: false,
+    disabledAt: new Date().toISOString(),
+  };
+  atomicWriteJson(paths.statePath, nextState);
+  return {
+    ok: true,
+    action: "opencode-plugin-disable",
+    installed: existsSync(state.pluginPath) && existsSync(join(state.skillPath, "SKILL.md")),
+    enabled: false,
+    managed: true,
+    integration: "plugin",
+    changed: state.enabled === true,
+    statePath: paths.statePath,
+    state: nextState,
+  };
+}
+
+export function removeOpenCodePluginInstallation(options = {}) {
+  const paths = resolvePaths(options);
+  const state = readAdapterState(paths.statePath);
+  const stateProblem = validateState(state, paths.statePath);
+  if (stateProblem) return { ...stateProblem, action: "opencode-plugin-remove" };
+  if (!state) {
+    return {
+      ok: true,
+      action: "opencode-plugin-remove",
+      skipped: true,
+      reason: "not_managed",
+      statePath: paths.statePath,
+    };
+  }
+
+  const openCodeConfigDir = resolve(state.openCodeConfigDir);
+  const pluginPath = openCodePluginPath(openCodeConfigDir);
+  const skillPath = openCodeSkillPath(openCodeConfigDir);
+  if (state.pluginPath !== pluginPath || state.skillPath !== skillPath) {
+    return {
+      ok: false,
+      action: "opencode-plugin-remove",
+      reason: "state_paths_invalid",
+      statePath: paths.statePath,
+    };
+  }
+  if (existsSync(pluginPath) && !isManagedLoader(pluginPath)) {
+    return {
+      ok: false,
+      action: "opencode-plugin-remove",
+      reason: "plugin_not_managed",
+      statePath: paths.statePath,
+      pluginPath,
+    };
+  }
+
+  rmSync(pluginPath, { force: true });
+  rmSync(skillPath, { recursive: true, force: true });
+  rmSync(paths.statePath, { force: true });
+  return {
+    ok: true,
+    action: "opencode-plugin-remove",
+    installed: false,
+    enabled: false,
+    managed: false,
+    integration: "plugin",
+    statePath: paths.statePath,
+    pluginPath,
+    skillPath,
+  };
+}
+
+export function defaultOpenCodePluginSourcePath() {
+  return join(ADAPTER_ROOT, "src", "plugin.mjs");
+}
+
+export function defaultOpenCodeSkillSourcePath() {
+  const packagedSkill = join(ADAPTER_ROOT, "skills", "memorax-code");
+  return existsSync(join(packagedSkill, "SKILL.md"))
+    ? packagedSkill
+    : resolve(ADAPTER_ROOT, "..", "memorax-code-codex-adapter", "skills", "memorax-code");
+}
+
+export function defaultOpenCodeCliBinDir(adapterRoot = ADAPTER_ROOT) {
+  const packageRoot = resolve(adapterRoot, "..", "..");
+  const candidates = [
+    resolve(packageRoot, "..", "..", ".bin"),
+    resolve(packageRoot, "..", "..", ".."),
+    resolve(packageRoot, "..", "..", "..", "..", "bin"),
+    join(packageRoot, "bin"),
+  ];
+  return candidates.find(hasMemoraxCliCommand);
+}
+
+function resolvePaths(options) {
+  const memoraxCodeHome = resolve(options.memoraxCodeHome ?? defaultMemoraxCodeHome());
+  const openCodeConfigDir = resolve(options.openCodeConfigDir ?? defaultOpenCodeConfigDir());
+  return {
+    memoraxCodeHome,
+    openCodeConfigDir,
+    statePath: resolve(options.statePath ?? adapterStatePath(memoraxCodeHome)),
+    pluginPath: openCodePluginPath(openCodeConfigDir),
+    skillPath: openCodeSkillPath(openCodeConfigDir),
+    pluginSourcePath: resolve(options.pluginSourcePath ?? defaultOpenCodePluginSourcePath()),
+    skillSourcePath: resolve(options.skillSourcePath ?? defaultOpenCodeSkillSourcePath()),
+    cliBinDir: stringOption(options.cliBinDir)
+      ? resolve(options.cliBinDir)
+      : defaultOpenCodeCliBinDir(),
+  };
+}
+
+function validateState(state, statePath) {
+  if (state?.unreadable) {
+    return { ok: false, reason: "state_unreadable", statePath };
+  }
+  if (state && state.version !== STATE_VERSION) {
+    return {
+      ok: false,
+      reason: "state_version_unsupported",
+      statePath,
+      expectedVersion: STATE_VERSION,
+      actualVersion: state.version,
+    };
+  }
+  if (state) {
+    const openCodeConfigDir = stringOption(state.openCodeConfigDir);
+    const pluginPath = stringOption(state.pluginPath);
+    const skillPath = stringOption(state.skillPath);
+    if (state.runtime !== "opencode"
+      || state.integration !== "plugin"
+      || !openCodeConfigDir
+      || !pluginPath
+      || !skillPath) {
+      return { ok: false, reason: "state_invalid", statePath };
+    }
+    const resolvedConfigDir = resolve(openCodeConfigDir);
+    if (openCodeConfigDir !== resolvedConfigDir
+      || pluginPath !== openCodePluginPath(resolvedConfigDir)
+      || skillPath !== openCodeSkillPath(resolvedConfigDir)) {
+      return { ok: false, reason: "state_paths_invalid", statePath };
+    }
+  }
+  return undefined;
+}
+
+function validateSources(paths) {
+  if (!existsSync(paths.pluginSourcePath)) {
+    return { ok: false, reason: "plugin_source_missing", sourcePath: paths.pluginSourcePath };
+  }
+  if (!existsSync(join(paths.skillSourcePath, "SKILL.md"))) {
+    return { ok: false, reason: "skill_source_missing", sourcePath: paths.skillSourcePath };
+  }
+  return undefined;
+}
+
+function conflict(reason, paths, conflictPath) {
+  return {
+    ok: false,
+    action: "opencode-plugin-install",
+    reason,
+    conflictPath,
+    statePath: paths.statePath,
+    pluginPath: paths.pluginPath,
+    skillPath: paths.skillPath,
+  };
+}
+
+function createManagedLoader(paths, pluginSourceSha256) {
+  const pluginUrl = pathToFileURL(paths.pluginSourcePath).href;
+  const pluginOptions = {
+    memoraxCodeHome: paths.memoraxCodeHome,
+    statePath: paths.statePath,
+    ...(paths.cliBinDir ? { cliBinDir: paths.cliBinDir } : {}),
+  };
+  return [
+    MANAGED_LOADER_HEADER,
+    `// Plugin source SHA-256: ${pluginSourceSha256}`,
+    `import { createMemoraxOpenCodePlugin } from ${JSON.stringify(pluginUrl)};`,
+    "",
+    `export const MemoraxOpenCodePlugin = createMemoraxOpenCodePlugin(${JSON.stringify(pluginOptions)});`,
+    "",
+  ].join("\n");
+}
+
+function materializeSkill(sourcePath, targetPath) {
+  mkdirSync(dirname(targetPath), { recursive: true });
+  const stagePath = `${targetPath}.tmp-${process.pid}-${randomUUID()}`;
+  try {
+    cpSync(sourcePath, stagePath, { recursive: true });
+    rmSync(targetPath, { recursive: true, force: true });
+    renameSync(stagePath, targetPath);
+  } finally {
+    rmSync(stagePath, { recursive: true, force: true });
+  }
+}
+
+function removePreviousInstallation(previousState, paths) {
+  if (!previousState) return;
+  if (previousState.pluginPath !== paths.pluginPath && isManagedLoader(previousState.pluginPath)) {
+    rmSync(previousState.pluginPath, { force: true });
+  }
+  if (previousState.skillPath !== paths.skillPath) {
+    rmSync(previousState.skillPath, { recursive: true, force: true });
+  }
+}
+
+function isManagedLoader(path) {
+  if (!path || !existsSync(path)) return false;
+  try {
+    return readFileSync(path, "utf8").startsWith(`${MANAGED_LOADER_HEADER}\n`);
+  } catch {
+    return false;
+  }
+}
+
+function fileContentsEqual(path, expected) {
+  try {
+    return readFileSync(path, "utf8") === expected;
+  } catch {
+    return false;
+  }
+}
+
+function fileSha256(path) {
+  return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+function hasMemoraxCliCommand(directory) {
+  return ["memorax-cli", "memorax-cli.cmd", "memorax-cli.exe"]
+    .some((name) => existsSync(join(directory, name)));
+}
+
+function directoriesEqual(sourceRoot, targetRoot) {
+  if (!existsSync(sourceRoot) || !existsSync(targetRoot)) return false;
+  const sourceEntries = collectDirectoryEntries(sourceRoot);
+  const targetEntries = collectDirectoryEntries(targetRoot);
+  if (sourceEntries.length !== targetEntries.length) return false;
+  return sourceEntries.every((source, index) => {
+    const target = targetEntries[index];
+    return source.path === target.path
+      && source.kind === target.kind
+      && source.content === target.content;
+  });
+}
+
+function collectDirectoryEntries(root) {
+  const entries = [];
+  visit(root);
+  return entries.sort((left, right) => left.path.localeCompare(right.path));
+
+  function visit(path) {
+    for (const name of readdirSync(path)) {
+      const absolutePath = join(path, name);
+      const entryPath = relative(root, absolutePath);
+      const stat = lstatSync(absolutePath);
+      if (stat.isDirectory()) {
+        entries.push({ path: entryPath, kind: "directory", content: "" });
+        visit(absolutePath);
+      } else if (stat.isSymbolicLink()) {
+        entries.push({ path: entryPath, kind: "symlink", content: readlinkSync(absolutePath) });
+      } else {
+        entries.push({ path: entryPath, kind: "file", content: readFileSync(absolutePath).toString("base64") });
+      }
+    }
+  }
+}
+
+function statusReason({ sourcesReady, pluginExists, pluginCurrent, skillExists, skillCurrent }) {
+  if (!sourcesReady) return "source_missing";
+  if (!pluginExists) return "plugin_missing";
+  if (!pluginCurrent) return "plugin_stale";
+  if (!skillExists) return "skill_missing";
+  if (!skillCurrent) return "skill_stale";
+  return "not_enabled";
+}
+
+function normalizeBackendUrl(value) {
+  return String(value).replace(/\/+$/, "");
+}
+
+function normalizeOptionalBackendUrl(value) {
+  return stringOption(value) ? normalizeBackendUrl(value) : undefined;
+}
+
+function skillSummary(skillPath, ok) {
+  return {
+    ok,
+    status: ok ? "installed" : "missing",
+    sourceKind: "canonical",
+    path: skillPath,
+  };
+}

--- a/packages/ts/memorax-code-opencode-adapter/test/plugin-install.test.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/test/plugin-install.test.mjs
@@ -1,0 +1,183 @@
+import { strict as assert } from "node:assert";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { test } from "node:test";
+import { defaultOpenCodeConfigDir } from "../src/adapter-paths.mjs";
+import {
+  defaultOpenCodeCliBinDir,
+  disableOpenCodePlugin,
+  ensureOpenCodePluginInstalled,
+  readOpenCodePluginStatus,
+  removeOpenCodePluginInstallation,
+} from "../src/plugin-install.mjs";
+
+test("OpenCode config discovery honors its explicit and XDG homes", () => {
+  assert.equal(
+    defaultOpenCodeConfigDir({ OPENCODE_CONFIG_DIR: "/custom/opencode", XDG_CONFIG_HOME: "/ignored" }, "/home/user"),
+    "/custom/opencode",
+  );
+  assert.equal(
+    defaultOpenCodeConfigDir({ XDG_CONFIG_HOME: "/xdg/config" }, "/home/user"),
+    "/xdg/config/opencode",
+  );
+  assert.equal(defaultOpenCodeConfigDir({}, "/home/user"), "/home/user/.config/opencode");
+});
+
+test("OpenCode CLI path discovery recognizes the staged npm package layout", async () => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-code-opencode-staged-layout-"));
+  try {
+    const packageRoot = join(root, "prefix", "lib", "node_modules", "@memorax", "memorax-code");
+    const adapterRoot = join(packageRoot, "lib", "memorax-code-opencode-adapter");
+    const commandBin = join(root, "prefix", "bin");
+    await mkdir(adapterRoot, { recursive: true });
+    await mkdir(commandBin, { recursive: true });
+    await writeFile(join(commandBin, "memorax-cli"), "#!/bin/sh\n");
+    assert.equal(defaultOpenCodeCliBinDir(adapterRoot), commandBin);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("OpenCode plugin install materializes a managed loader, canonical skill, and state", async () => {
+  const fixture = await createFixture("install");
+  try {
+    const installed = ensureOpenCodePluginInstalled(fixture.options);
+    assert.equal(installed.ok, true);
+    assert.equal(installed.changed, true);
+    assert.equal(installed.restartRequired, true);
+    const loader = await readFile(installed.pluginPath, "utf8");
+    assert.match(loader, /^\/\/ Managed by MemoraX Code/);
+    assert.match(loader, new RegExp(escapeRegex(JSON.stringify(pathToFileURL(fixture.pluginSourcePath).href))));
+    assert.match(loader, new RegExp(escapeRegex(`"memoraxCodeHome":${JSON.stringify(fixture.options.memoraxCodeHome)}`)));
+    assert.match(loader, /"cliBinDir":"\/managed\/bin"/);
+    assert.equal(await readFile(join(installed.skillPath, "SKILL.md"), "utf8"), "# MemoraX Code\n");
+    assert.equal(await readFile(join(installed.skillPath, "references", "search.md"), "utf8"), "search\n");
+    const state = JSON.parse(await readFile(installed.statePath, "utf8"));
+    assert.equal(state.runtime, "opencode");
+    assert.equal(state.openCodeConfigDir, fixture.openCodeConfigDir);
+
+    const status = readOpenCodePluginStatus(fixture.options);
+    assert.equal(status.ok, true);
+    assert.equal(status.installed, true);
+    assert.equal(status.current, true);
+
+    const unchanged = ensureOpenCodePluginInstalled(fixture.options);
+    assert.equal(unchanged.ok, true);
+    assert.equal(unchanged.changed, false);
+    assert.equal(unchanged.restartRequired, false);
+
+    await writeFile(fixture.pluginSourcePath, "export function createMemoraxOpenCodePlugin() { return 'updated'; }\n");
+    assert.equal(readOpenCodePluginStatus(fixture.options).pluginCurrent, false);
+    const updated = ensureOpenCodePluginInstalled(fixture.options);
+    assert.equal(updated.changed, true);
+    assert.equal(updated.restartRequired, true);
+    assert.match(await readFile(updated.pluginPath, "utf8"), /Plugin source SHA-256: [a-f0-9]{64}/);
+  } finally {
+    await rm(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("OpenCode plugin install refuses to overwrite an unmanaged discovery file", async () => {
+  const fixture = await createFixture("conflict");
+  const pluginPath = join(fixture.openCodeConfigDir, "plugins", "memorax-code.js");
+  try {
+    await mkdir(join(fixture.openCodeConfigDir, "plugins"), { recursive: true });
+    await writeFile(pluginPath, "export const UserPlugin = async () => ({});\n");
+
+    const result = ensureOpenCodePluginInstalled(fixture.options);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "plugin_conflict");
+    assert.equal(await readFile(pluginPath, "utf8"), "export const UserPlugin = async () => ({});\n");
+  } finally {
+    await rm(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("OpenCode plugin removal deletes only the recorded managed artifacts", async () => {
+  const fixture = await createFixture("remove");
+  try {
+    const installed = ensureOpenCodePluginInstalled(fixture.options);
+    assert.equal(installed.ok, true);
+    const unrelatedConfig = join(fixture.openCodeConfigDir, "opencode.jsonc");
+    await writeFile(unrelatedConfig, "{ // user config\n}\n");
+
+    const disabled = disableOpenCodePlugin(fixture.options);
+    assert.equal(disabled.ok, true);
+    assert.equal(disabled.enabled, false);
+    const disabledStatus = readOpenCodePluginStatus(fixture.options);
+    assert.equal(disabledStatus.ok, true);
+    assert.equal(disabledStatus.reason, "not_enabled");
+    assert.match(await readFile(installed.pluginPath, "utf8"), /^\/\/ Managed by MemoraX Code/);
+
+    const removed = removeOpenCodePluginInstallation(fixture.options);
+
+    assert.equal(removed.ok, true);
+    assert.equal(await readFile(unrelatedConfig, "utf8"), "{ // user config\n}\n");
+    await assert.rejects(readFile(installed.pluginPath), /ENOENT/);
+    await assert.rejects(readFile(join(installed.skillPath, "SKILL.md")), /ENOENT/);
+    await assert.rejects(readFile(installed.statePath), /ENOENT/);
+    assert.equal(readOpenCodePluginStatus(fixture.options).managed, false);
+  } finally {
+    await rm(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("OpenCode plugin removal fails closed for a state with unsafe managed paths", async () => {
+  const fixture = await createFixture("unsafe-state");
+  const sentinel = join(fixture.root, "do-not-delete");
+  const statePath = join(fixture.options.memoraxCodeHome, "adapters", "opencode", "state.json");
+  try {
+    await mkdir(sentinel, { recursive: true });
+    await writeFile(join(sentinel, "sentinel.txt"), "preserve\n");
+    await mkdir(join(fixture.options.memoraxCodeHome, "adapters", "opencode"), { recursive: true });
+    await writeFile(statePath, JSON.stringify({
+      version: 1,
+      runtime: "opencode",
+      integration: "plugin",
+      enabled: true,
+      openCodeConfigDir: fixture.openCodeConfigDir,
+      pluginPath: join(fixture.openCodeConfigDir, "plugins", "memorax-code.js"),
+      skillPath: sentinel,
+    }));
+
+    const removed = removeOpenCodePluginInstallation(fixture.options);
+
+    assert.equal(removed.ok, false);
+    assert.equal(removed.reason, "state_paths_invalid");
+    assert.equal(await readFile(join(sentinel, "sentinel.txt"), "utf8"), "preserve\n");
+  } finally {
+    await rm(fixture.root, { recursive: true, force: true });
+  }
+});
+
+async function createFixture(name) {
+  const root = await mkdtemp(join(tmpdir(), `memorax-code-opencode-${name}-`));
+  const openCodeConfigDir = join(root, "OpenCode Config With Spaces");
+  const memoraxCodeHome = join(root, "memorax-code");
+  const pluginSourcePath = join(root, "Adapter With Spaces", "plugin.mjs");
+  const skillSourcePath = join(root, "canonical-skill");
+  await mkdir(join(skillSourcePath, "references"), { recursive: true });
+  await mkdir(join(root, "Adapter With Spaces"), { recursive: true });
+  await writeFile(pluginSourcePath, "export function createMemoraxOpenCodePlugin() {}\n");
+  await writeFile(join(skillSourcePath, "SKILL.md"), "# MemoraX Code\n");
+  await writeFile(join(skillSourcePath, "references", "search.md"), "search\n");
+  return {
+    root,
+    openCodeConfigDir,
+    pluginSourcePath,
+    options: {
+      openCodeConfigDir,
+      memoraxCodeHome,
+      pluginSourcePath,
+      skillSourcePath,
+      cliBinDir: "/managed/bin",
+    },
+  };
+}
+
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/packages/ts/memorax-code-opencode-adapter/test/plugin-install.test.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/test/plugin-install.test.mjs
@@ -96,6 +96,44 @@ test("OpenCode plugin install refuses to overwrite an unmanaged discovery file",
   }
 });
 
+test("OpenCode plugin install refuses to overwrite a recorded loader without its managed marker", async () => {
+  const fixture = await createFixture("recorded-loader-conflict");
+  try {
+    const installed = ensureOpenCodePluginInstalled(fixture.options);
+    assert.equal(installed.ok, true);
+    const customLoader = "export const UserPlugin = async () => ({});\n";
+    await writeFile(installed.pluginPath, customLoader);
+
+    const result = ensureOpenCodePluginInstalled(fixture.options);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "plugin_conflict");
+    assert.equal(await readFile(installed.pluginPath, "utf8"), customLoader);
+  } finally {
+    await rm(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("OpenCode plugin install removes newly created artifacts when state persistence fails", async () => {
+  const fixture = await createFixture("state-write-failure");
+  const blockedStateDir = join(fixture.options.memoraxCodeHome, "adapters", "opencode");
+  const pluginPath = join(fixture.openCodeConfigDir, "plugins", "memorax-code.js");
+  const skillPath = join(fixture.openCodeConfigDir, "skills", "memorax-code");
+  try {
+    await mkdir(join(fixture.options.memoraxCodeHome, "adapters"), { recursive: true });
+    await writeFile(blockedStateDir, "not a directory\n");
+
+    assert.throws(() => ensureOpenCodePluginInstalled(fixture.options));
+    await assert.rejects(readFile(pluginPath), /ENOENT/);
+    await assert.rejects(readFile(join(skillPath, "SKILL.md")), /ENOENT/);
+
+    await rm(blockedStateDir, { force: true });
+    assert.equal(ensureOpenCodePluginInstalled(fixture.options).ok, true);
+  } finally {
+    await rm(fixture.root, { recursive: true, force: true });
+  }
+});
+
 test("OpenCode plugin removal deletes only the recorded managed artifacts", async () => {
   const fixture = await createFixture("remove");
   try {

--- a/packages/ts/memorax-code-opencode-adapter/test/plugin.test.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/test/plugin.test.mjs
@@ -1,5 +1,7 @@
 import { strict as assert } from "node:assert";
-import { delimiter } from "node:path";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
 import { test } from "node:test";
 import { createMemoraxOpenCodePlugin } from "../src/plugin.mjs";
 
@@ -40,4 +42,35 @@ test("shell.env clears inherited session identity without an OpenCode session", 
   assert.equal(output.env.MEMORAX_CODE_MEMORY_CLI_TRACE_CLIENT, "opencode");
   assert.equal(Object.hasOwn(output.env, "MEMORAX_CODE_MEMORY_CLI_TRACE_SESSION_ID"), false);
   assert.equal(Object.hasOwn(output.env, "MEMORAX_CODE_MEMORY_CLI_SESSION_ID"), false);
+});
+
+test("a loaded plugin follows the managed enabled state without an OpenCode restart", async () => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-code-opencode-plugin-state-"));
+  const statePath = join(root, "state.json");
+  try {
+    await writeState(false);
+    const plugin = createMemoraxOpenCodePlugin({ statePath });
+    const hooks = await plugin({});
+    const disabledOutput = { env: {} };
+    await hooks["shell.env"]({ sessionID: "session-disabled" }, disabledOutput);
+    assert.equal(disabledOutput.env.MEMORAX_CODE_MEMORY_CLI_TRACE_CLIENT, undefined);
+
+    await writeState(true);
+    const enabledOutput = { env: {} };
+    await hooks["shell.env"]({ sessionID: "session-enabled" }, enabledOutput);
+    assert.equal(enabledOutput.env.MEMORAX_CODE_MEMORY_CLI_TRACE_CLIENT, "opencode");
+    assert.equal(enabledOutput.env.MEMORAX_CODE_MEMORY_CLI_SESSION_ID, "session-enabled");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+
+  async function writeState(enabled) {
+    await mkdir(root, { recursive: true });
+    await writeFile(statePath, JSON.stringify({
+      version: 1,
+      runtime: "opencode",
+      integration: "plugin",
+      enabled,
+    }));
+  }
 });

--- a/scripts/build-npm-packages.mjs
+++ b/scripts/build-npm-packages.mjs
@@ -177,6 +177,7 @@ async function validateStaging(packageRoot) {
     "lib/memorax-code-claude-marketplace/plugins/memorax-code-claude-adapter/memorax-code-adapter-common/src/runtime-record.mjs",
     "lib/memorax-code-claude-marketplace/plugins/memorax-code-claude-adapter/memorax-code-adapter-common/src/hooks/ensure-backend-runner.mjs",
     "lib/memorax-code-opencode-adapter/src/plugin.mjs",
+    "lib/memorax-code-opencode-adapter/src/plugin-install.mjs",
     "lib/memorax-code-opencode-adapter/skills/memorax-code/SKILL.md",
   ]) {
     if (!(await stat(join(packageRoot, requiredPath)).catch(() => undefined))?.isFile()) {

--- a/scripts/npm-package-check.sh
+++ b/scripts/npm-package-check.sh
@@ -5,7 +5,8 @@ unset \
   MEMORAX_CODE_HOME \
   CODEX_HOME \
   CLAUDE_CONFIG_DIR \
-  CLAUDE_HOME
+  CLAUDE_HOME \
+  OPENCODE_CONFIG_DIR
 
 out_dir="${1:-dist/npm}"
 
@@ -151,6 +152,7 @@ for relative in [
     "lib/memorax-code-claude-marketplace/plugins/memorax-code-claude-adapter/memorax-code-adapter-common/src/repo-memory/repo-user-profile-context.mjs",
     "lib/memorax-code-claude-marketplace/plugins/memorax-code-claude-adapter/skills/memorax-code/SKILL.md",
     "lib/memorax-code-opencode-adapter/src/plugin.mjs",
+    "lib/memorax-code-opencode-adapter/src/plugin-install.mjs",
     "lib/memorax-code-opencode-adapter/skills/memorax-code/SKILL.md",
     "lib/memorax-code-backend/dist/service-entrypoint.js",
     "lib/memorax-code-backend/dist/memorax-cli.js",
@@ -247,6 +249,7 @@ export MEMORAX_CODE_HOME="$home_dir/.memorax-code"
 export CODEX_HOME="$home_dir/.codex-memorax-code-package-check"
 export CLAUDE_CONFIG_DIR="$home_dir/.claude-memorax-code-package-check"
 export CLAUDE_HOME="$CLAUDE_CONFIG_DIR"
+export OPENCODE_CONFIG_DIR="$home_dir/.config/opencode-memorax-code-package-check"
 package_install_port="$(node -e 'const net = require("node:net"); const server = net.createServer(); server.listen(0, "127.0.0.1", () => { console.log(server.address().port); server.close(); });')"
 export MEMORAX_CODE_BACKEND_PORT="$package_install_port"
 
@@ -316,6 +319,7 @@ for relative in \
   lib/memorax-code-claude-marketplace/plugins/memorax-code-claude-adapter/memorax-code-adapter-common/src/repo-memory/repo-user-profile-context.mjs \
   lib/memorax-code-claude-marketplace/plugins/memorax-code-claude-adapter/skills/memorax-code/SKILL.md \
   lib/memorax-code-opencode-adapter/src/plugin.mjs \
+  lib/memorax-code-opencode-adapter/src/plugin-install.mjs \
   lib/memorax-code-opencode-adapter/skills/memorax-code/SKILL.md
 do
   test -f "$package_install_root/$relative"
@@ -370,6 +374,11 @@ assert generation_manifest["contentDigest"] == current["contentDigest"]
 assert (generation / "lib" / "memorax-code-codex-adapter" / "runtime-hooks" / "memory-writeback.mjs").exists()
 assert (generation / "lib" / "memorax-code-claude-adapter" / "runtime-hooks" / "memory-turn.mjs").exists()
 assert current_path.stat().st_mode & 0o777 == 0o600
+opencode_config = Path(sys.argv[1]) / ".config" / "opencode-memorax-code-package-check"
+assert (opencode_config / "plugins" / "memorax-code.js").is_file()
+assert (opencode_config / "skills" / "memorax-code" / "SKILL.md").is_file()
+opencode_state = json.loads((home / ".memorax-code" / "adapters" / "opencode" / "state.json").read_text())
+assert opencode_state["enabled"] is True
 PY_POSTINSTALL
 
 "$prefix/bin/memorax-code" stop \
@@ -610,6 +619,7 @@ done
 
 MEMORAX_CODE_NPM_POSTINSTALL_UPDATE=1 \
 MEMORAX_CODE_SKIP_CLAUDE_ADAPTER_INSTALL=1 \
+MEMORAX_CODE_SKIP_OPENCODE_ADAPTER_INSTALL=1 \
 MEMORAX_CODE_HOME="$codex_memorax_code_home" \
 CODEX_HOME="$codex_home" \
 MEMORAX_CODE_BACKEND_PORT="$codex_port" \


### PR DESCRIPTION
## Change Summary

Add OpenCode to the managed MemoraX Code client lifecycle so installation can detect OpenCode Desktop or CLI, install the managed plugin and canonical skill, and safely remove managed artifacts. This builds on #45; automatic retrieval, writeback, reminders, Repo Memory maintenance, Viewer integration, and diagnostics remain in follow-up PRs.

## Implementation Highlights

- Detect OpenCode through its explicit, XDG, or default configuration directory, or through an `opencode` executable in `PATH`, covering Desktop-only, CLI-only, and combined installations.
- Register OpenCode as a managed Backend lifecycle participant for `start`, `restart`, `status`, `stop`, and `uninstall`, including persisted client selection and shared-Backend behavior.
- Materialize a managed thin loader and the canonical `memorax-code` skill without modifying OpenCode provider configuration or overwriting unmanaged destination files.
- Remove only MemoraX-managed OpenCode plugin, skill, and adapter-state artifacts during explicit uninstall and package-removal cleanup.
- Keep the root English, Chinese, and packaged npm READMEs unchanged; update only the architecture, installation, configuration, and troubleshooting references owned by this lifecycle change.

## Validation

Validated at commit `69cad51` on macOS and in a Linux Docker container. Windows was not tested. The validation covers Backend lifecycle composition, Desktop/CLI detection, managed installation and removal, documentation contracts, npm package staging, temporary installation, and artifact allowlists.

## Full End-to-End Validation Results

- Environment: macOS 26.5.1 arm64; Node.js 24.15.0; npm 11.12.1.
- Scenario or matrix: OpenCode managed lifecycle, Desktop-only/CLI-only/combined detection, managed plugin and skill installation, explicit uninstall, package-removal cleanup, and npm artifact installation.
- Command or workflow: `npm run typecheck --prefix packages/ts/memorax-code-backend`, `npm test --prefix packages/ts/memorax-code-backend`, `make test-opencode-adapter`, `make docs-check`, and `make npm-package-check`.
- Result: Backend typecheck passed; Backend tests passed 510 with 2 platform skips; OpenCode adapter tests passed 9/9; documentation tests passed 10/10; npm package tests passed 170/170. The 317-file pack allowlist, local-only gate, staging, temporary installation, and lifecycle checks completed successfully.
- Evidence or artifacts: Validation screenshot will be attached manually below.
- Reason not run / remaining risk: Automatic OpenCode memory behavior is outside this PR and remains in dependent PRs.

- Environment: `node:24-bookworm` Docker image; Debian 12 aarch64; Node.js 24.19.0; npm 11.17.0; unprivileged `node` user.
- Scenario or matrix: Backend lifecycle and source boundaries; managed plugin/skill/state cleanup; Desktop configuration-only detection; CLI-only detection without an existing configuration directory; combined Desktop and CLI detection.
- Command or workflow: Backend typecheck and build, 59 scoped Backend lifecycle/architecture tests, the complete OpenCode adapter suite, three OpenCode postinstall detection scenarios, and `make docs-check`.
- Result: Backend lifecycle/architecture tests passed 59/59; OpenCode adapter tests passed 9/9; OpenCode detection scenarios passed 3/3; documentation tests passed 10/10.
- Evidence or artifacts: Validation screenshot will be attached manually below.
- Reason not run / remaining risk: The unqualified Backend suite is not reported as passing in the copied Docker workspace because its worktree `.git` authority is intentionally unavailable there; the complete suite passed on macOS, and all Linux checks owned by this PR passed.

- Environment: Windows.
- Scenario or matrix: OpenCode executable detection, managed installation, lifecycle management, and uninstall cleanup.
- Command or workflow: Not run.
- Result: Not verified.
- Evidence or artifacts: None.
- Reason not run / remaining risk: Windows-specific executable discovery and filesystem behavior remain unverified.