### PR TITLE
feat: initialize missing Repo Memory in OpenCode

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -94,7 +94,7 @@ relationships; the arrow labels distinguish them. It is not an import graph.
 | `packages/ts/memorax-code-adapter-common` | Shared source for Backend connection authority, private runtime records, cross-process locking and configuration, Hook generations, Hook launch helpers, and Repo/Personal Memory helpers | Backend composition, native transcript interpretation, MemoraX request execution, or client plugin policy | `packages/ts/memorax-code-adapter-common/src/backend-connection.mjs`, `src/runtime-record.mjs`, `src/hooks`, and `src/repo-memory` |
 | `packages/ts/memorax-code-codex-adapter` | Codex plugin artifact, Hook shells and runtimes, session/workspace observation, diagnostics, and the canonical shared skill | Codex rollout semantics or Backend-side writeback authority | `.codex-plugin`, `hooks`, `runtime-hooks`, `src`, and `skills/memorax-code` |
 | `packages/ts/memorax-code-claude-adapter` | Claude Code plugin artifact, Hook shells and runtimes, configuration, installer, marketplace source, and diagnostics | Claude transcript semantics or Backend memory orchestration | `.claude-plugin`, `hooks`, `runtime-hooks`, `scripts`, and `src/plugin-install.mjs` |
-| `packages/ts/memorax-code-opencode-adapter` | OpenCode plugin runtime, managed thin-loader installation, automatic retrieval, SDK-backed writeback, shell-session identity, workspace runtime evidence and diagnostics, a materialized shared skill, and supervised repo-read maintenance | OpenCode message interpretation inside the Backend or model-provider configuration | `src/plugin.mjs`, `src/plugin-install.mjs`, `src/cli.mjs`, and the OpenCode materialization mapping in `scripts/npm-source-files.mjs` |
+| `packages/ts/memorax-code-opencode-adapter` | OpenCode plugin runtime, managed thin-loader installation, automatic retrieval, SDK-backed writeback, shell-session identity, workspace runtime evidence and diagnostics, a materialized shared skill, and supervised Repo Memory maintenance and missing-bundle initialization | OpenCode message interpretation inside the Backend or model-provider configuration | `src/plugin.mjs`, `src/plugin-install.mjs`, `src/cli.mjs`, `src/repo-memory-server-runner.mjs`, and the OpenCode materialization mapping in `scripts/npm-source-files.mjs` |
 | `packages/npm/memorax-code` | Installed executable wrappers, update, preinstall/postinstall, npm manifest, and release-package source | Backend lifecycle semantics, uninstall orchestration, or artifact staging | `bin`, `lib/run-entrypoint.mjs`, and `package.json` |
 | `scripts` | Backend build orchestration, staging/materialization, package layout, documentation, and local-only data gates | Product runtime authority | Package-build/check scripts and executable contract scripts |
 | `.github` | Issue and pull-request contribution templates | Product runtime behavior | `.github/ISSUE_TEMPLATE` and `.github/pull_request_template.md` |
@@ -334,11 +334,13 @@ sequenceDiagram
 ### 3.5 Repo Memory coordination
 
 Repo Memory is repository-local guidance under `.repo_memory`, not a MemoraX
-provider response. A turn-start result exposes a worktree to adapter Hooks only
-for a verified Git scope; the Viewer separately projects Repo Memory readiness.
-Adapter Hooks may schedule a missing bundle build using adapter-common
-supervision, locking, and job-policy helpers. They must use the
-Backend-resolved worktree rather than an arbitrary Hook `cwd`.
+provider response. In all three clients, an accepted turn-start result exposes
+a worktree to the maintenance-aware adapter integration only for a verified
+Git scope; the Viewer separately projects Repo Memory readiness. Codex and
+Claude Code Hooks and OpenCode's awaited `chat.message` handler may schedule a
+missing bundle build using adapter-common supervision, locking, and job-policy
+helpers. They must use the Backend-resolved worktree rather than adapter-local
+workspace input.
 
 Codex and OpenCode keep the generic shared Skill reminder available when the
 Backend or repository scope is unavailable. Their User Profile and Procedure
@@ -349,10 +351,10 @@ it is not repository-local content authority.
 
 A relevant repo-read can invoke supervised maintenance in all three clients.
 The runner validates the bundle and selects a background build, update, or
-no-op according to policy. OpenCode supports this on-demand path through the
-shared skill, but does not yet initialize a missing bundle automatically on the
-first prompt. Its automatic plugin runtime otherwise covers prompt retrieval,
-shared reminder injection, and completed-turn writeback.
+no-op according to policy. For OpenCode, both on-demand maintenance and
+first-eligible-prompt initialization run through a short-lived subagent session
+on the active OpenCode server; Desktop-only installations do not require a
+standalone OpenCode CLI.
 
 ## 4. Backend Modular Monolith
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -46,7 +46,8 @@ Please allow time for triage and remediation before public disclosure.
   commands fail open without starting a process.
 - Initial Repo Memory builds use only the Git worktree returned by an
   authenticated Backend turn-start request. Backend or workspace-scope
