### PR TITLE
feat: add supervised Repo Memory runner for OpenCode

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -94,7 +94,7 @@ relationships; the arrow labels distinguish them. It is not an import graph.
 | `packages/ts/memorax-code-adapter-common` | Shared source for Backend connection authority, private runtime records, cross-process locking and configuration, Hook generations, Hook launch helpers, and Repo/Personal Memory helpers | Backend composition, native transcript interpretation, MemoraX request execution, or client plugin policy | `packages/ts/memorax-code-adapter-common/src/backend-connection.mjs`, `src/runtime-record.mjs`, `src/hooks`, and `src/repo-memory` |
 | `packages/ts/memorax-code-codex-adapter` | Codex plugin artifact, Hook shells and runtimes, session/workspace observation, diagnostics, and the canonical shared skill | Codex rollout semantics or Backend-side writeback authority | `.codex-plugin`, `hooks`, `runtime-hooks`, `src`, and `skills/memorax-code` |
 | `packages/ts/memorax-code-claude-adapter` | Claude Code plugin artifact, Hook shells and runtimes, configuration, installer, marketplace source, and diagnostics | Claude transcript semantics or Backend memory orchestration | `.claude-plugin`, `hooks`, `runtime-hooks`, `scripts`, and `src/plugin-install.mjs` |
-| `packages/ts/memorax-code-opencode-adapter` | OpenCode plugin runtime, managed thin-loader installation, automatic retrieval, SDK-backed writeback, shell-session identity, and a materialized shared skill | OpenCode message interpretation inside the Backend, model-provider configuration, or background Repo Memory maintenance | `src/plugin.mjs`, `src/plugin-install.mjs`, and the OpenCode materialization mapping in `scripts/npm-source-files.mjs` |
+| `packages/ts/memorax-code-opencode-adapter` | OpenCode plugin runtime, managed thin-loader installation, automatic retrieval, SDK-backed writeback, shell-session identity, a materialized shared skill, and supervised repo-read maintenance | OpenCode message interpretation inside the Backend or model-provider configuration | `src/plugin.mjs`, `src/plugin-install.mjs`, and the OpenCode materialization mapping in `scripts/npm-source-files.mjs` |
 | `packages/npm/memorax-code` | Installed executable wrappers, update, preinstall/postinstall, npm manifest, and release-package source | Backend lifecycle semantics, uninstall orchestration, or artifact staging | `bin`, `lib/run-entrypoint.mjs`, and `package.json` |
 | `scripts` | Backend build orchestration, staging/materialization, package layout, documentation, and local-only data gates | Product runtime authority | Package-build/check scripts and executable contract scripts |
 | `.github` | Issue and pull-request contribution templates | Product runtime behavior | `.github/ISSUE_TEMPLATE` and `.github/pull_request_template.md` |
@@ -340,10 +340,12 @@ Backend-resolved worktree, and those builders read that worktree. The original
 client workspace remains metadata when an accepted turn's reminder is traced;
 it is not repository-local content authority.
 
-OpenCode supports active Repo Memory operations through the shared skill, but
-its plugin does not own supervised background Repo Memory maintenance. Its
-automatic runtime contract covers prompt retrieval, shared reminder injection,
-and completed-turn writeback.
+A relevant repo-read can invoke supervised maintenance in all three clients.
+The runner validates the bundle and selects a background build, update, or
+no-op according to policy. OpenCode supports this on-demand path through the
+shared skill, but does not yet initialize a missing bundle automatically on the
+first prompt. Its automatic plugin runtime otherwise covers prompt retrieval,
+shared reminder injection, and completed-turn writeback.
 
 ## 4. Backend Modular Monolith
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -240,10 +240,11 @@ only when the Backend has authorized a Git worktree and that worktree has no
 unavailable, the Hook skips the initial build instead of falling back to its
 local `cwd`.
 
-OpenCode supports active Repo Memory operations through the installed skill,
-but its plugin does not currently run background Repo Memory maintenance. Its
-automatic integration covers retrieval, shared reminder and personal-memory
-context injection, and completed-turn writeback.
+OpenCode runs supervised background maintenance when the installed skill
+selects repo-read. The configured policy may select a build, update, or no-op.
+OpenCode does not yet initialize a missing bundle automatically on the first
+prompt. Its automatic integration otherwise covers retrieval, shared reminder
+and personal-memory context injection, and completed-turn writeback.
 
 ## Local traces
 

--- a/packages/ts/memorax-code-opencode-adapter/hooks/repo-memory-job.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/hooks/repo-memory-job.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { runRepoMemoryJob } from "../../memorax-code-adapter-common/src/repo-memory/repo-memory-job-supervisor.mjs";
+import { evaluateRepository } from "../../memorax-code-adapter-common/src/repo-memory/repo-memory-update-policy-evaluator.mjs";
+
+const hookDir = dirname(fileURLToPath(import.meta.url));
+const adapterRoot = dirname(hookDir);
+const packagedValidator = resolve(adapterRoot, "skills/memorax-code/scripts/validate_memory.py");
+const validatorPath = existsSync(packagedValidator)
+  ? packagedValidator
+  : resolve(adapterRoot, "../memorax-code-codex-adapter/skills/memorax-code/scripts/validate_memory.py");
+
+try {
+  const payload = runRepoMemoryJob(process.argv.slice(2), {
+    runner: "opencode",
+    finalMessageSource: "stdout",
+    memorySkillInvocation: "the `memorax-code` skill",
+    validatorPath,
+    evaluateRepository,
+    createCommand({ prompt, repo }) {
+      return [
+        process.execPath,
+        resolve(adapterRoot, "src/repo-memory-server-runner.mjs"),
+        "--repo",
+        repo,
+        "--prompt",
+        prompt,
+      ];
+    },
+  });
+  process.stdout.write(`${JSON.stringify(payload)}\n`);
+} catch (error) {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exit(1);
+}

--- a/packages/ts/memorax-code-opencode-adapter/src/adapter-paths.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/src/adapter-paths.mjs
@@ -24,6 +24,10 @@ export function openCodeSkillPath(configDir = defaultOpenCodeConfigDir()) {
   return join(configDir, "skills", "memorax-code");
 }
 
+export function openCodeRepoMemoryHelperPath(configDir = defaultOpenCodeConfigDir()) {
+  return join(configDir, "hooks", "repo-memory-job.mjs");
+}
+
 function stringOption(value) {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }

