### PR TITLE
feat: add automatic memory retrieval for OpenCode

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -77,6 +77,7 @@ flowchart LR
   OpenCode --> OpenCodeAdapter
   CodexAdapter -. "versioned local Hook HTTP" .-> Backend
   ClaudeAdapter -. "versioned local Hook HTTP" .-> Backend
+  OpenCodeAdapter -. "versioned local plugin HTTP" .-> Backend
 
   Backend --> MemoraX
   Backend --> Local
@@ -93,7 +94,7 @@ relationships; the arrow labels distinguish them. It is not an import graph.
 | `packages/ts/memorax-code-adapter-common` | Shared source for Backend connection authority, private runtime records, cross-process locking and configuration, Hook generations, Hook launch helpers, and Repo/Personal Memory helpers | Backend composition, native transcript interpretation, MemoraX request execution, or client plugin policy | `packages/ts/memorax-code-adapter-common/src/backend-connection.mjs`, `src/runtime-record.mjs`, `src/hooks`, and `src/repo-memory` |
 | `packages/ts/memorax-code-codex-adapter` | Codex plugin artifact, Hook shells and runtimes, session/workspace observation, diagnostics, and the canonical shared skill | Codex rollout semantics or Backend-side writeback authority | `.codex-plugin`, `hooks`, `runtime-hooks`, `src`, and `skills/memorax-code` |
 | `packages/ts/memorax-code-claude-adapter` | Claude Code plugin artifact, Hook shells and runtimes, configuration, installer, marketplace source, and diagnostics | Claude transcript semantics or Backend memory orchestration | `.claude-plugin`, `hooks`, `runtime-hooks`, `scripts`, and `src/plugin-install.mjs` |
-| `packages/ts/memorax-code-opencode-adapter` | OpenCode plugin runtime, managed thin-loader installation, shell-session identity, and a materialized shared skill | OpenCode message interpretation inside the Backend or model-provider configuration | `src/plugin.mjs`, `src/plugin-install.mjs`, and the OpenCode materialization mapping in `scripts/npm-source-files.mjs` |
+| `packages/ts/memorax-code-opencode-adapter` | OpenCode plugin runtime, managed thin-loader installation, automatic retrieval, shell-session identity, and a materialized shared skill | OpenCode writeback content interpretation inside the Backend or model-provider configuration | `src/plugin.mjs`, `src/plugin-install.mjs`, and the OpenCode materialization mapping in `scripts/npm-source-files.mjs` |
 | `packages/npm/memorax-code` | Installed executable wrappers, update, preinstall/postinstall, npm manifest, and release-package source | Backend lifecycle semantics, uninstall orchestration, or artifact staging | `bin`, `lib/run-entrypoint.mjs`, and `package.json` |
 | `scripts` | Backend build orchestration, staging/materialization, package layout, documentation, and local-only data gates | Product runtime authority | Package-build/check scripts and executable contract scripts |
 | `.github` | Issue and pull-request contribution templates | Product runtime behavior | `.github/ISSUE_TEMPLATE` and `.github/pull_request_template.md` |
@@ -107,8 +108,8 @@ the owner of their behavior.
 
 - The Backend and all three adapters may import adapter-common. Adapter-common must
   not import those higher-level components back.
-- Adapter Hook runtimes do not import Backend implementation. They communicate
-  through versioned, client-qualified local HTTP commands.
+- Adapter Hook and plugin runtimes do not import Backend implementation. They
+  communicate through versioned, client-qualified local HTTP commands.
 - Backend lifecycle may load adapter configuration or installers through
   lifecycle participants. Request-time memory processing must not depend on
   plugin installation or install-watchdog behavior.