-  failures skip the build; client Hooks do not fall back to their local `cwd`.
+  failures skip the build; client integrations do not fall back to
+  adapter-local workspace input.
 - Codex and OpenCode read repository-local User Profile and Procedure Memory
   only from the worktree authorized by the current Backend turn-start result.
   Without that authority they keep only the generic Skill reminder and do not

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -236,17 +236,16 @@ Supported policies are `every-commit`, `commit-count`, `daily`,
 `pull-request`, `pull-request-or-daily`, and `adaptive`. Invalid policy values
 fall back to `adaptive`.
 
-In Codex and Claude Code, the first eligible prompt starts a background build
-only when the Backend has authorized a Git worktree and that worktree has no
-`.repo_memory/PROFILE.md`. If the Backend or workspace authority is
-unavailable, the Hook skips the initial build instead of falling back to its
-local `cwd`.
+In Codex, Claude Code, and OpenCode, the first eligible prompt starts a
+background build only when the Backend has authorized a Git worktree and that
+worktree has no `.repo_memory/PROFILE.md`. If the Backend or workspace
+authority is unavailable, the client integration skips that attempt instead
+of falling back to its local workspace path.
 
-OpenCode runs supervised background maintenance when the installed skill
-selects repo-read. The configured policy may select a build, update, or no-op.
-OpenCode does not yet initialize a missing bundle automatically on the first
-prompt. Its automatic integration otherwise covers retrieval, shared reminder
-and personal-memory context injection, and completed-turn writeback.
+A relevant repo-read runs supervised maintenance in all three clients. The
+configured policy may select a build, update, or no-op. OpenCode executes the
+job through its active local server. Desktop-only installations do not require
+a standalone `opencode` executable in `PATH`.
 
 ## Local traces
 

--- a/packages/ts/memorax-code-adapter-common/src/repo-memory/repo-memory-auto-build.mjs
+++ b/packages/ts/memorax-code-adapter-common/src/repo-memory/repo-memory-auto-build.mjs
@@ -11,10 +11,10 @@ export function scheduleMissingRepoMemoryBuild(repo, options = {}) {
 
     const jobHookPath = join(pluginRoot, "hooks", "repo-memory-job.mjs");
     if (!existsSync(jobHookPath)) return false;
-    const child = spawn(process.execPath, [jobHookPath, "maintain", "--repo", repoPath], {
+    const child = spawn(options.nodePath ?? process.execPath, [jobHookPath, "maintain", "--repo", repoPath], {
       cwd: repoPath,
       detached: true,
-      env: process.env,
+      env: options.env ?? process.env,
       stdio: "ignore",
       windowsHide: true,
     });

--- a/packages/ts/memorax-code-opencode-adapter/src/plugin.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/src/plugin.mjs
@@ -9,6 +9,7 @@ import {
   markSupplementalReminderForSession,
   personalMemoryReminderContext,
 } from "../../memorax-code-adapter-common/src/hooks/memory-skill-reminder-hook.mjs";
+import { scheduleMissingRepoMemoryBuild } from "../../memorax-code-adapter-common/src/repo-memory/repo-memory-auto-build.mjs";
 import { buildRepoProcedureMemoryContext } from "../../memorax-code-adapter-common/src/repo-memory/repo-procedure-memory-context.mjs";
 import { buildRepoUserProfilePreferencesContext } from "../../memorax-code-adapter-common/src/repo-memory/repo-user-profile-context.mjs";
 import { OPENCODE_REPO_MEMORY_AGENT } from "./repo-memory-server-runner.mjs";
@@ -188,6 +189,16 @@ export function createMemoraxOpenCodePlugin(options = {}) {
           }, TURN_START_TIMEOUT_MS);
           turnStartAccepted = true;
           if (!pluginEnabled(options)) return;
+          repositoryWorktree = stringValue(result?.repoMemoryWorktree);
+          const repoMemoryEnv = openCodeRepoMemoryEnv(options, openCodeServerUrl, sessionId);
+          if (repoMemoryEnv) {
+            scheduleMissingRepoMemoryBuild(repositoryWorktree, {
+              debugEnv: "MEMORAX_CODE_OPENCODE_PLUGIN_DEBUG",
+              pluginRoot: options.openCodeConfigDir,
+              env: repoMemoryEnv,
+              nodePath: options.nodePath,
+            });
+          }
           const turn = { sessionId, userMessageId };
           pendingTurns.set(turnKey(turn), turn);
           while (pendingTurns.size > MAX_PENDING_TURNS) {
@@ -196,7 +207,6 @@ export function createMemoraxOpenCodePlugin(options = {}) {
             pendingTurns.delete(oldest);
           }
           retrievalContext = stringValue(result?.additionalContext);
-          repositoryWorktree = stringValue(result?.repoMemoryWorktree);
         } catch (error) {
           debug(options, "opencode turn start failed", error);
         }
@@ -367,6 +377,17 @@ function urlString(value) {
   } catch {
     return undefined;
   }
+}
+
+function openCodeRepoMemoryEnv(options, serverUrl, sessionId) {
+  const memoraxCodeHome = stringValue(options.memoraxCodeHome);
+  if (!memoraxCodeHome || !serverUrl) return undefined;
+  return {
+    ...process.env,
+    MEMORAX_CODE_HOME: memoraxCodeHome,
+    MEMORAX_CODE_MEMORY_CLI_SESSION_ID: sessionId,
+    MEMORAX_CODE_OPENCODE_SERVER_URL: serverUrl,
+  };
 }
 
 function positiveInteger(value, fallback) {

--- a/packages/ts/memorax-code-opencode-adapter/test/plugin.test.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/test/plugin.test.mjs
@@ -71,6 +71,62 @@ test("repo-scoped reminder builders require a Backend-authorized worktree", asyn
   ]);
 });
 
