### PR TITLE
feat: add automatic memory writeback for OpenCode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,9 +40,10 @@ same change, then run the matching verification profile in Section 5.
 - Hook commands are versioned and client-qualified. Required session, turn, or
   prompt correlation must be validated at the HTTP boundary; incomplete,
   conflicting, unknown, or client-inapplicable identities fail closed.
-- Codex rollout JSONL and Claude Code transcript JSONL are the only content
-  authorities for their respective automatic writeback. Hook text, local
-  trace, latest-turn guesses, or the other client's format are not fallbacks.
+- Codex rollout JSONL, Claude Code transcript JSONL, and matching OpenCode SDK
+  session-message records are the only content authorities for their
+  respective automatic writeback. Hook or plugin text, local trace,
+  latest-turn guesses, or another client's format are not fallbacks.
 - Session, turn metadata, trace, and operational identity always include the
   client. Equal native IDs from different clients must remain isolated.
 - A live session is pinned to its resolved workspace and repository scope.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -94,7 +94,7 @@ relationships; the arrow labels distinguish them. It is not an import graph.
 | `packages/ts/memorax-code-adapter-common` | Shared source for Backend connection authority, private runtime records, cross-process locking and configuration, Hook generations, Hook launch helpers, and Repo/Personal Memory helpers | Backend composition, native transcript interpretation, MemoraX request execution, or client plugin policy | `packages/ts/memorax-code-adapter-common/src/backend-connection.mjs`, `src/runtime-record.mjs`, `src/hooks`, and `src/repo-memory` |
 | `packages/ts/memorax-code-codex-adapter` | Codex plugin artifact, Hook shells and runtimes, session/workspace observation, diagnostics, and the canonical shared skill | Codex rollout semantics or Backend-side writeback authority | `.codex-plugin`, `hooks`, `runtime-hooks`, `src`, and `skills/memorax-code` |
 | `packages/ts/memorax-code-claude-adapter` | Claude Code plugin artifact, Hook shells and runtimes, configuration, installer, marketplace source, and diagnostics | Claude transcript semantics or Backend memory orchestration | `.claude-plugin`, `hooks`, `runtime-hooks`, `scripts`, and `src/plugin-install.mjs` |
-| `packages/ts/memorax-code-opencode-adapter` | OpenCode plugin runtime, managed thin-loader installation, automatic retrieval, shell-session identity, and a materialized shared skill | OpenCode writeback content interpretation inside the Backend or model-provider configuration | `src/plugin.mjs`, `src/plugin-install.mjs`, and the OpenCode materialization mapping in `scripts/npm-source-files.mjs` |
+| `packages/ts/memorax-code-opencode-adapter` | OpenCode plugin runtime, managed thin-loader installation, automatic retrieval, SDK-backed writeback, shell-session identity, and a materialized shared skill | OpenCode message interpretation inside the Backend, model-provider configuration, or background Repo Memory maintenance | `src/plugin.mjs`, `src/plugin-install.mjs`, and the OpenCode materialization mapping in `scripts/npm-source-files.mjs` |
 | `packages/npm/memorax-code` | Installed executable wrappers, update, preinstall/postinstall, npm manifest, and release-package source | Backend lifecycle semantics, uninstall orchestration, or artifact staging | `bin`, `lib/run-entrypoint.mjs`, and `package.json` |
 | `scripts` | Backend build orchestration, staging/materialization, package layout, documentation, and local-only data gates | Product runtime authority | Package-build/check scripts and executable contract scripts |
 | `.github` | Issue and pull-request contribution templates | Product runtime behavior | `.github/ISSUE_TEMPLATE` and `.github/pull_request_template.md` |
@@ -211,9 +211,11 @@ sequenceDiagram
 Important distinctions:
 
 - Hook or plugin event fields supply protocol, correlation, and retrieval
-  input. They are not automatic writeback content authority.
-- Codex rollout JSONL and Claude Code transcript JSONL are the content
-  authorities for their respective clients.
+  input. Their prompt or event text is not automatic writeback content
+  authority; OpenCode's separately supplied SDK records are validated as
+  client-native content.
+- Codex rollout JSONL, Claude Code transcript JSONL, and OpenCode SDK session
+  message records are the content authorities for their respective clients.
 - Required client/session/turn identity and repository scope fail closed when
   incomplete, conflicting, or unprovable.
 - A malformed or incomplete direct `.git` directory is the sole documented
@@ -223,7 +225,7 @@ Important distinctions:
 - Local mode may authorize loopback requests without a configured token. Token
   authentication is required when configuration or exposure mode demands it.
 - Client-specific runtimes interpret native formats. Client-neutral memory
-  coordination does not parse or guess either format.
+  coordination does not parse, mix, or guess those formats.
 - OpenCode's awaited `chat.message` plugin event supplies the correlated user
   prompt and injects accepted retrieval context into that message's system
   context. Its `shell.env` event binds the native session identity and makes
