### PR TITLE
feat: finalize interrupted OpenCode turns

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -316,13 +316,15 @@ sequenceDiagram
   occur later through the automatic writeback runtime.
 - Buffering and chunking belong to the memory capability; rollout, transcript,
   and SDK message parsing remains client-specific.
-- OpenCode writeback accepts only the matching SDK user and completed assistant
-  records for the correlated session and parent message. It rejects errored,
-  summary, compaction, incomplete, or identity-mismatched messages and does not
-  fall back to plugin prompt text or local database guesses.
-- Because OpenCode completion notification is an event callback, the plugin
-  tracks idle-triggered SDK and writeback work and drains already-started tasks
-  during plugin disposal.
+- OpenCode terminal handling accepts only matching SDK user and completed
+  assistant records for the correlated session and parent message. An exact
+  `MessageAbortedError` closes the Turn as interrupted without writeback; other
+  errors, summary, compaction, incomplete, or identity-mismatched messages are
+  rejected. It does not fall back to plugin prompt text or local database
+  guesses.
+- Because OpenCode terminal notifications are event callbacks, the plugin
+  serializes idle- and interruption-triggered SDK reads per session, tracks
+  the resulting work, and drains already-started tasks during plugin disposal.
 - When a degraded direct-`.git` scope upgrades to verified Git scope, the
   buffer runtime cancels and discards pending fallback turns for the same
   client and session before buffering under the Git scope. It does not migrate

--- a/packages/ts/memorax-code-backend/src/clients/opencode/memory-hook-runtime.ts
+++ b/packages/ts/memorax-code-backend/src/clients/opencode/memory-hook-runtime.ts
@@ -37,6 +37,7 @@ import {
 
 export type OpenCodeMemoryHookWritebackSkipReason =
   | "turn_metadata_mismatch"
+  | "interrupted"
   | "config_missing"
   | OpenCodeMessageTurnFailureReason
   | RepositoryMemoryScopeFailureReason
@@ -195,6 +196,52 @@ export function createOpenCodeMemoryHookRuntime(
         });
         return { ok: true, scheduled: false, reason: materialized.reason };
       }
