### PR TITLE
feat: add shared memory reminders for OpenCode

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -238,8 +238,12 @@ Important distinctions:
 - Client-specific runtimes interpret native formats. Client-neutral memory
   coordination does not parse, mix, or guess those formats.
 - OpenCode's awaited `chat.message` plugin event supplies the correlated user
-  prompt and injects accepted retrieval context into that message's system
-  context. Its `shell.env` event binds the native session identity and makes
+  prompt and injects accepted retrieval plus shared Skill reminder, User
+  Profile, and Procedure Memory context into that message's system context. Its
+  stable `session.compacted` event marks a durable supplemental reminder for
+  the next real user message; synthetic and compaction messages do not consume
+  that pending state. Local reminder evaluation remains independent of Backend
+  recovery. Its `shell.env` event binds the native session identity and makes
   the packaged memory CLI available to agent-run shell commands.
 
 ### 3.3 Manual memory CLI flow
@@ -331,8 +335,8 @@ Backend-resolved worktree rather than an arbitrary Hook `cwd`.
 
 OpenCode supports active Repo Memory operations through the shared skill, but
 its plugin does not own supervised background Repo Memory maintenance. Its
-automatic runtime contract covers prompt retrieval and completed-turn
-writeback.
+automatic runtime contract covers prompt retrieval, shared reminder injection,
+and completed-turn writeback.
 
 ## 4. Backend Modular Monolith
 
@@ -514,10 +518,10 @@ repository-session bindings, in-flight provider operations, Viewer projection
 caches, and background reconciliation promises.
 
 Durable local state includes configuration, private runtime records, active
-client selection, client-qualified trace JSONL, and Repo Memory. State shared
-across processes requires a bounded lock, atomic replacement, or version
-validation appropriate to its record. An in-memory mutex is not cross-process
-authority.
+client selection, client-qualified trace JSONL, reminder cadence state, and Repo
+Memory. State shared across processes requires a bounded lock, atomic
+replacement, or version validation appropriate to its record. An in-memory
+mutex is not cross-process authority.
 
 Backend-owned remote memory state is limited to MemoraX memories and
 asynchronous writeback tasks. The provider adapter is the network boundary for

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -333,6 +333,13 @@ Adapter Hooks may schedule a missing bundle build using adapter-common
 supervision, locking, and job-policy helpers. They must use the
 Backend-resolved worktree rather than an arbitrary Hook `cwd`.
 
+Codex and OpenCode keep the generic shared Skill reminder available when the
+Backend or repository scope is unavailable. Their User Profile and Procedure
+Memory builders are enabled only when the current turn-start result includes a
+Backend-resolved worktree, and those builders read that worktree. The original
+client workspace remains metadata when an accepted turn's reminder is traced;
+it is not repository-local content authority.
+
 OpenCode supports active Repo Memory operations through the shared skill, but
 its plugin does not own supervised background Repo Memory maintenance. Its
 automatic runtime contract covers prompt retrieval, shared reminder injection,

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -47,6 +47,10 @@ Please allow time for triage and remediation before public disclosure.
 - Initial Repo Memory builds use only the Git worktree returned by an
   authenticated Backend turn-start request. Backend or workspace-scope
   failures skip the build; client Hooks do not fall back to their local `cwd`.
+- Codex and OpenCode read repository-local User Profile and Procedure Memory
+  only from the worktree authorized by the current Backend turn-start result.
+  Without that authority they keep only the generic Skill reminder and do not
+  fall back to the client `cwd` for repository-local content.
 - MemoraX-backed Search, Add, and automatic writeback may downgrade malformed
   or incomplete internal metadata in a direct `.git` directory to the
   canonical workspace folder identity. The CLI exposes the fallback reason,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -221,8 +221,8 @@ entered and do not pass through this detector.
 
 `[memory.skill_reminder].interval_turns` defaults to `5`; its environment
 override is `MEMORAX_CODE_MEMORY_SKILL_REMINDER_INTERVAL_TURNS`. A positive
-value controls the reminder cadence for Codex and Claude Code, beginning with
-the first eligible prompt.
+value controls the reminder cadence for Codex, Claude Code, and OpenCode,
+beginning with the first eligible prompt.
 
 | Field | Environment override | Fallback |
 | --- | --- | --- |
@@ -242,7 +242,8 @@ local `cwd`.
 
 OpenCode supports active Repo Memory operations through the installed skill,
 but its plugin does not currently run background Repo Memory maintenance. Its
-automatic integration covers retrieval and completed-turn writeback.
+automatic integration covers retrieval, shared reminder and personal-memory
+context injection, and completed-turn writeback.
 
 ## Local traces
 

--- a/packages/ts/memorax-code-adapter-common/src/hooks/memory-skill-reminder-hook.mjs
+++ b/packages/ts/memorax-code-adapter-common/src/hooks/memory-skill-reminder-hook.mjs
@@ -23,15 +23,30 @@ export function personalMemoryReminderContext(memorySkillInvocation) {
 export async function runMemorySkillReminderHook(options, hookInput) {
   try {
     const input = hookInput ?? await readStdinJson();
+    const result = await evaluateMemorySkillReminder(options, input);
+    if (!result) return;
+    process.stdout.write(`${JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: "UserPromptSubmit",
+        additionalContext: result.additionalContext,
+      },
+    })}\n`);
+    if (result.reminder) await notifyReminder(options, result.reminder);
+  } catch (error) {
+    debugError(options, error);
+  }
+}
+
+export async function evaluateMemorySkillReminder(options, input) {
+  try {
     const sessionId = stringOption(input.session_id) ?? stringOption(input.sessionId);
-    if (!sessionId) return;
+    if (!sessionId) return undefined;
     const transcriptPath = stringOption(input.transcript_path) ?? stringOption(input.transcriptPath);
-    if (options.requireTranscriptPath && !transcriptPath) return;
+    if (options.requireTranscriptPath && !transcriptPath) return undefined;
     const hookEventName = stringOption(input.hook_event_name) ?? stringOption(input.hookEventName) ?? "UserPromptSubmit";
+    if (hookEventName !== "UserPromptSubmit") return undefined;
 
-    const memoraxCodeHome = process.env.MEMORAX_CODE_HOME || defaultMemoraxCodeHome();
-    if (hookEventName !== "UserPromptSubmit") return;
-
+    const memoraxCodeHome = resolveMemoraxCodeHome(options);
     const statePath = join(memoraxCodeHome, "adapters", options.adapterDir, "memory-skill-reminders.json");
     const turnId = stringOption(input.turn_id)
       ?? stringOption(input.turnId)
@@ -64,34 +79,30 @@ export async function runMemorySkillReminderHook(options, hookInput) {
         turnCount: sessionState?.turnCount,
       };
     });
-    if (update.duplicate) return;
+    if (update.duplicate) return undefined;
     const { memoryReminderDue, supplementalReminderDue } = update;
 
     const baseAdditionalContext = stringOption(options.baseAdditionalContext);
-    if (baseAdditionalContext || memoryReminderDue || supplementalReminderDue) {
-      const cadenceReminderContext = memoryReminderDue
-        ? await buildCadenceReminderContext(options, input)
-        : undefined;
-      const personalMemoryContext = supplementalReminderDue || (memoryReminderDue && update.turnCount === 1)
-        ? await buildPersonalMemoryContext(options, input)
-        : undefined;
-      const reminderContext = stringOption(combinedReminderContext(options, {
-        memoryReminderDue,
-        supplementalReminderDue,
-      }, cadenceReminderContext, personalMemoryContext));
-      const additionalContext = [baseAdditionalContext, reminderContext].filter(Boolean).join("\n\n");
-      const triggers = [
-        ...(memoryReminderDue ? ["cadence"] : []),
-        ...(supplementalReminderDue ? ["post_compaction"] : []),
-      ];
-      process.stdout.write(`${JSON.stringify({
-        hookSpecificOutput: {
-          hookEventName: "UserPromptSubmit",
-          additionalContext,
-        },
-      })}\n`);
-      if (reminderContext) {
-        await notifyReminder(options, {
+    if (!baseAdditionalContext && !memoryReminderDue && !supplementalReminderDue) return undefined;
+    const cadenceReminderContext = memoryReminderDue
+      ? await buildCadenceReminderContext(options, input)
+      : undefined;
+    const personalMemoryContext = supplementalReminderDue || (memoryReminderDue && update.turnCount === 1)
+      ? await buildPersonalMemoryContext(options, input)
+      : undefined;
+    const reminderContext = stringOption(combinedReminderContext(options, {
+      memoryReminderDue,
+      supplementalReminderDue,
+    }, cadenceReminderContext, personalMemoryContext));
+    const additionalContext = [baseAdditionalContext, reminderContext].filter(Boolean).join("\n\n");
+    const triggers = [
+      ...(memoryReminderDue ? ["cadence"] : []),
+      ...(supplementalReminderDue ? ["post_compaction"] : []),
+    ];
+    return {
+      additionalContext,
+      ...(reminderContext ? {
+        reminder: {
           sessionId,
           turnId,
           transcriptPath,
@@ -99,13 +110,12 @@ export async function runMemorySkillReminderHook(options, hookInput) {
           workspaceKind: stringOption(input.workspace_kind) ?? stringOption(input.workspaceKind),
           content: reminderContext,
           triggers,
-        });
-      }
-    }
+        },
+      } : {}),
+    };
   } catch (error) {
-    if (process.env[options.debugEnv] === "1") {
-      console.error(error instanceof Error ? error.message : String(error));
-    }
+    debugError(options, error);
+    return undefined;
   }
 }
 
