### PR TITLE
feat: recover OpenCode Backend on plugin load

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -182,6 +182,17 @@ installations are supported. The installer records managed ownership under
 skill artifacts under the OpenCode configuration directory, and leaves model
 and provider configuration untouched.
 
+When that managed plugin is enabled, plugin initialization starts one
+best-effort Backend availability check without blocking OpenCode startup. The
+first prompt shares one bounded interaction budget with that check; expiry
+skips automatic memory handling for the current turn while Backend recovery
+continues in the background. Idle writeback for an already accepted turn may
+wait for the full in-process check. Recovery uses the package-recorded Node
+runtime and `memorax-code start` entrypoint, exact MemoraX Code home and
+OpenCode configuration directory, and the existing lifecycle lock. It does
+not replace persistent client selection, directly spawn the Backend, or
+recover a remote or invalid connection authority.
+
 ### 3.2 Hook and retrieval data flow
 
 ```mermaid

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,6 +39,11 @@ Please allow time for triage and remediation before public disclosure.
 - Hook, lifecycle, connection, PID, token, session, and workspace authority
   records are security-sensitive local state. Do not hand-edit or publish
   them.
+- The managed OpenCode plugin may recover an unavailable Backend only through
+  its package-recorded Node runtime and absolute `memorax-code` command, and
+  the currently resolved loopback HTTP authority. It preserves the existing
+  lifecycle lock and client selection; remote or invalid authority and removed
+  commands fail open without starting a process.
 - Initial Repo Memory builds use only the Git worktree returned by an
   authenticated Backend turn-start request. Backend or workspace-scope
   failures skip the build; client Hooks do not fall back to their local `cwd`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -94,6 +94,16 @@ MemoraX Code does not add entries to or otherwise modify `opencode.json` or
 `opencode.jsonc`. Restart or refresh OpenCode after installation or after these
 managed assets change.
 
+The managed loader records the exact MemoraX Code home, OpenCode configuration
+directory, installed Node runtime, and `memorax-code` entrypoint. When the
+enabled plugin loads, it performs a best-effort Backend health check and uses
+those installed package paths to restore an unavailable loopback Backend. A
+prompt waits no more than the plugin instance's single five-second recovery
+budget; if that budget expires, automatic memory handling for that turn is
+skipped while recovery continues in the background. This preserves the
+configured client selection. Remote Backend URLs, invalid connection
+authority, and a removed package command are not recovered automatically.
+
 ## MemoraX connection
 
 MemoraX is the required remote-memory service:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -116,6 +116,15 @@ or refresh OpenCode. The configuration root follows `OPENCODE_CONFIG_DIR`, then
 `XDG_CONFIG_HOME`, and otherwise defaults to `~/.config/opencode`. MemoraX Code
 does not add plugin entries to `opencode.json` or `opencode.jsonc`.
 
+An enabled managed plugin normally attempts to restore an unavailable local
+loopback Backend when OpenCode loads it. A prompt stops waiting after the
+plugin instance's single five-second recovery budget and skips automatic
+memory handling for that turn, but the Backend start continues in the
+background. If that recovery is skipped or fails, use `memorax-code status` and
+`memorax-code logs`, then run the start command above. Automatic recovery
+intentionally skips remote URLs, invalid connection authority, and stale
+loaders whose recorded package command no longer exists.
+
 An already-open client may keep its loaded plugin shell while a later prompt
 uses the updated Hook runtime. Restart or refresh the client to load a changed
 plugin manifest, icon, or bundled skill.

--- a/packages/ts/memorax-code-adapter-common/src/hooks/ensure-backend-runner.mjs
+++ b/packages/ts/memorax-code-adapter-common/src/hooks/ensure-backend-runner.mjs
@@ -14,10 +14,15 @@ export async function runEnsureBackendHook(options) {
   if (isRepoMemoryJobWorker() || ensureDisabled(options.ensureBackendValue)) return;
 
   const input = await readStdinJson();
+  await ensureBackendAvailable(options, input);
+}
+
+export async function ensureBackendAvailable(options, input = {}) {
   const homes = options.resolveHomes(input);
   let connection;
   try {
-    connection = resolveBackendConnection({ memoraxCodeHome: homes.memoraxCodeHome });
+    connection = options.backendConnection
+      ?? resolveBackendConnection({ memoraxCodeHome: homes.memoraxCodeHome });
   } catch (error) {
     options.debug?.(error instanceof Error ? error.message : String(error));
     return;
@@ -36,6 +41,7 @@ export async function runEnsureBackendHook(options) {
     command.value,
     options.buildStartArgs(homes, recoveryArguments),
     parsePositiveInt(options.startTimeoutValue, DEFAULT_ENSURE_BACKEND_START_TIMEOUT_MS),
+    options.nodePath,
   );
   if (result.code !== 0) {
     options.debug?.(
@@ -105,10 +111,10 @@ function memoraxCodeCommandAvailable(command) {
   return path.split(delimiter).some((dir) => dir && existsSync(join(dir, command)));
 }
 
-function runMemoraxCode(command, args, timeoutMs) {
+function runMemoraxCode(command, args, timeoutMs, nodePath) {
   return new Promise((resolve) => {
     const childArgs = nodeEntrypoint(command) ? [command, ...args] : args;
-    const childCommand = nodeEntrypoint(command) ? process.execPath : command;
+    const childCommand = nodeEntrypoint(command) ? (stringValue(nodePath) ?? process.execPath) : command;
     let stderr = "";
     let settled = false;
     const child = spawn(childCommand, childArgs, {

--- a/packages/ts/memorax-code-opencode-adapter/src/plugin-install.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/src/plugin-install.mjs
@@ -314,6 +314,14 @@ export function defaultOpenCodeCliBinDir(adapterRoot = ADAPTER_ROOT) {
   return candidates.find(hasMemoraxCliCommand);
 }
 
+export function defaultMemoraxCodeCommand(adapterRoot = ADAPTER_ROOT) {
+  const packageRoot = resolve(adapterRoot, "..", "..");
+  return [
+    join(packageRoot, "bin", "memorax-code.mjs"),
+    join(packageRoot, "npm", "memorax-code", "bin", "memorax-code.mjs"),
+  ].find((path) => existsSync(path));
+}
+
 function resolvePaths(options) {
   const memoraxCodeHome = resolve(options.memoraxCodeHome ?? defaultMemoraxCodeHome());
   const openCodeConfigDir = resolve(options.openCodeConfigDir ?? defaultOpenCodeConfigDir());
@@ -328,6 +336,12 @@ function resolvePaths(options) {
     cliBinDir: stringOption(options.cliBinDir)
       ? resolve(options.cliBinDir)
       : defaultOpenCodeCliBinDir(),
+    nodePath: stringOption(options.nodePath)
+      ? resolve(options.nodePath)
+      : process.execPath,
+    memoraxCodeCommand: stringOption(options.memoraxCodeCommand)
+      ? resolve(options.memoraxCodeCommand)
+      : defaultMemoraxCodeCommand(),
   };
 }
 
@@ -392,6 +406,9 @@ function createManagedLoader(paths, pluginSourceSha256) {
   const pluginOptions = {
     memoraxCodeHome: paths.memoraxCodeHome,
     statePath: paths.statePath,
+    openCodeConfigDir: paths.openCodeConfigDir,
+    ...(paths.memoraxCodeCommand ? { memoraxCodeCommand: paths.memoraxCodeCommand } : {}),
+    nodePath: paths.nodePath,
     ...(paths.cliBinDir ? { cliBinDir: paths.cliBinDir } : {}),
   };
   return [

--- a/packages/ts/memorax-code-opencode-adapter/src/plugin.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/src/plugin.mjs
@@ -1,7 +1,10 @@
 import { delimiter } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
 import { resolveBackendConnection } from "../../memorax-code-adapter-common/src/backend-connection.mjs";
 import { readAdapterState } from "../../memorax-code-adapter-common/src/config-utils.mjs";
+import { ensureBackendAvailable } from "../../memorax-code-adapter-common/src/hooks/ensure-backend-runner.mjs";
 
+const DEFAULT_BACKEND_PROMPT_WAIT_TIMEOUT_MS = 5_000;
 const TURN_START_TIMEOUT_MS = 12_000;
 const WRITEBACK_TIMEOUT_MS = 5_000;
 const MAX_PENDING_TURNS = 256;
@@ -19,6 +22,39 @@ export function createMemoraxOpenCodePlugin(options = {}) {
     const workspaceKind = project?.vcs === "git" ? "project" : "local";
     const pendingTurns = new Map();
     const inFlight = new Set();
+    const backendPromptWaitTimeoutMs = positiveInteger(
+      options.backendPromptWaitTimeoutValue,
+      DEFAULT_BACKEND_PROMPT_WAIT_TIMEOUT_MS,
+    );
+    let backendEnsurePromise;
+    let backendEnsureSettled = false;
+    let backendPromptGatePromise;
+
+    function ensureBackendReady() {
+      if (!managedPluginEnabled(options)) return Promise.resolve();
+      if (!backendEnsurePromise) {
+        const ensureOptions = backendEnsureOptions(options);
+        if (!ensureOptions) return Promise.resolve();
+        backendEnsurePromise = ensureBackendAvailable(ensureOptions)
+          .catch((error) => {
+            debug(options, "opencode backend recovery failed", error);
+          })
+          .then(() => {
+            backendEnsureSettled = true;
+          });
+        backendPromptGatePromise = Promise.race([
+          backendEnsurePromise.then(() => true),
+          delay(backendPromptWaitTimeoutMs, false, { ref: false }),
+        ]);
+      }
+      return backendEnsurePromise;
+    }
+
+    async function backendReadyForPrompt() {
+      ensureBackendReady();
+      if (!backendEnsurePromise || backendEnsureSettled) return true;
+      return await backendPromptGatePromise;
+    }
 
     function track(task) {
       const observed = task.catch((error) => {
@@ -29,6 +65,8 @@ export function createMemoraxOpenCodePlugin(options = {}) {
     }
 
     async function flushSession(sessionId) {
+      if (!pluginEnabled(options)) return;
+      await ensureBackendReady();
       if (!pluginEnabled(options)) return;
       const turns = [...pendingTurns.values()].filter((turn) => turn.sessionId === sessionId);
       if (turns.length === 0) return;
@@ -71,6 +109,8 @@ export function createMemoraxOpenCodePlugin(options = {}) {
       }
     }
 
+    void ensureBackendReady();
+
     return {
       "chat.message": async (input, output) => {
         if (!pluginEnabled(options)) return;
@@ -78,6 +118,15 @@ export function createMemoraxOpenCodePlugin(options = {}) {
         const sessionId = stringValue(input?.sessionID);
         const prompt = textParts(output?.parts);
         if (!sessionId || !userMessageId || !prompt) return;
+        if (!await backendReadyForPrompt()) {
+          debug(
+            options,
+            "opencode turn start skipped",
+            `Backend recovery exceeded the ${backendPromptWaitTimeoutMs} ms interaction budget`,
+          );
+          return;
+        }
+        if (!pluginEnabled(options)) return;
         try {
           const result = await postBackend(options, "/memory/turn-start", {
             version: 1,
@@ -134,7 +183,10 @@ export function createMemoraxOpenCodePlugin(options = {}) {
         }
       },
       async dispose() {
-        await Promise.allSettled([...inFlight]);
+        await Promise.allSettled([
+          ...inFlight,
+          ...(backendEnsurePromise ? [backendEnsurePromise] : []),
+        ]);
       },
     };
   };
@@ -206,13 +258,46 @@ function stringValue(value) {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
+function positiveInteger(value, fallback) {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
 function pluginEnabled(options) {
   const statePath = stringValue(options.statePath);
   if (!statePath) return true;
+  return managedPluginEnabled(options);
+}
+
+function managedPluginEnabled(options) {
+  const statePath = stringValue(options.statePath);
+  if (!statePath) return false;
   const state = readAdapterState(statePath);
   return state?.unreadable !== true
     && state?.version === 1
     && state?.runtime === "opencode"
     && state?.integration === "plugin"
     && state?.enabled === true;
+}
+
+function backendEnsureOptions(options) {
+  const memoraxCodeHome = stringValue(options.memoraxCodeHome);
+  const openCodeConfigDir = stringValue(options.openCodeConfigDir);
+  const memoraxCodeCommand = stringValue(options.memoraxCodeCommand);
+  if (!memoraxCodeHome || !openCodeConfigDir || !memoraxCodeCommand) return undefined;
+  return {
+    backendConnection: options.backendConnection,
+    healthTimeoutValue: options.healthTimeoutValue,
+    startTimeoutValue: options.startTimeoutValue,
+    memoraxCodeCommand,
+    nodePath: options.nodePath,
+    resolveHomes: () => ({ memoraxCodeHome, openCodeConfigDir }),
+    buildStartArgs: (homes, recoveryArguments) => [
+      "start",
+      "--home", homes.memoraxCodeHome,
+      "--opencode-config-dir", homes.openCodeConfigDir,
+      ...recoveryArguments,
+    ],
+    debug: (message) => debug(options, "opencode backend recovery skipped", message),
+  };
 }

--- a/packages/ts/memorax-code-opencode-adapter/test/plugin-install.test.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/test/plugin-install.test.mjs
@@ -6,6 +6,7 @@ import { pathToFileURL } from "node:url";
 import { test } from "node:test";
 import { defaultOpenCodeConfigDir } from "../src/adapter-paths.mjs";
 import {
+  defaultMemoraxCodeCommand,
   defaultOpenCodeCliBinDir,
   disableOpenCodePlugin,
   ensureOpenCodePluginInstalled,
@@ -31,10 +32,14 @@ test("OpenCode CLI path discovery recognizes the staged npm package layout", asy
     const packageRoot = join(root, "prefix", "lib", "node_modules", "@memorax", "memorax-code");
     const adapterRoot = join(packageRoot, "lib", "memorax-code-opencode-adapter");
     const commandBin = join(root, "prefix", "bin");
+    const lifecycleCommand = join(packageRoot, "bin", "memorax-code.mjs");
     await mkdir(adapterRoot, { recursive: true });
     await mkdir(commandBin, { recursive: true });
+    await mkdir(join(packageRoot, "bin"), { recursive: true });
     await writeFile(join(commandBin, "memorax-cli"), "#!/bin/sh\n");
+    await writeFile(lifecycleCommand, "#!/usr/bin/env node\n");
     assert.equal(defaultOpenCodeCliBinDir(adapterRoot), commandBin);
+    assert.equal(defaultMemoraxCodeCommand(adapterRoot), lifecycleCommand);
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -51,6 +56,9 @@ test("OpenCode plugin install materializes a managed loader, canonical skill, an
     assert.match(loader, /^\/\/ Managed by MemoraX Code/);
     assert.match(loader, new RegExp(escapeRegex(JSON.stringify(pathToFileURL(fixture.pluginSourcePath).href))));
     assert.match(loader, new RegExp(escapeRegex(`"memoraxCodeHome":${JSON.stringify(fixture.options.memoraxCodeHome)}`)));
+    assert.match(loader, new RegExp(escapeRegex(`"openCodeConfigDir":${JSON.stringify(fixture.openCodeConfigDir)}`)));
+    assert.match(loader, new RegExp(escapeRegex(`"memoraxCodeCommand":${JSON.stringify(fixture.memoraxCodeCommand)}`)));
+    assert.match(loader, new RegExp(escapeRegex(`"nodePath":${JSON.stringify(process.execPath)}`)));
     assert.match(loader, /"cliBinDir":"\/managed\/bin"/);
     assert.equal(await readFile(join(installed.skillPath, "SKILL.md"), "utf8"), "# MemoraX Code\n");
     assert.equal(await readFile(join(installed.skillPath, "references", "search.md"), "utf8"), "search\n");
@@ -196,21 +204,26 @@ async function createFixture(name) {
   const openCodeConfigDir = join(root, "OpenCode Config With Spaces");
   const memoraxCodeHome = join(root, "memorax-code");
   const pluginSourcePath = join(root, "Adapter With Spaces", "plugin.mjs");
+  const memoraxCodeCommand = join(root, "Package With Spaces", "bin", "memorax-code.mjs");
   const skillSourcePath = join(root, "canonical-skill");
   await mkdir(join(skillSourcePath, "references"), { recursive: true });
   await mkdir(join(root, "Adapter With Spaces"), { recursive: true });
+  await mkdir(join(root, "Package With Spaces", "bin"), { recursive: true });
   await writeFile(pluginSourcePath, "export function createMemoraxOpenCodePlugin() {}\n");
+  await writeFile(memoraxCodeCommand, "#!/usr/bin/env node\n");
   await writeFile(join(skillSourcePath, "SKILL.md"), "# MemoraX Code\n");
   await writeFile(join(skillSourcePath, "references", "search.md"), "search\n");
   return {
     root,
     openCodeConfigDir,
+    memoraxCodeCommand,
     pluginSourcePath,
     options: {
       openCodeConfigDir,
       memoraxCodeHome,
       pluginSourcePath,
       skillSourcePath,
+      memoraxCodeCommand,
       cliBinDir: "/managed/bin",
     },
   };

--- a/packages/ts/memorax-code-opencode-adapter/test/plugin.test.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/test/plugin.test.mjs
@@ -1,5 +1,5 @@
 import { strict as assert } from "node:assert";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
@@ -37,6 +37,74 @@ test("chat.message retrieves memory and injects it into the system prompt", asyn
     cwd: "/repo/worktree",
     workspaceKind: "project",
   });
+});
+
+test("managed plugin starts the Backend once and bounds prompt waiting", async () => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-code-opencode-backend-start-"));
+  const nodePath = process.execPath;
+  const memoraxCodeHome = join(root, "memorax-code-home");
+  const openCodeConfigDir = join(root, "opencode-config");
+  const statePath = join(root, "state.json");
+  const callsPath = join(root, "lifecycle-calls.jsonl");
+  const releasePath = join(root, "lifecycle-release");
+  const memoraxCodeCommand = join(root, "memorax-code.mjs");
+  const requests = [];
+  let hooks;
+  try {
+    await writeFile(statePath, JSON.stringify({
+      version: 1,
+      runtime: "opencode",
+      integration: "plugin",
+      enabled: true,
+    }));
+    await writeFile(memoraxCodeCommand, [
+      'import { appendFileSync, existsSync } from "node:fs";',
+      `appendFileSync(${JSON.stringify(callsPath)}, JSON.stringify(process.argv.slice(2)) + "\\n");`,
+      `while (!existsSync(${JSON.stringify(releasePath)})) await new Promise((resolve) => setTimeout(resolve, 5));`,
+    ].join("\n"));
+    const plugin = createMemoraxOpenCodePlugin({
+      statePath,
+      memoraxCodeHome,
+      openCodeConfigDir,
+      memoraxCodeCommand,
+      nodePath,
+      backendConnection: { url: "http://127.0.0.1:9", source: "option" },
+      healthTimeoutValue: "50",
+      startTimeoutValue: "1000",
+      backendPromptWaitTimeoutValue: "100",
+      fetchImpl: responseSequence(requests, [{ ok: true }]),
+    });
+    process.execPath = join(root, "opencode");
+    hooks = await plugin(pluginInput());
+    await waitForFile(callsPath);
+    const calls = (await readFile(callsPath, "utf8")).trim().split("\n").map(JSON.parse);
+    assert.deepEqual(calls, [[
+      "start",
+      "--home", memoraxCodeHome,
+      "--opencode-config-dir", openCodeConfigDir,
+      "--host", "127.0.0.1",
+      "--port", "9",
+    ]]);
+    const prompt = (id) => hooks["chat.message"](
+      { sessionID: `session-${id}` },
+      { message: { id }, parts: [{ type: "text", text: id }] },
+    );
+    await Promise.race([
+      Promise.all([prompt("user-start-1"), prompt("user-start-2")]),
+      delay(400).then(() => { throw new Error("Backend prompt wait was not bounded"); }),
+    ]);
+    assert.equal(requests.length, 0);
+
+    await writeFile(releasePath, "release\n");
+    await hooks.dispose();
+    await prompt("user-start-3");
+    assert.equal(requests.length, 1);
+  } finally {
+    process.execPath = nodePath;
+    await writeFile(releasePath, "release\n").catch(() => undefined);
+    await hooks?.dispose();
+    await rm(root, { recursive: true, force: true });
+  }
 });
 
 test("chat.message does not mistake a user diff summary for compaction", async () => {
@@ -329,4 +397,17 @@ function responseSequence(requests, responses) {
       headers: { "content-type": "application/json" },
     });
   };
+}
+
+async function waitForFile(path) {
+  for (let attempt = 0; attempt < 200; attempt += 1) {
+    try {
+      await readFile(path);
+      return;
+    } catch (error) {
+      if (error?.code !== "ENOENT") throw error;
+      await delay(5);
+    }
+  }
+  throw new Error(`Timed out waiting for ${path}`);
 }


### PR DESCRIPTION
## Change Summary
Restore an unavailable local Backend when the managed OpenCode plugin loads so memory features resume after a machine or client restart.

## Implementation Highlights
- Start one best-effort Backend availability check per managed plugin instance and share a bounded five-second gate across initial prompts.
- Continue recovery in the background after the prompt gate expires, allowing later prompts to resume automatic memory without blocking OpenCode startup.
- Launch the lifecycle entrypoint with the Node runtime recorded during installation while preserving loopback authority, lifecycle locking, and fail-closed handling.
- Keep the existing Codex and Claude recovery behavior unchanged and document the OpenCode lifecycle and trust boundary.

## Validation
- OpenCode adapter: 17/17 tests passed.
- Codex adapter: 202/202 tests passed.
- Claude Code adapter: 65/65 tests passed.
- `make docs-check` passed.
- `make npm-package-check` passed, including 170/170 package tests and the staged npm allowlist check.
- `git diff --cached --check` passed before commit; all README files are unchanged.

## Full End-to-End Validation Results
- Environment: Local macOS automated integration and package staging checks.
- Scenario or matrix: Managed OpenCode plugin with an unavailable loopback Backend, concurrent initial prompts, delayed recovery, and a later successful prompt.
- Command or workflow: Adapter suites, documentation contract checks, and npm package lifecycle checks listed above.
- Result: Recovery starts once with the recorded Node and exact managed paths; initial prompts share a bounded wait; a later prompt proceeds after recovery.
- Evidence or artifacts: Automated test output in the development task; no secrets, transcripts, or local paths are attached.
- Reason not run / remaining risk: Full macOS OpenCode Desktop/CLI and Linux CLI E2E is deferred until the complete OpenCode integration PR stack is assembled. Remaining risk is limited to real-client process lifecycle behavior beyond the covered managed-loader and package integration paths.