+      if (materialized.turn.outcome === "interrupted") {
+        if (!entry) {
+          options.diagnosticLogger?.("opencode_memory.writeback", {
+            scheduled: false,
+            reason: "turn_metadata_mismatch",
+            sessionId: command.sessionId,
+            userMessageId: command.userMessageId,
+            assistantMessageId: command.assistantMessageId,
+          });
+          return { ok: true, scheduled: false, reason: "turn_metadata_mismatch" };
+        }
+        const traceContext = entry.traceContext;
+        await recordTraceBestEffort("opencode_memory.interrupted_turn_end_event", recordTraceEvent({
+          eventId: traceTurnEventId(traceContext, "turn_end"),
+          memoraxCodeHome: options.memoraxCodeHome,
+          env: options.env,
+          traceContext,
+          type: "turn_end",
+          source: "opencode-plugin",
+          operation: "reply",
+          ok: true,
+          outcome: "interrupted",
+          response: {
+            assistantMessage: materialized.turn.assistantReply,
+          },
+        }), options.diagnosticLogger);
+        await recordTraceBestEffort(
+          "opencode_memory.interrupted_current_turn_close",
+          markCurrentTraceTurnOutcome(traceContext, "interrupted", {
+            client: "opencode",
+            memoraxCodeHome: options.memoraxCodeHome,
+            env: options.env,
+          }),
+          options.diagnosticLogger,
+        );
+        turnCoordinator.discardTurn(key, "interrupted");
+        options.diagnosticLogger?.("opencode_memory.writeback", {
+          scheduled: false,
+          reason: "interrupted",
+          metadataDisposition: "consumed",
+          sessionId: command.sessionId,
+          userMessageId: command.userMessageId,
+          assistantMessageId: command.assistantMessageId,
+        });
+        return { ok: true, scheduled: false, reason: "interrupted" };
+      }
       const traceContext = entry?.traceContext
         ?? traceContextFromOpenCodeHookBody(command, new Date(now()).toISOString());
       await recordTraceBestEffort("opencode_memory.turn_end_event", recordTraceEvent({
@@ -206,7 +253,7 @@ export function createOpenCodeMemoryHookRuntime(
         source: "opencode-plugin",
         operation: "writeback",
         ok: true,
-        outcome: "completed",
+        outcome: materialized.turn.outcome,
         response: {
           content: materialized.turn.assistantReply,
         },

--- a/packages/ts/memorax-code-backend/src/clients/opencode/message-turn.ts
+++ b/packages/ts/memorax-code-backend/src/clients/opencode/message-turn.ts
@@ -6,6 +6,7 @@ export type OpenCodeMessageTurn = Readonly<{
   assistantMessageId: string;
   userPrompt: string;
   assistantReply: string;
+  outcome: "completed" | "interrupted";
 }>;
 
 export type OpenCodeMessageTurnFailureReason =
@@ -50,7 +51,9 @@ export function openCodeMessageTurn(
   if (!Number.isFinite(assistantTime?.completed)) {
     return { ok: false, reason: "assistant_not_completed" };
   }
-  if (assistant.info.error !== undefined && assistant.info.error !== null) {
+  const assistantError = assistant.info.error;
+  const interrupted = isRecord(assistantError) && assistantError.name === "MessageAbortedError";
+  if (assistantError !== undefined && assistantError !== null && !interrupted) {
     return { ok: false, reason: "assistant_error" };
   }
   if (assistant.info.summary === true) {
@@ -62,7 +65,7 @@ export function openCodeMessageTurn(
   const userPrompt = messageText(user, input.sessionId, input.userMessageId);
   if (!userPrompt) return { ok: false, reason: "user_prompt_missing" };
   const assistantReply = messageText(assistant, input.sessionId, input.assistantMessageId);
-  if (!assistantReply) return { ok: false, reason: "assistant_message_missing" };
+  if (!assistantReply && !interrupted) return { ok: false, reason: "assistant_message_missing" };
   return {
     ok: true,
     turn: {
@@ -71,6 +74,7 @@ export function openCodeMessageTurn(
       assistantMessageId: input.assistantMessageId,
       userPrompt,
       assistantReply,
+      outcome: interrupted ? "interrupted" : "completed",
     },
   };
 }

--- a/packages/ts/memorax-code-backend/test/clients/opencode/opencode-memory-hook.test.mjs
+++ b/packages/ts/memorax-code-backend/test/clients/opencode/opencode-memory-hook.test.mjs
@@ -1,11 +1,12 @@
 import assert from "node:assert/strict";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
 import { createOpenCodeMemoryHookRuntime } from "../../../dist/clients/opencode/memory-hook-runtime.js";
 import { openCodeMessageTurn } from "../../../dist/clients/opencode/message-turn.js";
+import { openCodeTracePaths } from "../../../dist/trace/config.js";
 import {
   parseTurnStartCommand,
   parseWritebackCommand,
@@ -63,6 +64,7 @@ test("OpenCode SDK messages materialize only an exact completed normal turn", ()
       assistantMessageId: "assistant-1",
       userPrompt: "OpenCode user prompt.",
       assistantReply: "OpenCode assistant reply.",
+      outcome: "completed",
     },
   });
 
@@ -78,11 +80,30 @@ test("OpenCode SDK messages materialize only an exact completed normal turn", ()
     assistantMessageId: "assistant-1",
   }), valid, "user diff summary remains eligible for writeback");
 
+  const interrupted = openCodeMessages();
+  interrupted[1].info.error = { name: "MessageAbortedError" };
+  interrupted[1].parts = [];
+  assert.deepEqual(openCodeMessageTurn(interrupted, {
+    sessionId: "session-1",
+    userMessageId: "user-1",
+    assistantMessageId: "assistant-1",
+  }), {
+    ok: true,
+    turn: {
+      sessionId: "session-1",
+      userMessageId: "user-1",
+      assistantMessageId: "assistant-1",
+      userPrompt: "OpenCode user prompt.",
+      assistantReply: "",
+      outcome: "interrupted",
+    },
+  });
+
   for (const [name, mutate, reason] of [
     ["parent mismatch", (messages) => { messages[1].info.parentID = "other-user"; }, "message_identity_mismatch"],
     ["session mismatch", (messages) => { messages[1].info.sessionID = "other-session"; }, "message_identity_mismatch"],
     ["incomplete assistant", (messages) => { delete messages[1].info.time.completed; }, "assistant_not_completed"],
-    ["assistant error", (messages) => { messages[1].info.error = { name: "MessageAbortedError" }; }, "assistant_error"],
+    ["other assistant error", (messages) => { messages[1].info.error = { name: "UnknownError" }; }, "assistant_error"],
     ["summary assistant", (messages) => { messages[1].info.summary = true; }, "summary_message"],
     ["compaction turn", (messages) => { messages[0].parts.push(part("compaction", "user-1")); }, "compaction_message"],
   ]) {
@@ -93,6 +114,64 @@ test("OpenCode SDK messages materialize only an exact completed normal turn", ()
       userMessageId: "user-1",
       assistantMessageId: "assistant-1",
     }), { ok: false, reason }, name);
+  }
+});
+
+test("OpenCode finalizes an explicit MessageAbortedError without writeback", async () => {
+  const memoraxCodeHome = await mkdtemp(join(tmpdir(), "memorax-code-opencode-interrupted-"));
+  const writebacks = [];
+  const runtime = createOpenCodeMemoryHookRuntime({
+    automaticWriteback: (input) => {
+      writebacks.push(input);
+      return { accepted: true };
+    },
+    memoraxCodeHome,
+    env: {
+      MEMORAX_CODE_HOME: memoraxCodeHome,
+      MEMORAX_CODE_MEMORY_RETRIEVAL_ENABLED: "false",
+      MEMORAX_CODE_OPENCODE_TRACE_ENABLED: "true",
+    },
+  });
+  try {
+    await runtime.recordTurnStart({
+      version: 1,
+      client: "opencode",
+      sessionId: "session-1",
+      userMessageId: "user-1",
+      prompt: "OpenCode user prompt.",
+      cwd: TEST_WORKSPACE,
+      workspaceKind: "project",
+    });
+
+    const messages = openCodeMessages();
+    messages[1].info.error = { name: "MessageAbortedError" };
+    messages[1].parts = [];
+    assert.deepEqual(await runtime.writeback({
+      version: 1,
+      client: "opencode",
+      sessionId: "session-1",
+      userMessageId: "user-1",
+      assistantMessageId: "assistant-1",
+      messages,
+      cwd: TEST_WORKSPACE,
+      workspaceKind: "project",
+    }), { ok: true, scheduled: false, reason: "interrupted" });
+
+    assert.equal(runtime.size(), 0);
+    assert.equal(writebacks.length, 0);
+    const paths = openCodeTracePaths(memoraxCodeHome);
+    const events = (await readFile(paths.eventsJsonl("session-1"), "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    assert.deepEqual(events.map(({ type, outcome }) => ({ type, outcome })), [
+      { type: "turn_start", outcome: undefined },
+      { type: "turn_end", outcome: "interrupted" },
+    ]);
+    assert.equal(JSON.parse(await readFile(paths.currentTurnPath, "utf8")).turn_state, "interrupted");
+  } finally {
+    runtime.close();
+    await rm(memoraxCodeHome, { recursive: true, force: true });
   }
 });
 

--- a/packages/ts/memorax-code-opencode-adapter/src/plugin.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/src/plugin.mjs
@@ -34,6 +34,7 @@ export function createMemoraxOpenCodePlugin(options = {}) {
     const workspaceKind = project?.vcs === "git" ? "project" : "local";
     const openCodeServerUrl = urlString(serverUrl);
     const pendingTurns = new Map();
+    const sessionFlushes = new Map();
     const inFlight = new Set();
     const genericReminderOptions = memorySkillReminderOptions(options);
     const reminderEvaluator = options.memorySkillReminderEvaluator ?? evaluateMemorySkillReminder;
@@ -81,11 +82,13 @@ export function createMemoraxOpenCodePlugin(options = {}) {
       void observed.finally(() => inFlight.delete(observed));
     }
 
-    async function flushSession(sessionId) {
+    async function flushSession(sessionId, target) {
       if (!pluginEnabled(options)) return;
       await ensureBackendReady();
       if (!pluginEnabled(options)) return;
-      const turns = [...pendingTurns.values()].filter((turn) => turn.sessionId === sessionId);
+      const turns = target
+        ? [pendingTurns.get(turnKey(target))].filter(Boolean)
+        : [...pendingTurns.values()].filter((turn) => turn.sessionId === sessionId);
       if (turns.length === 0) return;
       const response = await client.session.messages({
         path: { id: sessionId },
@@ -100,7 +103,12 @@ export function createMemoraxOpenCodePlugin(options = {}) {
           && message.info.id === turn.userMessageId
           && message.info.sessionID === sessionId
         ));
-        const assistant = completedAssistantFor(messages, sessionId, turn.userMessageId);
+        const assistant = terminalAssistantFor(
+          messages,
+          sessionId,
+          turn.userMessageId,
+          target?.assistantMessageId,
+        );
         if (!user || !assistant) continue;
         let result;
         try {
@@ -124,6 +132,19 @@ export function createMemoraxOpenCodePlugin(options = {}) {
           pendingTurns.delete(turnKey(turn));
         }
       }
+    }
+
+    function queueSessionFlush(sessionId, target) {
+      const previous = sessionFlushes.get(sessionId) ?? Promise.resolve();
+      const queued = previous
+        .catch(() => undefined)
+        .then(() => flushSession(sessionId, target));
+      sessionFlushes.set(sessionId, queued);
+      const clear = () => {
+        if (sessionFlushes.get(sessionId) === queued) sessionFlushes.delete(sessionId);
+      };
+      void queued.then(clear, clear);
+      return queued;
     }
 
     void ensureBackendReady();
@@ -256,9 +277,21 @@ export function createMemoraxOpenCodePlugin(options = {}) {
           markSupplementalReminderForSession(genericReminderOptions, event.properties?.sessionID);
           return;
         }
+        if (event?.type === "message.updated") {
+          const interrupted = interruptedAssistantFromEvent(event, pendingTurns);
+          if (interrupted) {
+            track(
+              queueSessionFlush(interrupted.sessionId, interrupted),
+              "opencode interrupted turn finalization failed",
+            );
+          }
+          return;
+        }
         if (event?.type === "session.status" && event.properties?.status?.type === "idle") {
           const sessionId = stringValue(event.properties.sessionID);
-          if (sessionId) track(flushSession(sessionId), "opencode writeback failed");
+          if (sessionId) {
+            track(queueSessionFlush(sessionId), "opencode writeback failed");
+          }
         }
       },
       async dispose() {
@@ -274,14 +307,18 @@ export function createMemoraxOpenCodePlugin(options = {}) {
 export const MemoraxOpenCodePlugin = createMemoraxOpenCodePlugin();
 export default MemoraxOpenCodePlugin;
 
-function completedAssistantFor(messages, sessionId, userMessageId) {
+function terminalAssistantFor(messages, sessionId, userMessageId, assistantMessageId) {
   return messages
     .filter((message) => (
       message?.info?.role === "assistant"
       && message.info.sessionID === sessionId
       && message.info.parentID === userMessageId
+      && (!assistantMessageId || message.info.id === assistantMessageId)
       && Number.isFinite(message.info.time?.completed)
-      && message.info.error === undefined
+      && (
+        message.info.error === undefined
+        || message.info.error?.name === "MessageAbortedError"
+      )
       && message.info.summary !== true
       && !message.parts?.some((part) => part?.type === "compaction")
     ))
@@ -290,6 +327,24 @@ function completedAssistantFor(messages, sessionId, userMessageId) {
       || String(left.info.id).localeCompare(String(right.info.id))
     ))
     .at(-1);
+}
+
+function interruptedAssistantFromEvent(event, pendingTurns) {
+  const info = event?.properties?.info;
+  const sessionId = stringValue(info?.sessionID);
+  const userMessageId = stringValue(info?.parentID);
+  const assistantMessageId = stringValue(info?.id);
+  if (
+    info?.role !== "assistant"
+    || info?.error?.name !== "MessageAbortedError"
+    || !Number.isFinite(info?.time?.completed)
+    || info?.summary === true
+    || !sessionId
+    || !userMessageId
+    || !assistantMessageId
+    || !pendingTurns.has(turnKey({ sessionId, userMessageId }))
+  ) return undefined;
+  return { sessionId, userMessageId, assistantMessageId };
 }
 
 function textParts(parts) {

--- a/packages/ts/memorax-code-opencode-adapter/test/plugin.test.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/test/plugin.test.mjs
@@ -627,6 +627,82 @@ test("idle discards HTTP 413 without starving a runtime-closed retry", async () 
   );
 });
 
+test("message.updated finalizes only MessageAbortedError and serializes with idle", async () => {
+  const requests = [];
+  let clientCalls = 0;
+  let markIdleStarted;
+  let releaseIdle;
+  const idleStarted = new Promise((resolve) => { markIdleStarted = resolve; });
+  const idleReady = new Promise((resolve) => { releaseIdle = resolve; });
+  const assistantInfo = {
+    id: "assistant-interrupted",
+    role: "assistant",
+    sessionID: "session-interrupted",
+    parentID: "user-interrupted",
+    time: { completed: 123 },
+    error: { name: "MessageAbortedError" },
+  };
+  const interruptedMessages = [
+    {
+      info: { id: "user-interrupted", role: "user", sessionID: "session-interrupted" },
+      parts: [{ type: "text", text: "Stop this Turn." }],
+    },
+    { info: assistantInfo, parts: [] },
+  ];
+  const hooks = await createPluginWithoutReminders({
+    backendConnection: { url: "http://127.0.0.1:8787" },
+    fetchImpl: responseSequence(requests, [
+      { ok: true },
+      { ok: true, scheduled: false, reason: "interrupted" },
+    ]),
+  })(pluginInput({
+    client: {
+      session: {
+        async messages() {
+          clientCalls += 1;
+          if (clientCalls === 1) {
+            markIdleStarted();
+            await idleReady;
+            return { data: [] };
+          }
+          return { data: interruptedMessages };
+        },
+      },
+    },
+  }));
+
+  await hooks["chat.message"](
+    { sessionID: "session-interrupted" },
+    promptOutput("user-interrupted", "Stop this Turn."),
+  );
+  hooks.event(messageUpdatedEvent({
+    ...assistantInfo,
+    id: "assistant-other-error",
+    error: { name: "UnknownError" },
+  }));
+  await delay(0);
+  assert.equal(clientCalls, 0);
+
+  hooks.event(sessionIdleEvent("session-interrupted"));
+  await idleStarted;
+  const abortEvent = messageUpdatedEvent(assistantInfo);
+  hooks.event(abortEvent);
+  await delay(0);
+  assert.equal(clientCalls, 1, "the abort refresh waits for the idle refresh");
+
+  releaseIdle();
+  await hooks.dispose();
+  hooks.event(abortEvent);
+  await hooks.dispose();
+
+  assert.equal(clientCalls, 2);
+  assert.deepEqual(requests.map((request) => new URL(request.url).pathname), [
+    "/memory/turn-start",
+    "/memory/writeback",
+  ]);
+  assert.deepEqual(requests[1].body.messages, interruptedMessages);
+});
+
 function pluginInput(overrides = {}) {
   return {
     client: { session: { async messages() { return { data: [] }; } } },
@@ -636,6 +712,14 @@ function pluginInput(overrides = {}) {
     serverUrl: new URL("http://127.0.0.1:4096"),
     ...overrides,
   };
+}
+
+function messageUpdatedEvent(info) {
+  return { event: { type: "message.updated", properties: { info } } };
+}
+
+function sessionIdleEvent(sessionID) {
+  return { event: { type: "session.status", properties: { sessionID, status: { type: "idle" } } } };
 }
 
 function createPluginWithoutReminders(options) {


### PR DESCRIPTION
## Change Summary

Finalize explicit OpenCode `MessageAbortedError` turns immediately so traces and the Memory Viewer receive a formal interrupted terminal state while automatic Memory Add remains disabled for that turn.

## Implementation Highlights

- Listen for explicit OpenCode abort updates and refresh the authoritative SDK session messages instead of trusting event content.
- Serialize abort and idle refreshes per session to prevent duplicate terminal processing.
- Materialize only exact `MessageAbortedError` turns as interrupted, record `turn_end(outcome=interrupted)`, close current-turn state, and clear pending metadata without scheduling writeback.
- Preserve rejection of other errors, summary, compaction, incomplete, and identity-mismatched messages.

## Validation

- `npm run typecheck --prefix packages/ts/memorax-code-backend`: passed
- `npm test --prefix packages/ts/memorax-code-opencode-adapter`: 29 passed
- Focused Backend OpenCode memory-hook suite: 4 passed
- `npm test --prefix packages/ts/memorax-code-backend`: 516 passed, 2 skipped, 0 failed
- `make test-npm-package`: 170 passed; local-only trace contract passed
- `make docs-check`: 10 passed
- `git diff --check`: passed

## Full End-to-End Validation Results

- Environment: macOS development worktree
- Scenario or matrix: Explicit OpenCode abort, ordinary assistant error rejection, idle/abort serialization, pending cleanup, and no interrupted-turn writeback
- Command or workflow: OpenCode adapter integration suite, Backend OpenCode hook suite, full Backend suite, and isolated npm package checks
- Result: Explicit aborts reached a formal interrupted terminal state immediately; other errors stayed rejected; no Memory Add was scheduled; all automated checks passed
- Evidence or artifacts: Redacted automated results are summarized above
- Reason not run / remaining risk: A live model-backed OpenCode E2E is deferred to the final aggregate OpenCode validation; remaining risk is limited to real-client event timing beyond the covered SDK/event serialization cases