@@ -249,9 +251,10 @@ Writeback is a separate branch, not the tail of every memory operation.
 
 ```mermaid
 sequenceDiagram
-  participant Hook as client Stop Hook
+  participant Client as supported client
+  participant Integration as adapter Hook or plugin
+  participant Authority as client-native content authority
   participant Service as memory service
-  participant Native as rollout/transcript reader
   participant Coordinator as turn coordinator
   participant Scope as repository scope
   participant Runtime as automatic writeback runtime
@@ -261,9 +264,17 @@ sequenceDiagram
   participant Reconciler as status reconciler
   participant Trace as local trace
 
-  Hook->>Service: client-qualified writeback correlation
-  Service->>Native: read the exact completed native Turn
-  Native->>Coordinator: native content and correlation plus scope resolver
+  Client->>Integration: completion signal and correlation
+  alt OpenCode
+    Integration->>Authority: fetch session messages through the client SDK
+    Authority-->>Integration: matching user and completed assistant records
+    Integration->>Service: correlation and SDK message records
+  else Codex or Claude Code
+    Integration->>Service: client-qualified writeback correlation
+    Service->>Authority: read the exact rollout or transcript Turn
+    Authority-->>Service: matching native Turn
+  end
+  Service->>Coordinator: validated native content and correlation plus scope resolver
   Coordinator->>Scope: resolve and revalidate current scope
   Scope-->>Coordinator: current repository identity
   Coordinator->>Runtime: enqueue the materialized Turn
@@ -281,8 +292,15 @@ sequenceDiagram
 - Retrieval events do not enter reconciliation.
 - Local enqueue acceptance is the metadata-consumption point; provider I/O may
   occur later through the automatic writeback runtime.
-- Buffering and chunking belong to the memory capability; transcript parsing
-  remains client-specific.
+- Buffering and chunking belong to the memory capability; rollout, transcript,
+  and SDK message parsing remains client-specific.
+- OpenCode writeback accepts only the matching SDK user and completed assistant
+  records for the correlated session and parent message. It rejects errored,
+  summary, compaction, incomplete, or identity-mismatched messages and does not
+  fall back to plugin prompt text or local database guesses.
+- Because OpenCode completion notification is an event callback, the plugin
+  tracks idle-triggered SDK and writeback work and drains already-started tasks
+  during plugin disposal.
 - When a degraded direct-`.git` scope upgrades to verified Git scope, the
   buffer runtime cancels and discards pending fallback turns for the same
   client and session before buffering under the Git scope. It does not migrate
@@ -302,7 +320,8 @@ Backend-resolved worktree rather than an arbitrary Hook `cwd`.
 
 OpenCode supports active Repo Memory operations through the shared skill, but
 its plugin does not own supervised background Repo Memory maintenance. Its
-automatic runtime contract currently covers prompt retrieval.
+automatic runtime contract covers prompt retrieval and completed-turn
+writeback.
 
 ## 4. Backend Modular Monolith
 
@@ -326,7 +345,7 @@ src/
   clients/
     codex/                Codex native interpretation and lifecycle adapters
     claude/               Claude native interpretation and lifecycle participant
-    opencode/             OpenCode retrieval runtime and lifecycle participant
+    opencode/             OpenCode retrieval, SDK message interpretation, and lifecycle participant
   config/                 Backend and proxy/config interpretation
   entrypoints/            process and management-CLI orchestration
   lifecycle/
@@ -362,7 +381,7 @@ entrypoints and compatibility facades. It is not another implementation area.
 | `src/lifecycle/backend` | Managed process, PID/token/connection records, status probing, cleanup, and shutdown requests | Helper contracts do not depend back on the full service implementation |
 | `src/clients/codex` | Codex rollout, prompt, turn-index, and workspace interpretation; Hook memory runtime; plugin integration glue; and lifecycle participant | No Claude format fallback; request runtime remains HTTP-composition independent |
 | `src/clients/claude` | Claude transcript/turn interpretation, Hook memory runtime, and lifecycle participant | No Codex format fallback; request runtime remains HTTP-composition independent |
-| `src/clients/opencode` | OpenCode plugin memory retrieval runtime and lifecycle participant | Request runtime remains HTTP-composition independent and does not infer writeback content |
+| `src/clients/opencode` | OpenCode SDK message validation and text materialization, plugin memory runtime, and lifecycle participant | No Hook-text, database, rollout, or transcript fallback; request runtime remains HTTP-composition independent |
 | `src/memory` | Memory commands, retrieval, writeback, turn coordination, repository session pinning, manual CLI, buffering/chunking, task projection, and reconciliation | Client-neutral modules do not parse native transcript formats |
 | `src/repository` | Read-only repository identity and Repo Memory readiness | Scope derivation does not execute Git or use synchronous filesystem reads |
 | `src/provider/memorax` | MemoraX config interpretation, query/add/status payloads, HTTP transport, and normalized results | Independent from server routing and plugin lifecycle |
@@ -467,7 +486,7 @@ and
 | --- | --- | --- |
 | Models, model-provider credentials, native tools, and model-provider traffic | Codex, Claude Code, or OpenCode | Backend and adapters must not proxy or persist this authority |
 | Hook command identity | Versioned, client-qualified command plus validated required session/turn fields | Parsed HTTP request objects |
-| Automatic writeback content | Codex rollout JSONL or Claude Code transcript JSONL for the matching client | Hook text, trace, latest-Turn guesses, and the other client's format are not fallbacks |
+| Automatic writeback content | Codex rollout JSONL, Claude Code transcript JSONL, or OpenCode SDK session messages for the matching client and Turn | Hook or plugin text, trace, latest-Turn guesses, local database guesses, and another client's format are not fallbacks |
 | Workspace and repository identity | Backend read-only resolution held by the live repository-session runtime; its only permitted scope transition is the same-root degraded-direct-`.git` to verified-Git upgrade | Project labels, Viewer catalog entries, and Hook `cwd` |
 | Backend connection and managed-process ownership | Versioned private connection/token/PID records plus lifecycle lock/version validation | In-memory state in any one process |
 | MemoraX memory result and asynchronous task state | Normalized response from `provider/memorax` | Observability, trace, Viewer, and task projections |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,9 +28,9 @@ Please allow time for triage and remediation before public disclosure.
 
 ### Client and local Backend
 
-- Codex and Claude Code own provider credentials, models, native tools, and
-  provider traffic. MemoraX Code does not proxy OpenAI Responses or Anthropic
-  Messages traffic and does not need client provider credentials.
+- Codex, Claude Code, and OpenCode own provider credentials, models, native
+  tools, and provider traffic. MemoraX Code does not proxy model-provider
+  traffic and does not need client provider credentials.
 - The managed Backend binds to loopback by default. External binding requires
   explicit opt-in and a Backend token; deployment operators must provide an
   appropriate authenticated and encrypted network boundary.
@@ -65,9 +65,10 @@ When OpenCode automatic retrieval is enabled, each eligible user prompt is
 used as the search query.
 Active adds and automatic writeback send the selected content needed to create
 memory. Automatic writeback may include selected user instructions and the
-matching final assistant response from an exact Codex or Claude Code
-transcript turn. It does not send the retained trace file, raw transcript
-path, or trace-only provenance as part of that payload.
+matching final assistant response from an exact Codex rollout, Claude Code
+transcript, or OpenCode SDK session-message turn. It does not send the retained
+trace file, raw transcript path, SDK message records, or trace-only provenance
+as part of that payload.
 
 Automatic writeback bounds each selected message to its configured Add limit,
 then applies a local best-effort detector before hashing, buffering, chunking,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -141,20 +141,20 @@ Automatic prompt retrieval is disabled by default.
 | `memory_type_order` | `MEMORAX_CODE_MEMORAX_MEMORY_TYPE_ORDER` | `core,episodic,semantic,procedural,unclassified` |
 
 The TOML form of `memory_type_order` is an array of strings; the environment
-form is comma-separated. `enabled` controls automatic `UserPromptSubmit`
-retrieval only. Explicit `memorax-cli search` remains available when
+form is comma-separated. `enabled` controls automatic prompt retrieval only.
+Explicit `memorax-cli search` remains available when
 credentials and a trusted workspace scope resolve.
 
 ## Writeback and explicit add
 
-New configurations explicitly set automatic transcript writeback to enabled.
+New configurations explicitly set automatic completed-turn writeback to enabled.
 An existing configuration without `enabled` remains disabled.
 
 | Field | Environment override | Fallback |
 | --- | --- | --- |
 | `enabled` | `MEMORAX_CODE_MEMORY_WRITEBACK_ENABLED` | `false` when absent |
 | `buffer_enabled` | `MEMORAX_CODE_MEMORY_WRITEBACK_BUFFER_ENABLED` | `true` |
-| `buffer_max_turns` | `MEMORAX_CODE_MEMORY_WRITEBACK_BUFFER_MAX_TURNS` | `8`; `-1` disables automatic Hook writeback |
+| `buffer_max_turns` | `MEMORAX_CODE_MEMORY_WRITEBACK_BUFFER_MAX_TURNS` | `8`; `-1` disables automatic writeback |
 | `buffer_max_age_ms` | `MEMORAX_CODE_MEMORY_WRITEBACK_BUFFER_MAX_AGE_MS` | `600000` |
 | `buffer_max_chars` | `MEMORAX_CODE_MEMORY_WRITEBACK_BUFFER_MAX_CHARS` | `128000` |
 | `max_message_chars` | `MEMORAX_CODE_MEMORY_WRITEBACK_MAX_MESSAGE_CHARS` | `64000` |
@@ -232,7 +232,7 @@ local `cwd`.
 
 OpenCode supports active Repo Memory operations through the installed skill,
 but its plugin does not currently run background Repo Memory maintenance. Its
-automatic integration currently covers retrieval.
+automatic integration covers retrieval and completed-turn writeback.
 
 ## Local traces
 

--- a/packages/ts/memorax-code-backend/src/clients/opencode/memory-hook-runtime.ts
+++ b/packages/ts/memorax-code-backend/src/clients/opencode/memory-hook-runtime.ts
@@ -1,35 +1,70 @@
+import {
+  createAutomaticMemoryWritebackRuntime,
+  type AutomaticMemoryWritebackEnqueue,
+  type AutomaticMemoryWritebackRejectionReason,
+  type AutomaticMemoryWritebackRuntime,
+} from "../../memory/automatic-writeback.js";
 import { retrieveAutomaticMemoryContext } from "../../memory/automatic-retrieval.js";
 import type {
   MemoryHookTurnStartResult,
   OpenCodeTurnStartCommand,
+  OpenCodeWritebackCommand,
 } from "../../memory/hook-command.js";
 import type { MemoryDiagnosticLogger, MemoryObservabilityHook } from "../../memory/observability.js";
+import {
+  createMemoryTurnCoordinator,
+  type MemoryTurnCoordinator,
+  type MemoryTurnState,
+} from "../../memory/turn-coordinator.js";
 import {
   createRepositoryMemorySessionRuntime,
   resolvedRepoMemoryWorktree,
   type ConfiguredRepositoryMemoryResult,
   type RepositoryMemorySessionRuntime,
 } from "../../memory/repository-session.js";
-import { traceContextFromOpenCodeHookBody } from "../../trace/context.js";
+import type { RepositoryMemoryScopeFailureReason } from "../../repository/scope.js";
+import { traceContextFromOpenCodeHookBody, type TraceContext } from "../../trace/context.js";
 import {
+  markCurrentTraceTurnOutcome,
   recordTraceEvent,
   traceTurnEventId,
   writeCurrentTraceTurn,
 } from "../../trace/store.js";
+import {
+  openCodeMessageTurn,
+  type OpenCodeMessageTurnFailureReason,
+} from "./message-turn.js";
+
+export type OpenCodeMemoryHookWritebackSkipReason =
+  | "turn_metadata_mismatch"
+  | "config_missing"
+  | OpenCodeMessageTurnFailureReason
+  | RepositoryMemoryScopeFailureReason
+  | AutomaticMemoryWritebackRejectionReason;
+
+export type OpenCodeMemoryHookWritebackResult =
+  | { ok: true; scheduled: true }
+  | { ok: true; scheduled: false; reason: OpenCodeMemoryHookWritebackSkipReason };
 
 export type OpenCodeMemoryHookRuntimeOptions = {
+  automaticWriteback?: AutomaticMemoryWritebackEnqueue;
   diagnosticLogger?: MemoryDiagnosticLogger;
   env?: Record<string, string | undefined>;
   fetchImpl?: typeof fetch;
   now?: () => number;
+  ttlMs?: number;
   maxEntries?: number;
+  cleanupIntervalMs?: number;
   memoryObservability?: MemoryObservabilityHook;
   memoraxCodeHome?: string;
   repositoryMemorySession?: RepositoryMemorySessionRuntime;
+  turnCoordinator?: MemoryTurnCoordinator;
 };
 
 export type OpenCodeMemoryHookRuntime = {
   recordTurnStart(command: OpenCodeTurnStartCommand): Promise<MemoryHookTurnStartResult>;
+  writeback(command: OpenCodeWritebackCommand): Promise<OpenCodeMemoryHookWritebackResult>;
+  size(): number;
   close(): void;
 };
 
@@ -39,13 +74,33 @@ export function createOpenCodeMemoryHookRuntime(
   options: OpenCodeMemoryHookRuntimeOptions = {},
 ): OpenCodeMemoryHookRuntime {
   const now = options.now ?? (() => Date.now());
-  const repositoryMemorySession = options.repositoryMemorySession ?? createRepositoryMemorySessionRuntime();
+  const automaticWritebackRuntime: {
+    enqueue: AutomaticMemoryWritebackEnqueue;
+    discardForScopeUpgrade?: AutomaticMemoryWritebackRuntime["discardForScopeUpgrade"];
+    close?: () => void;
+  } | undefined = options.turnCoordinator
+    ? undefined
+    : options.automaticWriteback
+      ? { enqueue: options.automaticWriteback }
+      : createAutomaticMemoryWritebackRuntime({ diagnosticLogger: options.diagnosticLogger });
+  const turnCoordinator = options.turnCoordinator ?? createMemoryTurnCoordinator({
+    automaticWriteback: automaticWritebackRuntime!.enqueue,
+    now,
+    ttlMs: options.ttlMs,
+    maxEntries: options.maxEntries,
+    cleanupIntervalMs: options.cleanupIntervalMs,
+  });
+  const ownsTurnCoordinator = options.turnCoordinator === undefined;
+  const repositoryMemorySession = options.repositoryMemorySession ?? createRepositoryMemorySessionRuntime({
+    onScopeUpgrade: automaticWritebackRuntime?.discardForScopeUpgrade,
+  });
   const ownsRepositoryMemorySession = options.repositoryMemorySession === undefined;
   const retrievalTurns = new Set<string>();
   const retrievalTurnLimit = positiveInteger(options.maxEntries, 256);
 
   return {
     async recordTurnStart(command) {
+      turnCoordinator.pruneExpired();
       const createdAt = now();
       const traceContext = traceContextFromOpenCodeHookBody(command, new Date(createdAt).toISOString());
       const repositoryMemory = await resolveHookRepositoryMemory(
@@ -54,6 +109,16 @@ export function createOpenCodeMemoryHookRuntime(
         repositoryMemorySession,
       );
       const repoMemoryWorktree = resolvedRepoMemoryWorktree(repositoryMemory);
+      turnCoordinator.recordTurnStart({
+        client: OPENCODE_MEMORY_TURN_CLIENT,
+        sessionId: command.sessionId,
+        clientTurnId: command.userMessageId,
+        cwd: command.cwd,
+        workspaceKind: command.workspaceKind,
+        createdAt,
+        traceContext,
+        repositoryMemory,
+      });
       await recordTraceBestEffort("opencode_memory.turn_start_event", recordTraceEvent({
         eventId: traceTurnEventId(traceContext, "turn_start"),
         memoraxCodeHome: options.memoraxCodeHome,
@@ -80,6 +145,7 @@ export function createOpenCodeMemoryHookRuntime(
       options.diagnosticLogger?.("opencode_memory.turn_start", {
         sessionId: command.sessionId,
         userMessageId: command.userMessageId,
+        cacheSize: turnCoordinator.size(OPENCODE_MEMORY_TURN_CLIENT),
         workspace: repositoryMemory.ok ? repositoryMemory.memory.scope?.repositorySlug : undefined,
         workspaceScopeReason: repositoryMemory.ok ? undefined : repositoryMemory.reason,
       });
@@ -114,11 +180,108 @@ export function createOpenCodeMemoryHookRuntime(
         ...(retrieval.context ? { additionalContext: retrieval.context } : {}),
       };
     },
+    async writeback(command) {
+      turnCoordinator.pruneExpired();
+      const key = openCodeTurnKey(command.sessionId, command.userMessageId);
+      const entry = turnCoordinator.getTurn(key);
+      const materialized = openCodeMessageTurn(command.messages, command);
+      if (!materialized.ok) {
+        options.diagnosticLogger?.("opencode_memory.writeback", {
+          scheduled: false,
+          reason: materialized.reason,
+          sessionId: command.sessionId,
+          userMessageId: command.userMessageId,
+          assistantMessageId: command.assistantMessageId,
+        });
+        return { ok: true, scheduled: false, reason: materialized.reason };
+      }
+      const traceContext = entry?.traceContext
+        ?? traceContextFromOpenCodeHookBody(command, new Date(now()).toISOString());
+      await recordTraceBestEffort("opencode_memory.turn_end_event", recordTraceEvent({
+        eventId: traceTurnEventId(traceContext, "turn_end"),
+        memoraxCodeHome: options.memoraxCodeHome,
+        env: options.env,
+        traceContext,
+        type: "turn_end",
+        source: "opencode-plugin",
+        operation: "writeback",
+        ok: true,
+        outcome: "completed",
+        response: {
+          content: materialized.turn.assistantReply,
+        },
+      }), options.diagnosticLogger);
+      await recordTraceBestEffort("opencode_memory.current_turn_close", markCurrentTraceTurnOutcome(
+        traceContext,
+        "completed",
+        {
+          client: "opencode",
+          memoraxCodeHome: options.memoraxCodeHome,
+          env: options.env,
+        },
+      ), options.diagnosticLogger);
+      const writeback = await turnCoordinator.completeMaterializedTurn({
+        key,
+        metadata: entry,
+        resolveRepositoryMemory: () => resolveCurrentHookRepositoryMemory(
+          entry,
+          command,
+          options,
+          repositoryMemorySession,
+        ),
+        userText: materialized.turn.userPrompt,
+        assistantText: materialized.turn.assistantReply,
+        writeback: {
+          client: OPENCODE_MEMORY_TURN_CLIENT,
+          sessionKey: command.sessionId,
+          env: options.env ?? process.env,
+          fetchImpl: options.fetchImpl,
+          memoryObservability: options.memoryObservability,
+          memoryObservabilitySource: "opencode_plugin_writeback",
+          traceContext,
+        },
+      });
+      if (!writeback.scheduled) {
+        options.diagnosticLogger?.("opencode_memory.writeback", {
+          scheduled: false,
+          reason: writeback.reason,
+          metadataDisposition: writeback.metadataDisposition,
+          sessionId: command.sessionId,
+          userMessageId: command.userMessageId,
+          assistantMessageId: command.assistantMessageId,
+        });
+        return { ok: true, scheduled: false, reason: writeback.reason };
+      }
+      options.diagnosticLogger?.("opencode_memory.writeback", {
+        scheduled: true,
+        metadataDisposition: writeback.metadataDisposition,
+        sessionId: command.sessionId,
+        userMessageId: command.userMessageId,
+        assistantMessageId: command.assistantMessageId,
+        promptChars: materialized.turn.userPrompt.length,
+        assistantChars: materialized.turn.assistantReply.length,
+        contentSource: "opencode_sdk_messages",
+      });
+      return { ok: true, scheduled: true };
+    },
+    size() {
+      return turnCoordinator.size(OPENCODE_MEMORY_TURN_CLIENT);
+    },
     close() {
       retrievalTurns.clear();
+      if (ownsTurnCoordinator) turnCoordinator.close();
       if (ownsRepositoryMemorySession) repositoryMemorySession.close();
+      automaticWritebackRuntime?.close?.();
     },
   };
+}
+
+function openCodeTurnKey(sessionId: string, userMessageId: string) {
+  return {
+    client: OPENCODE_MEMORY_TURN_CLIENT,
+    sessionId,
+    clientTurnId: userMessageId,
+  } as const;
 }
 
 async function resolveHookRepositoryMemory(
@@ -131,6 +294,23 @@ async function resolveHookRepositoryMemory(
     sessionId: command.sessionId,
     workspaceRoot: command.cwd,
     workspaceKind: command.workspaceKind,
+    memoraxCodeHome: options.memoraxCodeHome ?? options.env?.MEMORAX_CODE_HOME,
+    env: options.env,
+  });
+}
+
+async function resolveCurrentHookRepositoryMemory(
+  entry: MemoryTurnState | undefined,
+  command: OpenCodeWritebackCommand,
+  options: OpenCodeMemoryHookRuntimeOptions,
+  repositoryMemorySession: RepositoryMemorySessionRuntime,
+): Promise<ConfiguredRepositoryMemoryResult> {
+  return await repositoryMemorySession.resolve({
+    client: OPENCODE_MEMORY_TURN_CLIENT,
+    sessionId: command.sessionId,
+    workspaceRoot: command.cwd ?? entry?.cwd,
+    workspaceKind: command.workspaceKind ?? entry?.workspaceKind,
+    requireBoundScope: true,
     memoraxCodeHome: options.memoraxCodeHome ?? options.env?.MEMORAX_CODE_HOME,
     env: options.env,
   });

--- a/packages/ts/memorax-code-backend/src/clients/opencode/message-turn.ts
+++ b/packages/ts/memorax-code-backend/src/clients/opencode/message-turn.ts
@@ -1,0 +1,120 @@
+import { isRecord } from "../../shared/record.js";
+
+export type OpenCodeMessageTurn = Readonly<{
+  sessionId: string;
+  userMessageId: string;
+  assistantMessageId: string;
+  userPrompt: string;
+  assistantReply: string;
+}>;
+
+export type OpenCodeMessageTurnFailureReason =
+  | "user_message_not_found"
+  | "assistant_message_not_found"
+  | "message_identity_mismatch"
+  | "assistant_not_completed"
+  | "assistant_error"
+  | "summary_message"
+  | "compaction_message"
+  | "user_prompt_missing"
+  | "assistant_message_missing";
+
+export type OpenCodeMessageTurnResult =
+  | { ok: true; turn: OpenCodeMessageTurn }
+  | { ok: false; reason: OpenCodeMessageTurnFailureReason };
+
+export function openCodeMessageTurn(
+  messages: readonly unknown[],
+  input: {
+    sessionId: string;
+    userMessageId: string;
+    assistantMessageId: string;
+  },
+): OpenCodeMessageTurnResult {
+  const user = messages.find((message) => messageId(message) === input.userMessageId);
+  if (!isMessageRecord(user) || user.info.role !== "user") {
+    return { ok: false, reason: "user_message_not_found" };
+  }
+  const assistant = messages.find((message) => messageId(message) === input.assistantMessageId);
+  if (!isMessageRecord(assistant) || assistant.info.role !== "assistant") {
+    return { ok: false, reason: "assistant_message_not_found" };
+  }
+  if (
+    stringField(user.info, "sessionID") !== input.sessionId
+    || stringField(assistant.info, "sessionID") !== input.sessionId
+    || stringField(assistant.info, "parentID") !== input.userMessageId
+  ) {
+    return { ok: false, reason: "message_identity_mismatch" };
+  }
+  const assistantTime = isRecord(assistant.info.time) ? assistant.info.time : undefined;
+  if (!Number.isFinite(assistantTime?.completed)) {
+    return { ok: false, reason: "assistant_not_completed" };
+  }
+  if (assistant.info.error !== undefined && assistant.info.error !== null) {
+    return { ok: false, reason: "assistant_error" };
+  }
+  if (assistant.info.summary === true) {
+    return { ok: false, reason: "summary_message" };
+  }
+  if (hasCompactionPart(user.parts) || hasCompactionPart(assistant.parts)) {
+    return { ok: false, reason: "compaction_message" };
+  }
+  const userPrompt = messageText(user, input.sessionId, input.userMessageId);
+  if (!userPrompt) return { ok: false, reason: "user_prompt_missing" };
+  const assistantReply = messageText(assistant, input.sessionId, input.assistantMessageId);
+  if (!assistantReply) return { ok: false, reason: "assistant_message_missing" };
+  return {
+    ok: true,
+    turn: {
+      sessionId: input.sessionId,
+      userMessageId: input.userMessageId,
+      assistantMessageId: input.assistantMessageId,
+      userPrompt,
+      assistantReply,
+    },
+  };
+}
+
+type OpenCodeMessageRecord = Readonly<{
+  info: Record<string, unknown>;
+  parts: readonly unknown[];
+}>;
+
+function isMessageRecord(value: unknown): value is OpenCodeMessageRecord {
+  return isRecord(value) && isRecord(value.info) && Array.isArray(value.parts);
+}
+
+function messageId(value: unknown): string | undefined {
+  return isMessageRecord(value) ? stringField(value.info, "id") : undefined;
+}
+
+function messageText(
+  message: OpenCodeMessageRecord,
+  sessionId: string,
+  messageId: string,
+): string {
+  return message.parts
+    .flatMap((part): string[] => {
+      if (!isRecord(part)
+        || part.type !== "text"
+        || part.synthetic === true
+        || part.ignored === true
+        || stringField(part, "sessionID") !== sessionId
+        || stringField(part, "messageID") !== messageId) {
+        return [];
+      }
+      const text = stringField(part, "text");
+      return text ? [text] : [];
+    })
+    .join("\n\n")
+    .trim();
+}
+
+function hasCompactionPart(parts: readonly unknown[]): boolean {
+  return parts.some((part) => isRecord(part) && part.type === "compaction");
+}
+
+function stringField(value: Record<string, unknown>, key: string): string | undefined {
+  const field = value[key];
+  return typeof field === "string" && field.trim() ? field.trim() : undefined;
+}

--- a/packages/ts/memorax-code-backend/src/memory/automatic-writeback.ts
+++ b/packages/ts/memorax-code-backend/src/memory/automatic-writeback.ts
@@ -36,7 +36,7 @@ import {
   type MemoryPayloadRedactionKind,
 } from "./payload-redaction.js";
 
-export type AutomaticMemoryWritebackClient = "codex" | "claude-code";
+export type AutomaticMemoryWritebackClient = "codex" | "claude-code" | "opencode";
 
 export type AutomaticMemoryWritebackOptions = {
   client: AutomaticMemoryWritebackClient;
@@ -121,7 +121,6 @@ export function createAutomaticMemoryWritebackRuntime(
       return enqueueAutomaticMemoryWritebackForRuntime(state, options);
     },
     discardForScopeUpgrade(upgrade) {
-      if (upgrade.client === "opencode") return 0;
       return state.writebackBuffer.discardForScopeUpgrade({
         client: upgrade.client,
         sessionKey: upgrade.sessionId,

--- a/packages/ts/memorax-code-backend/src/memory/hook-command.ts
+++ b/packages/ts/memorax-code-backend/src/memory/hook-command.ts
@@ -17,13 +17,19 @@ const TURN_START_KEYS: Readonly<Record<MemoryHookClient, ReadonlySet<string>>> =
   "claude-code": new Set([...BASE_COMMAND_KEYS, "promptId", "prompt", "transcriptPath"]),
   opencode: new Set([...BASE_COMMAND_KEYS, "userMessageId", "prompt"]),
 };
-const WRITEBACK_KEYS: Readonly<Partial<Record<MemoryHookClient, ReadonlySet<string>>>> = {
+const WRITEBACK_KEYS: Readonly<Record<MemoryHookClient, ReadonlySet<string>>> = {
   codex: new Set([...BASE_COMMAND_KEYS, "turnId", "lastAssistantMessage", "transcriptPath"]),
   "claude-code": new Set([
     ...BASE_COMMAND_KEYS,
     "promptId",
     "lastAssistantMessage",
     "transcriptPath",
+  ]),
+  opencode: new Set([
+    ...BASE_COMMAND_KEYS,
+    "userMessageId",
+    "assistantMessageId",
+    "messages",
   ]),
 };
 const SKILL_REMINDER_KEYS: Readonly<Partial<Record<MemoryHookClient, ReadonlySet<string>>>> = {
@@ -76,7 +82,13 @@ export type ClaudeWritebackCommand = MemoryHookCommandBase<"claude-code"> & Read
   transcriptPath: string;
 }>;
 
-export type WritebackCommand = CodexWritebackCommand | ClaudeWritebackCommand;
+export type OpenCodeWritebackCommand = MemoryHookCommandBase<"opencode"> & Readonly<{
+  userMessageId: string;
+  assistantMessageId: string;
+  messages: readonly unknown[];
+}>;
+
+export type WritebackCommand = CodexWritebackCommand | ClaudeWritebackCommand | OpenCodeWritebackCommand;
 
 export type SkillReminderTrigger = "cadence" | "post_compaction";
 
@@ -157,6 +169,23 @@ export function parseWritebackCommand(
   if (!isRecord(value)) return invalidCommand();
   const base = parseCommandBase(value, WRITEBACK_KEYS);
   if (!base) return invalidCommand();
+  if (base.client === "opencode") {
+    const userMessageId = requiredStringField(value, "userMessageId");
+    const assistantMessageId = requiredStringField(value, "assistantMessageId");
+    if (!userMessageId || !assistantMessageId || !Array.isArray(value.messages)) {
+      return invalidCommand();
+    }
+    return {
+      ok: true,
+      command: {
+        ...base,
+        client: "opencode",
+        userMessageId,
+        assistantMessageId,
+        messages: value.messages,
+      },
+    };
+  }
   const lastAssistantMessage = requiredStringField(value, "lastAssistantMessage");
   if (!lastAssistantMessage) return invalidCommand();
   if (base.client === "codex") {

--- a/packages/ts/memorax-code-backend/src/memory/observability.ts
+++ b/packages/ts/memorax-code-backend/src/memory/observability.ts
@@ -8,6 +8,7 @@ export type MemoryObservabilitySource =
   | "claude_hook_retrieval"
   | "claude_hook_writeback"
   | "opencode_plugin_retrieval"
+  | "opencode_plugin_writeback"
   | "memory_cli"
   | "writeback_reconciler"
   | "unknown";

--- a/packages/ts/memorax-code-backend/src/memory/service.ts
+++ b/packages/ts/memorax-code-backend/src/memory/service.ts
@@ -11,6 +11,7 @@ import {
 } from "../clients/claude/memory-hook-runtime.js";
 import {
   createOpenCodeMemoryHookRuntime,
+  type OpenCodeMemoryHookWritebackResult,
 } from "../clients/opencode/memory-hook-runtime.js";
 import { createMemoryTurnCoordinator } from "./turn-coordinator.js";
 import {
@@ -29,7 +30,8 @@ export type MemoryServiceOptions = Omit<
 
 type MemoryHookWritebackResult =
   | CodexMemoryHookWritebackResult
-  | ClaudeMemoryHookWritebackResult;
+  | ClaudeMemoryHookWritebackResult
+  | OpenCodeMemoryHookWritebackResult;
 
 export type MemoryService = {
   recordTurnStart(command: TurnStartCommand): Promise<MemoryHookTurnStartResult>;
@@ -65,6 +67,7 @@ export function createMemoryService(options: MemoryServiceOptions = {}): MemoryS
   const openCodeHook = createOpenCodeMemoryHookRuntime({
     ...options,
     repositoryMemorySession,
+    turnCoordinator,
   });
   let closed = false;
   return {
@@ -85,6 +88,8 @@ export function createMemoryService(options: MemoryServiceOptions = {}): MemoryS
           return await codexHook.writeback(command);
         case "claude-code":
           return await claudeHook.writeback(command);
+        case "opencode":
+          return await openCodeHook.writeback(command);
       }
       return unsupportedMemoryHookCommand(command);
     },

--- a/packages/ts/memorax-code-backend/src/memory/writeback-buffer.ts
+++ b/packages/ts/memorax-code-backend/src/memory/writeback-buffer.ts
@@ -12,7 +12,7 @@ import {
 import type { TraceContext } from "../trace/context.js";
 
 export type MemoryWritebackBufferDecision = {
-  client: "codex" | "claude-code";
+  client: "codex" | "claude-code" | "opencode";
   sessionKey: string;
   idempotencyKey: string;
   messages: WritebackMessage[];

--- a/packages/ts/memorax-code-backend/src/viewer/store.ts
+++ b/packages/ts/memorax-code-backend/src/viewer/store.ts
@@ -1213,7 +1213,7 @@ function memoryViewerClient(input: MemoryObservabilityEvent): TraceClient {
   if (input.traceContext?.client === "codex") return "codex";
   if (input.traceContext?.client === "opencode") return "opencode";
   if (input.source === "claude_hook_retrieval" || input.source === "claude_hook_writeback") return "claude";
-  if (input.source === "opencode_plugin_retrieval") return "opencode";
+  if (input.source === "opencode_plugin_retrieval" || input.source === "opencode_plugin_writeback") return "opencode";
   return "codex";
 }
 

--- a/packages/ts/memorax-code-backend/test/architecture/source-boundaries.test.mjs
+++ b/packages/ts/memorax-code-backend/test/architecture/source-boundaries.test.mjs
@@ -41,6 +41,7 @@ const rules = [
       "clients/claude/transcript-turn.ts",
       "clients/codex/memory-hook-runtime.ts",
       "clients/opencode/memory-hook-runtime.ts",
+      "clients/opencode/message-turn.ts",
       "memory/turn-coordinator.ts",
       "memory/service.ts",
       "memory/writeback-buffer.ts",
@@ -79,7 +80,12 @@ const rules = [
   },
   {
     name: "Hook memory runtimes use normalized automatic writeback",
-    importers: ["clients/claude/memory-hook-runtime.ts", "clients/codex/memory-hook-runtime.ts", "memory/turn-coordinator.ts"],
+    importers: [
+      "clients/claude/memory-hook-runtime.ts",
+      "clients/codex/memory-hook-runtime.ts",
+      "clients/opencode/memory-hook-runtime.ts",
+      "memory/turn-coordinator.ts",
+    ],
     forbidden: ["memory/writeback"],
   },
   {
@@ -94,13 +100,13 @@ const rules = [
   },
   {
     name: "OpenCode memory hook runtime stays independent from HTTP and Backend composition",
-    importers: ["clients/opencode/memory-hook-runtime.ts"],
+    importers: ["clients/opencode/memory-hook-runtime.ts", "clients/opencode/message-turn.ts"],
     forbidden: ["node:http", "server-", "entrypoints/", "transport/http/", "app/state"],
   },
   {
     name: "memory turn coordinator stays independent from HTTP, Backend composition, and client transcripts",
     importers: ["memory/turn-coordinator.ts"],
-    forbidden: ["node:http", "server-", "entrypoints/", "transport/http/", "app/state", "clients/codex/rollout", "clients/claude/"],
+    forbidden: ["node:http", "server-", "entrypoints/", "transport/http/", "app/state", "clients/codex/rollout", "clients/claude/", "clients/opencode/"],
   },
   {
     name: "writeback reconciliation stays independent from HTTP, Backend composition, and Viewer models",

--- a/packages/ts/memorax-code-backend/test/clients/opencode/opencode-memory-hook.test.mjs
+++ b/packages/ts/memorax-code-backend/test/clients/opencode/opencode-memory-hook.test.mjs
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
 import { createOpenCodeMemoryHookRuntime } from "../../../dist/clients/opencode/memory-hook-runtime.js";
+import { openCodeMessageTurn } from "../../../dist/clients/opencode/message-turn.js";
 import {
   parseTurnStartCommand,
   parseWritebackCommand,
@@ -12,14 +13,22 @@ import {
 
 const TEST_WORKSPACE = fileURLToPath(new URL("../../..", import.meta.url));
 
-test("OpenCode turn-start commands keep a closed client-specific schema", () => {
+test("OpenCode Hook commands keep a closed client-specific schema", () => {
   assert.equal(parseTurnStartCommand({
     version: 1,
     client: "opencode",
     sessionId: "session-1",
     userMessageId: "user-1",
-    prompt: "Use the OpenCode prompt.",
+    prompt: "Use the OpenCode SDK turn.",
     cwd: TEST_WORKSPACE,
+  }).ok, true);
+  assert.equal(parseWritebackCommand({
+    version: 1,
+    client: "opencode",
+    sessionId: "session-1",
+    userMessageId: "user-1",
+    assistantMessageId: "assistant-1",
+    messages: [],
   }).ok, true);
   assert.equal(parseTurnStartCommand({
     version: 1,
@@ -36,10 +45,58 @@ test("OpenCode turn-start commands keep a closed client-specific schema", () => 
     userMessageId: "user-1",
     assistantMessageId: "assistant-1",
     messages: [],
+    lastAssistantMessage: "Hook text is not OpenCode writeback authority.",
   }).ok, false);
 });
 
-test("OpenCode runtime reuses repository scope and automatic retrieval", async () => {
+test("OpenCode SDK messages materialize only an exact completed normal turn", () => {
+  const valid = openCodeMessageTurn(openCodeMessages(), {
+    sessionId: "session-1",
+    userMessageId: "user-1",
+    assistantMessageId: "assistant-1",
+  });
+  assert.deepEqual(valid, {
+    ok: true,
+    turn: {
+      sessionId: "session-1",
+      userMessageId: "user-1",
+      assistantMessageId: "assistant-1",
+      userPrompt: "OpenCode user prompt.",
+      assistantReply: "OpenCode assistant reply.",
+    },
+  });
+
+  const withUserDiffSummary = openCodeMessages();
+  withUserDiffSummary[0].info.summary = {
+    title: "Turn changes",
+    body: "Files changed during this turn",
+    diffs: [],
+  };
+  assert.deepEqual(openCodeMessageTurn(withUserDiffSummary, {
+    sessionId: "session-1",
+    userMessageId: "user-1",
+    assistantMessageId: "assistant-1",
+  }), valid, "user diff summary remains eligible for writeback");
+
+  for (const [name, mutate, reason] of [
+    ["parent mismatch", (messages) => { messages[1].info.parentID = "other-user"; }, "message_identity_mismatch"],
+    ["session mismatch", (messages) => { messages[1].info.sessionID = "other-session"; }, "message_identity_mismatch"],
+    ["incomplete assistant", (messages) => { delete messages[1].info.time.completed; }, "assistant_not_completed"],
+    ["assistant error", (messages) => { messages[1].info.error = { name: "MessageAbortedError" }; }, "assistant_error"],
+    ["summary assistant", (messages) => { messages[1].info.summary = true; }, "summary_message"],
+    ["compaction turn", (messages) => { messages[0].parts.push(part("compaction", "user-1")); }, "compaction_message"],
+  ]) {
+    const messages = openCodeMessages();
+    mutate(messages);
+    assert.deepEqual(openCodeMessageTurn(messages, {
+      sessionId: "session-1",
+      userMessageId: "user-1",
+      assistantMessageId: "assistant-1",
+    }), { ok: false, reason }, name);
+  }
+});
+
+test("OpenCode runtime reuses retrieval, scope, and automatic writeback", async () => {
   const memoraxCodeHome = await mkdtemp(join(tmpdir(), "memorax-code-opencode-runtime-"));
   const requests = [];
   const runtime = createOpenCodeMemoryHookRuntime({
@@ -48,13 +105,17 @@ test("OpenCode runtime reuses repository scope and automatic retrieval", async (
       MEMORAX_CODE_HOME: memoraxCodeHome,
       MEMORAX_CODE_OPENCODE_TRACE_ENABLED: "false",
       MEMORAX_CODE_MEMORY_RETRIEVAL_ENABLED: "true",
+      MEMORAX_CODE_MEMORY_WRITEBACK_ENABLED: "true",
+      MEMORAX_CODE_MEMORY_WRITEBACK_BUFFER_ENABLED: "false",
       MEMORAX_CODE_MEMORAX_ENDPOINT: "http://memorax.test",
       MEMORAX_CODE_MEMORAX_API_KEY: "secret",
       MEMORAX_CODE_MEMORAX_USER_ID: "user-1",
     },
     fetchImpl: async (url, init) => {
-      requests.push({ url: String(url), body: JSON.parse(init.body) });
-      return new Response(JSON.stringify({
+      const request = { url: String(url), body: JSON.parse(init.body) };
+      requests.push(request);
+      const searching = request.url.endsWith("/v1/memories/search");
+      return new Response(JSON.stringify(searching ? {
         success: true,
         data: {
           task_id: "search-1",
@@ -66,6 +127,9 @@ test("OpenCode runtime reuses repository scope and automatic retrieval", async (
             metadata: { memory_type: "core" },
           }],
         },
+      } : {
+        success: true,
+        data: { task_id: "writeback-1", status: "queued" },
       }), {
         status: 200,
         headers: { "content-type": "application/json" },
@@ -73,7 +137,7 @@ test("OpenCode runtime reuses repository scope and automatic retrieval", async (
     },
   });
   try {
-    const command = {
+    const start = await runtime.recordTurnStart({
       version: 1,
       client: "opencode",
       sessionId: "session-1",
@@ -81,16 +145,81 @@ test("OpenCode runtime reuses repository scope and automatic retrieval", async (
       prompt: "OpenCode user prompt.",
       cwd: TEST_WORKSPACE,
       workspaceKind: "project",
-    };
-    const start = await runtime.recordTurnStart(command);
+    });
     assert.match(start.additionalContext, /shared retrieval runtime/);
 
-    const duplicate = await runtime.recordTurnStart(command);
-    assert.equal(duplicate.additionalContext, undefined);
-    assert.equal(requests.length, 1);
-    assert.equal(new URL(requests[0].url).pathname, "/v1/memories/search");
+    assert.deepEqual(await runtime.writeback({
+      version: 1,
+      client: "opencode",
+      sessionId: "session-1",
+      userMessageId: "user-1",
+      assistantMessageId: "assistant-1",
+      messages: openCodeMessages(),
+      cwd: TEST_WORKSPACE,
+      workspaceKind: "project",
+    }), { ok: true, scheduled: true });
+    await waitFor(() => requests.length === 2);
+    assert.deepEqual(requests.map((request) => new URL(request.url).pathname), [
+      "/v1/memories/search",
+      "/v1/memories/add",
+    ]);
+    assert.deepEqual(requests[1].body.messages.map(({ role, content }) => ({ role, content })), [
+      { role: "user", content: "OpenCode user prompt." },
+      { role: "assistant", content: "OpenCode assistant reply." },
+    ]);
   } finally {
     runtime.close();
     await rm(memoraxCodeHome, { recursive: true, force: true });
   }
 });
+
+function openCodeMessages() {
+  return [
+    {
+      info: {
+        id: "user-1",
+        sessionID: "session-1",
+        role: "user",
+        time: { created: 1 },
+      },
+      parts: [textPart("user-1", "OpenCode user prompt.")],
+    },
+    {
+      info: {
+        id: "assistant-1",
+        sessionID: "session-1",
+        role: "assistant",
+        parentID: "user-1",
+        time: { created: 2, completed: 3 },
+      },
+      parts: [textPart("assistant-1", "OpenCode assistant reply.")],
+    },
+  ];
+}
+
+function textPart(messageID, text) {
+  return {
+    id: `${messageID}-text`,
+    sessionID: "session-1",
+    messageID,
+    type: "text",
+    text,
+  };
+}
+
+function part(type, messageID) {
+  return {
+    id: `${messageID}-${type}`,
+    sessionID: "session-1",
+    messageID,
+    type,
+  };
+}
+
+async function waitFor(predicate) {
+  const deadline = Date.now() + 1_000;
+  while (!predicate()) {
+    if (Date.now() > deadline) throw new Error("timed out waiting for OpenCode writeback");
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}

--- a/packages/ts/memorax-code-backend/test/memory/memory-turn-coordinator.test.mjs
+++ b/packages/ts/memorax-code-backend/test/memory/memory-turn-coordinator.test.mjs
@@ -13,14 +13,17 @@ test("memory turn coordinator isolates identical client turn keys", () => {
   try {
     coordinator.recordTurnStart(turnStart("codex"));
     coordinator.recordTurnStart(turnStart("claude-code"));
+    coordinator.recordTurnStart(turnStart("opencode"));
 
-    assert.equal(coordinator.size(), 2);
+    assert.equal(coordinator.size(), 3);
     assert.equal(coordinator.size("codex"), 1);
     assert.equal(coordinator.size("claude-code"), 1);
+    assert.equal(coordinator.size("opencode"), 1);
     assert.equal(coordinator.getTurn(turnKey("codex"))?.client, "codex");
     assert.equal(coordinator.discardTurn(turnKey("codex"), "interrupted"), true);
     assert.equal(coordinator.getTurn(turnKey("codex")), undefined);
     assert.equal(coordinator.getTurn(turnKey("claude-code"))?.client, "claude-code");
+    assert.equal(coordinator.getTurn(turnKey("opencode"))?.client, "opencode");
   } finally {
     coordinator.close();
   }

--- a/packages/ts/memorax-code-backend/test/transport/http/memory-hook.test.mjs
+++ b/packages/ts/memorax-code-backend/test/transport/http/memory-hook.test.mjs
@@ -124,6 +124,14 @@ test("Backend memory hook endpoints reject commands outside the closed schema", 
     userMessageId: "user-opencode-turn-start",
     prompt: "OpenCode turn start.",
   };
+  const openCodeWriteback = {
+    version: 1,
+    client: "opencode",
+    sessionId: "session-opencode-writeback",
+    userMessageId: "user-opencode-writeback",
+    assistantMessageId: "assistant-opencode-writeback",
+    messages: [],
+  };
   try {
     for (const [caseName, path, body] of [
       ["unversioned command", "/memory/turn-start", {
@@ -198,6 +206,14 @@ test("Backend memory hook endpoints reject commands outside the closed schema", 
       ["transcript field on OpenCode turn-start", "/memory/turn-start", {
         ...openCodeTurnStart,
         transcriptPath: "/tmp/opencode.jsonl",
+      }],
+      ["Hook assistant text on OpenCode writeback", "/memory/writeback", {
+        ...openCodeWriteback,
+        lastAssistantMessage: "Hook text is not OpenCode writeback authority.",
+      }],
+      ["invalid OpenCode messages container", "/memory/writeback", {
+        ...openCodeWriteback,
+        messages: {},
       }],
     ]) {
       const response = await fetch(`${url}${path}`, {

--- a/packages/ts/memorax-code-opencode-adapter/src/plugin.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/src/plugin.mjs
@@ -6,6 +6,13 @@ const TURN_START_TIMEOUT_MS = 12_000;
 const WRITEBACK_TIMEOUT_MS = 5_000;
 const MAX_PENDING_TURNS = 256;
 
+class BackendHttpResponseError extends Error {
+  constructor(path, status) {
+    super(`Backend ${path} returned HTTP ${status}`);
+    this.status = status;
+  }
+}
+
 export function createMemoraxOpenCodePlugin(options = {}) {
   return async ({ client, project, directory, worktree }) => {
     const workspaceRoot = project?.vcs === "git" ? worktree : directory;
@@ -40,17 +47,27 @@ export function createMemoraxOpenCodePlugin(options = {}) {
         ));
         const assistant = completedAssistantFor(messages, sessionId, turn.userMessageId);
         if (!user || !assistant) continue;
-        const result = await postBackend(options, "/memory/writeback", {
-          version: 1,
-          client: "opencode",
-          sessionId,
-          userMessageId: turn.userMessageId,
-          assistantMessageId: assistant.info.id,
-          messages: [user, assistant],
-          cwd: workspaceRoot,
-          workspaceKind,
-        }, WRITEBACK_TIMEOUT_MS);
-        if (result?.ok === true) pendingTurns.delete(turnKey(turn));
+        let result;
+        try {
+          result = await postBackend(options, "/memory/writeback", {
+            version: 1,
+            client: "opencode",
+            sessionId,
+            userMessageId: turn.userMessageId,
+            assistantMessageId: assistant.info.id,
+            messages: [user, assistant],
+            cwd: workspaceRoot,
+            workspaceKind,
+          }, WRITEBACK_TIMEOUT_MS);
+        } catch (error) {
+          if (!(error instanceof BackendHttpResponseError) || error.status !== 413) throw error;
+          pendingTurns.delete(turnKey(turn));
+          debug(options, "opencode oversized writeback discarded", error);
+          continue;
+        }
+        if (result?.ok === true && result.reason !== "runtime_closed") {
+          pendingTurns.delete(turnKey(turn));
+        }
       }
     }
 
@@ -175,7 +192,7 @@ async function postBackend(options, path, body, timeoutMs) {
   });
   if (!response.ok) {
     await response.arrayBuffer().catch(() => undefined);
-    throw new Error(`Backend ${path} returned HTTP ${response.status}`);
+    throw new BackendHttpResponseError(path, response.status);
   }
   return await response.json();
 }

--- a/packages/ts/memorax-code-opencode-adapter/src/plugin.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/src/plugin.mjs
@@ -3,11 +3,56 @@ import { resolveBackendConnection } from "../../memorax-code-adapter-common/src/
 import { readAdapterState } from "../../memorax-code-adapter-common/src/config-utils.mjs";
 
 const TURN_START_TIMEOUT_MS = 12_000;
+const WRITEBACK_TIMEOUT_MS = 5_000;
+const MAX_PENDING_TURNS = 256;
 
 export function createMemoraxOpenCodePlugin(options = {}) {
-  return async ({ project, directory, worktree }) => {
+  return async ({ client, project, directory, worktree }) => {
     const workspaceRoot = project?.vcs === "git" ? worktree : directory;
     const workspaceKind = project?.vcs === "git" ? "project" : "local";
+    const pendingTurns = new Map();
+    const inFlight = new Set();
+
+    function track(task) {
+      const observed = task.catch((error) => {
+        debug(options, "opencode writeback failed", error);
+      });
+      inFlight.add(observed);
+      void observed.finally(() => inFlight.delete(observed));
+    }
+
+    async function flushSession(sessionId) {
+      if (!pluginEnabled(options)) return;
+      const turns = [...pendingTurns.values()].filter((turn) => turn.sessionId === sessionId);
+      if (turns.length === 0) return;
+      const response = await client.session.messages({
+        path: { id: sessionId },
+        query: { directory },
+        throwOnError: true,
+      });
+      if (!pluginEnabled(options)) return;
+      const messages = Array.isArray(response?.data) ? response.data : [];
+      for (const turn of turns) {
+        const user = messages.find((message) => (
+          message?.info?.role === "user"
+          && message.info.id === turn.userMessageId
+          && message.info.sessionID === sessionId
+        ));
+        const assistant = completedAssistantFor(messages, sessionId, turn.userMessageId);
+        if (!user || !assistant) continue;
+        const result = await postBackend(options, "/memory/writeback", {
+          version: 1,
+          client: "opencode",
+          sessionId,
+          userMessageId: turn.userMessageId,
+          assistantMessageId: assistant.info.id,
+          messages: [user, assistant],
+          cwd: workspaceRoot,
+          workspaceKind,
+        }, WRITEBACK_TIMEOUT_MS);
+        if (result?.ok === true) pendingTurns.delete(turnKey(turn));
+      }
+    }
 
     return {
       "chat.message": async (input, output) => {
@@ -27,6 +72,13 @@ export function createMemoraxOpenCodePlugin(options = {}) {
             workspaceKind,
           }, TURN_START_TIMEOUT_MS);
           if (!pluginEnabled(options)) return;
+          const turn = { sessionId, userMessageId };
+          pendingTurns.set(turnKey(turn), turn);
+          while (pendingTurns.size > MAX_PENDING_TURNS) {
+            const oldest = pendingTurns.keys().next().value;
+            if (typeof oldest !== "string") break;
+            pendingTurns.delete(oldest);
+          }
           const additionalContext = stringValue(result?.additionalContext);
           if (additionalContext) {
             const existing = stringValue(output.message.system);
@@ -57,12 +109,40 @@ export function createMemoraxOpenCodePlugin(options = {}) {
             : [cliBinDir, ...pathEntries].join(delimiter);
         }
       },
+      event({ event }) {
+        if (!pluginEnabled(options)) return;
+        if (event?.type === "session.status" && event.properties?.status?.type === "idle") {
+          const sessionId = stringValue(event.properties.sessionID);
+          if (sessionId) track(flushSession(sessionId));
+        }
+      },
+      async dispose() {
+        await Promise.allSettled([...inFlight]);
+      },
     };
   };
 }
 
 export const MemoraxOpenCodePlugin = createMemoraxOpenCodePlugin();
 export default MemoraxOpenCodePlugin;
+
+function completedAssistantFor(messages, sessionId, userMessageId) {
+  return messages
+    .filter((message) => (
+      message?.info?.role === "assistant"
+      && message.info.sessionID === sessionId
+      && message.info.parentID === userMessageId
+      && Number.isFinite(message.info.time?.completed)
+      && message.info.error === undefined
+      && message.info.summary !== true
+      && !message.parts?.some((part) => part?.type === "compaction")
+    ))
+    .sort((left, right) => (
+      Number(left.info.time.completed) - Number(right.info.time.completed)
+      || String(left.info.id).localeCompare(String(right.info.id))
+    ))
+    .at(-1);
+}
 
 function textParts(parts) {
   if (!Array.isArray(parts)) return "";
@@ -77,6 +157,10 @@ function textParts(parts) {
     ))
     .join("\n\n")
     .trim();
+}
+
+function turnKey(turn) {
+  return JSON.stringify([turn.sessionId, turn.userMessageId]);
 }
 
 async function postBackend(options, path, body, timeoutMs) {

--- a/packages/ts/memorax-code-opencode-adapter/test/plugin.test.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/test/plugin.test.mjs
@@ -249,6 +249,66 @@ test("idle reads authoritative SDK messages and dispose drains the pending write
   });
 });
 
+test("idle discards HTTP 413 without starving a runtime-closed retry", async () => {
+  const requests = [];
+  const names = ["oversized", "retry"];
+  const messages = names.flatMap((name, index) => {
+    const userId = `user-${name}`;
+    return [
+      {
+        info: { id: userId, role: "user", sessionID: "session-retry" },
+        parts: [{ type: "text", text: `Prompt ${name}.` }],
+      },
+      {
+        info: {
+          id: `assistant-${name}`,
+          role: "assistant",
+          sessionID: "session-retry",
+          parentID: userId,
+          time: { completed: index + 1 },
+        },
+        parts: [{ type: "text", text: `Reply ${name}.` }],
+      },
+    ];
+  });
+  const plugin = createMemoraxOpenCodePlugin({
+    backendConnection: { url: "http://127.0.0.1:8787" },
+    fetchImpl: responseSequence(requests, [
+      { ok: true },
+      { ok: true },
+      new Response(null, { status: 413 }),
+      { ok: true, scheduled: false, reason: "runtime_closed" },
+      { ok: true, scheduled: true },
+    ]),
+  });
+  const hooks = await plugin(pluginInput({
+    client: { session: { async messages() { return { data: messages }; } } },
+  }));
+  for (const name of names) {
+    await hooks["chat.message"](
+      { sessionID: "session-retry" },
+      { message: { id: `user-${name}` }, parts: [{ type: "text", text: `Prompt ${name}.` }] },
+    );
+  }
+  const idle = () => hooks.event({
+    event: {
+      type: "session.status",
+      properties: { sessionID: "session-retry", status: { type: "idle" } },
+    },
+  });
+
+  idle();
+  await hooks.dispose();
+  idle();
+  await hooks.dispose();
+
+  assert.deepEqual(
+    requests.filter((request) => request.url.endsWith("/memory/writeback"))
+      .map((request) => request.body.userMessageId),
+    ["user-oversized", "user-retry", "user-retry"],
+  );
+});
+
 function pluginInput(overrides = {}) {
   return {
     client: { session: { async messages() { return { data: [] }; } } },
@@ -263,6 +323,7 @@ function responseSequence(requests, responses) {
   return async (url, options) => {
     requests.push({ url: String(url), options, body: JSON.parse(options.body) });
     const body = responses.shift() ?? { ok: true };
+    if (body instanceof Response) return body;
     return new Response(JSON.stringify(body), {
       status: 200,
       headers: { "content-type": "application/json" },

--- a/packages/ts/memorax-code-opencode-adapter/test/plugin.test.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/test/plugin.test.mjs
@@ -2,6 +2,7 @@ import { strict as assert } from "node:assert";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
 import { test } from "node:test";
 import { createMemoraxOpenCodePlugin } from "../src/plugin.mjs";
 
@@ -151,6 +152,101 @@ test("a loaded plugin follows the managed enabled state without an OpenCode rest
       enabled,
     }));
   }
+});
+
+test("idle reads authoritative SDK messages and dispose drains the pending writeback", async () => {
+  const requests = [];
+  let releaseMessages;
+  const messagesReady = new Promise((resolve) => {
+    releaseMessages = resolve;
+  });
+  const clientCalls = [];
+  const input = pluginInput({
+    client: {
+      session: {
+        async messages(options) {
+          clientCalls.push(options);
+          await messagesReady;
+          return {
+            data: [
+              {
+                info: { id: "user-3", role: "user", sessionID: "session-3" },
+                parts: [{ type: "text", text: "Implement the adapter." }],
+              },
+              {
+                info: {
+                  id: "assistant-3",
+                  role: "assistant",
+                  sessionID: "session-3",
+                  parentID: "user-3",
+                  time: { completed: 123 },
+                },
+                parts: [{ type: "text", text: "Implemented." }],
+              },
+            ],
+          };
+        },
+      },
+    },
+  });
+  const plugin = createMemoraxOpenCodePlugin({
+    backendConnection: { url: "http://127.0.0.1:8787" },
+    fetchImpl: responseSequence(requests, [{ ok: true }, { ok: true }]),
+  });
+  const hooks = await plugin(input);
+  await hooks["chat.message"](
+    { sessionID: "session-3" },
+    { message: { id: "user-3" }, parts: [{ type: "text", text: "Implement the adapter." }] },
+  );
+
+  hooks.event({
+    event: {
+      type: "session.status",
+      properties: { sessionID: "session-3", status: { type: "idle" } },
+    },
+  });
+  let disposed = false;
+  const disposing = hooks.dispose().then(() => {
+    disposed = true;
+  });
+  await delay(10);
+  assert.equal(disposed, false);
+
+  releaseMessages();
+  await disposing;
+
+  assert.deepEqual(clientCalls, [{
+    path: { id: "session-3" },
+    query: { directory: "/repo/directory" },
+    throwOnError: true,
+  }]);
+  assert.equal(requests.length, 2);
+  assert.equal(requests[1].url, "http://127.0.0.1:8787/memory/writeback");
+  assert.deepEqual(requests[1].body, {
+    version: 1,
+    client: "opencode",
+    sessionId: "session-3",
+    userMessageId: "user-3",
+    assistantMessageId: "assistant-3",
+    messages: [
+      {
+        info: { id: "user-3", role: "user", sessionID: "session-3" },
+        parts: [{ type: "text", text: "Implement the adapter." }],
+      },
+      {
+        info: {
+          id: "assistant-3",
+          role: "assistant",
+          sessionID: "session-3",
+          parentID: "user-3",
+          time: { completed: 123 },
+        },
+        parts: [{ type: "text", text: "Implemented." }],
+      },
+    ],
+    cwd: "/repo/worktree",
+    workspaceKind: "project",
+  });
 });
 
 function pluginInput(overrides = {}) {


### PR DESCRIPTION
## Change Summary
Add automatic completed-turn memory writeback for OpenCode by reading correlated native session messages through the OpenCode SDK and reusing the existing repository-scoped writeback pipeline.

## Implementation Highlights
- Track accepted OpenCode prompts and, when the session becomes idle, submit the matching completed user and assistant messages from the OpenCode SDK to the authenticated local Backend.
- Validate session, role, parent, completion, error, summary, compaction, and text-part identity before reusing the shared turn coordinator, repository scope, redaction, buffering, chunking, observability, and Add flow.
- Keep this increment limited to normally completed turns; interruption terminal-state handling, recovery, reminders, Repo Memory maintenance, and Viewer UI remain in later PRs.

## Validation
- `npm run typecheck --prefix packages/ts/memorax-code-backend` — passed
- `npm test --prefix packages/ts/memorax-code-backend` — 515 passed, 2 skipped
- `make test-opencode-adapter` — 15 passed
- `make docs-check` — 10 passed
- `make npm-package-check` — 170 package checks passed; 319 packed files matched the allowlist

## Full End-to-End Validation Results
This is an incremental integration PR, so no screenshot-only evidence is included. Full macOS and Linux Docker E2E validation will be recorded after the complete OpenCode integration stack is assembled. Windows remains unverified.