@@ -125,21 +135,28 @@ export function markSupplementalReminderAfterCompact(options, input) {
     const hookEventName = stringOption(input.hook_event_name) ?? stringOption(input.hookEventName);
     if (hookEventName !== "SessionStart" || stringOption(input.source) !== "compact") return;
     const sessionId = stringOption(input.session_id) ?? stringOption(input.sessionId);
-    if (!sessionId) return;
-    const memoraxCodeHome = process.env.MEMORAX_CODE_HOME || defaultMemoraxCodeHome();
+    markSupplementalReminderForSession(options, sessionId);
+  } catch (error) {
+    debugError(options, error);
+  }
+}
+
+export function markSupplementalReminderForSession(options, sessionId) {
+  try {
+    const normalizedSessionId = stringOption(sessionId);
+    if (!normalizedSessionId) return;
+    const memoraxCodeHome = resolveMemoraxCodeHome(options);
     const statePath = join(memoraxCodeHome, "adapters", options.adapterDir, "memory-skill-reminders.json");
     withJsonFileLock(statePath, () => {
       const existing = readJsonFile(statePath);
       atomicWriteJson(statePath, markSupplementalReminderPending(
         existing?.unreadable ? undefined : existing?.value,
         options.runtime,
-        sessionId,
+        normalizedSessionId,
       ));
     });
   } catch (error) {
-    if (process.env[options.debugEnv] === "1") {
-      console.error(error instanceof Error ? error.message : String(error));
-    }
+    debugError(options, error);
   }
 }
 