+test("chat.message starts missing Repo Memory for the Backend-authorized worktree", async () => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-code-opencode-auto-build-"));
+  const nodePath = process.execPath;
+  const backendRepo = join(root, "backend-repo");
+  const pluginWorktree = join(root, "plugin-worktree");
+  const memoraxCodeHome = join(root, "memorax-code-home");
+  const openCodeConfigDir = join(root, "opencode-config");
+  const jobLog = join(root, "repo-memory-job.json");
+  let hooks;
+  try {
+    await Promise.all([
+      mkdir(backendRepo, { recursive: true }),
+      mkdir(pluginWorktree, { recursive: true }),
+      mkdir(join(openCodeConfigDir, "hooks"), { recursive: true }),
+    ]);
+    await writeFile(join(openCodeConfigDir, "hooks", "repo-memory-job.mjs"), [
+      'import { writeFileSync } from "node:fs";',
+      `writeFileSync(${JSON.stringify(jobLog)}, JSON.stringify({`,
+      "  args: process.argv.slice(2),",
+      "  cwd: process.cwd(),",
+      "  memoraxCodeHome: process.env.MEMORAX_CODE_HOME,",
+      "  parentSessionId: process.env.MEMORAX_CODE_MEMORY_CLI_SESSION_ID,",
+      "  serverUrl: process.env.MEMORAX_CODE_OPENCODE_SERVER_URL,",
+      "}));",
+      "",
+    ].join("\n"));
+    const plugin = createPluginWithoutReminders({
+      memoraxCodeHome,
+      openCodeConfigDir,
+      nodePath,
+      backendConnection: { url: "http://127.0.0.1:8787" },
+      fetchImpl: responseSequence([], [{ ok: true, repoMemoryWorktree: backendRepo }]),
+    });
+    process.execPath = join(root, "opencode");
+    hooks = await plugin(pluginInput({ directory: pluginWorktree, worktree: pluginWorktree }));
+
+    await hooks["chat.message"](
+      { sessionID: "session-auto-build" },
+      promptOutput("user-auto-build", "Build missing Repo Memory."),
+    );
+
+    await waitForFile(jobLog);
+    assert.deepEqual(JSON.parse(await readFile(jobLog, "utf8")), {
+      args: ["maintain", "--repo", backendRepo],
+      cwd: await realpath(backendRepo),
+      memoraxCodeHome,
+      parentSessionId: "session-auto-build",
+      serverUrl: "http://127.0.0.1:4096/",
+    });
+  } finally {
+    process.execPath = nodePath;
+    await hooks?.dispose();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("managed plugin starts the Backend once and bounds prompt waiting", async () => {
   const root = await mkdtemp(join(tmpdir(), "memorax-code-opencode-backend-start-"));
   const nodePath = process.execPath;


### PR DESCRIPTION
## Change Summary

Initialize a missing Repo Memory bundle in the background from the first eligible OpenCode prompt, bringing the automatic initialization path in line with Codex and Claude Code.

## Implementation Highlights

- Schedule the existing supervised Repo Memory maintainer only after Backend turn-start accepts the prompt and returns an authorized Git worktree.
- Pass the active OpenCode server URL, parent session ID, and exact MemoraX Code home to the background job without falling back to the plugin workspace.
- Launch the helper with the Node runtime recorded by the managed OpenCode installation, avoiding OpenCode or Bun process executables.
- Preserve existing bundle checks, job deduplication, repo-read maintenance, and README scope while updating architecture, configuration, and security documentation.

## Validation

- npm test --prefix packages/ts/memorax-code-opencode-adapter: 28 passed
- Focused Codex Repo Memory auto-build test: 1 passed
- Focused Claude Code authorized-worktree auto-build test: 1 passed
- make npm-package-check: 170 passed; local-only trace contract and 324-file package allowlist passed
- make docs-check: 10 passed; documentation and README sync contracts passed
- git diff --check

## Full End-to-End Validation Results

- Environment: macOS development worktree
- Scenario or matrix: First eligible OpenCode prompt with a Backend-authorized Git worktree and no Repo Memory profile
- Command or workflow: OpenCode plugin integration test plus npm package staging and lifecycle checks
- Result: The plugin launched the existing supervised maintainer with the authorized worktree, active server URL, parent session, exact state home, and managed Node runtime
- Evidence or artifacts: Redacted automated results are summarized above
- Reason not run / remaining risk: A real model-backed OpenCode E2E is deferred to the final full-stack OpenCode validation so the integrated flow is exercised once after the remaining PRs land