--- a/packages/ts/memorax-code-opencode-adapter/src/plugin-install.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/src/plugin-install.mjs
@@ -127,7 +127,7 @@ export function ensureOpenCodePluginInstalled(options = {}) {
     backendUrlMatches: true,
     opencodeSkills: skillSummary(paths.skillPath, true),
     changed: !current,
-    restartRequired: !pluginCurrent || !skillCurrent,
+    restartRequired: !pluginCurrent || !skillCurrent || previousState?.enabled !== true,
     statePath: paths.statePath,
     pluginPath: paths.pluginPath,
     skillPath: paths.skillPath,

--- a/packages/ts/memorax-code-opencode-adapter/src/plugin-install.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/src/plugin-install.mjs
@@ -24,6 +24,7 @@ import {
   defaultMemoraxCodeHome,
   defaultOpenCodeConfigDir,
   openCodePluginPath,
+  openCodeRepoMemoryHelperPath,
   openCodeSkillPath,
 } from "./adapter-paths.mjs";
 
@@ -43,22 +44,35 @@ export function ensureOpenCodePluginInstalled(options = {}) {
   const pluginIsManaged = previousState?.pluginPath === paths.pluginPath
     && (!pluginExists || isManagedLoader(paths.pluginPath));
   const skillIsManaged = previousState?.skillPath === paths.skillPath;
+  const repoMemoryHelperExists = existsSync(paths.repoMemoryHelperPath);
+  const repoMemoryHelperIsManaged = previousState?.repoMemoryHelperPath
+    === paths.repoMemoryHelperPath
+    && (!repoMemoryHelperExists || isManagedLoader(paths.repoMemoryHelperPath));
   if (pluginExists && !pluginIsManaged) {
     return conflict("plugin_conflict", paths, paths.pluginPath);
   }
   if (existsSync(paths.skillPath) && !skillIsManaged) {
     return conflict("skill_conflict", paths, paths.skillPath);
   }
+  if (repoMemoryHelperExists && !repoMemoryHelperIsManaged) {
+    return conflict("repo_memory_helper_conflict", paths, paths.repoMemoryHelperPath);
+  }
 
   const backendUrl = normalizeBackendUrl(
     options.backendUrl ?? previousState?.backendUrl ?? BACKEND_DEFAULT,
   );
   const pluginSourceSha256 = fileSha256(paths.pluginSourcePath);
+  const repoMemoryHelperSourceSha256 = fileSha256(paths.repoMemoryHelperSourcePath);
   const loader = createManagedLoader(paths, pluginSourceSha256);
-  const artifactsCurrent = pluginIsManaged
-    && skillIsManaged
-    && fileContentsEqual(paths.pluginPath, loader)
-    && directoriesEqual(paths.skillSourcePath, paths.skillPath);
+  const repoMemoryHelperLoader = createManagedRepoMemoryHelperLoader(
+    paths,
+    repoMemoryHelperSourceSha256,
+  );
+  const pluginCurrent = pluginIsManaged && fileContentsEqual(paths.pluginPath, loader);
+  const skillCurrent = skillIsManaged && directoriesEqual(paths.skillSourcePath, paths.skillPath);
+  const repoMemoryHelperCurrent = repoMemoryHelperIsManaged
+    && fileContentsEqual(paths.repoMemoryHelperPath, repoMemoryHelperLoader);
+  const artifactsCurrent = pluginCurrent && skillCurrent && repoMemoryHelperCurrent;
   const current = artifactsCurrent
     && previousState?.enabled === true
     && normalizeOptionalBackendUrl(previousState.backendUrl) === backendUrl;
@@ -76,21 +90,27 @@ export function ensureOpenCodePluginInstalled(options = {}) {
     pluginSourceSha256,
     skillPath: paths.skillPath,
     skillSourcePath: paths.skillSourcePath,
+    repoMemoryHelperPath: paths.repoMemoryHelperPath,
+    repoMemoryHelperSourcePath: paths.repoMemoryHelperSourcePath,
+    repoMemoryHelperSourceSha256,
     ...(paths.cliBinDir ? { cliBinDir: paths.cliBinDir } : {}),
     installedAt: stringOption(previousState?.installedAt) ?? now,
     updatedAt: now,
   };
   const pluginExisted = existsSync(paths.pluginPath);
   const skillExisted = existsSync(paths.skillPath);
+  const repoMemoryHelperExisted = existsSync(paths.repoMemoryHelperPath);
   try {
-    if (!artifactsCurrent) {
-      materializeSkill(paths.skillSourcePath, paths.skillPath);
-      atomicWriteText(paths.pluginPath, loader);
+    if (!skillCurrent) materializeSkill(paths.skillSourcePath, paths.skillPath);
+    if (!pluginCurrent) atomicWriteText(paths.pluginPath, loader);
+    if (!repoMemoryHelperCurrent) {
+      atomicWriteText(paths.repoMemoryHelperPath, repoMemoryHelperLoader);
     }
     atomicWriteJson(paths.statePath, state);
   } catch (error) {
     removeNewArtifact(paths.pluginPath, pluginExisted);
     removeNewArtifact(paths.skillPath, skillExisted, true);
+    removeNewArtifact(paths.repoMemoryHelperPath, repoMemoryHelperExisted);
     throw error;
   }
   removePreviousInstallation(previousState, paths);
@@ -107,10 +127,11 @@ export function ensureOpenCodePluginInstalled(options = {}) {
     backendUrlMatches: true,
     opencodeSkills: skillSummary(paths.skillPath, true),
     changed: !current,
-    restartRequired: !artifactsCurrent,
+    restartRequired: !pluginCurrent || !skillCurrent,
     statePath: paths.statePath,
     pluginPath: paths.pluginPath,
     skillPath: paths.skillPath,
+    repoMemoryHelperPath: paths.repoMemoryHelperPath,
     state,
   };
 }
@@ -135,6 +156,7 @@ export function readOpenCodePluginStatus(options = {}) {
       statePath: paths.statePath,
       pluginPath: paths.pluginPath,
       skillPath: paths.skillPath,
+      repoMemoryHelperPath: paths.repoMemoryHelperPath,
       skipped: true,
       reason: "not_managed",
     };
@@ -145,9 +167,14 @@ export function readOpenCodePluginStatus(options = {}) {
     openCodeConfigDir: state.openCodeConfigDir,
     pluginSourcePath: options.pluginSourcePath ?? state.pluginSourcePath,
     skillSourcePath: options.skillSourcePath ?? state.skillSourcePath,
+    repoMemoryHelperSourcePath: options.repoMemoryHelperSourcePath
+      ?? state.repoMemoryHelperSourcePath,
     cliBinDir: options.cliBinDir ?? state.cliBinDir,
   });
-  if (state.pluginPath !== configuredPaths.pluginPath || state.skillPath !== configuredPaths.skillPath) {
+  if (state.pluginPath !== configuredPaths.pluginPath
+    || state.skillPath !== configuredPaths.skillPath
+    || (state.repoMemoryHelperPath
+      && state.repoMemoryHelperPath !== configuredPaths.repoMemoryHelperPath)) {
     return {
       ok: false,
       action: "opencode-plugin-status",
@@ -161,16 +188,32 @@ export function readOpenCodePluginStatus(options = {}) {
 
   const pluginExists = existsSync(configuredPaths.pluginPath);
   const skillExists = existsSync(join(configuredPaths.skillPath, "SKILL.md"));
+  const repoMemoryHelperExists = existsSync(configuredPaths.repoMemoryHelperPath);
+  const repoMemoryHelperRecorded = state.repoMemoryHelperPath
+    === configuredPaths.repoMemoryHelperPath;
   const sourcesReady = !validateSources(configuredPaths);
   const pluginSourceSha256 = sourcesReady ? fileSha256(configuredPaths.pluginSourcePath) : undefined;
+  const repoMemoryHelperSourceSha256 = sourcesReady
+    ? fileSha256(configuredPaths.repoMemoryHelperSourcePath)
+    : undefined;
   const pluginCurrent = sourcesReady && fileContentsEqual(
     configuredPaths.pluginPath,
     createManagedLoader(configuredPaths, pluginSourceSha256),
   );
   const skillCurrent = sourcesReady
     && directoriesEqual(configuredPaths.skillSourcePath, configuredPaths.skillPath);
-  const installed = pluginExists && skillExists;
-  const enabled = state.enabled === true && installed && pluginCurrent && skillCurrent;
+  const repoMemoryHelperCurrent = repoMemoryHelperRecorded
+    && sourcesReady
+    && fileContentsEqual(
+      configuredPaths.repoMemoryHelperPath,
+      createManagedRepoMemoryHelperLoader(configuredPaths, repoMemoryHelperSourceSha256),
+    );
+  const installed = pluginExists && skillExists && repoMemoryHelperExists;
+  const enabled = state.enabled === true
+    && installed
+    && pluginCurrent
+    && skillCurrent
+    && repoMemoryHelperCurrent;
   const configuredBackendUrl = normalizeOptionalBackendUrl(state.backendUrl);
   const expectedBackendUrl = normalizeOptionalBackendUrl(options.backendUrl);
   const backendUrlMatches = !expectedBackendUrl || configuredBackendUrl === expectedBackendUrl;
@@ -181,11 +224,13 @@ export function readOpenCodePluginStatus(options = {}) {
     enabled,
     managed: true,
     integration: "plugin",
-    current: pluginCurrent && skillCurrent,
+    current: pluginCurrent && skillCurrent && repoMemoryHelperCurrent,
     pluginExists,
     pluginCurrent,
     skillExists,
     skillCurrent,
+    repoMemoryHelperExists,
+    repoMemoryHelperCurrent,
     configuredBackendUrl,
     expectedBackendUrl,
     backendUrlMatches,
@@ -193,11 +238,21 @@ export function readOpenCodePluginStatus(options = {}) {
     statePath: paths.statePath,
     pluginPath: configuredPaths.pluginPath,
     skillPath: configuredPaths.skillPath,
+    repoMemoryHelperPath: configuredPaths.repoMemoryHelperPath,
     state,
     ...(!backendUrlMatches
       ? { reason: "backend_url_mismatch" }
       : !enabled
-        ? { reason: statusReason({ sourcesReady, pluginExists, pluginCurrent, skillExists, skillCurrent }) }
+        ? { reason: statusReason({
+          sourcesReady,
+          pluginExists,
+          pluginCurrent,
+          skillExists,
+          skillCurrent,
+          repoMemoryHelperExists,
+          repoMemoryHelperRecorded,
+          repoMemoryHelperCurrent,
+        }) }
         : {}),
   };
 }
@@ -227,10 +282,13 @@ export function disableOpenCodePlugin(options = {}) {
     disabledAt: new Date().toISOString(),
   };
   atomicWriteJson(paths.statePath, nextState);
+  const repoMemoryHelperPath = stringOption(state.repoMemoryHelperPath);
   return {
     ok: true,
     action: "opencode-plugin-disable",
-    installed: existsSync(state.pluginPath) && existsSync(join(state.skillPath, "SKILL.md")),
+    installed: existsSync(state.pluginPath)
+      && existsSync(join(state.skillPath, "SKILL.md"))
+      && Boolean(repoMemoryHelperPath && existsSync(repoMemoryHelperPath)),
     enabled: false,
     managed: true,
     integration: "plugin",
@@ -258,7 +316,12 @@ export function removeOpenCodePluginInstallation(options = {}) {
   const openCodeConfigDir = resolve(state.openCodeConfigDir);
   const pluginPath = openCodePluginPath(openCodeConfigDir);
   const skillPath = openCodeSkillPath(openCodeConfigDir);
-  if (state.pluginPath !== pluginPath || state.skillPath !== skillPath) {
+  const repoMemoryHelperPath = openCodeRepoMemoryHelperPath(openCodeConfigDir);
+  const recordedRepoMemoryHelperPath = stringOption(state.repoMemoryHelperPath);
+  if (state.pluginPath !== pluginPath
+    || state.skillPath !== skillPath
+    || (recordedRepoMemoryHelperPath
+      && recordedRepoMemoryHelperPath !== repoMemoryHelperPath)) {
     return {
       ok: false,
       action: "opencode-plugin-remove",
@@ -275,9 +338,21 @@ export function removeOpenCodePluginInstallation(options = {}) {
       pluginPath,
     };
   }
+  if (recordedRepoMemoryHelperPath
+    && existsSync(repoMemoryHelperPath)
+    && !isManagedLoader(repoMemoryHelperPath)) {
+    return {
+      ok: false,
+      action: "opencode-plugin-remove",
+      reason: "repo_memory_helper_not_managed",
+      statePath: paths.statePath,
+      repoMemoryHelperPath,
+    };
+  }
 
   rmSync(pluginPath, { force: true });
   rmSync(skillPath, { recursive: true, force: true });
+  if (recordedRepoMemoryHelperPath) rmSync(repoMemoryHelperPath, { force: true });
   rmSync(paths.statePath, { force: true });
   return {
     ok: true,
@@ -289,6 +364,7 @@ export function removeOpenCodePluginInstallation(options = {}) {
     statePath: paths.statePath,
     pluginPath,
     skillPath,
+    repoMemoryHelperPath,
   };
 }
 
@@ -301,6 +377,10 @@ export function defaultOpenCodeSkillSourcePath() {
   return existsSync(join(packagedSkill, "SKILL.md"))
     ? packagedSkill
     : resolve(ADAPTER_ROOT, "..", "memorax-code-codex-adapter", "skills", "memorax-code");
+}
+
+export function defaultOpenCodeRepoMemoryHelperSourcePath() {
+  return join(ADAPTER_ROOT, "hooks", "repo-memory-job.mjs");
 }
 
 export function defaultOpenCodeCliBinDir(adapterRoot = ADAPTER_ROOT) {
@@ -331,8 +411,12 @@ function resolvePaths(options) {
     statePath: resolve(options.statePath ?? adapterStatePath(memoraxCodeHome)),
     pluginPath: openCodePluginPath(openCodeConfigDir),
     skillPath: openCodeSkillPath(openCodeConfigDir),
+    repoMemoryHelperPath: openCodeRepoMemoryHelperPath(openCodeConfigDir),
     pluginSourcePath: resolve(options.pluginSourcePath ?? defaultOpenCodePluginSourcePath()),
     skillSourcePath: resolve(options.skillSourcePath ?? defaultOpenCodeSkillSourcePath()),
+    repoMemoryHelperSourcePath: resolve(
+      options.repoMemoryHelperSourcePath ?? defaultOpenCodeRepoMemoryHelperSourcePath(),
+    ),
     cliBinDir: stringOption(options.cliBinDir)
       ? resolve(options.cliBinDir)
       : defaultOpenCodeCliBinDir(),
@@ -362,17 +446,32 @@ function validateState(state, statePath) {
     const openCodeConfigDir = stringOption(state.openCodeConfigDir);
     const pluginPath = stringOption(state.pluginPath);
     const skillPath = stringOption(state.skillPath);
+    const repoMemoryHelperPath = stringOption(state.repoMemoryHelperPath);
+    const repoMemoryHelperSourcePath = stringOption(state.repoMemoryHelperSourcePath);
+    const repoMemoryHelperSourceSha256 = stringOption(state.repoMemoryHelperSourceSha256);
+    const hasRepoMemoryHelperState = [
+      "repoMemoryHelperPath",
+      "repoMemoryHelperSourcePath",
+      "repoMemoryHelperSourceSha256",
+    ].some((field) => Object.hasOwn(state, field));
     if (state.runtime !== "opencode"
       || state.integration !== "plugin"
       || !openCodeConfigDir
       || !pluginPath
-      || !skillPath) {
+      || !skillPath
+      || (hasRepoMemoryHelperState && (
+        !repoMemoryHelperPath
+        || !repoMemoryHelperSourcePath
+        || !/^[a-f0-9]{64}$/.test(repoMemoryHelperSourceSha256 ?? "")
+      ))) {
       return { ok: false, reason: "state_invalid", statePath };
     }
     const resolvedConfigDir = resolve(openCodeConfigDir);
     if (openCodeConfigDir !== resolvedConfigDir
       || pluginPath !== openCodePluginPath(resolvedConfigDir)
-      || skillPath !== openCodeSkillPath(resolvedConfigDir)) {
+      || skillPath !== openCodeSkillPath(resolvedConfigDir)
+      || (repoMemoryHelperPath
+        && repoMemoryHelperPath !== openCodeRepoMemoryHelperPath(resolvedConfigDir))) {
       return { ok: false, reason: "state_paths_invalid", statePath };
     }
   }
@@ -386,6 +485,13 @@ function validateSources(paths) {
   if (!existsSync(join(paths.skillSourcePath, "SKILL.md"))) {
     return { ok: false, reason: "skill_source_missing", sourcePath: paths.skillSourcePath };
   }
+  if (!existsSync(paths.repoMemoryHelperSourcePath)) {
+    return {
+      ok: false,
+      reason: "repo_memory_helper_source_missing",
+      sourcePath: paths.repoMemoryHelperSourcePath,
+    };
+  }
   return undefined;
 }
 
@@ -398,6 +504,7 @@ function conflict(reason, paths, conflictPath) {
     statePath: paths.statePath,
     pluginPath: paths.pluginPath,
     skillPath: paths.skillPath,
+    repoMemoryHelperPath: paths.repoMemoryHelperPath,
   };
 }
 
@@ -421,6 +528,16 @@ function createManagedLoader(paths, pluginSourceSha256) {
   ].join("\n");
 }
 
+function createManagedRepoMemoryHelperLoader(paths, sourceSha256) {
+  const helperUrl = pathToFileURL(paths.repoMemoryHelperSourcePath).href;
+  return [
+    MANAGED_LOADER_HEADER,
+    `// Repo Memory helper source SHA-256: ${sourceSha256}`,
+    `import ${JSON.stringify(helperUrl)};`,
+    "",
+  ].join("\n");
+}
+
 function materializeSkill(sourcePath, targetPath) {
   mkdirSync(dirname(targetPath), { recursive: true });
   const stagePath = `${targetPath}.tmp-${process.pid}-${randomUUID()}`;
@@ -440,6 +557,10 @@ function removePreviousInstallation(previousState, paths) {
   }
   if (previousState.skillPath !== paths.skillPath) {
     rmSync(previousState.skillPath, { recursive: true, force: true });
+  }
+  if (previousState.repoMemoryHelperPath !== paths.repoMemoryHelperPath
+    && isManagedLoader(previousState.repoMemoryHelperPath)) {
+    rmSync(previousState.repoMemoryHelperPath, { force: true });
   }
 }
 
@@ -513,12 +634,24 @@ function collectDirectoryEntries(root) {
   }
 }
 
-function statusReason({ sourcesReady, pluginExists, pluginCurrent, skillExists, skillCurrent }) {
+function statusReason({
+  sourcesReady,
+  pluginExists,
+  pluginCurrent,
+  skillExists,
+  skillCurrent,
+  repoMemoryHelperExists,
+  repoMemoryHelperRecorded,
+  repoMemoryHelperCurrent,
+}) {
   if (!sourcesReady) return "source_missing";
   if (!pluginExists) return "plugin_missing";
   if (!pluginCurrent) return "plugin_stale";
   if (!skillExists) return "skill_missing";
   if (!skillCurrent) return "skill_stale";
+  if (!repoMemoryHelperExists) return "repo_memory_helper_missing";
+  if (!repoMemoryHelperRecorded) return "repo_memory_helper_unmanaged";
+  if (!repoMemoryHelperCurrent) return "repo_memory_helper_stale";
   return "not_enabled";
 }
 

--- a/packages/ts/memorax-code-opencode-adapter/src/plugin.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/src/plugin.mjs
@@ -128,16 +128,12 @@ export function createMemoraxOpenCodePlugin(options = {}) {
       config: async (config) => {
         if (!pluginEnabled(options)) return;
         config.agent ??= {};
+        const configuredAgent = config.agent[OPENCODE_REPO_MEMORY_AGENT];
         config.agent[OPENCODE_REPO_MEMORY_AGENT] = {
           description: "Managed MemoraX Code Repo Memory maintenance agent.",
           mode: "subagent",
-          permission: {
-            edit: "allow",
-            bash: "allow",
-            webfetch: "allow",
-            doom_loop: "allow",
-            external_directory: "allow",
-          },
+          hidden: true,
+          ...(configuredAgent && typeof configuredAgent === "object" ? configuredAgent : {}),
         };
       },
       "chat.message": async (input, output) => {

--- a/packages/ts/memorax-code-opencode-adapter/src/plugin.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/src/plugin.mjs
@@ -10,6 +10,7 @@ import {
 } from "../../memorax-code-adapter-common/src/hooks/memory-skill-reminder-hook.mjs";
 import { buildRepoProcedureMemoryContext } from "../../memorax-code-adapter-common/src/repo-memory/repo-procedure-memory-context.mjs";
 import { buildRepoUserProfilePreferencesContext } from "../../memorax-code-adapter-common/src/repo-memory/repo-user-profile-context.mjs";
+import { OPENCODE_REPO_MEMORY_AGENT } from "./repo-memory-server-runner.mjs";
 
 const DEFAULT_BACKEND_PROMPT_WAIT_TIMEOUT_MS = 5_000;
 const TURN_START_TIMEOUT_MS = 12_000;
@@ -26,9 +27,10 @@ class BackendHttpResponseError extends Error {
 }
 
 export function createMemoraxOpenCodePlugin(options = {}) {
-  return async ({ client, project, directory, worktree }) => {
+  return async ({ client, project, directory, worktree, serverUrl }) => {
     const workspaceRoot = project?.vcs === "git" ? worktree : directory;
     const workspaceKind = project?.vcs === "git" ? "project" : "local";
+    const openCodeServerUrl = urlString(serverUrl);
     const pendingTurns = new Map();
     const inFlight = new Set();
     const genericReminderOptions = memorySkillReminderOptions(options);
@@ -123,8 +125,24 @@ export function createMemoraxOpenCodePlugin(options = {}) {
     void ensureBackendReady();
 
     return {
+      config: async (config) => {
+        if (!pluginEnabled(options)) return;
+        config.agent ??= {};
+        config.agent[OPENCODE_REPO_MEMORY_AGENT] = {
+          description: "Managed MemoraX Code Repo Memory maintenance agent.",
+          mode: "subagent",
+          permission: {
+            edit: "allow",
+            bash: "allow",
+            webfetch: "allow",
+            doom_loop: "allow",
+            external_directory: "allow",
+          },
+        };
+      },
       "chat.message": async (input, output) => {
         if (!pluginEnabled(options)) return;
+        if (stringValue(input?.agent) === OPENCODE_REPO_MEMORY_AGENT) return;
         const userMessageId = stringValue(output?.message?.id) ?? stringValue(input?.messageID);
         const sessionId = stringValue(input?.sessionID);
         if (Array.isArray(output?.parts) && output.parts.some((part) => part?.type === "compaction")) return;
@@ -203,6 +221,9 @@ export function createMemoraxOpenCodePlugin(options = {}) {
       "shell.env": async (input, output) => {
         if (!pluginEnabled(options)) return;
         output.env.MEMORAX_CODE_MEMORY_CLI_TRACE_CLIENT = "opencode";
+        if (openCodeServerUrl) {
+          output.env.MEMORAX_CODE_OPENCODE_SERVER_URL = openCodeServerUrl;
+        }
         const sessionId = stringValue(input?.sessionID);
         delete output.env.MEMORAX_CODE_MEMORY_CLI_TRACE_SESSION_ID;
         delete output.env.MEMORAX_CODE_MEMORY_CLI_SESSION_ID;
@@ -334,6 +355,18 @@ function debug(options, message, error) {
 
 function stringValue(value) {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function urlString(value) {
+  try {
+    return value instanceof URL
+      ? value.href
+      : stringValue(value)
+        ? new URL(value).href
+        : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 function positiveInteger(value, fallback) {

--- a/packages/ts/memorax-code-opencode-adapter/src/repo-memory-server-runner.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/src/repo-memory-server-runner.mjs
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const OPENCODE_REPO_MEMORY_AGENT = "memorax-code-repo-memory";
+
+export async function runOpenCodeRepoMemory(input, options = {}) {
+  const env = options.env ?? process.env;
+  const serverUrl = stringValue(input?.serverUrl)
+    ?? stringValue(env.MEMORAX_CODE_OPENCODE_SERVER_URL);
+  if (!serverUrl) {
+    throw new Error(
+      "OpenCode repo memory runner requires --server-url or MEMORAX_CODE_OPENCODE_SERVER_URL",
+    );
+  }
+  const repo = stringValue(input?.repo);
+  if (!repo) throw new Error("OpenCode repo memory runner requires --repo");
+  const prompt = stringValue(input?.prompt);
+  if (!prompt) throw new Error("OpenCode repo memory runner requires --prompt");
+
+  const baseUrl = normalizedServerUrl(serverUrl);
+  const directory = resolve(repo);
+  const parentID = stringValue(input?.parentID)
+    ?? stringValue(env.MEMORAX_CODE_MEMORY_CLI_SESSION_ID);
+  const fetchImpl = options.fetchImpl ?? fetch;
+  let sessionID;
+  try {
+    const session = await requestJson(fetchImpl, endpoint(baseUrl, "/session", directory), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        ...(parentID ? { parentID } : {}),
+        title: "MemoraX Code Repo Memory",
+      }),
+    }, "session creation");
+    sessionID = stringValue(session?.id);
+    if (!sessionID) throw new Error("OpenCode session creation returned no session id");
+
+    const message = await requestJson(
+      fetchImpl,
+      endpoint(baseUrl, `/session/${encodeURIComponent(sessionID)}/message`, directory),
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          agent: OPENCODE_REPO_MEMORY_AGENT,
+          parts: [{ type: "text", text: prompt }],
+        }),
+      },
+      "blocking prompt",
+    );
+    const finalText = messageText(message);
+    if (!finalText) throw new Error("OpenCode repo memory runner received no final text");
+    return finalText;
+  } finally {
+    if (sessionID) {
+      await bestEffortDelete(
+        fetchImpl,
+        endpoint(baseUrl, `/session/${encodeURIComponent(sessionID)}`, directory),
+      );
+    }
+  }
+}
+
+function parseArgs(values) {
+  const result = {};
+  for (let index = 0; index < values.length; index += 1) {
+    const value = values[index];
+    if (value === "--server-url") result.serverUrl = requiredValue(values, ++index, value);
+    else if (value === "--repo") result.repo = requiredValue(values, ++index, value);
+    else if (value === "--prompt") result.prompt = requiredValue(values, ++index, value);
+    else if (value === "--parent-id") result.parentID = requiredValue(values, ++index, value);
+    else throw new Error(`unknown argument: ${value}`);
+  }
+  return result;
+}
+
+function requiredValue(values, index, option) {
+  const value = values[index];
+  if (!value || value.startsWith("--")) throw new Error(`${option} requires a value`);
+  return value;
+}
+
+function normalizedServerUrl(value) {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "http:" && url.protocol !== "https:") throw new Error();
+    return url;
+  } catch {
+    throw new Error("OpenCode repo memory runner requires a valid HTTP server URL");
+  }
+}
+
+function endpoint(baseUrl, pathname, directory) {
+  const url = new URL(pathname, baseUrl);
+  url.searchParams.set("directory", directory);
+  return url;
+}
+
+async function requestJson(fetchImpl, url, init, operation) {
+  let response;
+  try {
+    response = await fetchImpl(url, init);
+  } catch (error) {
+    throw new Error(`OpenCode ${operation} request failed: ${errorMessage(error)}`);
+  }
+  const body = await response.text();
+  if (!response.ok) {
+    const detail = responseDetail(body);
+    throw new Error(
+      `OpenCode ${operation} failed with HTTP ${response.status}${detail ? `: ${detail}` : ""}`,
+    );
+  }
+  if (!body.trim()) throw new Error(`OpenCode ${operation} returned an empty response`);
+  try {
+    return JSON.parse(body);
+  } catch {
+    throw new Error(`OpenCode ${operation} returned invalid JSON`);
+  }
+}
+
+async function bestEffortDelete(fetchImpl, url) {
+  try {
+    await fetchImpl(url, { method: "DELETE" });
+  } catch {
+    // Session cleanup must not replace the prompt result or its error.
+  }
+}
+
+function messageText(message) {
+  const payload = message?.data ?? message;
+  if (!Array.isArray(payload?.parts)) return undefined;
+  return payload.parts
+    .flatMap((part) => part?.type === "text" && stringValue(part.text) ? [part.text.trim()] : [])
+    .join("\n\n")
+    .trim() || undefined;
+}
+
+function responseDetail(body) {
+  if (!body.trim()) return undefined;
+  try {
+    const parsed = JSON.parse(body);
+    return stringValue(parsed?.data?.message)
+      ?? stringValue(parsed?.message)
+      ?? stringValue(parsed?.error);
+  } catch {
+    return body.trim().slice(0, 300);
+  }
+}
+
+function stringValue(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isDirectExecution() {
+  return process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+}
+
+if (isDirectExecution()) {
+  try {
+    const finalText = await runOpenCodeRepoMemory(parseArgs(process.argv.slice(2)));
+    process.stdout.write(`${finalText}\n`);
+  } catch (error) {
+    process.stderr.write(`${errorMessage(error)}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/packages/ts/memorax-code-opencode-adapter/src/repo-memory-server-runner.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/src/repo-memory-server-runner.mjs
@@ -6,8 +6,8 @@ export const OPENCODE_REPO_MEMORY_AGENT = "memorax-code-repo-memory";
 
 export async function runOpenCodeRepoMemory(input, options = {}) {
   const env = options.env ?? process.env;
-  const serverUrl = stringValue(input?.serverUrl)
-    ?? stringValue(env.MEMORAX_CODE_OPENCODE_SERVER_URL);
+  const managedServerUrl = stringValue(env.MEMORAX_CODE_OPENCODE_SERVER_URL);
+  const serverUrl = stringValue(input?.serverUrl) ?? managedServerUrl;
   if (!serverUrl) {
     throw new Error(
       "OpenCode repo memory runner requires --server-url or MEMORAX_CODE_OPENCODE_SERVER_URL",
@@ -19,6 +19,7 @@ export async function runOpenCodeRepoMemory(input, options = {}) {
   if (!prompt) throw new Error("OpenCode repo memory runner requires --prompt");
 
   const baseUrl = normalizedServerUrl(serverUrl);
+  const authorization = serverAuthorization(env, baseUrl, managedServerUrl);
   const directory = resolve(repo);
   const parentID = stringValue(input?.parentID)
     ?? stringValue(env.MEMORAX_CODE_MEMORY_CLI_SESSION_ID);
@@ -27,7 +28,10 @@ export async function runOpenCodeRepoMemory(input, options = {}) {
   try {
     const session = await requestJson(fetchImpl, endpoint(baseUrl, "/session", directory), {
       method: "POST",
-      headers: { "content-type": "application/json" },
+      headers: {
+        "content-type": "application/json",
+        ...(authorization ? { authorization } : {}),
+      },
       body: JSON.stringify({
         ...(parentID ? { parentID } : {}),
         title: "MemoraX Code Repo Memory",
@@ -41,7 +45,10 @@ export async function runOpenCodeRepoMemory(input, options = {}) {
       endpoint(baseUrl, `/session/${encodeURIComponent(sessionID)}/message`, directory),
       {
         method: "POST",
-        headers: { "content-type": "application/json" },
+        headers: {
+          "content-type": "application/json",
+          ...(authorization ? { authorization } : {}),
+        },
         body: JSON.stringify({
           agent: OPENCODE_REPO_MEMORY_AGENT,
           parts: [{ type: "text", text: prompt }],
@@ -57,6 +64,7 @@ export async function runOpenCodeRepoMemory(input, options = {}) {
       await bestEffortDelete(
         fetchImpl,
         endpoint(baseUrl, `/session/${encodeURIComponent(sessionID)}`, directory),
+        authorization,
       );
     }
   }
@@ -97,6 +105,20 @@ function endpoint(baseUrl, pathname, directory) {
   return url;
 }
 
+function serverAuthorization(env, targetUrl, managedServerUrl) {
+  const password = rawString(env.OPENCODE_SERVER_PASSWORD);
+  if (!password || !managedServerUrl) return undefined;
+  let managedUrl;
+  try {
+    managedUrl = normalizedServerUrl(managedServerUrl);
+  } catch {
+    return undefined;
+  }
+  if (targetUrl.origin !== managedUrl.origin) return undefined;
+  const username = rawString(env.OPENCODE_SERVER_USERNAME) ?? "opencode";
+  return `Basic ${Buffer.from(`${username}:${password}`).toString("base64")}`;
+}
+
 async function requestJson(fetchImpl, url, init, operation) {
   let response;
   try {
@@ -119,9 +141,12 @@ async function requestJson(fetchImpl, url, init, operation) {
   }
 }
 
-async function bestEffortDelete(fetchImpl, url) {
+async function bestEffortDelete(fetchImpl, url, authorization) {
   try {
-    await fetchImpl(url, { method: "DELETE" });
+    await fetchImpl(url, {
+      method: "DELETE",
+      headers: authorization ? { authorization } : {},
+    });
   } catch {
     // Session cleanup must not replace the prompt result or its error.
   }
@@ -150,6 +175,10 @@ function responseDetail(body) {
 
 function stringValue(value) {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function rawString(value) {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 
 function errorMessage(error) {

--- a/packages/ts/memorax-code-opencode-adapter/src/repo-memory-server-runner.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/src/repo-memory-server-runner.mjs
@@ -35,6 +35,13 @@ export async function runOpenCodeRepoMemory(input, options = {}) {
       body: JSON.stringify({
         ...(parentID ? { parentID } : {}),
         title: "MemoraX Code Repo Memory",
+        permission: [
+          { permission: "edit", pattern: "*", action: "allow" },
+          { permission: "bash", pattern: "*", action: "allow" },
+          { permission: "webfetch", pattern: "*", action: "allow" },
+          { permission: "doom_loop", pattern: "*", action: "allow" },
+          { permission: "external_directory", pattern: "*", action: "allow" },
+        ],
       }),
     }, "session creation");
     sessionID = stringValue(session?.id);

--- a/packages/ts/memorax-code-opencode-adapter/test/plugin-install.test.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/test/plugin-install.test.mjs
@@ -1,4 +1,5 @@
 import { strict as assert } from "node:assert";
+import { spawnSync } from "node:child_process";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -60,16 +61,35 @@ test("OpenCode plugin install materializes a managed loader, canonical skill, an
     assert.match(loader, new RegExp(escapeRegex(`"memoraxCodeCommand":${JSON.stringify(fixture.memoraxCodeCommand)}`)));
     assert.match(loader, new RegExp(escapeRegex(`"nodePath":${JSON.stringify(process.execPath)}`)));
     assert.match(loader, /"cliBinDir":"\/managed\/bin"/);
+    const repoMemoryHelperLoader = await readFile(installed.repoMemoryHelperPath, "utf8");
+    assert.match(repoMemoryHelperLoader, /^\/\/ Managed by MemoraX Code/);
+    assert.match(
+      repoMemoryHelperLoader,
+      new RegExp(escapeRegex(JSON.stringify(pathToFileURL(fixture.repoMemoryHelperSourcePath).href))),
+    );
+    assert.doesNotMatch(repoMemoryHelperLoader, /process\.argv/);
+    const helperRun = spawnSync(
+      process.execPath,
+      [installed.repoMemoryHelperPath, "maintain", "--repo", fixture.root],
+      { encoding: "utf8" },
+    );
+    assert.equal(helperRun.status, 0, helperRun.stderr);
+    assert.deepEqual(JSON.parse(helperRun.stdout), ["maintain", "--repo", fixture.root]);
     assert.equal(await readFile(join(installed.skillPath, "SKILL.md"), "utf8"), "# MemoraX Code\n");
     assert.equal(await readFile(join(installed.skillPath, "references", "search.md"), "utf8"), "search\n");
     const state = JSON.parse(await readFile(installed.statePath, "utf8"));
     assert.equal(state.runtime, "opencode");
     assert.equal(state.openCodeConfigDir, fixture.openCodeConfigDir);
+    assert.equal(state.repoMemoryHelperPath, installed.repoMemoryHelperPath);
+    assert.equal(state.repoMemoryHelperSourcePath, fixture.repoMemoryHelperSourcePath);
+    assert.match(state.repoMemoryHelperSourceSha256, /^[a-f0-9]{64}$/);
 
     const status = readOpenCodePluginStatus(fixture.options);
     assert.equal(status.ok, true);
     assert.equal(status.installed, true);
     assert.equal(status.current, true);
+    assert.equal(status.repoMemoryHelperExists, true);
+    assert.equal(status.repoMemoryHelperCurrent, true);
 
     const unchanged = ensureOpenCodePluginInstalled(fixture.options);
     assert.equal(unchanged.ok, true);
@@ -82,6 +102,37 @@ test("OpenCode plugin install materializes a managed loader, canonical skill, an
     assert.equal(updated.changed, true);
     assert.equal(updated.restartRequired, true);
     assert.match(await readFile(updated.pluginPath, "utf8"), /Plugin source SHA-256: [a-f0-9]{64}/);
+
+    await writeFile(
+      fixture.repoMemoryHelperSourcePath,
+      "process.stdout.write(JSON.stringify(['updated', ...process.argv.slice(2)]));\n",
+    );
+    assert.equal(readOpenCodePluginStatus(fixture.options).repoMemoryHelperCurrent, false);
+    const helperUpdated = ensureOpenCodePluginInstalled(fixture.options);
+    assert.equal(helperUpdated.changed, true);
+    assert.equal(helperUpdated.restartRequired, false);
+    assert.match(
+      await readFile(helperUpdated.repoMemoryHelperPath, "utf8"),
+      /Repo Memory helper source SHA-256: [a-f0-9]{64}/,
+    );
+  } finally {
+    await rm(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("OpenCode plugin install refuses to overwrite an unmanaged Repo Memory helper", async () => {
+  const fixture = await createFixture("helper-conflict");
+  const helperPath = join(fixture.openCodeConfigDir, "hooks", "repo-memory-job.mjs");
+  try {
+    await mkdir(join(fixture.openCodeConfigDir, "hooks"), { recursive: true });
+    await writeFile(helperPath, "console.log('user helper');\n");
+
+    const result = ensureOpenCodePluginInstalled(fixture.options);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "repo_memory_helper_conflict");
+    assert.equal(result.conflictPath, helperPath);
+    assert.equal(await readFile(helperPath, "utf8"), "console.log('user helper');\n");
   } finally {
     await rm(fixture.root, { recursive: true, force: true });
   }
@@ -127,6 +178,7 @@ test("OpenCode plugin install removes newly created artifacts when state persist
   const blockedStateDir = join(fixture.options.memoraxCodeHome, "adapters", "opencode");
   const pluginPath = join(fixture.openCodeConfigDir, "plugins", "memorax-code.js");
   const skillPath = join(fixture.openCodeConfigDir, "skills", "memorax-code");
+  const helperPath = join(fixture.openCodeConfigDir, "hooks", "repo-memory-job.mjs");
   try {
     await mkdir(join(fixture.options.memoraxCodeHome, "adapters"), { recursive: true });
     await writeFile(blockedStateDir, "not a directory\n");
@@ -134,6 +186,7 @@ test("OpenCode plugin install removes newly created artifacts when state persist
     assert.throws(() => ensureOpenCodePluginInstalled(fixture.options));
     await assert.rejects(readFile(pluginPath), /ENOENT/);
     await assert.rejects(readFile(join(skillPath, "SKILL.md")), /ENOENT/);
+    await assert.rejects(readFile(helperPath), /ENOENT/);
 
     await rm(blockedStateDir, { force: true });
     assert.equal(ensureOpenCodePluginInstalled(fixture.options).ok, true);
@@ -157,6 +210,10 @@ test("OpenCode plugin removal deletes only the recorded managed artifacts", asyn
     assert.equal(disabledStatus.ok, true);
     assert.equal(disabledStatus.reason, "not_enabled");
     assert.match(await readFile(installed.pluginPath, "utf8"), /^\/\/ Managed by MemoraX Code/);
+    assert.match(
+      await readFile(installed.repoMemoryHelperPath, "utf8"),
+      /^\/\/ Managed by MemoraX Code/,
+    );
 
     const removed = removeOpenCodePluginInstallation(fixture.options);
 
@@ -164,8 +221,30 @@ test("OpenCode plugin removal deletes only the recorded managed artifacts", asyn
     assert.equal(await readFile(unrelatedConfig, "utf8"), "{ // user config\n}\n");
     await assert.rejects(readFile(installed.pluginPath), /ENOENT/);
     await assert.rejects(readFile(join(installed.skillPath, "SKILL.md")), /ENOENT/);
+    await assert.rejects(readFile(installed.repoMemoryHelperPath), /ENOENT/);
     await assert.rejects(readFile(installed.statePath), /ENOENT/);
     assert.equal(readOpenCodePluginStatus(fixture.options).managed, false);
+  } finally {
+    await rm(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("OpenCode plugin removal preserves all artifacts when the recorded helper is unmanaged", async () => {
+  const fixture = await createFixture("unmanaged-helper-removal");
+  try {
+    const installed = ensureOpenCodePluginInstalled(fixture.options);
+    await writeFile(installed.repoMemoryHelperPath, "console.log('replacement');\n");
+
+    const removed = removeOpenCodePluginInstallation(fixture.options);
+
+    assert.equal(removed.ok, false);
+    assert.equal(removed.reason, "repo_memory_helper_not_managed");
+    assert.match(await readFile(installed.pluginPath, "utf8"), /^\/\/ Managed by MemoraX Code/);
+    assert.equal(
+      await readFile(installed.repoMemoryHelperPath, "utf8"),
+      "console.log('replacement');\n",
+    );
+    assert.equal(JSON.parse(await readFile(installed.statePath, "utf8")).enabled, true);
   } finally {
     await rm(fixture.root, { recursive: true, force: true });
   }
@@ -204,12 +283,23 @@ async function createFixture(name) {
   const openCodeConfigDir = join(root, "OpenCode Config With Spaces");
   const memoraxCodeHome = join(root, "memorax-code");
   const pluginSourcePath = join(root, "Adapter With Spaces", "plugin.mjs");
+  const repoMemoryHelperSourcePath = join(
+    root,
+    "Adapter With Spaces",
+    "hooks",
+    "repo-memory-job.mjs",
+  );
   const memoraxCodeCommand = join(root, "Package With Spaces", "bin", "memorax-code.mjs");
   const skillSourcePath = join(root, "canonical-skill");
   await mkdir(join(skillSourcePath, "references"), { recursive: true });
   await mkdir(join(root, "Adapter With Spaces"), { recursive: true });
+  await mkdir(join(root, "Adapter With Spaces", "hooks"), { recursive: true });
   await mkdir(join(root, "Package With Spaces", "bin"), { recursive: true });
   await writeFile(pluginSourcePath, "export function createMemoraxOpenCodePlugin() {}\n");
+  await writeFile(
+    repoMemoryHelperSourcePath,
+    "process.stdout.write(JSON.stringify(process.argv.slice(2)));\n",
+  );
   await writeFile(memoraxCodeCommand, "#!/usr/bin/env node\n");
   await writeFile(join(skillSourcePath, "SKILL.md"), "# MemoraX Code\n");
   await writeFile(join(skillSourcePath, "references", "search.md"), "search\n");
@@ -218,10 +308,12 @@ async function createFixture(name) {
     openCodeConfigDir,
     memoraxCodeCommand,
     pluginSourcePath,
+    repoMemoryHelperSourcePath,
     options: {
       openCodeConfigDir,
       memoraxCodeHome,
       pluginSourcePath,
+      repoMemoryHelperSourcePath,
       skillSourcePath,
       memoraxCodeCommand,
       cliBinDir: "/managed/bin",

--- a/packages/ts/memorax-code-opencode-adapter/test/plugin-install.test.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/test/plugin-install.test.mjs
@@ -96,6 +96,11 @@ test("OpenCode plugin install materializes a managed loader, canonical skill, an
     assert.equal(unchanged.changed, false);
     assert.equal(unchanged.restartRequired, false);
 
+    assert.equal(disableOpenCodePlugin(fixture.options).enabled, false);
+    const reenabled = ensureOpenCodePluginInstalled(fixture.options);
+    assert.equal(reenabled.changed, true);
+    assert.equal(reenabled.restartRequired, true);
+
     await writeFile(fixture.pluginSourcePath, "export function createMemoraxOpenCodePlugin() { return 'updated'; }\n");
     assert.equal(readOpenCodePluginStatus(fixture.options).pluginCurrent, false);
     const updated = ensureOpenCodePluginInstalled(fixture.options);

--- a/packages/ts/memorax-code-opencode-adapter/test/plugin.test.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/test/plugin.test.mjs
@@ -5,6 +5,7 @@ import { delimiter, join } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { test } from "node:test";
 import { createMemoraxOpenCodePlugin } from "../src/plugin.mjs";
+import { OPENCODE_REPO_MEMORY_AGENT } from "../src/repo-memory-server-runner.mjs";
 
 test("chat.message retrieves memory and injects it into the system prompt", async () => {
   const requests = [];
@@ -193,6 +194,44 @@ test("chat.message ignores compaction-containing and synthetic-only messages", a
   assert.equal(requests.length, 0);
 });
 
+test("the managed Repo Memory agent is registered and isolated from prompt handling", async () => {
+  const requests = [];
+  let reminderCalls = 0;
+  const plugin = createMemoraxOpenCodePlugin({
+    backendConnection: { url: "http://127.0.0.1:8787" },
+    fetchImpl: responseSequence(requests, []),
+    memorySkillReminderEvaluator: async () => {
+      reminderCalls += 1;
+      return { additionalContext: "must not be injected" };
+    },
+  });
+  const hooks = await plugin(pluginInput());
+  const config = { agent: { existing: { description: "Keep me." } } };
+
+  await hooks.config(config);
+  const output = promptOutput("repo-memory-user", "Maintain Repo Memory");
+  await hooks["chat.message"]({
+    sessionID: "repo-memory-session",
+    agent: OPENCODE_REPO_MEMORY_AGENT,
+  }, output);
+
+  assert.deepEqual(config.agent.existing, { description: "Keep me." });
+  assert.deepEqual(config.agent[OPENCODE_REPO_MEMORY_AGENT], {
+    description: "Managed MemoraX Code Repo Memory maintenance agent.",
+    mode: "subagent",
+    permission: {
+      edit: "allow",
+      bash: "allow",
+      webfetch: "allow",
+      doom_loop: "allow",
+      external_directory: "allow",
+    },
+  });
+  assert.equal(reminderCalls, 0);
+  assert.equal(requests.length, 0);
+  assert.equal(output.message.system, undefined);
+});
+
 test("OpenCode forwards first-prompt and post-compaction reminders once", async () => {
   const memoraxCodeHome = await mkdtemp(join(tmpdir(), "memorax-code-opencode-reminder-"));
   const requests = [];
@@ -244,6 +283,7 @@ test("shell.env overwrites the OpenCode session identity and prepends the manage
       MEMORAX_CODE_MEMORY_CLI_TRACE_CLIENT: "codex",
       MEMORAX_CODE_MEMORY_CLI_TRACE_SESSION_ID: "old-session",
       MEMORAX_CODE_MEMORY_CLI_SESSION_ID: "old-session",
+      MEMORAX_CODE_OPENCODE_SERVER_URL: "http://127.0.0.1:1/",
       PATH: ["/usr/bin", "/bin"].join(delimiter),
     },
   };
@@ -253,6 +293,7 @@ test("shell.env overwrites the OpenCode session identity and prepends the manage
   assert.equal(output.env.MEMORAX_CODE_MEMORY_CLI_TRACE_CLIENT, "opencode");
   assert.equal(output.env.MEMORAX_CODE_MEMORY_CLI_TRACE_SESSION_ID, "session-2");
   assert.equal(output.env.MEMORAX_CODE_MEMORY_CLI_SESSION_ID, "session-2");
+  assert.equal(output.env.MEMORAX_CODE_OPENCODE_SERVER_URL, "http://127.0.0.1:4096/");
   assert.equal(output.env.PATH, [cliBinDir, "/usr/bin", "/bin"].join(delimiter));
 });
 
@@ -470,6 +511,7 @@ function pluginInput(overrides = {}) {
     project: { vcs: "git" },
     directory: "/repo/directory",
     worktree: "/repo/worktree",
+    serverUrl: new URL("http://127.0.0.1:4096"),
     ...overrides,
   };
 }

--- a/packages/ts/memorax-code-opencode-adapter/test/plugin.test.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/test/plugin.test.mjs
@@ -206,7 +206,16 @@ test("the managed Repo Memory agent is registered and isolated from prompt handl
     },
   });
   const hooks = await plugin(pluginInput());
-  const config = { agent: { existing: { description: "Keep me." } } };
+  const config = {
+    agent: {
+      existing: { description: "Keep me." },
+      [OPENCODE_REPO_MEMORY_AGENT]: {
+        description: "User-configured Repo Memory agent.",
+        disable: true,
+        permission: { bash: "deny" },
+      },
+    },
+  };
 
   await hooks.config(config);
   const output = promptOutput("repo-memory-user", "Maintain Repo Memory");
@@ -217,15 +226,11 @@ test("the managed Repo Memory agent is registered and isolated from prompt handl
 
   assert.deepEqual(config.agent.existing, { description: "Keep me." });
   assert.deepEqual(config.agent[OPENCODE_REPO_MEMORY_AGENT], {
-    description: "Managed MemoraX Code Repo Memory maintenance agent.",
+    description: "User-configured Repo Memory agent.",
     mode: "subagent",
-    permission: {
-      edit: "allow",
-      bash: "allow",
-      webfetch: "allow",
-      doom_loop: "allow",
-      external_directory: "allow",
-    },
+    hidden: true,
+    disable: true,
+    permission: { bash: "deny" },
   });
   assert.equal(reminderCalls, 0);
   assert.equal(requests.length, 0);

--- a/packages/ts/memorax-code-opencode-adapter/test/repo-memory-job-hook.test.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/test/repo-memory-job-hook.test.mjs
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { repoMemoryJobsDir } from "../../memorax-code-adapter-common/src/repo-memory/repo-memory-job-marker.mjs";
+
+const adapterRoot = fileURLToPath(new URL("..", import.meta.url));
+const jobHook = join(adapterRoot, "hooks", "repo-memory-job.mjs");
+
+test("OpenCode repo memory launcher uses the local server runner", () => {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), "opencode-repo-memory-job-")));
+  const repo = join(root, "repo");
+  const memoraxCodeHome = join(root, "memorax-code");
+  try {
+    const head = initRepo(repo);
+    const result = runJob(["start", "--mode", "build", "--repo", repo, "--dry-run"], {
+      MEMORAX_CODE_HOME: memoraxCodeHome,
+    });
+    assert.equal(result.status, 0, result.stderr);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.runner, "opencode");
+    assert.equal(payload.finalMessageSource, "stdout");
+    assert.equal(payload.snapshotHead, head);
+    assert.equal(dirname(dirname(payload.jobPath)), repoMemoryJobsDir(memoraxCodeHome));
+    assert.deepEqual(payload.command.slice(0, 4), [
+      process.execPath,
+      join(adapterRoot, "src", "repo-memory-server-runner.mjs"),
+      "--repo",
+      repo,
+    ]);
+    assert.equal(payload.command[4], "--prompt");
+    assert.match(payload.command[5], /the `memorax-code` skill/);
+    assert.match(payload.command[5], /repo-build operation/);
+    assert.match(payload.command[5], /authorized background repo-memory worker/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function runJob(args, env = {}) {
+  return spawnSync(process.execPath, [jobHook, ...args], {
+    encoding: "utf8",
+    env: { ...process.env, ...env },
+  });
+}
+
+function initRepo(repo) {
+  mkdirSync(repo, { recursive: true });
+  execFileSync("git", ["init", "--quiet"], { cwd: repo });
+  execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: repo });
+  execFileSync("git", ["config", "user.name", "Test User"], { cwd: repo });
+  writeFileSync(join(repo, "README.md"), "# fixture\n");
+  execFileSync("git", ["add", "README.md"], { cwd: repo });
+  execFileSync("git", ["commit", "--quiet", "-m", "initial"], { cwd: repo });
+  return execFileSync("git", ["rev-parse", "HEAD"], { cwd: repo, encoding: "utf8" }).trim();
+}

--- a/packages/ts/memorax-code-opencode-adapter/test/repo-memory-server-runner.test.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/test/repo-memory-server-runner.test.mjs
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import {
+  OPENCODE_REPO_MEMORY_AGENT,
+  runOpenCodeRepoMemory,
+} from "../src/repo-memory-server-runner.mjs";
+
+test("OpenCode repo memory runner creates, prompts, and deletes a background session", async () => {
+  const root = await mkdtemp(join(tmpdir(), "opencode-repo-memory-runner-"));
+  const requests = [];
+  const server = await startServer(async (request, response) => {
+    requests.push({
+      method: request.method,
+      url: request.url,
+      body: await requestBody(request),
+    });
+    if (request.method === "POST" && request.url.startsWith("/session?")) {
+      return json(response, 200, { id: "session-repo-memory" });
+    }
+    if (request.method === "POST" && request.url.startsWith("/session/session-repo-memory/message?")) {
+      return json(response, 200, {
+        info: { role: "assistant" },
+        parts: [
+          { type: "text", text: "Repo Memory updated." },
+          { type: "tool", tool: "write" },
+          { type: "text", text: "Validation passed." },
+        ],
+      });
+    }
+    if (request.method === "DELETE") return json(response, 200, true);
+    return json(response, 404, { message: "not found" });
+  });
+  try {
+    const result = await runOpenCodeRepoMemory({
+      serverUrl: server.url,
+      repo: root,
+      prompt: "Build Repo Memory.",
+    }, {
+      env: { MEMORAX_CODE_MEMORY_CLI_SESSION_ID: "parent-session" },
+    });
+
+    assert.equal(result, "Repo Memory updated.\n\nValidation passed.");
+    assert.equal(requests.length, 3);
+    assert.deepEqual(requests.map((request) => request.method), ["POST", "POST", "DELETE"]);
+    for (const request of requests) {
+      assert.equal(new URL(request.url, server.url).searchParams.get("directory"), root);
+    }
+    assert.deepEqual(JSON.parse(requests[0].body), {
+      parentID: "parent-session",
+      title: "MemoraX Code Repo Memory",
+    });
+    assert.deepEqual(JSON.parse(requests[1].body), {
+      agent: OPENCODE_REPO_MEMORY_AGENT,
+      parts: [{ type: "text", text: "Build Repo Memory." }],
+    });
+  } finally {
+    await server.close();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("OpenCode repo memory runner preserves prompt failures and still deletes the session", async () => {
+  const root = await mkdtemp(join(tmpdir(), "opencode-repo-memory-failure-"));
+  let deleted = false;
+  const server = await startServer(async (request, response) => {
+    if (request.method === "POST" && request.url.startsWith("/session?")) {
+      return json(response, 200, { id: "session-failure" });
+    }
+    if (request.method === "POST") {
+      return json(response, 500, { message: "model unavailable" });
+    }
+    deleted = true;
+    return json(response, 500, { message: "cleanup failed" });
+  });
+  try {
+    await assert.rejects(
+      runOpenCodeRepoMemory({
+        serverUrl: server.url,
+        repo: root,
+        prompt: "Build Repo Memory.",
+      }),
+      /OpenCode blocking prompt failed with HTTP 500: model unavailable/,
+    );
+    assert.equal(deleted, true);
+  } finally {
+    await server.close();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+async function startServer(handler) {
+  const server = createServer((request, response) => {
+    void handler(request, response);
+  });
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  return {
+    url: `http://127.0.0.1:${address.port}`,
+    close: () => new Promise((resolve, reject) => {
+      server.close((error) => error ? reject(error) : resolve());
+    }),
+  };
+}
+
+function requestBody(request) {
+  return new Promise((resolve, reject) => {
+    let body = "";
+    request.setEncoding("utf8");
+    request.on("data", (chunk) => { body += chunk; });
+    request.on("end", () => resolve(body));
+    request.on("error", reject);
+  });
+}
+
+function json(response, status, body) {
+  response.writeHead(status, { "content-type": "application/json" });
+  response.end(JSON.stringify(body));
+}

--- a/packages/ts/memorax-code-opencode-adapter/test/repo-memory-server-runner.test.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/test/repo-memory-server-runner.test.mjs
@@ -12,12 +12,17 @@ import {
 test("OpenCode repo memory runner creates, prompts, and deletes a background session", async () => {
   const root = await mkdtemp(join(tmpdir(), "opencode-repo-memory-runner-"));
   const requests = [];
+  const authorization = `Basic ${Buffer.from("memorax-user: secret ").toString("base64")}`;
   const server = await startServer(async (request, response) => {
     requests.push({
       method: request.method,
       url: request.url,
+      authorization: request.headers.authorization,
       body: await requestBody(request),
     });
+    if (request.headers.authorization !== authorization) {
+      return json(response, 401, { message: "unauthorized" });
+    }
     if (request.method === "POST" && request.url.startsWith("/session?")) {
       return json(response, 200, { id: "session-repo-memory" });
     }
@@ -40,12 +45,22 @@ test("OpenCode repo memory runner creates, prompts, and deletes a background ses
       repo: root,
       prompt: "Build Repo Memory.",
     }, {
-      env: { MEMORAX_CODE_MEMORY_CLI_SESSION_ID: "parent-session" },
+      env: {
+        MEMORAX_CODE_MEMORY_CLI_SESSION_ID: "parent-session",
+        MEMORAX_CODE_OPENCODE_SERVER_URL: server.url,
+        OPENCODE_SERVER_USERNAME: "memorax-user",
+        OPENCODE_SERVER_PASSWORD: " secret ",
+      },
     });
 
     assert.equal(result, "Repo Memory updated.\n\nValidation passed.");
     assert.equal(requests.length, 3);
     assert.deepEqual(requests.map((request) => request.method), ["POST", "POST", "DELETE"]);
+    assert.deepEqual(requests.map((request) => request.authorization), [
+      authorization,
+      authorization,
+      authorization,
+    ]);
     for (const request of requests) {
       assert.equal(new URL(request.url, server.url).searchParams.get("directory"), root);
     }

--- a/packages/ts/memorax-code-opencode-adapter/test/repo-memory-server-runner.test.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/test/repo-memory-server-runner.test.mjs
@@ -67,6 +67,13 @@ test("OpenCode repo memory runner creates, prompts, and deletes a background ses
     assert.deepEqual(JSON.parse(requests[0].body), {
       parentID: "parent-session",
       title: "MemoraX Code Repo Memory",
+      permission: [
+        { permission: "edit", pattern: "*", action: "allow" },
+        { permission: "bash", pattern: "*", action: "allow" },
+        { permission: "webfetch", pattern: "*", action: "allow" },
+        { permission: "doom_loop", pattern: "*", action: "allow" },
+        { permission: "external_directory", pattern: "*", action: "allow" },
+      ],
     });
     assert.deepEqual(JSON.parse(requests[1].body), {
       agent: OPENCODE_REPO_MEMORY_AGENT,

--- a/scripts/build-npm-packages.mjs
+++ b/scripts/build-npm-packages.mjs
@@ -178,6 +178,8 @@ async function validateStaging(packageRoot) {
     "lib/memorax-code-claude-marketplace/plugins/memorax-code-claude-adapter/memorax-code-adapter-common/src/hooks/ensure-backend-runner.mjs",
     "lib/memorax-code-opencode-adapter/src/plugin.mjs",
     "lib/memorax-code-opencode-adapter/src/plugin-install.mjs",
+    "lib/memorax-code-opencode-adapter/src/repo-memory-server-runner.mjs",
+    "lib/memorax-code-opencode-adapter/hooks/repo-memory-job.mjs",
     "lib/memorax-code-opencode-adapter/skills/memorax-code/SKILL.md",
   ]) {
     if (!(await stat(join(packageRoot, requiredPath)).catch(() => undefined))?.isFile()) {

--- a/scripts/check-local-trace-only.mjs
+++ b/scripts/check-local-trace-only.mjs
@@ -52,6 +52,7 @@ const reviewedNetworkSources = new Set([
   "packages/ts/memorax-code-codex-adapter/src/cli.mjs",
   "packages/ts/memorax-code-codex-adapter/skills/memorax-code/scripts/detect_updates.py",
   "packages/ts/memorax-code-opencode-adapter/src/plugin.mjs",
+  "packages/ts/memorax-code-opencode-adapter/src/repo-memory-server-runner.mjs",
 ]);
 
 const localTraceCoreSources = new Set([

--- a/scripts/npm-package-check.sh
+++ b/scripts/npm-package-check.sh
@@ -153,6 +153,8 @@ for relative in [
     "lib/memorax-code-claude-marketplace/plugins/memorax-code-claude-adapter/skills/memorax-code/SKILL.md",
     "lib/memorax-code-opencode-adapter/src/plugin.mjs",
     "lib/memorax-code-opencode-adapter/src/plugin-install.mjs",
+    "lib/memorax-code-opencode-adapter/src/repo-memory-server-runner.mjs",
+    "lib/memorax-code-opencode-adapter/hooks/repo-memory-job.mjs",
     "lib/memorax-code-opencode-adapter/skills/memorax-code/SKILL.md",
     "lib/memorax-code-backend/dist/service-entrypoint.js",
     "lib/memorax-code-backend/dist/memorax-cli.js",
@@ -320,6 +322,8 @@ for relative in \
   lib/memorax-code-claude-marketplace/plugins/memorax-code-claude-adapter/skills/memorax-code/SKILL.md \
   lib/memorax-code-opencode-adapter/src/plugin.mjs \
   lib/memorax-code-opencode-adapter/src/plugin-install.mjs \
+  lib/memorax-code-opencode-adapter/src/repo-memory-server-runner.mjs \
+  lib/memorax-code-opencode-adapter/hooks/repo-memory-job.mjs \
   lib/memorax-code-opencode-adapter/skills/memorax-code/SKILL.md
 do
   test -f "$package_install_root/$relative"
@@ -378,8 +382,10 @@ assert current_path.stat().st_mode & 0o777 == 0o600
 opencode_config = Path(sys.argv[1]) / ".config" / "opencode-memorax-code-package-check"
 assert (opencode_config / "plugins" / "memorax-code.js").is_file()
 assert (opencode_config / "skills" / "memorax-code" / "SKILL.md").is_file()
+assert (opencode_config / "hooks" / "repo-memory-job.mjs").is_file()
 opencode_state = json.loads((home / ".memorax-code" / "adapters" / "opencode" / "state.json").read_text())
 assert opencode_state["enabled"] is True
+assert Path(opencode_state["repoMemoryHelperPath"]) == opencode_config / "hooks" / "repo-memory-job.mjs"
 PY_POSTINSTALL
 
 "$prefix/bin/memorax-code" stop \

--- a/scripts/npm-source-files.mjs
+++ b/scripts/npm-source-files.mjs
@@ -19,6 +19,10 @@ export const npmMainSourceTrees = Object.freeze([
     destination: "lib/memorax-code-opencode-adapter/src",
   },
   {
+    source: "packages/ts/memorax-code-opencode-adapter/hooks",
+    destination: "lib/memorax-code-opencode-adapter/hooks",
+  },
+  {
     source: "packages/ts/memorax-code-codex-adapter/skills/memorax-code",
     destination: "lib/memorax-code-claude-adapter/skills/memorax-code",
   },


### PR DESCRIPTION
## Change Summary

Add supervised Repo Memory maintenance to OpenCode so an explicit `repo-read` can build or update repository memory in the background through the local OpenCode server.

## Implementation Highlights

- Install a managed Repo Memory helper that reuses the shared supervisor, validation, deduplication, and update policy.
- Run maintenance in a temporary OpenCode session with a dedicated subagent, isolate it from normal retrieval/reminder/writeback handling, and clean up the session afterward.
- Carry the local OpenCode server URL and parent session identity into the helper flow, while preserving the existing managed installation, rollback, conflict, status, and uninstall contracts.
- Include the helper and runner in npm staging and document the on-demand maintenance boundary without changing the README files or adding first-prompt initialization.

## Validation

- `npm test --prefix packages/ts/memorax-code-opencode-adapter`: 25 passed
- `make npm-package-check`: 170 passed; local-only trace contract and 321-file package allowlist passed
- `make docs-check`: 10 passed; documentation and README sync contracts passed
- `git diff --cached --check`

## Full End-to-End Validation Results

- Environment: macOS development worktree
- Scenario or matrix: Managed helper installation, on-demand job launch, OpenCode session create/prompt/delete flow, dedicated-agent isolation, package staging, and uninstall safety
- Command or workflow: Commands listed in Validation
- Result: All focused and package lifecycle checks passed
- Evidence or artifacts: Redacted command results are summarized above; no screenshots are included for this intermediate PR
- Reason not run / remaining risk: A real OpenCode model-backed E2E is deferred to the final full-stack OpenCode PR so the complete integrated flow is validated once; this PR validates the local HTTP runner with an isolated server fixture