@@ -187,6 +204,18 @@ function memoryReminderContext(options) {
 
 function defaultMemoraxCodeHome() {
   return process.env.HOME ? join(process.env.HOME, ".memorax-code") : ".memorax-code";
+}
+
+function resolveMemoraxCodeHome(options) {
+  return stringOption(options.memoraxCodeHome)
+    ?? process.env.MEMORAX_CODE_HOME
+    ?? defaultMemoraxCodeHome();
+}
+
+function debugError(options, error) {
+  if (process.env[options.debugEnv] === "1") {
+    console.error(error instanceof Error ? error.message : String(error));
+  }
 }
 
 function nextReminderState(existing, runtime, sessionId, turnId) {

--- a/packages/ts/memorax-code-backend/src/config/memorax-code.ts
+++ b/packages/ts/memorax-code-backend/src/config/memorax-code.ts
@@ -134,7 +134,7 @@ export function renderDefaultMemoraxCodeConfig(): string {
     "[memory.add]",
     `output_language = "${MEMORAX_DEFAULT_MEMORY_OUTPUT_LANGUAGE}" # Language for newly generated MemoraX memories.`,
     "",
-    "# Controls how often Codex and Claude Code native client sessions see the MemoraX Code skill reminder.",
+    "# Controls how often Codex, Claude Code, and OpenCode native client sessions see the MemoraX Code skill reminder.",
     "[memory.skill_reminder]",
     "interval_turns = 5 # Show the MemoraX Code skill reminder every N native client turns, starting on the first turn.",
     "",

--- a/packages/ts/memorax-code-backend/src/memory/hook-command.ts
+++ b/packages/ts/memorax-code-backend/src/memory/hook-command.ts
@@ -35,6 +35,7 @@ const WRITEBACK_KEYS: Readonly<Record<MemoryHookClient, ReadonlySet<string>>> = 
 const SKILL_REMINDER_KEYS: Readonly<Partial<Record<MemoryHookClient, ReadonlySet<string>>>> = {
   codex: new Set([...BASE_COMMAND_KEYS, "turnId", "transcriptPath", "content", "triggers"]),
   "claude-code": new Set([...BASE_COMMAND_KEYS, "promptId", "transcriptPath", "content", "triggers"]),
+  opencode: new Set([...BASE_COMMAND_KEYS, "userMessageId", "content", "triggers"]),
 };
 
 type MemoryHookCommandBase<Client extends MemoryHookClient> = Readonly<{
@@ -106,7 +107,16 @@ export type ClaudeSkillReminderCommand = MemoryHookCommandBase<"claude-code"> & 
   triggers: SkillReminderTrigger[];
 }>;
 
-export type SkillReminderCommand = CodexSkillReminderCommand | ClaudeSkillReminderCommand;
+export type OpenCodeSkillReminderCommand = MemoryHookCommandBase<"opencode"> & Readonly<{
+  userMessageId: string;
+  content: string;
+  triggers: SkillReminderTrigger[];
+}>;
+
+export type SkillReminderCommand =
+  | CodexSkillReminderCommand
+  | ClaudeSkillReminderCommand
+  | OpenCodeSkillReminderCommand;
 
 export type MemoryHookCommandParseResult<Command> =
   | { ok: true; command: Command }
@@ -224,10 +234,25 @@ export function parseSkillReminderCommand(
   if (!isRecord(value)) return invalidCommand();
   const base = parseCommandBase(value, SKILL_REMINDER_KEYS);
   if (!base) return invalidCommand();
-  const transcriptPath = requiredStringField(value, "transcriptPath");
   const content = requiredContentField(value, "content");
   const triggers = skillReminderTriggers(value.triggers);
-  if (!transcriptPath || !content || !triggers) return invalidCommand();
+  if (!content || !triggers) return invalidCommand();
+  if (base.client === "opencode") {
+    const userMessageId = requiredStringField(value, "userMessageId");
+    if (!userMessageId) return invalidCommand();
+    return {
+      ok: true,
+      command: {
+        ...base,
+        client: "opencode",
+        userMessageId,
+        content,
+        triggers,
+      },
+    };
+  }
+  const transcriptPath = requiredStringField(value, "transcriptPath");
+  if (!transcriptPath) return invalidCommand();
   if (base.client === "codex") {
     const turnId = requiredStringField(value, "turnId");
     if (!turnId) return invalidCommand();

--- a/packages/ts/memorax-code-backend/src/memory/reminder-trace-recorder.ts
+++ b/packages/ts/memorax-code-backend/src/memory/reminder-trace-recorder.ts
@@ -6,6 +6,7 @@ import {
 import {
   traceContextFromClaudeHookBody,
   traceContextFromHookBody,
+  traceContextFromOpenCodeHookBody,
   type TraceContext,
 } from "../trace/context.js";
 import { recordTraceEvent } from "../trace/store.js";
@@ -39,7 +40,7 @@ export function createMemoryReminderTraceRecorder(
         env: options.env,
         traceContext,
         type: "skill_reminder",
-        source: request.client === "codex" ? "codex-hook" : "claude-hook",
+        source: reminderSource(request),
         operation: "reminder",
         ok: true,
         request: {
@@ -53,7 +54,7 @@ export function createMemoryReminderTraceRecorder(
       options.diagnosticLogger?.("memory_hook.skill_reminder", {
         client: request.client,
         sessionId: request.sessionId,
-        turnId: request.client === "codex" ? request.turnId : request.promptId,
+        turnId: reminderTurnId(request),
         triggers: request.triggers,
         contentChars: request.content.length,
       });
@@ -64,7 +65,20 @@ export function createMemoryReminderTraceRecorder(
 
 function traceContextForReminder(command: SkillReminderCommand): TraceContext | undefined {
   if (command.client === "codex") return traceContextFromHookBody(command);
-  return traceContextFromClaudeHookBody(command);
+  if (command.client === "claude-code") return traceContextFromClaudeHookBody(command);
+  return traceContextFromOpenCodeHookBody(command);
+}
+
+function reminderSource(command: SkillReminderCommand): string {
+  if (command.client === "codex") return "codex-hook";
+  if (command.client === "claude-code") return "claude-hook";
+  return "opencode-plugin";
+}
+
+function reminderTurnId(command: SkillReminderCommand): string {
+  if (command.client === "codex") return command.turnId;
+  if (command.client === "claude-code") return command.promptId;
+  return command.userMessageId;
 }
 
 async function recordTraceBestEffort(

--- a/packages/ts/memorax-code-backend/test/transport/http/memory-hook.test.mjs
+++ b/packages/ts/memorax-code-backend/test/transport/http/memory-hook.test.mjs
@@ -244,6 +244,7 @@ test("Backend memory hook endpoints write client-isolated trace events", async (
     MEMORAX_CODE_HOME: undefined,
     MEMORAX_CODE_CLAUDE_TRACE_ENABLED: undefined,
     MEMORAX_CODE_CODEX_TRACE_ENABLED: undefined,
+    MEMORAX_CODE_OPENCODE_TRACE_ENABLED: undefined,
   });
   const originalFetch = globalThis.fetch;
   globalThis.fetch = fetchImpl;
@@ -363,6 +364,39 @@ test("Backend memory hook endpoints write client-isolated trace events", async (
     assert.equal(claudeReminder.status, 200);
     assert.deepEqual(await claudeReminder.json(), { ok: true });
 
+    const mismatchedOpenCodeReminder = await originalFetch(`${url}/memory/skill-reminder`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        version: 1,
+        client: "opencode",
+        sessionId: "session-trace-hook",
+        turnId: "turn-trace-hook",
+        transcriptPath,
+        content: "OpenCode reminder commands must use userMessageId.",
+        triggers: ["post_compaction"],
+      }),
+    });
+    assert.equal(mismatchedOpenCodeReminder.status, 200);
+    assert.deepEqual(await mismatchedOpenCodeReminder.json(), { ok: true });
+
+    const openCodeReminder = await originalFetch(`${url}/memory/skill-reminder`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        version: 1,
+        client: "opencode",
+        sessionId: "session-trace-hook",
+        userMessageId: "turn-trace-hook",
+        cwd: TEST_WORKSPACE,
+        workspaceKind: "project",
+        content: "MemoraX Code reminder: use the memorax-code skill in OpenCode.",
+        triggers: ["post_compaction"],
+      }),
+    });
+    assert.equal(openCodeReminder.status, 200);
+    assert.deepEqual(await openCodeReminder.json(), { ok: true });
+
     const writeback = await originalFetch(`${url}/memory/writeback`, {
       method: "POST",
       headers: { "content-type": "application/json" },
@@ -417,6 +451,23 @@ test("Backend memory hook endpoints write client-isolated trace events", async (
     assert.deepEqual(claudeEvents[0].response, {
       role: "developer",
       content: "MemoraX Code reminder: use the skill in Claude when prior work could help.",
+    });
+    const openCodeEventsPath = clientTracePaths("opencode", sessionHome).eventsJsonl("session-trace-hook");
+    await waitForFile(openCodeEventsPath, /skill_reminder/, "OpenCode reminder trace event was not written");
+    const openCodeEvents = (await readFile(openCodeEventsPath, "utf8")).trim().split("\n").map((line) => JSON.parse(line));
+    assert.equal(openCodeEvents.length, 1);
+    assert.equal(openCodeEvents[0].type, "skill_reminder");
+    assert.equal(openCodeEvents[0].source, "opencode-plugin");
+    assert.equal(openCodeEvents[0].operation, "reminder");
+    assert.equal(openCodeEvents[0].trace.client, "opencode");
+    assert.equal(openCodeEvents[0].trace.session_id, "session-trace-hook");
+    assert.equal(openCodeEvents[0].trace.turn_id, "turn-trace-hook");
+    assert.equal(openCodeEvents[0].trace.context_origin, "opencode-hook-body");
+    assert.equal(openCodeEvents[0].trace.transcript_path, undefined);
+    assert.deepEqual(openCodeEvents[0].request.triggers, ["post_compaction"]);
+    assert.deepEqual(openCodeEvents[0].response, {
+      role: "developer",
+      content: "MemoraX Code reminder: use the memorax-code skill in OpenCode.",
     });
     const turnEnd = events.find((event) => event.type === "turn_end");
     assert.equal(turnEnd.source, "codex-hook");

--- a/packages/ts/memorax-code-codex-adapter/runtime-hooks/memory-skill-reminder.mjs
+++ b/packages/ts/memorax-code-codex-adapter/runtime-hooks/memory-skill-reminder.mjs
@@ -37,8 +37,16 @@ try {
       additionalReminderContext: PERSONAL_MEMORY_REMINDER_CONTEXT,
       adapterDir: "codex",
       baseAdditionalContext: turnStartResult.additionalContext,
-      buildCadenceReminderContext: (hookInput) => buildRepoProcedureMemoryContext(hookInput, personalMemoryContextOptions),
-      buildPersonalMemoryContext: (hookInput) => buildRepoUserProfilePreferencesContext(hookInput, personalMemoryContextOptions),
+      ...(turnStartResult.repoMemoryWorktree ? {
+        buildCadenceReminderContext: (hookInput) => buildRepoProcedureMemoryContext({
+          ...hookInput,
+          cwd: turnStartResult.repoMemoryWorktree,
+        }, personalMemoryContextOptions),
+        buildPersonalMemoryContext: (hookInput) => buildRepoUserProfilePreferencesContext({
+          ...hookInput,
+          cwd: turnStartResult.repoMemoryWorktree,
+        }, personalMemoryContextOptions),
+      } : {}),
       debugEnv: "MEMORAX_CODE_CODEX_HOOK_DEBUG",
       onReminder: turnStartResult.recorded ? recordReminder : undefined,
       remindOnFirstTurn: true,

--- a/packages/ts/memorax-code-codex-adapter/test/repo-procedure-memory-context.test.mjs
+++ b/packages/ts/memorax-code-codex-adapter/test/repo-procedure-memory-context.test.mjs
@@ -1,15 +1,36 @@
 import { strict as assert } from "node:assert";
 import { spawn, spawnSync } from "node:child_process";
 import { chmod, mkdir, mkdtemp, rename, rm, symlink, writeFile } from "node:fs/promises";
+import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
-import { test } from "node:test";
+import { after, before, test } from "node:test";
 import { fileURLToPath } from "node:url";
 
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const runtimeHookPath = join(packageRoot, "hooks", "runtime-hook.mjs");
 const hookPath = [runtimeHookPath, "memory-skill-reminder"];
 const captureHookPath = [runtimeHookPath, "capture-cwd"];
+let authorizedBackendUrl;
+const authorizedBackend = createServer(async (request, response) => {
+  let body = "";
+  for await (const chunk of request) body += String(chunk);
+  const parsed = body ? JSON.parse(body) : {};
+  const result = request.url === "/memory/turn-start" && typeof parsed.cwd === "string"
+    ? { ok: true, repoMemoryWorktree: parsed.cwd }
+    : { ok: true };
+  response.writeHead(200, { "content-type": "application/json" });
+  response.end(JSON.stringify(result));
+});
+
+before(async () => {
+  await new Promise((resolveListen) => authorizedBackend.listen(0, "127.0.0.1", resolveListen));
+  authorizedBackendUrl = `http://127.0.0.1:${authorizedBackend.address().port}`;
+});
+
+after(async () => {
+  await new Promise((resolveClose) => authorizedBackend.close(resolveClose));
+});
 
 test("multiple procedure files join the existing first and sixth turn cadence", async () => {
   const root = await mkdtemp(join(tmpdir(), "memorax-code-procedure-context-cadence-"));
@@ -235,7 +256,7 @@ function runHook(command, input, env) {
     const childEnv = { ...process.env };
     delete childEnv.MEMORAX_CODE_MEMORY_SKILL_REMINDER_INTERVAL_TURNS;
     delete childEnv.PLUGIN_DATA;
-    childEnv.MEMORAX_CODE_BACKEND_URL = "http://127.0.0.1:1";
+    childEnv.MEMORAX_CODE_BACKEND_URL = authorizedBackendUrl;
     childEnv.MEMORAX_CODE_CODEX_MEMORY_HOOK_TIMEOUT_MS = "100";
     Object.assign(childEnv, env);
     const child = spawn(process.execPath, command, {

--- a/packages/ts/memorax-code-codex-adapter/test/repo-user-profile-context.test.mjs
+++ b/packages/ts/memorax-code-codex-adapter/test/repo-user-profile-context.test.mjs
@@ -4,7 +4,7 @@ import { mkdir, mkdtemp, rename, rm, symlink, writeFile } from "node:fs/promises
 import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
-import { test } from "node:test";
+import { after, before, test } from "node:test";
 import { fileURLToPath } from "node:url";
 import { buildRepoUserProfilePreferencesContext } from "../../memorax-code-adapter-common/src/repo-memory/repo-user-profile-context.mjs";
 
@@ -19,6 +19,32 @@ const PERSONAL_MEMORY_CONTEXT_OPTIONS = {
   debugEnv: "MEMORAX_CODE_CODEX_HOOK_DEBUG",
   sessionKeyPrefix: "codex",
 };
+const authorizedWorktreeOverrides = new Map();
+const authorizedBackendRequests = [];
+let authorizedBackendUrl;
+const authorizedBackend = createServer(async (request, response) => {
+  let body = "";
+  for await (const chunk of request) body += String(chunk);
+  const parsed = body ? JSON.parse(body) : {};
+  authorizedBackendRequests.push({ path: request.url, body: parsed });
+  const repositoryWorktree = authorizedWorktreeOverrides.has(parsed.sessionId)
+    ? authorizedWorktreeOverrides.get(parsed.sessionId)
+    : parsed.cwd;
+  const result = request.url === "/memory/turn-start" && repositoryWorktree
+    ? { ok: true, repoMemoryWorktree: repositoryWorktree }
+    : { ok: true };
+  response.writeHead(200, { "content-type": "application/json" });
+  response.end(JSON.stringify(result));
+});
+
+before(async () => {
+  await new Promise((resolveListen) => authorizedBackend.listen(0, "127.0.0.1", resolveListen));
+  authorizedBackendUrl = `http://127.0.0.1:${authorizedBackend.address().port}`;
+});
+
+after(async () => {
+  await new Promise((resolveClose) => authorizedBackend.close(resolveClose));
+});
 
 test("active preferences join the first prompt and the first prompt after compact", async () => {
   const root = await mkdtemp(join(tmpdir(), "memorax-code-user-profile-context-lifecycle-"));
@@ -157,43 +183,99 @@ test("preference and procedure contexts stay in one ordered payload", async () =
 
 test("the exact injected preference context is sent to the trace reminder endpoint", async () => {
   const root = await mkdtemp(join(tmpdir(), "memorax-code-user-profile-context-trace-"));
-  const requests = [];
-  const server = createServer(async (request, response) => {
-    let body = "";
-    for await (const chunk of request) body += String(chunk);
-    requests.push({ path: request.url, body: JSON.parse(body) });
-    response.writeHead(200, { "content-type": "application/json" });
-    response.end('{"ok":true}');
-  });
-  await new Promise((resolveListen) => server.listen(0, "127.0.0.1", resolveListen));
-  const address = server.address();
+  const sessionId = "trace-native-thread";
   try {
     const repo = await createRepo(root, "trace");
     const memoraxCodeHome = join(root, "memorax-code");
-    await writeRegistry(memoraxCodeHome, "native-thread");
+    await writeRegistry(memoraxCodeHome, sessionId);
     await writePreferences(repo, [
       preference("pref_language", "用户偏好使用中文交流。", "与用户交流时。", "用户明确要求其他语言。"),
     ]);
 
     const result = await runHook(hookPath, {
       hook_event_name: "UserPromptSubmit",
-      session_id: "native-thread",
+      session_id: sessionId,
       transcript_path: "/tmp/native-thread.jsonl",
       turn_id: "turn-1",
       cwd: repo,
       prompt: "first prompt",
-    }, {
-      MEMORAX_CODE_HOME: memoraxCodeHome,
-      MEMORAX_CODE_BACKEND_URL: `http://127.0.0.1:${address.port}`,
-    });
+    }, { MEMORAX_CODE_HOME: memoraxCodeHome });
 
     const context = reminderContext(result.stdout);
+    const requests = authorizedBackendRequests.filter((request) => request.body.sessionId === sessionId);
     assert.deepEqual(requests.map((request) => request.path), ["/memory/turn-start", "/memory/skill-reminder"]);
     assert.equal(requests[1].body.content, context);
     assert.deepEqual(requests[1].body.triggers, ["cadence"]);
     assert.match(requests[1].body.content, /Description: 用户偏好使用中文交流。/);
   } finally {
-    await new Promise((resolveClose) => server.close(resolveClose));
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("repo-scoped contexts require the Backend-authorized worktree", async () => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-code-personal-memory-scope-"));
+  const unavailableSession = "scope-unavailable";
+  const authorizedSession = "scope-authorized";
+  try {
+    const hookRepo = await createRepo(root, "hook-scope");
+    const authorizedRepo = await createRepo(root, "authorized-scope");
+    const memoraxCodeHome = join(root, "memorax-code");
+    await writePreferences(hookRepo, [
+      preference("pref_hook", "hook repo profile must not appear", "always", "never"),
+    ]);
+    await writeProcedure(hookRepo, "hook.md", "# Hook repo procedure must not appear");
+    await writePreferences(authorizedRepo, [
+      preference("pref_authorized", "authorized repo profile", "always", "never"),
+    ]);
+    await writeProcedure(authorizedRepo, "authorized.md", "# Authorized repo procedure");
+    authorizedWorktreeOverrides.set(unavailableSession, undefined);
+    authorizedWorktreeOverrides.set(authorizedSession, authorizedRepo);
+
+    const unavailable = await runHook(hookPath, {
+      hook_event_name: "UserPromptSubmit",
+      session_id: unavailableSession,
+      transcript_path: "/tmp/scope-unavailable.jsonl",
+      turn_id: "turn-unavailable",
+      cwd: hookRepo,
+      prompt: "prompt without repository authority",
+    }, { MEMORAX_CODE_HOME: memoraxCodeHome });
+    assert.equal(reminderContext(unavailable.stdout), MEMORY_REMINDER_CONTEXT);
+
+    const authorized = await runHook(hookPath, {
+      hook_event_name: "UserPromptSubmit",
+      session_id: authorizedSession,
+      transcript_path: "/tmp/scope-authorized.jsonl",
+      turn_id: "turn-authorized",
+      cwd: hookRepo,
+      prompt: "prompt with repository authority",
+    }, { MEMORAX_CODE_HOME: memoraxCodeHome });
+    const authorizedContext = reminderContext(authorized.stdout);
+    assert.match(authorizedContext, /Description: authorized repo profile/);
+    assert.match(authorizedContext, /Authorized repo procedure/);
+    assert.doesNotMatch(authorizedContext, /hook repo profile must not appear/);
+    assert.doesNotMatch(authorizedContext, /Hook repo procedure must not appear/);
+
+    const unavailableRequests = authorizedBackendRequests.filter(
+      (request) => request.body.sessionId === unavailableSession,
+    );
+    assert.deepEqual(unavailableRequests.map((request) => request.path), [
+      "/memory/turn-start",
+      "/memory/skill-reminder",
+    ]);
+    assert.equal(unavailableRequests[1].body.cwd, hookRepo);
+    assert.equal(unavailableRequests[1].body.content, MEMORY_REMINDER_CONTEXT);
+    const authorizedRequests = authorizedBackendRequests.filter(
+      (request) => request.body.sessionId === authorizedSession,
+    );
+    assert.deepEqual(authorizedRequests.map((request) => request.path), [
+      "/memory/turn-start",
+      "/memory/skill-reminder",
+    ]);
+    assert.equal(authorizedRequests[1].body.cwd, hookRepo);
+    assert.equal(authorizedRequests[1].body.content, authorizedContext);
+  } finally {
+    authorizedWorktreeOverrides.delete(unavailableSession);
+    authorizedWorktreeOverrides.delete(authorizedSession);
     await rm(root, { recursive: true, force: true });
   }
 });
@@ -359,7 +441,7 @@ function runHook(command, input, env) {
     const childEnv = { ...process.env };
     delete childEnv.MEMORAX_CODE_MEMORY_SKILL_REMINDER_INTERVAL_TURNS;
     delete childEnv.PLUGIN_DATA;
-    childEnv.MEMORAX_CODE_BACKEND_URL = "http://127.0.0.1:1";
+    childEnv.MEMORAX_CODE_BACKEND_URL = authorizedBackendUrl;
     childEnv.MEMORAX_CODE_CODEX_MEMORY_HOOK_TIMEOUT_MS = "100";
     Object.assign(childEnv, env);
     const child = spawn(process.execPath, command, {

--- a/packages/ts/memorax-code-opencode-adapter/src/plugin.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/src/plugin.mjs
@@ -3,11 +3,20 @@ import { setTimeout as delay } from "node:timers/promises";
 import { resolveBackendConnection } from "../../memorax-code-adapter-common/src/backend-connection.mjs";
 import { readAdapterState } from "../../memorax-code-adapter-common/src/config-utils.mjs";
 import { ensureBackendAvailable } from "../../memorax-code-adapter-common/src/hooks/ensure-backend-runner.mjs";
+import {
+  evaluateMemorySkillReminder,
+  markSupplementalReminderForSession,
+  personalMemoryReminderContext,
+} from "../../memorax-code-adapter-common/src/hooks/memory-skill-reminder-hook.mjs";
+import { buildRepoProcedureMemoryContext } from "../../memorax-code-adapter-common/src/repo-memory/repo-procedure-memory-context.mjs";
+import { buildRepoUserProfilePreferencesContext } from "../../memorax-code-adapter-common/src/repo-memory/repo-user-profile-context.mjs";
 
 const DEFAULT_BACKEND_PROMPT_WAIT_TIMEOUT_MS = 5_000;
 const TURN_START_TIMEOUT_MS = 12_000;
+const REMINDER_TRACE_TIMEOUT_MS = 1_000;
 const WRITEBACK_TIMEOUT_MS = 5_000;
 const MAX_PENDING_TURNS = 256;
+const MEMORY_SKILL_INVOCATION = "the `memorax-code` skill";
 
 class BackendHttpResponseError extends Error {
   constructor(path, status) {
@@ -22,6 +31,8 @@ export function createMemoraxOpenCodePlugin(options = {}) {
     const workspaceKind = project?.vcs === "git" ? "project" : "local";
     const pendingTurns = new Map();
     const inFlight = new Set();
+    const reminderOptions = memorySkillReminderOptions(options);
+    const reminderEvaluator = options.memorySkillReminderEvaluator ?? evaluateMemorySkillReminder;
     const backendPromptWaitTimeoutMs = positiveInteger(
       options.backendPromptWaitTimeoutValue,
       DEFAULT_BACKEND_PROMPT_WAIT_TIMEOUT_MS,
@@ -56,9 +67,9 @@ export function createMemoraxOpenCodePlugin(options = {}) {
       return await backendPromptGatePromise;
     }
 
-    function track(task) {
+    function track(task, failureMessage) {
       const observed = task.catch((error) => {
-        debug(options, "opencode writeback failed", error);
+        debug(options, failureMessage, error);
       });
       inFlight.add(observed);
       void observed.finally(() => inFlight.delete(observed));
@@ -118,15 +129,25 @@ export function createMemoraxOpenCodePlugin(options = {}) {
         const sessionId = stringValue(input?.sessionID);
         const prompt = textParts(output?.parts);
         if (!sessionId || !userMessageId || !prompt) return;
+        const reminderResult = await evaluateReminder(reminderEvaluator, reminderOptions, {
+          hookEventName: "UserPromptSubmit",
+          sessionId,
+          turnId: userMessageId,
+          cwd: workspaceRoot,
+          workspaceKind,
+        }, options);
         if (!await backendReadyForPrompt()) {
           debug(
             options,
             "opencode turn start skipped",
             `Backend recovery exceeded the ${backendPromptWaitTimeoutMs} ms interaction budget`,
           );
+          appendSystemContexts(output, reminderResult?.additionalContext);
           return;
         }
         if (!pluginEnabled(options)) return;
+        let retrievalContext;
+        let turnStartAccepted = false;
         try {
           const result = await postBackend(options, "/memory/turn-start", {
             version: 1,
@@ -137,6 +158,7 @@ export function createMemoraxOpenCodePlugin(options = {}) {
             cwd: workspaceRoot,
             workspaceKind,
           }, TURN_START_TIMEOUT_MS);
+          turnStartAccepted = true;
           if (!pluginEnabled(options)) return;
           const turn = { sessionId, userMessageId };
           pendingTurns.set(turnKey(turn), turn);
@@ -145,16 +167,17 @@ export function createMemoraxOpenCodePlugin(options = {}) {
             if (typeof oldest !== "string") break;
             pendingTurns.delete(oldest);
           }
-          const additionalContext = stringValue(result?.additionalContext);
-          if (additionalContext) {
-            const existing = stringValue(output.message.system);
-            output.message.system = existing
-              ? `${existing}\n\n${additionalContext}`
-              : additionalContext;
-          }
+          retrievalContext = stringValue(result?.additionalContext);
         } catch (error) {
           debug(options, "opencode turn start failed", error);
         }
+        if (turnStartAccepted && reminderResult?.reminder) {
+          track(
+            recordReminder(options, reminderResult.reminder),
+            "opencode reminder trace failed",
+          );
+        }
+        appendSystemContexts(output, retrievalContext, reminderResult?.additionalContext);
       },
       "shell.env": async (input, output) => {
         if (!pluginEnabled(options)) return;
@@ -177,9 +200,13 @@ export function createMemoraxOpenCodePlugin(options = {}) {
       },
       event({ event }) {
         if (!pluginEnabled(options)) return;
+        if (event?.type === "session.compacted") {
+          markSupplementalReminderForSession(reminderOptions, event.properties?.sessionID);
+          return;
+        }
         if (event?.type === "session.status" && event.properties?.status?.type === "idle") {
           const sessionId = stringValue(event.properties.sessionID);
-          if (sessionId) track(flushSession(sessionId));
+          if (sessionId) track(flushSession(sessionId), "opencode writeback failed");
         }
       },
       async dispose() {
@@ -232,6 +259,36 @@ function turnKey(turn) {
   return JSON.stringify([turn.sessionId, turn.userMessageId]);
 }
 
+async function evaluateReminder(evaluator, reminderOptions, input, options) {
+  try {
+    return await evaluator(reminderOptions, input);
+  } catch (error) {
+    debug(options, "opencode memory reminder failed", error);
+    return undefined;
+  }
+}
+
+function appendSystemContexts(output, ...contexts) {
+  const additions = contexts.map(stringValue).filter(Boolean);
+  if (additions.length === 0) return;
+  const existing = stringValue(output?.message?.system);
+  output.message.system = [existing, ...additions].filter(Boolean).join("\n\n");
+}
+
+function recordReminder(options, reminder) {
+  if (!reminder.turnId) return Promise.resolve();
+  return postBackend(options, "/memory/skill-reminder", {
+    version: 1,
+    client: "opencode",
+    sessionId: reminder.sessionId,
+    userMessageId: reminder.turnId,
+    cwd: reminder.cwd,
+    workspaceKind: reminder.workspaceKind,
+    content: reminder.content,
+    triggers: reminder.triggers,
+  }, REMINDER_TRACE_TIMEOUT_MS);
+}
+
 async function postBackend(options, path, body, timeoutMs) {
   const connection = options.backendConnection ?? resolveBackendConnection(options);
   const headers = { "content-type": "application/json", connection: "close" };
@@ -278,6 +335,26 @@ function managedPluginEnabled(options) {
     && state?.runtime === "opencode"
     && state?.integration === "plugin"
     && state?.enabled === true;
+}
+
+function memorySkillReminderOptions(options) {
+  const personalMemoryContextOptions = {
+    adapterDir: "opencode",
+    debugEnv: "MEMORAX_CODE_OPENCODE_PLUGIN_DEBUG",
+    sessionKeyPrefix: "opencode",
+  };
+  return {
+    additionalReminderContext: personalMemoryReminderContext(MEMORY_SKILL_INVOCATION),
+    adapterDir: "opencode",
+    buildCadenceReminderContext: (input) => buildRepoProcedureMemoryContext(input, personalMemoryContextOptions),
+    buildPersonalMemoryContext: (input) => buildRepoUserProfilePreferencesContext(input, personalMemoryContextOptions),
+    debugEnv: "MEMORAX_CODE_OPENCODE_PLUGIN_DEBUG",
+    memoraxCodeHome: options.memoraxCodeHome,
+    memorySkillInvocation: MEMORY_SKILL_INVOCATION,
+    remindOnFirstTurn: true,
+    runtime: "opencode",
+    supplementalReminderAfterCompact: true,
+  };
 }
 
 function backendEnsureOptions(options) {

--- a/packages/ts/memorax-code-opencode-adapter/src/plugin.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/src/plugin.mjs
@@ -31,7 +31,7 @@ export function createMemoraxOpenCodePlugin(options = {}) {
     const workspaceKind = project?.vcs === "git" ? "project" : "local";
     const pendingTurns = new Map();
     const inFlight = new Set();
-    const reminderOptions = memorySkillReminderOptions(options);
+    const genericReminderOptions = memorySkillReminderOptions(options);
     const reminderEvaluator = options.memorySkillReminderEvaluator ?? evaluateMemorySkillReminder;
     const backendPromptWaitTimeoutMs = positiveInteger(
       options.backendPromptWaitTimeoutValue,
@@ -129,24 +129,33 @@ export function createMemoraxOpenCodePlugin(options = {}) {
         const sessionId = stringValue(input?.sessionID);
         const prompt = textParts(output?.parts);
         if (!sessionId || !userMessageId || !prompt) return;
-        const reminderResult = await evaluateReminder(reminderEvaluator, reminderOptions, {
+        const reminderInput = {
           hookEventName: "UserPromptSubmit",
           sessionId,
           turnId: userMessageId,
           cwd: workspaceRoot,
           workspaceKind,
-        }, options);
+        };
         if (!await backendReadyForPrompt()) {
           debug(
             options,
             "opencode turn start skipped",
             `Backend recovery exceeded the ${backendPromptWaitTimeoutMs} ms interaction budget`,
           );
+          if (!pluginEnabled(options)) return;
+          const reminderResult = await evaluateReminder(
+            reminderEvaluator,
+            genericReminderOptions,
+            reminderInput,
+            options,
+          );
+          if (!pluginEnabled(options)) return;
           appendSystemContexts(output, reminderResult?.additionalContext);
           return;
         }
         if (!pluginEnabled(options)) return;
         let retrievalContext;
+        let repositoryWorktree;
         let turnStartAccepted = false;
         try {
           const result = await postBackend(options, "/memory/turn-start", {
@@ -168,9 +177,20 @@ export function createMemoraxOpenCodePlugin(options = {}) {
             pendingTurns.delete(oldest);
           }
           retrievalContext = stringValue(result?.additionalContext);
+          repositoryWorktree = stringValue(result?.repoMemoryWorktree);
         } catch (error) {
           debug(options, "opencode turn start failed", error);
         }
+        if (!pluginEnabled(options)) return;
+        const reminderResult = await evaluateReminder(
+          reminderEvaluator,
+          repositoryWorktree
+            ? memorySkillReminderOptions(options, repositoryWorktree)
+            : genericReminderOptions,
+          reminderInput,
+          options,
+        );
+        if (!pluginEnabled(options)) return;
         if (turnStartAccepted && reminderResult?.reminder) {
           track(
             recordReminder(options, reminderResult.reminder),
@@ -201,7 +221,7 @@ export function createMemoraxOpenCodePlugin(options = {}) {
       event({ event }) {
         if (!pluginEnabled(options)) return;
         if (event?.type === "session.compacted") {
-          markSupplementalReminderForSession(reminderOptions, event.properties?.sessionID);
+          markSupplementalReminderForSession(genericReminderOptions, event.properties?.sessionID);
           return;
         }
         if (event?.type === "session.status" && event.properties?.status?.type === "idle") {
@@ -337,7 +357,7 @@ function managedPluginEnabled(options) {
     && state?.enabled === true;
 }
 
-function memorySkillReminderOptions(options) {
+function memorySkillReminderOptions(options, repositoryWorktree) {
   const personalMemoryContextOptions = {
     adapterDir: "opencode",
     debugEnv: "MEMORAX_CODE_OPENCODE_PLUGIN_DEBUG",
@@ -346,8 +366,16 @@ function memorySkillReminderOptions(options) {
   return {
     additionalReminderContext: personalMemoryReminderContext(MEMORY_SKILL_INVOCATION),
     adapterDir: "opencode",
-    buildCadenceReminderContext: (input) => buildRepoProcedureMemoryContext(input, personalMemoryContextOptions),
-    buildPersonalMemoryContext: (input) => buildRepoUserProfilePreferencesContext(input, personalMemoryContextOptions),
+    ...(repositoryWorktree ? {
+      buildCadenceReminderContext: (input) => buildRepoProcedureMemoryContext({
+        ...input,
+        cwd: repositoryWorktree,
+      }, personalMemoryContextOptions),
+      buildPersonalMemoryContext: (input) => buildRepoUserProfilePreferencesContext({
+        ...input,
+        cwd: repositoryWorktree,
+      }, personalMemoryContextOptions),
+    } : {}),
     debugEnv: "MEMORAX_CODE_OPENCODE_PLUGIN_DEBUG",
     memoraxCodeHome: options.memoraxCodeHome,
     memorySkillInvocation: MEMORY_SKILL_INVOCATION,

--- a/packages/ts/memorax-code-opencode-adapter/src/plugin.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/src/plugin.mjs
@@ -127,6 +127,7 @@ export function createMemoraxOpenCodePlugin(options = {}) {
         if (!pluginEnabled(options)) return;
         const userMessageId = stringValue(output?.message?.id) ?? stringValue(input?.messageID);
         const sessionId = stringValue(input?.sessionID);
+        if (Array.isArray(output?.parts) && output.parts.some((part) => part?.type === "compaction")) return;
         const prompt = textParts(output?.parts);
         if (!sessionId || !userMessageId || !prompt) return;
         const reminderInput = {

--- a/packages/ts/memorax-code-opencode-adapter/test/plugin.test.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/test/plugin.test.mjs
@@ -8,7 +8,7 @@ import { createMemoraxOpenCodePlugin } from "../src/plugin.mjs";
 
 test("chat.message retrieves memory and injects it into the system prompt", async () => {
   const requests = [];
-  const plugin = createMemoraxOpenCodePlugin({
+  const plugin = createPluginWithoutReminders({
     backendConnection: { url: "http://127.0.0.1:8787", token: "test-token" },
     fetchImpl: responseSequence(requests, [{ ok: true, additionalContext: "Remember the repository boundary." }]),
   });
@@ -73,6 +73,7 @@ test("managed plugin starts the Backend once and bounds prompt waiting", async (
       startTimeoutValue: "1000",
       backendPromptWaitTimeoutValue: "100",
       fetchImpl: responseSequence(requests, [{ ok: true }]),
+      memorySkillReminderEvaluator: async () => ({ additionalContext: "Local reminder context." }),
     });
     process.execPath = join(root, "opencode");
     hooks = await plugin(pluginInput());
@@ -85,15 +86,18 @@ test("managed plugin starts the Backend once and bounds prompt waiting", async (
       "--host", "127.0.0.1",
       "--port", "9",
     ]]);
-    const prompt = (id) => hooks["chat.message"](
-      { sessionID: `session-${id}` },
-      { message: { id }, parts: [{ type: "text", text: id }] },
-    );
-    await Promise.race([
+    const prompt = async (id) => {
+      const output = promptOutput(id, id);
+      await hooks["chat.message"]({ sessionID: `session-${id}` }, output);
+      return output;
+    };
+    const [first, second] = await Promise.race([
       Promise.all([prompt("user-start-1"), prompt("user-start-2")]),
       delay(400).then(() => { throw new Error("Backend prompt wait was not bounded"); }),
     ]);
     assert.equal(requests.length, 0);
+    assert.equal(first.message.system, "Local reminder context.");
+    assert.equal(second.message.system, "Local reminder context.");
 
     await writeFile(releasePath, "release\n");
     await hooks.dispose();
@@ -109,7 +113,7 @@ test("managed plugin starts the Backend once and bounds prompt waiting", async (
 
 test("chat.message does not mistake a user diff summary for compaction", async () => {
   const requests = [];
-  const plugin = createMemoraxOpenCodePlugin({
+  const plugin = createPluginWithoutReminders({
     backendConnection: { url: "http://127.0.0.1:8787" },
     fetchImpl: responseSequence(requests, [{ ok: true }]),
   });
@@ -130,7 +134,7 @@ test("chat.message does not mistake a user diff summary for compaction", async (
 
 test("chat.message ignores compaction and synthetic-only messages", async () => {
   const requests = [];
-  const plugin = createMemoraxOpenCodePlugin({
+  const plugin = createPluginWithoutReminders({
     backendConnection: { url: "http://127.0.0.1:8787" },
     fetchImpl: responseSequence(requests, []),
   });
@@ -148,9 +152,50 @@ test("chat.message ignores compaction and synthetic-only messages", async () => 
   assert.equal(requests.length, 0);
 });
 
+test("OpenCode forwards first-prompt and post-compaction reminders once", async () => {
+  const memoraxCodeHome = await mkdtemp(join(tmpdir(), "memorax-code-opencode-reminder-"));
+  const requests = [];
+  let hooks;
+  try {
+    const plugin = createMemoraxOpenCodePlugin({
+      memoraxCodeHome,
+      backendConnection: { url: "http://127.0.0.1:8787" },
+      fetchImpl: memoryResponse(requests),
+    });
+    hooks = await plugin(pluginInput());
+
+    const first = promptOutput("user-reminder-1", "First prompt");
+    await hooks["chat.message"]({ sessionID: "session-reminder" }, first);
+    hooks.event({
+      event: {
+        type: "session.compacted",
+        properties: { sessionID: "session-reminder" },
+      },
+    });
+    const second = promptOutput("user-reminder-2", "After compaction");
+    await hooks["chat.message"]({ sessionID: "session-reminder" }, second);
+    const third = promptOutput("user-reminder-3", "Later prompt");
+    await hooks["chat.message"]({ sessionID: "session-reminder" }, third);
+
+    await hooks.dispose();
+    assert.match(first.message.system, /MemoraX Code reminder: proactively invoke/);
+    assert.match(second.message.system, /MemoraX Code personal-memory reminder/);
+    assert.equal(third.message.system, "Retrieved user-reminder-3.");
+    const reminderRequests = requests.filter((request) => request.path === "/memory/skill-reminder");
+    assert.deepEqual(reminderRequests.map((request) => request.body.triggers), [
+      ["cadence"],
+      ["post_compaction"],
+    ]);
+    assert.equal(Object.hasOwn(reminderRequests[0].body, "transcriptPath"), false);
+  } finally {
+    await hooks?.dispose();
+    await rm(memoraxCodeHome, { recursive: true, force: true });
+  }
+});
+
 test("shell.env overwrites the OpenCode session identity and prepends the managed CLI path", async () => {
   const cliBinDir = "/memorax/bin";
-  const plugin = createMemoraxOpenCodePlugin({ cliBinDir });
+  const plugin = createPluginWithoutReminders({ cliBinDir });
   const hooks = await plugin(pluginInput());
   const output = {
     env: {
@@ -193,7 +238,7 @@ test("a loaded plugin follows the managed enabled state without an OpenCode rest
   const requests = [];
   try {
     await writeState(false);
-    const plugin = createMemoraxOpenCodePlugin({
+    const plugin = createPluginWithoutReminders({
       statePath,
       backendConnection: { url: "http://127.0.0.1:8787" },
       fetchImpl: responseSequence(requests, [{ ok: true }]),
@@ -257,7 +302,7 @@ test("idle reads authoritative SDK messages and dispose drains the pending write
       },
     },
   });
-  const plugin = createMemoraxOpenCodePlugin({
+  const plugin = createPluginWithoutReminders({
     backendConnection: { url: "http://127.0.0.1:8787" },
     fetchImpl: responseSequence(requests, [{ ok: true }, { ok: true }]),
   });
@@ -339,7 +384,7 @@ test("idle discards HTTP 413 without starving a runtime-closed retry", async () 
       },
     ];
   });
-  const plugin = createMemoraxOpenCodePlugin({
+  const plugin = createPluginWithoutReminders({
     backendConnection: { url: "http://127.0.0.1:8787" },
     fetchImpl: responseSequence(requests, [
       { ok: true },
@@ -384,6 +429,35 @@ function pluginInput(overrides = {}) {
     directory: "/repo/directory",
     worktree: "/repo/worktree",
     ...overrides,
+  };
+}
+
+function createPluginWithoutReminders(options) {
+  return createMemoraxOpenCodePlugin({
+    memorySkillReminderEvaluator: async () => undefined,
+    ...options,
+  });
+}
+
+function promptOutput(id, text, system) {
+  return {
+    message: { id, ...(system ? { system } : {}) },
+    parts: [{ type: "text", text }],
+  };
+}
+
+function memoryResponse(requests) {
+  return async (url, options) => {
+    const parsedUrl = new URL(url);
+    const body = JSON.parse(options.body);
+    requests.push({ url: String(url), path: parsedUrl.pathname, options, body });
+    const responseBody = parsedUrl.pathname === "/memory/turn-start"
+      ? { ok: true, additionalContext: `Retrieved ${body.userMessageId}.` }
+      : { ok: true };
+    return new Response(JSON.stringify(responseBody), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
   };
 }
 

--- a/packages/ts/memorax-code-opencode-adapter/test/plugin.test.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/test/plugin.test.mjs
@@ -39,6 +39,37 @@ test("chat.message retrieves memory and injects it into the system prompt", asyn
   });
 });
 
+test("repo-scoped reminder builders require a Backend-authorized worktree", async () => {
+  const evaluations = [];
+  const plugin = createMemoraxOpenCodePlugin({
+    backendConnection: { url: "http://127.0.0.1:8787" },
+    fetchImpl: responseSequence([], [
+      { ok: true },
+      { ok: true, repoMemoryWorktree: "/repo/authorized" },
+    ]),
+    memorySkillReminderEvaluator: async (options, input) => {
+      const profileBuilder = typeof options.buildPersonalMemoryContext === "function";
+      const procedureBuilder = typeof options.buildCadenceReminderContext === "function";
+      const repositoryContext = profileBuilder && procedureBuilder;
+      evaluations.push({ profileBuilder, procedureBuilder, cwd: input.cwd });
+      return { additionalContext: repositoryContext ? "Authorized repo context." : "Generic reminder context." };
+    },
+  });
+  const hooks = await plugin(pluginInput());
+  const generic = promptOutput("user-scope-1", "First prompt");
+  const authorized = promptOutput("user-scope-2", "Second prompt");
+
+  await hooks["chat.message"]({ sessionID: "session-scope" }, generic);
+  await hooks["chat.message"]({ sessionID: "session-scope" }, authorized);
+
+  assert.equal(generic.message.system, "Generic reminder context.");
+  assert.equal(authorized.message.system, "Authorized repo context.");
+  assert.deepEqual(evaluations, [
+    { profileBuilder: false, procedureBuilder: false, cwd: "/repo/worktree" },
+    { profileBuilder: true, procedureBuilder: true, cwd: "/repo/worktree" },
+  ]);
+});
+
 test("managed plugin starts the Backend once and bounds prompt waiting", async () => {
   const root = await mkdtemp(join(tmpdir(), "memorax-code-opencode-backend-start-"));
   const nodePath = process.execPath;
@@ -186,6 +217,7 @@ test("OpenCode forwards first-prompt and post-compaction reminders once", async 
       ["cadence"],
       ["post_compaction"],
     ]);
+    assert.equal(reminderRequests.every((request) => request.body.cwd === "/repo/worktree"), true);
     assert.equal(Object.hasOwn(reminderRequests[0].body, "transcriptPath"), false);
   } finally {
     await hooks?.dispose();

--- a/packages/ts/memorax-code-opencode-adapter/test/plugin.test.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/test/plugin.test.mjs
@@ -163,7 +163,7 @@ test("chat.message does not mistake a user diff summary for compaction", async (
   assert.equal(requests[0].body.prompt, "Keep recalling memory.");
 });
 
-test("chat.message ignores compaction and synthetic-only messages", async () => {
+test("chat.message ignores compaction-containing and synthetic-only messages", async () => {
   const requests = [];
   const plugin = createPluginWithoutReminders({
     backendConnection: { url: "http://127.0.0.1:8787" },
@@ -174,6 +174,16 @@ test("chat.message ignores compaction and synthetic-only messages", async () => 
   await hooks["chat.message"](
     { sessionID: "session-compaction" },
     { message: { id: "user-compaction" }, parts: [{ type: "compaction", auto: true }] },
+  );
+  await hooks["chat.message"](
+    { sessionID: "session-mixed-compaction" },
+    {
+      message: { id: "user-mixed-compaction" },
+      parts: [
+        { type: "compaction", auto: true },
+        { type: "text", text: "internal compaction summary" },
+      ],
+    },
   );
   await hooks["chat.message"](
     { sessionID: "session-synthetic" },


### PR DESCRIPTION
## Change Summary

Add shared skill reminders and personal-memory context injection to OpenCode so its native prompt flow matches the existing Codex and Claude Code cadence.

## Implementation Highlights

- Reuse the shared reminder evaluator for first-prompt and configured cadence injection, including User Profile and Procedure Memory context.
- Mark the next real prompt after `session.compacted` for a supplemental reminder without consuming synthetic messages.
- Record client-qualified OpenCode reminder traces only after Backend turn-start acceptance, while keeping local reminder injection available during bounded Backend recovery.
- Extend the closed Backend command schema and architecture/configuration documentation without changing README files.

## Validation

- `npm run typecheck --prefix packages/ts/memorax-code-backend`
- Focused Backend OpenCode/HTTP memory-hook tests: 7 passed
- `npm test --prefix packages/ts/memorax-code-opencode-adapter`: 18 passed
- `npm test --prefix packages/ts/memorax-code-codex-adapter`: 202 passed
- `npm test --prefix packages/ts/memorax-code-claude-adapter`: 65 passed
- `make docs-check`
- `make npm-package-check`: 170 package checks passed; package layout and local-only trace contract passed

## Full End-to-End Validation Results

- Environment: macOS development worktree
- Scenario or matrix: Focused reminder, compaction, Backend recovery, trace, and cross-adapter regression coverage
- Command or workflow: Commands listed in Validation
- Result: All focused checks passed
- Evidence or artifacts: Redacted command results are summarized above; no screenshots are included for this intermediate PR
- Reason not run / remaining risk: A real OpenCode client E2E is deferred to the final full-stack OpenCode PR so the complete integrated flow is validated once