@@ -185,8 +186,8 @@ and provider configuration untouched.
 
 ```mermaid
 sequenceDiagram
-  participant Client as Codex or Claude Code
-  participant Hook as adapter Hook runtime
+  participant Client as supported client
+  participant Hook as adapter Hook or plugin runtime
   participant HTTP as Backend Hook HTTP
   participant Service as memory service
   participant Native as client-native runtime
@@ -209,8 +210,8 @@ sequenceDiagram
 
 Important distinctions:
 
-- Hook payload is protocol and correlation input. It is not automatic
-  writeback content authority.
+- Hook or plugin event fields supply protocol, correlation, and retrieval
+  input. They are not automatic writeback content authority.
 - Codex rollout JSONL and Claude Code transcript JSONL are the content
   authorities for their respective clients.
 - Required client/session/turn identity and repository scope fail closed when
@@ -223,6 +224,10 @@ Important distinctions:
   authentication is required when configuration or exposure mode demands it.
 - Client-specific runtimes interpret native formats. Client-neutral memory
   coordination does not parse or guess either format.
+- OpenCode's awaited `chat.message` plugin event supplies the correlated user
+  prompt and injects accepted retrieval context into that message's system
+  context. Its `shell.env` event binds the native session identity and makes
+  the packaged memory CLI available to agent-run shell commands.
 
 ### 3.3 Manual memory CLI flow
 
@@ -295,6 +300,10 @@ Adapter Hooks may schedule a missing bundle build using adapter-common
 supervision, locking, and job-policy helpers. They must use the
 Backend-resolved worktree rather than an arbitrary Hook `cwd`.
 
+OpenCode supports active Repo Memory operations through the shared skill, but
+its plugin does not own supervised background Repo Memory maintenance. Its
+automatic runtime contract currently covers prompt retrieval.
+
 ## 4. Backend Modular Monolith
 
 The Backend is organized by capability, with lightweight capability-local
@@ -317,7 +326,7 @@ src/
   clients/
     codex/                Codex native interpretation and lifecycle adapters
     claude/               Claude native interpretation and lifecycle participant
-    opencode/             OpenCode lifecycle participant
+    opencode/             OpenCode retrieval runtime and lifecycle participant
   config/                 Backend and proxy/config interpretation
   entrypoints/            process and management-CLI orchestration
   lifecycle/
@@ -353,7 +362,7 @@ entrypoints and compatibility facades. It is not another implementation area.
 | `src/lifecycle/backend` | Managed process, PID/token/connection records, status probing, cleanup, and shutdown requests | Helper contracts do not depend back on the full service implementation |
 | `src/clients/codex` | Codex rollout, prompt, turn-index, and workspace interpretation; Hook memory runtime; plugin integration glue; and lifecycle participant | No Claude format fallback; request runtime remains HTTP-composition independent |
 | `src/clients/claude` | Claude transcript/turn interpretation, Hook memory runtime, and lifecycle participant | No Codex format fallback; request runtime remains HTTP-composition independent |
-| `src/clients/opencode` | OpenCode lifecycle participant | Request-time memory flow remains independent from plugin installation |
+| `src/clients/opencode` | OpenCode plugin memory retrieval runtime and lifecycle participant | Request runtime remains HTTP-composition independent and does not infer writeback content |
 | `src/memory` | Memory commands, retrieval, writeback, turn coordination, repository session pinning, manual CLI, buffering/chunking, task projection, and reconciliation | Client-neutral modules do not parse native transcript formats |
 | `src/repository` | Read-only repository identity and Repo Memory readiness | Scope derivation does not execute Git or use synchronous filesystem reads |
 | `src/provider/memorax` | MemoraX config interpretation, query/add/status payloads, HTTP transport, and normalized results | Independent from server routing and plugin lifecycle |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,9 +1,9 @@
 # Security Policy
 
-MemoraX Code is a local-first integration for Codex and Claude Code with an
-optional external bind mode and required communication with MemoraX for
-cloud-backed memory. Security reports should distinguish the local Backend,
-client-owned provider traffic, and MemoraX memory traffic.
+MemoraX Code is a local-first integration for Codex, Claude Code, and OpenCode
+with an optional external bind mode and required communication with MemoraX
+for cloud-backed memory. Security reports should distinguish the local
+Backend, client-owned provider traffic, and MemoraX memory traffic.
 
 ## Supported Versions
 
@@ -61,6 +61,8 @@ the generated configuration's automatic writeback; automatic retrieval remains
 disabled until explicitly enabled.
 
 Memory searches send the query and repository-scoped identity to MemoraX.
+When OpenCode automatic retrieval is enabled, each eligible user prompt is
+used as the search query.
 Active adds and automatic writeback send the selected content needed to create
 memory. Automatic writeback may include selected user instructions and the
 matching final assistant response from an exact Codex or Claude Code
@@ -113,11 +115,12 @@ the product creates or tightens the home to mode `0700` and newly seeded
 configuration to mode `0600`; Windows relies on the current user's filesystem
 ACLs.
 
-Codex and Claude Code local trace capture is enabled by default and may include
-prompts, responses, recalled memory, writeback content, reminder text, and
-local paths. Trace files stay under `MEMORAX_CODE_HOME`. The shipped package
-has no trace uploader, collector, receiver, or export command. This does not
-change the separate MemoraX queries and writeback described above.
+Codex, Claude Code, and OpenCode local trace capture is enabled by default.
+Depending on the enabled client capabilities, traces may include prompts,
+responses, recalled memory, writeback content, reminder text, and local paths.
+Trace files stay under `MEMORAX_CODE_HOME`. The shipped package has no trace
+uploader, collector, receiver, or export command. This does not change the
+separate MemoraX queries and writeback described above.
 
 The local `/memory-viewer` surface is a content-free activity summary. It must
 not expose conversation or memory text, session/turn identifiers, paths, or

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -41,9 +41,9 @@ are not a compatibility contract.
 The generated template selects all three clients, disables automatic retrieval,
 enables automatic writeback, sets the preferred language to Chinese (`zh`),
 uses a five-turn skill reminder and the adaptive repository-update policy, and
-enables content-bearing local traces for Codex and Claude Code. npm installation
-may narrow `[clients]` to clients detected on the host. The tables below list
-all fallbacks, including tuning fields omitted from the generated file.
+enables content-bearing local traces for all three clients. npm installation may
+narrow `[clients]` to clients detected on the host. The tables below list all
+fallbacks, including tuning fields omitted from the generated file.
 
 On POSIX systems MemoraX Code creates `$MEMORAX_CODE_HOME` with mode `0700`
 and a new `config.toml` with mode `0600`. Windows relies on the current user's
@@ -230,24 +230,26 @@ only when the Backend has authorized a Git worktree and that worktree has no
 unavailable, the Hook skips the initial build instead of falling back to its
 local `cwd`.
 
-OpenCode supports active Repo Memory operations through the installed skill;
-background Repo Memory maintenance is added separately from its installation
-lifecycle.
+OpenCode supports active Repo Memory operations through the installed skill,
+but its plugin does not currently run background Repo Memory maintenance. Its
+automatic integration currently covers retrieval.
 
 ## Local traces
 
-`[trace.codex]` and `[trace.claude]` support the same fields:
+`[trace.codex]`, `[trace.claude]`, and `[trace.opencode]` support the same
+fields:
 
-| Field | Codex environment | Claude environment | Fallback |
-| --- | --- | --- | --- |
-| `enabled` | `MEMORAX_CODE_CODEX_TRACE_ENABLED` | `MEMORAX_CODE_CLAUDE_TRACE_ENABLED` | `true` |
-| `capture_content` | `MEMORAX_CODE_CODEX_TRACE_CAPTURE_CONTENT` | `MEMORAX_CODE_CLAUDE_TRACE_CAPTURE_CONTENT` | `true` |
-| `retention_days` | `MEMORAX_CODE_CODEX_TRACE_RETENTION_DAYS` | `MEMORAX_CODE_CLAUDE_TRACE_RETENTION_DAYS` | `7` |
-| `max_event_chars` | `MEMORAX_CODE_CODEX_TRACE_MAX_EVENT_CHARS` | `MEMORAX_CODE_CLAUDE_TRACE_MAX_EVENT_CHARS` | `20000` |
-| `max_file_bytes` | `MEMORAX_CODE_CODEX_TRACE_MAX_FILE_BYTES` | `MEMORAX_CODE_CLAUDE_TRACE_MAX_FILE_BYTES` | `52428800` |
+| Field | Codex environment | Claude environment | OpenCode environment | Fallback |
+| --- | --- | --- | --- | --- |
+| `enabled` | `MEMORAX_CODE_CODEX_TRACE_ENABLED` | `MEMORAX_CODE_CLAUDE_TRACE_ENABLED` | `MEMORAX_CODE_OPENCODE_TRACE_ENABLED` | `true` |
+| `capture_content` | `MEMORAX_CODE_CODEX_TRACE_CAPTURE_CONTENT` | `MEMORAX_CODE_CLAUDE_TRACE_CAPTURE_CONTENT` | `MEMORAX_CODE_OPENCODE_TRACE_CAPTURE_CONTENT` | `true` |
+| `retention_days` | `MEMORAX_CODE_CODEX_TRACE_RETENTION_DAYS` | `MEMORAX_CODE_CLAUDE_TRACE_RETENTION_DAYS` | `MEMORAX_CODE_OPENCODE_TRACE_RETENTION_DAYS` | `7` |
+| `max_event_chars` | `MEMORAX_CODE_CODEX_TRACE_MAX_EVENT_CHARS` | `MEMORAX_CODE_CLAUDE_TRACE_MAX_EVENT_CHARS` | `MEMORAX_CODE_OPENCODE_TRACE_MAX_EVENT_CHARS` | `20000` |
+| `max_file_bytes` | `MEMORAX_CODE_CODEX_TRACE_MAX_FILE_BYTES` | `MEMORAX_CODE_CLAUDE_TRACE_MAX_FILE_BYTES` | `MEMORAX_CODE_OPENCODE_TRACE_MAX_FILE_BYTES` | `52428800` |
 
-Content capture can include prompts, responses, recalled memory, writeback
-content, reminder text, and local paths. Set `capture_content=false` for
+Depending on the enabled client capabilities, content capture can include
+prompts, responses, recalled memory, writeback content, reminder text, and
+local paths. Set `capture_content=false` for
 metadata-only local traces, or `enabled=false` to disable a client's trace.
 Trace files stay under `$MEMORAX_CODE_HOME`; MemoraX Code has no trace upload,
 export, or public collector.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -160,12 +160,13 @@ MemoraX Code reads filesystem Git metadata without executing Git. Linked
 worktrees share the remote repository identity; non-Git workspaces use the
 normalized folder name. Resolution never falls back to the bare base user ID.
 
-A live Codex or Claude Code session remains pinned to the repository or local
-workspace resolved at the start of the session. Starting the client from a
-parent workspace and then entering a nested Git repository does not rebind the
-session. The only in-session scope upgrade is from a direct `.git` directory
-whose internal metadata was malformed or incomplete to a verified Git
-repository at the same canonical workspace root and for the same Base User ID.
+A live Codex, Claude Code, or OpenCode session remains pinned to the repository
+or local workspace resolved at the start of the session. Starting the client
+from a parent workspace and then entering a nested Git repository does not
+rebind the session. The only in-session scope upgrade is from a direct `.git`
+directory whose internal metadata was malformed or incomplete to a verified
+Git repository at the same canonical workspace root and for the same Base User
+ID.
 
 During that degraded state, MemoraX Code reports
 `workspaceScopeFallbackReason: git_metadata_invalid` for manual CLI operations

--- a/packages/npm/memorax-code/bin/memorax-code-plugin-postinstall.mjs
+++ b/packages/npm/memorax-code/bin/memorax-code-plugin-postinstall.mjs
@@ -743,6 +743,10 @@ function defaultMemoraxCodeConfig() {
     "enabled = true # Enable local Claude session memory trace collection.",
     "capture_content = true # Store content in local Claude trace events.",
     "",
+    "[trace.opencode]",
+    "enabled = true # Enable local OpenCode session memory trace collection.",
+    "capture_content = true # Store content in local OpenCode trace events.",
+    "",
   ].join("\n");
 }
 

--- a/packages/npm/memorax-code/test/postinstall.test.mjs
+++ b/packages/npm/memorax-code/test/postinstall.test.mjs
@@ -1510,6 +1510,8 @@ test("postinstall seeds default MemoraX Code config on first install when memory
     assert.match(config, /\[trace\.claude\]/);
     assert.match(config, /enabled = true # Enable local Claude session memory trace collection\./);
     assert.match(config, /capture_content = true # Store content in local Claude trace events\./);
+    assert.match(config, /\[trace\.opencode\]/);
+    assert.match(config, /capture_content = true # Store content in local OpenCode trace events\./);
     assert.deepEqual(activeTomlSections(config), [
       "clients",
       "memorax",
@@ -1520,6 +1522,7 @@ test("postinstall seeds default MemoraX Code config on first install when memory
       "memory.writeback",
       "trace.claude",
       "trace.codex",
+      "trace.opencode",
     ]);
     assert.doesNotMatch(
       config,

--- a/packages/ts/memorax-code-backend/src/clients/opencode/memory-hook-runtime.ts
+++ b/packages/ts/memorax-code-backend/src/clients/opencode/memory-hook-runtime.ts
@@ -1,0 +1,157 @@
+import { retrieveAutomaticMemoryContext } from "../../memory/automatic-retrieval.js";
+import type {
+  MemoryHookTurnStartResult,
+  OpenCodeTurnStartCommand,
+} from "../../memory/hook-command.js";
+import type { MemoryDiagnosticLogger, MemoryObservabilityHook } from "../../memory/observability.js";
+import {
+  createRepositoryMemorySessionRuntime,
+  resolvedRepoMemoryWorktree,
+  type ConfiguredRepositoryMemoryResult,
+  type RepositoryMemorySessionRuntime,
+} from "../../memory/repository-session.js";
+import { traceContextFromOpenCodeHookBody } from "../../trace/context.js";
+import {
+  recordTraceEvent,
+  traceTurnEventId,
+  writeCurrentTraceTurn,
+} from "../../trace/store.js";
+
+export type OpenCodeMemoryHookRuntimeOptions = {
+  diagnosticLogger?: MemoryDiagnosticLogger;
+  env?: Record<string, string | undefined>;
+  fetchImpl?: typeof fetch;
+  now?: () => number;
+  maxEntries?: number;
+  memoryObservability?: MemoryObservabilityHook;
+  memoraxCodeHome?: string;
+  repositoryMemorySession?: RepositoryMemorySessionRuntime;
+};
+
+export type OpenCodeMemoryHookRuntime = {
+  recordTurnStart(command: OpenCodeTurnStartCommand): Promise<MemoryHookTurnStartResult>;
+  close(): void;
+};
+
+const OPENCODE_MEMORY_TURN_CLIENT = "opencode" as const;
+
+export function createOpenCodeMemoryHookRuntime(
+  options: OpenCodeMemoryHookRuntimeOptions = {},
+): OpenCodeMemoryHookRuntime {
+  const now = options.now ?? (() => Date.now());
+  const repositoryMemorySession = options.repositoryMemorySession ?? createRepositoryMemorySessionRuntime();
+  const ownsRepositoryMemorySession = options.repositoryMemorySession === undefined;
+  const retrievalTurns = new Set<string>();
+  const retrievalTurnLimit = positiveInteger(options.maxEntries, 256);
+
+  return {
+    async recordTurnStart(command) {
+      const createdAt = now();
+      const traceContext = traceContextFromOpenCodeHookBody(command, new Date(createdAt).toISOString());
+      const repositoryMemory = await resolveHookRepositoryMemory(
+        command,
+        options,
+        repositoryMemorySession,
+      );
+      const repoMemoryWorktree = resolvedRepoMemoryWorktree(repositoryMemory);
+      await recordTraceBestEffort("opencode_memory.turn_start_event", recordTraceEvent({
+        eventId: traceTurnEventId(traceContext, "turn_start"),
+        memoraxCodeHome: options.memoraxCodeHome,
+        env: options.env,
+        traceContext,
+        type: "turn_start",
+        source: "opencode-plugin",
+        operation: "query",
+        ok: true,
+        request: {
+          prompt: command.prompt,
+          cwd: command.cwd,
+        },
+      }), options.diagnosticLogger);
+      await recordTraceBestEffort("opencode_memory.current_turn_write", writeCurrentTraceTurn(
+        traceContext,
+        {
+          client: "opencode",
+          memoraxCodeHome: options.memoraxCodeHome,
+          env: options.env,
+          now: () => new Date(now()),
+        },
+      ), options.diagnosticLogger);
+      options.diagnosticLogger?.("opencode_memory.turn_start", {
+        sessionId: command.sessionId,
+        userMessageId: command.userMessageId,
+        workspace: repositoryMemory.ok ? repositoryMemory.memory.scope?.repositorySlug : undefined,
+        workspaceScopeReason: repositoryMemory.ok ? undefined : repositoryMemory.reason,
+      });
+
+      const retrievalKey = JSON.stringify([command.sessionId, command.userMessageId]);
+      if (retrievalTurns.has(retrievalKey)) {
+        return {
+          ok: true,
+          ...(repoMemoryWorktree ? { repoMemoryWorktree } : {}),
+        };
+      }
+      retrievalTurns.add(retrievalKey);
+      while (retrievalTurns.size > retrievalTurnLimit) {
+        const oldest = retrievalTurns.values().next().value;
+        if (typeof oldest !== "string") break;
+        retrievalTurns.delete(oldest);
+      }
+      const retrieval = await retrieveAutomaticMemoryContext({
+        diagnosticLogger: options.diagnosticLogger,
+        env: options.env ?? process.env,
+        fetchImpl: options.fetchImpl,
+        memoryObservability: options.memoryObservability,
+        memoryObservabilitySource: "opencode_plugin_retrieval",
+        query: command.prompt,
+        repositoryMemory,
+        sessionKey: command.sessionId,
+        traceContext,
+      });
+      return {
+        ok: true,
+        ...(repoMemoryWorktree ? { repoMemoryWorktree } : {}),
+        ...(retrieval.context ? { additionalContext: retrieval.context } : {}),
+      };
+    },
+    close() {
+      retrievalTurns.clear();
+      if (ownsRepositoryMemorySession) repositoryMemorySession.close();
+    },
+  };
+}
+
+async function resolveHookRepositoryMemory(
+  command: OpenCodeTurnStartCommand,
+  options: OpenCodeMemoryHookRuntimeOptions,
+  repositoryMemorySession: RepositoryMemorySessionRuntime,
+): Promise<ConfiguredRepositoryMemoryResult> {
+  return await repositoryMemorySession.resolve({
+    client: OPENCODE_MEMORY_TURN_CLIENT,
+    sessionId: command.sessionId,
+    workspaceRoot: command.cwd,
+    workspaceKind: command.workspaceKind,
+    memoraxCodeHome: options.memoraxCodeHome ?? options.env?.MEMORAX_CODE_HOME,
+    env: options.env,
+  });
+}
+
+async function recordTraceBestEffort(
+  label: string,
+  promise: Promise<unknown>,
+  diagnosticLogger?: MemoryDiagnosticLogger,
+): Promise<void> {
+  try {
+    await promise;
+  } catch (error) {
+    diagnosticLogger?.("opencode_trace.write_failed", {
+      label,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+function positiveInteger(value: unknown, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}

--- a/packages/ts/memorax-code-backend/src/config/memorax-code.ts
+++ b/packages/ts/memorax-code-backend/src/config/memorax-code.ts
@@ -85,6 +85,13 @@ export type MemoraxCodeConfig = Readonly<{
       max_event_chars?: number;
       max_file_bytes?: number;
     }>;
+    opencode?: Readonly<{
+      enabled?: boolean;
+      capture_content?: boolean;
+      retention_days?: number;
+      max_event_chars?: number;
+      max_file_bytes?: number;
+    }>;
   }>;
 }>;
 
@@ -145,6 +152,10 @@ export function renderDefaultMemoraxCodeConfig(): string {
     "[trace.claude]",
     "enabled = true # Enable local Claude session memory trace collection.",
     "capture_content = true # Store content in local Claude trace events.",
+    "",
+    "[trace.opencode]",
+    "enabled = true # Enable local OpenCode session memory trace collection.",
+    "capture_content = true # Store content in local OpenCode trace events.",
     "",
   ].join("\n");
 }
@@ -225,6 +236,7 @@ function normalizeMemoraxCodeConfig(value: unknown): MemoraxCodeConfig {
   const repoUpdate = recordValue(memory?.repo_update);
   const traceCodex = recordValue(trace?.codex);
   const traceClaude = recordValue(trace?.claude);
+  const traceOpenCode = recordValue(trace?.opencode);
 
   return (prune({
     clients: prune({
@@ -294,6 +306,13 @@ function normalizeMemoraxCodeConfig(value: unknown): MemoraxCodeConfig {
         retention_days: numberField(traceClaude, "retention_days"),
         max_event_chars: numberField(traceClaude, "max_event_chars"),
         max_file_bytes: numberField(traceClaude, "max_file_bytes"),
+      }),
+      opencode: prune({
+        enabled: booleanField(traceOpenCode, "enabled"),
+        capture_content: booleanField(traceOpenCode, "capture_content"),
+        retention_days: numberField(traceOpenCode, "retention_days"),
+        max_event_chars: numberField(traceOpenCode, "max_event_chars"),
+        max_file_bytes: numberField(traceOpenCode, "max_file_bytes"),
       }),
     }),
   }) ?? {}) as MemoraxCodeConfig;

--- a/packages/ts/memorax-code-backend/src/memory/automatic-writeback.ts
+++ b/packages/ts/memorax-code-backend/src/memory/automatic-writeback.ts
@@ -121,6 +121,7 @@ export function createAutomaticMemoryWritebackRuntime(
       return enqueueAutomaticMemoryWritebackForRuntime(state, options);
     },
     discardForScopeUpgrade(upgrade) {
+      if (upgrade.client === "opencode") return 0;
       return state.writebackBuffer.discardForScopeUpgrade({
         client: upgrade.client,
         sessionKey: upgrade.sessionId,

--- a/packages/ts/memorax-code-backend/src/memory/cli.ts
+++ b/packages/ts/memorax-code-backend/src/memory/cli.ts
@@ -281,7 +281,7 @@ async function resolveMemoryCliRepositoryMemory(options: MemoryCliOptions): Prom
   });
   if (!commandMemory.ok || !commandMemory.memory.scope) return commandMemory;
   if (turnMemory?.ok && (!turnMemory.memory.scope || !repositoryMemoryScopesMatch(commandMemory.memory.scope, turnMemory.memory.scope))) {
-    const clientLabel = traceBinding?.client === "claude" ? "Claude" : "Codex";
+    const clientLabel = traceClientLabel(traceBinding?.client);
     return {
       ok: false,
       reason: "workspace_scope_mismatch",
@@ -297,9 +297,9 @@ function memoryCliRepositoryFailure(
   fields: Pick<MemoryCliResult, "query"> = {},
 ): MemoryCliResult {
   const userAction = failure.reason === "workspace_scope_mismatch"
-    ? "Start a new Codex or Claude Code session from the target repository or local workspace."
+    ? "Start a new Codex, Claude Code, or OpenCode session from the target repository or local workspace."
     : failure.reason === "workspace_scope_unavailable"
-      ? "Start a new Codex or Claude Code session from the target repository or local workspace. If the problem continues, make sure its .git metadata is readable and valid."
+      ? "Start a new Codex, Claude Code, or OpenCode session from the target repository or local workspace. If the problem continues, make sure its .git metadata is readable and valid."
       : undefined;
   return {
     ok: false,
@@ -399,6 +399,12 @@ function memoryCliTraceBinding(
 
 function memoryCliTraceEventType(event: MemoryObservabilityEvent): string {
   return event.operation === "writeback" ? "memory_cli_add" : "memory_cli_search";
+}
+
+function traceClientLabel(client: TraceClient | undefined): string {
+  if (client === "claude") return "Claude";
+  if (client === "opencode") return "OpenCode";
+  return "Codex";
 }
 
 function memoryAddContentOptions(

--- a/packages/ts/memorax-code-backend/src/memory/hook-command.ts
+++ b/packages/ts/memorax-code-backend/src/memory/hook-command.ts
@@ -3,7 +3,7 @@ import { isRecord } from "../shared/record.js";
 export const MEMORY_HOOK_COMMAND_VERSION = 1 as const;
 export const INVALID_MEMORY_HOOK_COMMAND = "invalid memory Hook command";
 
-export type MemoryHookClient = "codex" | "claude-code";
+export type MemoryHookClient = "codex" | "claude-code" | "opencode";
 
 const BASE_COMMAND_KEYS = [
   "version",
@@ -15,8 +15,9 @@ const BASE_COMMAND_KEYS = [
 const TURN_START_KEYS: Readonly<Record<MemoryHookClient, ReadonlySet<string>>> = {
   codex: new Set([...BASE_COMMAND_KEYS, "turnId", "prompt", "transcriptPath"]),
   "claude-code": new Set([...BASE_COMMAND_KEYS, "promptId", "prompt", "transcriptPath"]),
+  opencode: new Set([...BASE_COMMAND_KEYS, "userMessageId", "prompt"]),
 };
-const WRITEBACK_KEYS: Readonly<Record<MemoryHookClient, ReadonlySet<string>>> = {
+const WRITEBACK_KEYS: Readonly<Partial<Record<MemoryHookClient, ReadonlySet<string>>>> = {
   codex: new Set([...BASE_COMMAND_KEYS, "turnId", "lastAssistantMessage", "transcriptPath"]),
   "claude-code": new Set([
     ...BASE_COMMAND_KEYS,
@@ -25,7 +26,7 @@ const WRITEBACK_KEYS: Readonly<Record<MemoryHookClient, ReadonlySet<string>>> = 
     "transcriptPath",
   ]),
 };
-const SKILL_REMINDER_KEYS: Readonly<Record<MemoryHookClient, ReadonlySet<string>>> = {
+const SKILL_REMINDER_KEYS: Readonly<Partial<Record<MemoryHookClient, ReadonlySet<string>>>> = {
   codex: new Set([...BASE_COMMAND_KEYS, "turnId", "transcriptPath", "content", "triggers"]),
   "claude-code": new Set([...BASE_COMMAND_KEYS, "promptId", "transcriptPath", "content", "triggers"]),
 };
@@ -50,7 +51,12 @@ export type ClaudeTurnStartCommand = MemoryHookCommandBase<"claude-code"> & Read
   transcriptPath: string;
 }>;
 
-export type TurnStartCommand = CodexTurnStartCommand | ClaudeTurnStartCommand;
+export type OpenCodeTurnStartCommand = MemoryHookCommandBase<"opencode"> & Readonly<{
+  userMessageId: string;
+  prompt: string;
+}>;
+
+export type TurnStartCommand = CodexTurnStartCommand | ClaudeTurnStartCommand | OpenCodeTurnStartCommand;
 
 export type MemoryHookTurnStartResult = Readonly<{
   ok: true;
@@ -101,11 +107,11 @@ export function parseTurnStartCommand(
   const base = parseCommandBase(value, TURN_START_KEYS);
   if (!base) return invalidCommand();
   const prompt = requiredStringField(value, "prompt");
-  const transcriptPath = requiredStringField(value, "transcriptPath");
-  if (!prompt || !transcriptPath) return invalidCommand();
+  if (!prompt) return invalidCommand();
   if (base.client === "codex") {
+    const transcriptPath = requiredStringField(value, "transcriptPath");
     const turnId = optionalStringField(value, "turnId");
-    if (!turnId.ok) return invalidCommand();
+    if (!transcriptPath || !turnId.ok) return invalidCommand();
     return {
       ok: true,
       command: {
@@ -117,8 +123,22 @@ export function parseTurnStartCommand(
       },
     };
   }
+  if (base.client === "opencode") {
+    const userMessageId = requiredStringField(value, "userMessageId");
+    if (!userMessageId) return invalidCommand();
+    return {
+      ok: true,
+      command: {
+        ...base,
+        client: "opencode",
+        userMessageId,
+        prompt,
+      },
+    };
+  }
   const promptId = requiredStringField(value, "promptId");
-  if (!promptId) return invalidCommand();
+  const transcriptPath = requiredStringField(value, "transcriptPath");
+  if (!promptId || !transcriptPath) return invalidCommand();
   return {
     ok: true,
     command: {
@@ -194,6 +214,7 @@ export function parseSkillReminderCommand(
       },
     };
   }
+  if (base.client !== "claude-code") return invalidCommand();
   const promptId = requiredStringField(value, "promptId");
   if (!promptId) return invalidCommand();
   return {
@@ -211,12 +232,13 @@ export function parseSkillReminderCommand(
 
 function parseCommandBase(
   value: Record<string, unknown>,
-  allowedKeys: Readonly<Record<MemoryHookClient, ReadonlySet<string>>>,
+  allowedKeys: Readonly<Partial<Record<MemoryHookClient, ReadonlySet<string>>>>,
 ): MemoryHookCommandBase<MemoryHookClient> | undefined {
   if (value.version !== MEMORY_HOOK_COMMAND_VERSION) return undefined;
   const client = value.client;
-  if (client !== "codex" && client !== "claude-code") return undefined;
-  if (Object.keys(value).some((key) => !allowedKeys[client].has(key))) return undefined;
+  if (client !== "codex" && client !== "claude-code" && client !== "opencode") return undefined;
+  const clientKeys = allowedKeys[client];
+  if (!clientKeys || Object.keys(value).some((key) => !clientKeys.has(key))) return undefined;
   const sessionId = requiredStringField(value, "sessionId");
   if (!sessionId) return undefined;
   const cwd = optionalStringField(value, "cwd");

--- a/packages/ts/memorax-code-backend/src/memory/observability.ts
+++ b/packages/ts/memorax-code-backend/src/memory/observability.ts
@@ -7,6 +7,7 @@ export type MemoryObservabilitySource =
   | "codex_hook_retrieval"
   | "claude_hook_retrieval"
   | "claude_hook_writeback"
+  | "opencode_plugin_retrieval"
   | "memory_cli"
   | "writeback_reconciler"
   | "unknown";

--- a/packages/ts/memorax-code-backend/src/memory/service.ts
+++ b/packages/ts/memorax-code-backend/src/memory/service.ts
@@ -9,6 +9,9 @@ import {
   type ClaudeMemoryHookRuntimeOptions,
   type ClaudeMemoryHookWritebackResult,
 } from "../clients/claude/memory-hook-runtime.js";
+import {
+  createOpenCodeMemoryHookRuntime,
+} from "../clients/opencode/memory-hook-runtime.js";
 import { createMemoryTurnCoordinator } from "./turn-coordinator.js";
 import {
   createRepositoryMemorySessionRuntime,
@@ -59,6 +62,10 @@ export function createMemoryService(options: MemoryServiceOptions = {}): MemoryS
     repositoryMemorySession,
     turnCoordinator,
   });
+  const openCodeHook = createOpenCodeMemoryHookRuntime({
+    ...options,
+    repositoryMemorySession,
+  });
   let closed = false;
   return {
     async recordTurnStart(command) {
@@ -67,6 +74,8 @@ export function createMemoryService(options: MemoryServiceOptions = {}): MemoryS
           return await codexHook.recordTurnStart(command);
         case "claude-code":
           return await claudeHook.recordTurnStart(command);
+        case "opencode":
+          return await openCodeHook.recordTurnStart(command);
       }
       return unsupportedMemoryHookCommand(command);
     },
@@ -87,6 +96,7 @@ export function createMemoryService(options: MemoryServiceOptions = {}): MemoryS
       closed = true;
       codexHook.close();
       claudeHook.close();
+      openCodeHook.close();
       turnCoordinator.close();
       repositoryMemorySession.close();
       automaticWriteback.close();

--- a/packages/ts/memorax-code-backend/src/trace/config.ts
+++ b/packages/ts/memorax-code-backend/src/trace/config.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { loadMemoraxCodeConfig, type MemoraxCodeConfig } from "../config/memorax-code.js";
 import { isTraceClient, type TraceClient } from "./context.js";
 
-export const TRACE_CLIENTS: readonly TraceClient[] = ["codex", "claude"];
+export const TRACE_CLIENTS: readonly TraceClient[] = ["codex", "claude", "opencode"];
 
 export type ClientTraceConfig = Readonly<{
   enabled: boolean;
@@ -16,6 +16,7 @@ export type ClientTraceConfig = Readonly<{
 
 export type CodexTraceConfig = ClientTraceConfig;
 export type ClaudeTraceConfig = ClientTraceConfig;
+export type OpenCodeTraceConfig = ClientTraceConfig;
 
 export type ClientTracePaths = Readonly<{
   root: string;
@@ -29,6 +30,7 @@ export type ClientTracePaths = Readonly<{
 
 export type CodexTracePaths = ClientTracePaths;
 export type ClaudeTracePaths = ClientTracePaths;
+export type OpenCodeTracePaths = ClientTracePaths;
 
 export const CODEX_TRACE_DEFAULT_CONFIG: CodexTraceConfig = {
   enabled: true,
@@ -39,6 +41,14 @@ export const CODEX_TRACE_DEFAULT_CONFIG: CodexTraceConfig = {
 };
 
 export const CLAUDE_TRACE_DEFAULT_CONFIG: ClaudeTraceConfig = {
+  enabled: true,
+  captureContent: true,
+  retentionDays: 7,
+  maxEventChars: 20_000,
+  maxFileBytes: 52_428_800,
+};
+
+export const OPENCODE_TRACE_DEFAULT_CONFIG: OpenCodeTraceConfig = {
   enabled: true,
   captureContent: true,
   retentionDays: 7,
@@ -67,6 +77,13 @@ export function claudeTraceConfigFromEnv(
   return clientTraceConfigFromEnv("claude", env, fileConfig);
 }
 
+export function openCodeTraceConfigFromEnv(
+  env: Record<string, string | undefined> = process.env,
+  fileConfig?: MemoraxCodeConfig,
+): OpenCodeTraceConfig {
+  return clientTraceConfigFromEnv("opencode", env, fileConfig);
+}
+
 export function clientTraceConfigFromEnv(
   client: TraceClient,
   env: Record<string, string | undefined> = process.env,
@@ -75,8 +92,16 @@ export function clientTraceConfigFromEnv(
   assertTraceClient(client);
   const config = fileConfig ?? loadMemoraxCodeConfig(memoraxCodeHomeForTrace(env), { warn: () => undefined });
   const section = config.trace?.[client];
-  const defaults = client === "claude" ? CLAUDE_TRACE_DEFAULT_CONFIG : CODEX_TRACE_DEFAULT_CONFIG;
-  const prefix = client === "claude" ? "MEMORAX_CODE_CLAUDE_TRACE" : "MEMORAX_CODE_CODEX_TRACE";
+  const defaults = client === "claude"
+    ? CLAUDE_TRACE_DEFAULT_CONFIG
+    : client === "opencode"
+      ? OPENCODE_TRACE_DEFAULT_CONFIG
+      : CODEX_TRACE_DEFAULT_CONFIG;
+  const prefix = client === "claude"
+    ? "MEMORAX_CODE_CLAUDE_TRACE"
+    : client === "opencode"
+      ? "MEMORAX_CODE_OPENCODE_TRACE"
+      : "MEMORAX_CODE_CODEX_TRACE";
   return {
     enabled: booleanValue(env[`${prefix}_ENABLED`], section?.enabled ?? defaults.enabled),
     captureContent: booleanValue(env[`${prefix}_CAPTURE_CONTENT`], section?.capture_content ?? defaults.captureContent),
@@ -96,6 +121,10 @@ export function tracePaths(memoraxCodeHome = memoraxCodeHomeForTrace(process.env
 
 export function claudeTracePaths(memoraxCodeHome = memoraxCodeHomeForTrace(process.env)): ClaudeTracePaths {
   return clientTracePaths("claude", memoraxCodeHome);
+}
+
+export function openCodeTracePaths(memoraxCodeHome = memoraxCodeHomeForTrace(process.env)): OpenCodeTracePaths {
+  return clientTracePaths("opencode", memoraxCodeHome);
 }
 
 export function clientTracePaths(

--- a/packages/ts/memorax-code-backend/src/trace/context.ts
+++ b/packages/ts/memorax-code-backend/src/trace/context.ts
@@ -7,9 +7,10 @@ import {
 export type TraceContextOrigin =
   | "codex-hook-body"
   | "claude-hook-body"
+  | "opencode-hook-body"
   | "current-turn-file"
   | "manual";
-export type TraceClient = "codex" | "claude";
+export type TraceClient = "codex" | "claude" | "opencode";
 
 export type TraceRelatedTurn = Readonly<{
   turnId?: string;
@@ -82,6 +83,28 @@ export function traceContextFromClaudeHookBody(
   });
 }
 
+export function traceContextFromOpenCodeHookBody(
+  body: unknown,
+  capturedAt = new Date().toISOString(),
+): TraceContext | undefined {
+  if (!isRecord(body)) return undefined;
+  const sessionId = stringField(body, "sessionId");
+  const turnId = stringField(body, "userMessageId");
+  if (!sessionId || !turnId) return undefined;
+  const cwd = stringField(body, "cwd");
+  return pruneTraceContext({
+    schemaVersion: "1",
+    client: "opencode",
+    sessionId,
+    turnId,
+    cwd,
+    memoryProject: resolveMemoryProject(cwd),
+    workspaceKind: stringField(body, "workspaceKind"),
+    contextOrigin: "opencode-hook-body",
+    capturedAt,
+  });
+}
+
 export function traceContextFromCurrentTurnRecord(
   value: unknown,
 ): TraceContext | undefined {
@@ -142,7 +165,7 @@ function pruneRecord<T extends Record<string, unknown>>(value: T): T {
 }
 
 export function isTraceClient(value: unknown): value is TraceClient {
-  return value === "codex" || value === "claude";
+  return value === "codex" || value === "claude" || value === "opencode";
 }
 
 function stringField(record: Record<string, unknown>, key: string): string | undefined {

--- a/packages/ts/memorax-code-backend/src/trace/store.ts
+++ b/packages/ts/memorax-code-backend/src/trace/store.ts
@@ -90,6 +90,7 @@ type ExistingTraceJson = Record<string, unknown> & {
   updated_at?: unknown;
   codex?: unknown;
   claude?: unknown;
+  opencode?: unknown;
 };
 
 const eventCounters = new Map<string, number>();

--- a/packages/ts/memorax-code-backend/src/viewer/store.ts
+++ b/packages/ts/memorax-code-backend/src/viewer/store.ts
@@ -105,6 +105,7 @@ let liveEventsVersion = 0;
 type CombinedTraceHistory = Readonly<{
   codex: readonly MemoryViewerEvent[];
   claude: readonly MemoryViewerEvent[];
+  opencode: readonly MemoryViewerEvent[];
   claudeLocal: readonly MemoryViewerEvent[];
   values: MemoryViewerEvent[];
 }>;
@@ -466,9 +467,9 @@ async function readTraceHistory(
     },
     compare: compareMemoryViewerEvents,
   });
-  if (client === "codex") {
-    const codex = await readClient("codex");
-    return { ...codex, claudeLocal: EMPTY_MEMORY_VIEWER_HISTORY };
+  if (client === "codex" || client === "opencode") {
+    const selected = await readClient(client);
+    return { ...selected, claudeLocal: EMPTY_MEMORY_VIEWER_HISTORY };
   }
 
   const claudeLocalPromise = readClaudeLocalTranscriptHistory(claudeProjectsRoot, resolveProject);
@@ -482,6 +483,7 @@ async function readTraceHistory(
         `${historyCacheRoot}\u0000client=claude\u0000source=${claudeProjectsRoot || "disabled"}`,
         EMPTY_MEMORY_VIEWER_HISTORY,
         claude.values,
+        EMPTY_MEMORY_VIEWER_HISTORY,
         claudeLocal,
       ),
       complete: claude.complete,
@@ -489,9 +491,10 @@ async function readTraceHistory(
     };
   }
 
-  const [codex, claude, claudeLocal] = await Promise.all([
+  const [codex, claude, opencode, claudeLocal] = await Promise.all([
     readClient("codex"),
     readClient("claude"),
+    readClient("opencode"),
     claudeLocalPromise,
   ]);
   return {
@@ -499,9 +502,10 @@ async function readTraceHistory(
       `${historyCacheRoot}\u0000client=all\u0000source=${claudeProjectsRoot || "disabled"}`,
       codex.values,
       claude.values,
+      opencode.values,
       claudeLocal,
     ),
-    complete: codex.complete && claude.complete,
+    complete: codex.complete && claude.complete && opencode.complete,
     claudeLocal,
   };
 }
@@ -510,18 +514,20 @@ function combinedTraceHistory(
   cacheKey: string,
   codex: readonly MemoryViewerEvent[],
   claude: readonly MemoryViewerEvent[],
+  opencode: readonly MemoryViewerEvent[],
   claudeLocal: readonly MemoryViewerEvent[],
 ): MemoryViewerEvent[] {
   const cached = combinedTraceHistories.get(cacheKey);
   if (cached?.codex === codex
     && cached.claude === claude
+    && cached.opencode === opencode
     && cached.claudeLocal === claudeLocal) {
     return cached.values;
   }
   // Native Claude transcripts invalidate this cached identity, but they are
   // admitted only after retained and live Hook trace events are merged.
-  const values = [...codex, ...claude].sort(compareMemoryViewerEvents);
-  combinedTraceHistories.set(cacheKey, { codex, claude, claudeLocal, values });
+  const values = [...codex, ...claude, ...opencode].sort(compareMemoryViewerEvents);
+  combinedTraceHistories.set(cacheKey, { codex, claude, opencode, claudeLocal, values });
   return values;
 }
 
@@ -1205,23 +1211,24 @@ function sessionId(value: unknown): string {
 function memoryViewerClient(input: MemoryObservabilityEvent): TraceClient {
   if (input.traceContext?.client === "claude") return "claude";
   if (input.traceContext?.client === "codex") return "codex";
+  if (input.traceContext?.client === "opencode") return "opencode";
   if (input.source === "claude_hook_retrieval" || input.source === "claude_hook_writeback") return "claude";
+  if (input.source === "opencode_plugin_retrieval") return "opencode";
   return "codex";
 }
 
 function memoryViewerEventId(client: TraceClient, eventId: string | undefined): string {
   if (eventId) return persistedMemoryViewerEventId(client, eventId);
-  return client === "codex"
-    ? `memory-viewer:${randomUUID()}`
-    : `claude-memory-viewer:${randomUUID()}`;
+  return `${client === "codex" ? "" : `${client}-`}memory-viewer:${randomUUID()}`;
 }
 
 function persistedMemoryViewerEventId(client: TraceClient, eventId: string): string {
-  return client === "codex" ? `trace:${eventId}` : `claude-trace:${eventId}`;
+  return client === "codex" ? `trace:${eventId}` : `${client}-trace:${eventId}`;
 }
 
 function memoryViewerProjectionKey(memoraxCodeHome: string, client: TraceClient | undefined): string {
   if (client === "claude") return clientTracePaths("claude", memoraxCodeHome).sessionsRoot;
+  if (client === "opencode") return clientTracePaths("opencode", memoraxCodeHome).sessionsRoot;
   const codexSessionsRoot = tracePaths(memoraxCodeHome).sessionsRoot;
   return client === "codex" ? `${codexSessionsRoot}\u0000client=codex` : codexSessionsRoot;
 }

--- a/packages/ts/memorax-code-backend/test/architecture/source-boundaries.test.mjs
+++ b/packages/ts/memorax-code-backend/test/architecture/source-boundaries.test.mjs
@@ -40,6 +40,7 @@ const rules = [
       "clients/claude/memory-hook-runtime.ts",
       "clients/claude/transcript-turn.ts",
       "clients/codex/memory-hook-runtime.ts",
+      "clients/opencode/memory-hook-runtime.ts",
       "memory/turn-coordinator.ts",
       "memory/service.ts",
       "memory/writeback-buffer.ts",
@@ -59,6 +60,7 @@ const rules = [
       "memory/automatic-writeback.ts",
       "clients/claude/memory-hook-runtime.ts",
       "clients/codex/memory-hook-runtime.ts",
+      "clients/opencode/memory-hook-runtime.ts",
       "provider/memorax/adapter.ts",
       "memory/turn-coordinator.ts",
       "memory/service.ts",
@@ -88,6 +90,11 @@ const rules = [
   {
     name: "Claude memory hook runtime stays independent from HTTP and Backend composition",
     importers: ["clients/claude/memory-hook-runtime.ts", "clients/claude/transcript-turn.ts"],
+    forbidden: ["node:http", "server-", "entrypoints/", "transport/http/", "app/state"],
+  },
+  {
+    name: "OpenCode memory hook runtime stays independent from HTTP and Backend composition",
+    importers: ["clients/opencode/memory-hook-runtime.ts"],
     forbidden: ["node:http", "server-", "entrypoints/", "transport/http/", "app/state"],
   },
   {

--- a/packages/ts/memorax-code-backend/test/clients/opencode/opencode-memory-hook.test.mjs
+++ b/packages/ts/memorax-code-backend/test/clients/opencode/opencode-memory-hook.test.mjs
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+import { createOpenCodeMemoryHookRuntime } from "../../../dist/clients/opencode/memory-hook-runtime.js";
+import {
+  parseTurnStartCommand,
+  parseWritebackCommand,
+} from "../../../dist/memory/hook-command.js";
+
+const TEST_WORKSPACE = fileURLToPath(new URL("../../..", import.meta.url));
+
+test("OpenCode turn-start commands keep a closed client-specific schema", () => {
+  assert.equal(parseTurnStartCommand({
+    version: 1,
+    client: "opencode",
+    sessionId: "session-1",
+    userMessageId: "user-1",
+    prompt: "Use the OpenCode prompt.",
+    cwd: TEST_WORKSPACE,
+  }).ok, true);
+  assert.equal(parseTurnStartCommand({
+    version: 1,
+    client: "opencode",
+    sessionId: "session-1",
+    userMessageId: "user-1",
+    prompt: "Do not accept another client's transcript field.",
+    transcriptPath: "/tmp/transcript.jsonl",
+  }).ok, false);
+  assert.equal(parseWritebackCommand({
+    version: 1,
+    client: "opencode",
+    sessionId: "session-1",
+    userMessageId: "user-1",
+    assistantMessageId: "assistant-1",
+    messages: [],
+  }).ok, false);
+});
+
+test("OpenCode runtime reuses repository scope and automatic retrieval", async () => {
+  const memoraxCodeHome = await mkdtemp(join(tmpdir(), "memorax-code-opencode-runtime-"));
+  const requests = [];
+  const runtime = createOpenCodeMemoryHookRuntime({
+    memoraxCodeHome,
+    env: {
+      MEMORAX_CODE_HOME: memoraxCodeHome,
+      MEMORAX_CODE_OPENCODE_TRACE_ENABLED: "false",
+      MEMORAX_CODE_MEMORY_RETRIEVAL_ENABLED: "true",
+      MEMORAX_CODE_MEMORAX_ENDPOINT: "http://memorax.test",
+      MEMORAX_CODE_MEMORAX_API_KEY: "secret",
+      MEMORAX_CODE_MEMORAX_USER_ID: "user-1",
+    },
+    fetchImpl: async (url, init) => {
+      requests.push({ url: String(url), body: JSON.parse(init.body) });
+      return new Response(JSON.stringify({
+        success: true,
+        data: {
+          task_id: "search-1",
+          status: "completed",
+          data: [{
+            id: "memory-1",
+            memory: "OpenCode can reuse the shared retrieval runtime.",
+            score: 0.9,
+            metadata: { memory_type: "core" },
+          }],
+        },
+      }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    },
+  });
+  try {
+    const command = {
+      version: 1,
+      client: "opencode",
+      sessionId: "session-1",
+      userMessageId: "user-1",
+      prompt: "OpenCode user prompt.",
+      cwd: TEST_WORKSPACE,
+      workspaceKind: "project",
+    };
+    const start = await runtime.recordTurnStart(command);
+    assert.match(start.additionalContext, /shared retrieval runtime/);
+
+    const duplicate = await runtime.recordTurnStart(command);
+    assert.equal(duplicate.additionalContext, undefined);
+    assert.equal(requests.length, 1);
+    assert.equal(new URL(requests[0].url).pathname, "/v1/memories/search");
+  } finally {
+    runtime.close();
+    await rm(memoraxCodeHome, { recursive: true, force: true });
+  }
+});

--- a/packages/ts/memorax-code-backend/test/memory/memory-cli.test.mjs
+++ b/packages/ts/memorax-code-backend/test/memory/memory-cli.test.mjs
@@ -7,9 +7,17 @@ import { tmpdir } from "node:os";
 import { test } from "node:test";
 import { promisify } from "node:util";
 import { runMemoryCli } from "../../dist/memory/cli.js";
-import { traceContextFromClaudeHookBody, traceContextFromHookBody } from "../../dist/trace/context.js";
-import { claudeTracePaths, tracePaths } from "../../dist/trace/config.js";
-import { writeCurrentClaudeTurn, writeCurrentCodexTurn } from "../../dist/trace/store.js";
+import {
+  traceContextFromClaudeHookBody,
+  traceContextFromHookBody,
+  traceContextFromOpenCodeHookBody,
+} from "../../dist/trace/context.js";
+import { claudeTracePaths, openCodeTracePaths, tracePaths } from "../../dist/trace/config.js";
+import {
+  writeCurrentClaudeTurn,
+  writeCurrentCodexTurn,
+  writeCurrentTraceTurn,
+} from "../../dist/trace/store.js";
 import { listen } from "../support/helpers.mjs";
 
 const execFileAsync = promisify(execFile);
@@ -173,7 +181,7 @@ test("memory CLI rejects a nested repository outside the current turn scope", as
   assert.equal(result.workspaceScopeReason, "workspace_scope_mismatch");
   assert.equal(
     result.userAction,
-    "Start a new Codex or Claude Code session from the target repository or local workspace.",
+    "Start a new Codex, Claude Code, or OpenCode session from the target repository or local workspace.",
   );
   assert.equal(requestCount, 0);
 });
@@ -294,7 +302,7 @@ test("memory CLI gives the same scope recovery guidance for a Claude turn", asyn
   assert.equal(result.workspaceScopeReason, "workspace_scope_mismatch");
   assert.equal(
     result.userAction,
-    "Start a new Codex or Claude Code session from the target repository or local workspace.",
+    "Start a new Codex, Claude Code, or OpenCode session from the target repository or local workspace.",
   );
   assert.equal(requestCount, 0);
 });
@@ -773,6 +781,66 @@ test("memory CLI search binds to Claude trace without writing the same-id Codex 
   } finally {
     await new Promise((resolve) => server.close(resolve));
   }
+});
+
+test("memory CLI search binds to OpenCode trace instead of an inherited Codex thread", async () => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-code-cli-opencode-trace-"));
+  const sessionId = "shared-opencode-cli-session";
+  const codexWorkspace = join(root, "codex-workspace");
+  const openCodeWorkspace = join(root, "opencode-workspace");
+  const openCodeNestedCwd = join(openCodeWorkspace, "src");
+  await Promise.all([
+    mkdir(codexWorkspace, { recursive: true }),
+    mkdir(openCodeNestedCwd, { recursive: true }),
+  ]);
+  await writeCurrentCodexTurn(traceContextFromHookBody({
+    session_id: sessionId,
+    turn_id: "codex-turn",
+    cwd: codexWorkspace,
+  }), { memoraxCodeHome: root });
+  await writeCurrentTraceTurn(traceContextFromOpenCodeHookBody({
+    sessionId,
+    userMessageId: "opencode-user-message",
+    cwd: openCodeWorkspace,
+  }), {
+    client: "opencode",
+    memoraxCodeHome: root,
+  });
+  const requests = [];
+
+  const result = await runMemoryCli(["search", "--query", "OpenCode trace bridge"], {
+    env: {
+      CODEX_THREAD_ID: sessionId,
+      MEMORAX_CODE_MEMORY_CLI_TRACE_CLIENT: "opencode",
+      MEMORAX_CODE_MEMORY_CLI_TRACE_SESSION_ID: sessionId,
+      MEMORAX_CODE_HOME: root,
+      MEMORAX_CODE_MEMORAX_ENDPOINT: "http://memorax.test",
+      MEMORAX_CODE_MEMORAX_API_KEY: "secret",
+      MEMORAX_CODE_MEMORAX_USER_ID: "user-1",
+    },
+    cwd: openCodeNestedCwd,
+    fetchImpl: async (_url, init) => {
+      requests.push(JSON.parse(init.body));
+      return new Response(JSON.stringify({ success: true, data: { data: [] } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    },
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(requests.length, 1);
+  assert.equal(requests[0].user_id, "user-1@opencode-workspace");
+  const events = (await readFile(openCodeTracePaths(root).eventsJsonl(sessionId), "utf8"))
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line));
+  assert.equal(events.length, 1);
+  assert.equal(events[0].type, "memory_cli_search");
+  assert.equal(events[0].trace.client, "opencode");
+  assert.equal(events[0].trace.turn_id, "opencode-user-message");
+  assert.equal(events[0].trace.context_origin, "current-turn-file");
+  await assert.rejects(readFile(tracePaths(root).eventsJsonl(sessionId), "utf8"));
 });
 
 test("memory CLI search does not trace to a different Codex thread current turn", async () => {

--- a/packages/ts/memorax-code-backend/test/memory/memory-service.test.mjs
+++ b/packages/ts/memorax-code-backend/test/memory/memory-service.test.mjs
@@ -28,6 +28,7 @@ test("memory service exposes a sealed Hook facade and closes idempotently", asyn
     },
     env: {
       MEMORAX_CODE_CODEX_TRACE_ENABLED: "false",
+      MEMORAX_CODE_OPENCODE_TRACE_ENABLED: "false",
       MEMORAX_CODE_MEMORAX_ENDPOINT: "http://memorax.test",
       MEMORAX_CODE_MEMORAX_API_KEY: "secret",
       MEMORAX_CODE_MEMORAX_USER_ID: "user-1",
@@ -64,6 +65,15 @@ test("memory service exposes a sealed Hook facade and closes idempotently", asyn
       transcriptPath: join(memoraxCodeHome, "missing-claude-transcript.jsonl"),
     });
     assert.equal(diagnosticEvents.some((event) => event.message === "claude_memory_hook.turn_start"), true);
+    await service.recordTurnStart({
+      version: 1,
+      client: "opencode",
+      sessionId: "session-opencode-memory-service",
+      userMessageId: "user-opencode-memory-service",
+      prompt: "Record this exact OpenCode turn in the runtime.",
+      cwd: firstWorkspace,
+    });
+    assert.equal(diagnosticEvents.some((event) => event.message === "opencode_memory.turn_start"), true);
 
     await assert.rejects(service.recordTurnStart({
       version: 1,

--- a/packages/ts/memorax-code-backend/test/trace/claude-memory-trace.test.mjs
+++ b/packages/ts/memorax-code-backend/test/trace/claude-memory-trace.test.mjs
@@ -10,9 +10,14 @@ import {
   clientTraceConfigFromEnv,
   clientTracePaths,
   codexTraceConfigFromEnv,
+  openCodeTraceConfigFromEnv,
+  openCodeTracePaths,
   tracePaths,
 } from "../../dist/trace/config.js";
-import { traceContextFromClaudeHookBody } from "../../dist/trace/context.js";
+import {
+  traceContextFromClaudeHookBody,
+  traceContextFromOpenCodeHookBody,
+} from "../../dist/trace/context.js";
 import {
   markCurrentClaudeTurnOutcome,
   markCurrentCodexTurnOutcome,
@@ -31,6 +36,7 @@ test("claude trace config defaults to enabled and reads isolated overrides", asy
   const root = await mkdtemp(join(tmpdir(), "memorax-code-claude-trace-config-"));
   try {
     assert.match(renderDefaultMemoraxCodeConfig(), /\[trace\.claude\]\nenabled = true/);
+    assert.match(renderDefaultMemoraxCodeConfig(), /\[trace\.opencode\]\nenabled = true/);
     assert.deepEqual(claudeTraceConfigFromEnv({ MEMORAX_CODE_HOME: root }), {
       enabled: true,
       captureContent: true,
@@ -50,6 +56,13 @@ test("claude trace config defaults to enabled and reads isolated overrides", asy
       "retention_days = 3",
       "max_event_chars = 1234",
       "max_file_bytes = 9999",
+      "",
+      "[trace.opencode]",
+      "enabled = false",
+      "capture_content = false",
+      "retention_days = 4",
+      "max_event_chars = 2345",
+      "max_file_bytes = 7777",
       "",
     ].join("\n"), "utf8");
 
@@ -82,6 +95,13 @@ test("claude trace config defaults to enabled and reads isolated overrides", asy
       maxEventChars: 20_000,
       maxFileBytes: 52_428_800,
     });
+    assert.deepEqual(openCodeTraceConfigFromEnv({ MEMORAX_CODE_HOME: root }, config), {
+      enabled: false,
+      captureContent: false,
+      retentionDays: 4,
+      maxEventChars: 2345,
+      maxFileBytes: 7777,
+    });
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -105,7 +125,23 @@ test("Claude Hook trace context maps prompt identity without provider assumption
   });
 });
 
-test("trace store isolates Codex and Claude sessions with the same id", async () => {
+test("OpenCode Hook trace context maps SDK message identity", () => {
+  assert.deepEqual(traceContextFromOpenCodeHookBody({
+    sessionId: "opencode-session",
+    userMessageId: "opencode-user-message",
+    workspaceKind: "project",
+  }, "2026-07-24T00:00:00.000Z"), {
+    schemaVersion: "1",
+    client: "opencode",
+    sessionId: "opencode-session",
+    turnId: "opencode-user-message",
+    workspaceKind: "project",
+    contextOrigin: "opencode-hook-body",
+    capturedAt: "2026-07-24T00:00:00.000Z",
+  });
+});
+
+test("trace store isolates Codex, Claude, and OpenCode sessions with the same id", async () => {
   const root = await mkdtemp(join(tmpdir(), "memorax-code-client-trace-isolation-"));
   const sessionId = "shared-session";
   try {
@@ -118,6 +154,10 @@ test("trace store isolates Codex and Claude sessions with the same id", async ()
       sessionId,
       turnId: "codex-turn",
       transcriptPath: "/tmp/codex.jsonl",
+    });
+    const opencode = traceContextFromOpenCodeHookBody({
+      sessionId,
+      userMessageId: "opencode-turn",
     });
     await Promise.all([
       recordClaudeTraceEvent({
@@ -138,25 +178,43 @@ test("trace store isolates Codex and Claude sessions with the same id", async ()
         ok: true,
         request: { query: "codex query" },
       }),
+      recordTraceEvent({
+        memoraxCodeHome: root,
+        traceContext: opencode,
+        type: "memory_retrieve",
+        source: "opencode_plugin_retrieval",
+        operation: "retrieve",
+        ok: true,
+        request: { query: "opencode query" },
+      }),
     ]);
 
     const claudeEvent = JSON.parse(await readFile(claudeTracePaths(root).eventsJsonl(sessionId), "utf8"));
     const codexEvent = JSON.parse(await readFile(tracePaths(root).eventsJsonl(sessionId), "utf8"));
+    const opencodeEvent = JSON.parse(await readFile(openCodeTracePaths(root).eventsJsonl(sessionId), "utf8"));
     assert.equal(claudeEvent.trace.client, "claude");
     assert.equal(claudeEvent.trace.turn_id, "claude-turn");
     assert.equal(claudeEvent.request.query, "claude query");
     assert.equal(codexEvent.trace.client, "codex");
     assert.equal(codexEvent.trace.turn_id, "codex-turn");
     assert.equal(codexEvent.request.query, "codex query");
+    assert.equal(opencodeEvent.trace.client, "opencode");
+    assert.equal(opencodeEvent.trace.turn_id, "opencode-turn");
+    assert.equal(opencodeEvent.request.query, "opencode query");
 
     const claudeTrace = JSON.parse(await readFile(claudeTracePaths(root).traceJson(sessionId), "utf8"));
     const codexTrace = JSON.parse(await readFile(tracePaths(root).traceJson(sessionId), "utf8"));
+    const opencodeTrace = JSON.parse(await readFile(openCodeTracePaths(root).traceJson(sessionId), "utf8"));
     assert.equal(claudeTrace.client, "claude");
     assert.equal(claudeTrace.claude.transcript_path, "/tmp/claude.jsonl");
     assert.equal(claudeTrace.codex, undefined);
     assert.equal(codexTrace.client, "codex");
     assert.equal(codexTrace.codex.transcript_path, "/tmp/codex.jsonl");
     assert.equal(codexTrace.claude, undefined);
+    assert.equal(opencodeTrace.client, "opencode");
+    assert.deepEqual(opencodeTrace.opencode, {});
+    assert.equal(opencodeTrace.codex, undefined);
+    assert.equal(opencodeTrace.claude, undefined);
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/packages/ts/memorax-code-backend/test/transport/http/memory-hook.test.mjs
+++ b/packages/ts/memorax-code-backend/test/transport/http/memory-hook.test.mjs
@@ -117,6 +117,13 @@ test("Backend memory hook endpoints reject commands outside the closed schema", 
     lastAssistantMessage: "Claude writeback.",
     transcriptPath: "/tmp/claude.jsonl",
   };
+  const openCodeTurnStart = {
+    version: 1,
+    client: "opencode",
+    sessionId: "session-opencode-turn-start",
+    userMessageId: "user-opencode-turn-start",
+    prompt: "OpenCode turn start.",
+  };
   try {
     for (const [caseName, path, body] of [
       ["unversioned command", "/memory/turn-start", {
@@ -187,6 +194,10 @@ test("Backend memory hook endpoints reject commands outside the closed schema", 
       ["invalid optional Claude workspace kind", "/memory/writeback", {
         ...claudeWriteback,
         workspaceKind: {},
+      }],
+      ["transcript field on OpenCode turn-start", "/memory/turn-start", {
+        ...openCodeTurnStart,
+        transcriptPath: "/tmp/opencode.jsonl",
       }],
     ]) {
       const response = await fetch(`${url}${path}`, {

--- a/packages/ts/memorax-code-backend/test/viewer/history/memory-viewer-client-history.test.mjs
+++ b/packages/ts/memorax-code-backend/test/viewer/history/memory-viewer-client-history.test.mjs
@@ -38,6 +38,11 @@ test("memory viewer combines client-isolated history without identity collisions
     timestamp: "2026-07-28T00:01:00.000Z",
     response: { items: [{ memory: "Claude memory." }] },
   }]);
+  await writeTraceEvents(memoraxCodeHome, "opencode", "shared-session", [{
+    ...shared,
+    timestamp: "2026-07-28T00:02:00.000Z",
+    response: { items: [{ memory: "OpenCode memory." }] },
+  }]);
 
   const all = await listMemoryViewerDataWithHistory(memoraxCodeHome);
   assert.deepEqual(all.events.map(({ client, id, content }) => ({ client, id, content })), [{
@@ -48,9 +53,13 @@ test("memory viewer combines client-isolated history without identity collisions
     client: "claude",
     id: "claude-trace:shared-event",
     content: "Claude memory.",
+  }, {
+    client: "opencode",
+    id: "opencode-trace:shared-event",
+    content: "OpenCode memory.",
   }]);
-  assert.equal(new Set(all.events.map((event) => event.id)).size, 2);
-  assert.equal(new Set(all.events.map((event) => event.eventKey)).size, 2);
+  assert.equal(new Set(all.events.map((event) => event.id)).size, 3);
+  assert.equal(new Set(all.events.map((event) => event.eventKey)).size, 3);
   assert.equal(
     all.events[0].eventKey,
     JSON.stringify(["codex", "shared-session", "trace:shared-event"]),
@@ -70,13 +79,18 @@ test("memory viewer combines client-isolated history without identity collisions
     projectId,
     sessionId: "shared-session",
     eventCount: 1,
+  }, {
+    client: "opencode",
+    projectId,
+    sessionId: "shared-session",
+    eventCount: 1,
   }]);
   assert.deepEqual(
     all.activityProjectSessions.map((entry) => entry.client),
-    ["claude", "codex"],
+    ["claude", "codex", "opencode"],
   );
 
-  for (const client of ["codex", "claude"]) {
+  for (const client of ["codex", "claude", "opencode"]) {
     const selected = await listMemoryViewerDataWithHistory(memoraxCodeHome, { client });
     assert.deepEqual(selected.events.map((event) => event.client), [client]);
     assert.deepEqual(selected.projectSessions.map((entry) => entry.client), [client]);
@@ -343,16 +357,24 @@ test("memory viewer assigns a client to live events and preserves Codex identiti
     traceContext: context("claude"),
   });
   recordMemoryViewerEvent({
+    eventId: "same-live-event",
+    source: "memory_cli",
+    operation: "retrieve",
+    ok: true,
+    traceContext: context("opencode"),
+  });
+  recordMemoryViewerEvent({
     source: "workflow_startup",
     operation: "retrieve",
     ok: true,
   });
 
   const live = listMemoryViewerEvents();
-  assert.deepEqual(live.map((event) => event.client), ["codex", "claude", "codex"]);
+  assert.deepEqual(live.map((event) => event.client), ["codex", "claude", "opencode", "codex"]);
   assert.equal(live[0].id, "trace:same-live-event");
   assert.equal(live[1].id, "claude-trace:same-live-event");
-  assert.equal(new Set(live.map((event) => event.eventKey)).size, 3);
+  assert.equal(live[2].id, "opencode-trace:same-live-event");
+  assert.equal(new Set(live.map((event) => event.eventKey)).size, 4);
 });
 
 async function writeTraceEvents(memoraxCodeHome, client, sessionDir, events) {

--- a/packages/ts/memorax-code-opencode-adapter/src/plugin.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/src/plugin.mjs
@@ -1,32 +1,105 @@
 import { delimiter } from "node:path";
+import { resolveBackendConnection } from "../../memorax-code-adapter-common/src/backend-connection.mjs";
 import { readAdapterState } from "../../memorax-code-adapter-common/src/config-utils.mjs";
 
+const TURN_START_TIMEOUT_MS = 12_000;
+
 export function createMemoraxOpenCodePlugin(options = {}) {
-  return async () => ({
-    "shell.env": async (input, output) => {
-      if (!pluginEnabled(options)) return;
-      output.env.MEMORAX_CODE_MEMORY_CLI_TRACE_CLIENT = "opencode";
-      const sessionId = stringValue(input?.sessionID);
-      delete output.env.MEMORAX_CODE_MEMORY_CLI_TRACE_SESSION_ID;
-      delete output.env.MEMORAX_CODE_MEMORY_CLI_SESSION_ID;
-      if (sessionId) {
-        output.env.MEMORAX_CODE_MEMORY_CLI_TRACE_SESSION_ID = sessionId;
-        output.env.MEMORAX_CODE_MEMORY_CLI_SESSION_ID = sessionId;
-      }
-      const cliBinDir = stringValue(options.cliBinDir);
-      if (cliBinDir) {
-        const currentPath = output.env.PATH ?? process.env.PATH ?? "";
-        const pathEntries = currentPath.split(delimiter).filter(Boolean);
-        output.env.PATH = pathEntries.includes(cliBinDir)
-          ? currentPath
-          : [cliBinDir, ...pathEntries].join(delimiter);
-      }
-    },
-  });
+  return async ({ project, directory, worktree }) => {
+    const workspaceRoot = project?.vcs === "git" ? worktree : directory;
+    const workspaceKind = project?.vcs === "git" ? "project" : "local";
+
+    return {
+      "chat.message": async (input, output) => {
+        if (!pluginEnabled(options)) return;
+        const userMessageId = stringValue(output?.message?.id) ?? stringValue(input?.messageID);
+        const sessionId = stringValue(input?.sessionID);
+        const prompt = textParts(output?.parts);
+        if (!sessionId || !userMessageId || !prompt) return;
+        try {
+          const result = await postBackend(options, "/memory/turn-start", {
+            version: 1,
+            client: "opencode",
+            sessionId,
+            userMessageId,
+            prompt,
+            cwd: workspaceRoot,
+            workspaceKind,
+          }, TURN_START_TIMEOUT_MS);
+          if (!pluginEnabled(options)) return;
+          const additionalContext = stringValue(result?.additionalContext);
+          if (additionalContext) {
+            const existing = stringValue(output.message.system);
+            output.message.system = existing
+              ? `${existing}\n\n${additionalContext}`
+              : additionalContext;
+          }
+        } catch (error) {
+          debug(options, "opencode turn start failed", error);
+        }
+      },
+      "shell.env": async (input, output) => {
+        if (!pluginEnabled(options)) return;
+        output.env.MEMORAX_CODE_MEMORY_CLI_TRACE_CLIENT = "opencode";
+        const sessionId = stringValue(input?.sessionID);
+        delete output.env.MEMORAX_CODE_MEMORY_CLI_TRACE_SESSION_ID;
+        delete output.env.MEMORAX_CODE_MEMORY_CLI_SESSION_ID;
+        if (sessionId) {
+          output.env.MEMORAX_CODE_MEMORY_CLI_TRACE_SESSION_ID = sessionId;
+          output.env.MEMORAX_CODE_MEMORY_CLI_SESSION_ID = sessionId;
+        }
+        const cliBinDir = stringValue(options.cliBinDir);
+        if (cliBinDir) {
+          const currentPath = output.env.PATH ?? process.env.PATH ?? "";
+          const pathEntries = currentPath.split(delimiter).filter(Boolean);
+          output.env.PATH = pathEntries.includes(cliBinDir)
+            ? currentPath
+            : [cliBinDir, ...pathEntries].join(delimiter);
+        }
+      },
+    };
+  };
 }
 
 export const MemoraxOpenCodePlugin = createMemoraxOpenCodePlugin();
 export default MemoraxOpenCodePlugin;
+
+function textParts(parts) {
+  if (!Array.isArray(parts)) return "";
+  return parts
+    .flatMap((part) => (
+      part?.type === "text"
+      && part.synthetic !== true
+      && part.ignored !== true
+      && stringValue(part.text)
+        ? [part.text.trim()]
+        : []
+    ))
+    .join("\n\n")
+    .trim();
+}
+
+async function postBackend(options, path, body, timeoutMs) {
+  const connection = options.backendConnection ?? resolveBackendConnection(options);
+  const headers = { "content-type": "application/json", connection: "close" };
+  if (connection.token) headers["x-memorax-code-backend-token"] = connection.token;
+  const response = await (options.fetchImpl ?? fetch)(new URL(path, connection.url), {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  if (!response.ok) {
+    await response.arrayBuffer().catch(() => undefined);
+    throw new Error(`Backend ${path} returned HTTP ${response.status}`);
+  }
+  return await response.json();
+}
+
+function debug(options, message, error) {
+  if (options.debug !== true && process.env.MEMORAX_CODE_OPENCODE_PLUGIN_DEBUG !== "1") return;
+  console.error(`${message}: ${error instanceof Error ? error.message : String(error)}`);
+}
 
 function stringValue(value) {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;

--- a/packages/ts/memorax-code-opencode-adapter/test/plugin.test.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/test/plugin.test.mjs
@@ -5,10 +5,84 @@ import { delimiter, join } from "node:path";
 import { test } from "node:test";
 import { createMemoraxOpenCodePlugin } from "../src/plugin.mjs";
 
+test("chat.message retrieves memory and injects it into the system prompt", async () => {
+  const requests = [];
+  const plugin = createMemoraxOpenCodePlugin({
+    backendConnection: { url: "http://127.0.0.1:8787", token: "test-token" },
+    fetchImpl: responseSequence(requests, [{ ok: true, additionalContext: "Remember the repository boundary." }]),
+  });
+  const hooks = await plugin(pluginInput());
+  const output = {
+    message: { id: "user-1", system: "Existing system context" },
+    parts: [
+      { type: "text", text: "First prompt line" },
+      { type: "text", text: "ignored", synthetic: true },
+      { type: "text", text: "Second prompt line" },
+    ],
+  };
+
+  await hooks["chat.message"]({ sessionID: "session-1" }, output);
+
+  assert.equal(output.message.system, "Existing system context\n\nRemember the repository boundary.");
+  assert.equal(requests.length, 1);
+  assert.equal(requests[0].url, "http://127.0.0.1:8787/memory/turn-start");
+  assert.equal(requests[0].options.headers["x-memorax-code-backend-token"], "test-token");
+  assert.deepEqual(requests[0].body, {
+    version: 1,
+    client: "opencode",
+    sessionId: "session-1",
+    userMessageId: "user-1",
+    prompt: "First prompt line\n\nSecond prompt line",
+    cwd: "/repo/worktree",
+    workspaceKind: "project",
+  });
+});
+
+test("chat.message does not mistake a user diff summary for compaction", async () => {
+  const requests = [];
+  const plugin = createMemoraxOpenCodePlugin({
+    backendConnection: { url: "http://127.0.0.1:8787" },
+    fetchImpl: responseSequence(requests, [{ ok: true }]),
+  });
+  const hooks = await plugin(pluginInput());
+  const output = {
+    message: {
+      id: "user-with-summary",
+      summary: { title: "Edited files", body: "One change", diffs: [] },
+    },
+    parts: [{ type: "text", text: "Keep recalling memory." }],
+  };
+
+  await hooks["chat.message"]({ sessionID: "session-with-summary" }, output);
+
+  assert.equal(requests.length, 1);
+  assert.equal(requests[0].body.prompt, "Keep recalling memory.");
+});
+
+test("chat.message ignores compaction and synthetic-only messages", async () => {
+  const requests = [];
+  const plugin = createMemoraxOpenCodePlugin({
+    backendConnection: { url: "http://127.0.0.1:8787" },
+    fetchImpl: responseSequence(requests, []),
+  });
+  const hooks = await plugin(pluginInput());
+
+  await hooks["chat.message"](
+    { sessionID: "session-compaction" },
+    { message: { id: "user-compaction" }, parts: [{ type: "compaction", auto: true }] },
+  );
+  await hooks["chat.message"](
+    { sessionID: "session-synthetic" },
+    { message: { id: "user-synthetic" }, parts: [{ type: "text", text: "generated", synthetic: true }] },
+  );
+
+  assert.equal(requests.length, 0);
+});
+
 test("shell.env overwrites the OpenCode session identity and prepends the managed CLI path", async () => {
   const cliBinDir = "/memorax/bin";
   const plugin = createMemoraxOpenCodePlugin({ cliBinDir });
-  const hooks = await plugin({});
+  const hooks = await plugin(pluginInput());
   const output = {
     env: {
       MEMORAX_CODE_MEMORY_CLI_TRACE_CLIENT: "codex",
@@ -47,19 +121,23 @@ test("shell.env clears inherited session identity without an OpenCode session", 
 test("a loaded plugin follows the managed enabled state without an OpenCode restart", async () => {
   const root = await mkdtemp(join(tmpdir(), "memorax-code-opencode-plugin-state-"));
   const statePath = join(root, "state.json");
+  const requests = [];
   try {
     await writeState(false);
-    const plugin = createMemoraxOpenCodePlugin({ statePath });
-    const hooks = await plugin({});
-    const disabledOutput = { env: {} };
-    await hooks["shell.env"]({ sessionID: "session-disabled" }, disabledOutput);
-    assert.equal(disabledOutput.env.MEMORAX_CODE_MEMORY_CLI_TRACE_CLIENT, undefined);
+    const plugin = createMemoraxOpenCodePlugin({
+      statePath,
+      backendConnection: { url: "http://127.0.0.1:8787" },
+      fetchImpl: responseSequence(requests, [{ ok: true }]),
+    });
+    const hooks = await plugin(pluginInput());
+    const disabledOutput = { message: { id: "user-disabled" }, parts: [{ type: "text", text: "ignored" }] };
+    await hooks["chat.message"]({ sessionID: "session-disabled" }, disabledOutput);
+    assert.equal(requests.length, 0);
 
     await writeState(true);
-    const enabledOutput = { env: {} };
-    await hooks["shell.env"]({ sessionID: "session-enabled" }, enabledOutput);
-    assert.equal(enabledOutput.env.MEMORAX_CODE_MEMORY_CLI_TRACE_CLIENT, "opencode");
-    assert.equal(enabledOutput.env.MEMORAX_CODE_MEMORY_CLI_SESSION_ID, "session-enabled");
+    const enabledOutput = { message: { id: "user-enabled" }, parts: [{ type: "text", text: "remember" }] };
+    await hooks["chat.message"]({ sessionID: "session-enabled" }, enabledOutput);
+    assert.equal(requests.length, 1);
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -74,3 +152,24 @@ test("a loaded plugin follows the managed enabled state without an OpenCode rest
     }));
   }
 });
+
+function pluginInput(overrides = {}) {
+  return {
+    client: { session: { async messages() { return { data: [] }; } } },
+    project: { vcs: "git" },
+    directory: "/repo/directory",
+    worktree: "/repo/worktree",
+    ...overrides,
+  };
+}
+
+function responseSequence(requests, responses) {
+  return async (url, options) => {
+    requests.push({ url: String(url), options, body: JSON.parse(options.body) });
+    const body = responses.shift() ?? { ok: true };
+    return new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  };
+}

--- a/scripts/check-local-trace-only.mjs
+++ b/scripts/check-local-trace-only.mjs
@@ -28,6 +28,7 @@ const reviewedNetworkSources = new Set([
   "packages/ts/memorax-code-backend/src/app/backend-server.ts",
   "packages/ts/memorax-code-backend/src/clients/claude/memory-hook-runtime.ts",
   "packages/ts/memorax-code-backend/src/clients/codex/memory-hook-runtime.ts",
+  "packages/ts/memorax-code-backend/src/clients/opencode/memory-hook-runtime.ts",
   "packages/ts/memorax-code-backend/src/lifecycle/backend/service.ts",
   "packages/ts/memorax-code-backend/src/lifecycle/backend/status.ts",
   "packages/ts/memorax-code-backend/src/memory/automatic-retrieval.ts",
@@ -50,6 +51,7 @@ const reviewedNetworkSources = new Set([
   "packages/ts/memorax-code-codex-adapter/runtime-hooks/memory-writeback.mjs",
   "packages/ts/memorax-code-codex-adapter/src/cli.mjs",
   "packages/ts/memorax-code-codex-adapter/skills/memorax-code/scripts/detect_updates.py",
+  "packages/ts/memorax-code-opencode-adapter/src/plugin.mjs",
 ]);
 
 const localTraceCoreSources = new Set([

--- a/scripts/npm-package-check.sh
+++ b/scripts/npm-package-check.sh
@@ -359,6 +359,7 @@ assert config_sections == {
     "memory.writeback",
     "trace.claude",
     "trace.codex",
+    "trace.opencode",
 }
 assert 'output_language = "zh"' in config_text
 assert memorax_code_config.stat().st_mode & 0o777 == 0o600


### PR DESCRIPTION
## Change Summary
Add automatic memory retrieval for eligible OpenCode prompts, reusing the authenticated local Backend and injecting accepted memory context without blocking the prompt on retrieval failures.

## Implementation Highlights
- Route client-qualified OpenCode turn-start events through the existing repository scope and MemoraX retrieval runtime, with per-message deduplication and fail-open behavior.
- Add OpenCode trace configuration, current-turn identity, CLI binding, and Viewer history isolation without enabling automatic writeback or background Repo Memory maintenance.

## Validation
- `npm run typecheck --prefix packages/ts/memorax-code-backend`
- `npm test --prefix packages/ts/memorax-code-backend` — 514 passed, 2 skipped
- `make test-opencode-adapter` — 14 passed
- `make docs-check` — passed
- `make npm-package-check` — 170 package checks passed

## Full End-to-End Validation Results
This is an incremental integration PR, so no screenshot-only evidence is included. Full macOS and Linux Docker E2E validation will be recorded after the complete OpenCode integration stack is assembled. Windows remains unverified.