### PR TITLE
docs: add OpenCode to quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Coding agents are good at the task in front of them, but a new session often
 starts without the architecture, failed attempts, repository rules, or working
 preferences established before it.
 
-MemoraX Code gives Codex and Claude Code a shared memory layer for that context.
+MemoraX Code gives Codex, Claude Code, and OpenCode a shared memory layer for
+that context.
 It can recall prior engineering knowledge, capture reusable lessons from
 completed work, maintain repository knowledge, and carry your procedures and
 preferences into future sessions.
@@ -46,8 +47,8 @@ and validation sooner.
 
 ## Quick Start
 
-Prepare Node.js 24+ and either Codex or Claude Code. Python 3 is required for
-Repo Memory operations.
+Prepare Node.js 24+ and at least one of Codex, Claude Code, or OpenCode. Python
+3 is required for Repo Memory operations.
 
 ### Install and Connect
 
@@ -64,18 +65,19 @@ npm install -g @memorax/memorax-code --foreground-scripts
 ```
 
 Keep `--foreground-scripts` so the complete setup remains visible. The
-installer automatically detects runnable Codex and Claude Code clients and
-connects the clients it finds. Follow the prompts to enter your Base User ID,
-preferred language, and API key. Codex users must also approve Hook activation
-and trust when prompted.
+installer automatically detects available Codex, Claude Code, and OpenCode
+clients and connects the clients it finds. Follow the prompts to enter your
+Base User ID, preferred language, and API key. Codex users must also approve
+Hook activation and trust when prompted. Restart or refresh every detected
+client after installation before starting a new session.
 
 If setup is skipped or cannot prompt, the package remains installed but
 MemoraX-backed search, retrieval, and writeback remain unavailable.
 
 ### Try Cross-Session Memory
 
-Clone the example repository from the product website, then open Codex or
-Claude Code in the project directory:
+Clone the example repository from the product website, then open Codex, Claude
+Code, or OpenCode in the project directory:
 
 ```bash
 git clone https://github.com/SWE-agent/test-repo.git
@@ -83,7 +85,8 @@ cd test-repo
 ```
 
 Invoke the Skill as `$memorax-code` in Codex or `/memorax-code` in Claude Code.
-The prompts below use its product name and work in either client.
+In OpenCode, ask the agent to use the `memorax-code` skill by name. The prompts
+below use its product name and work in all three clients.
 
 Send these prompts in order in the same session:
 
@@ -127,8 +130,8 @@ the current repository.
 | **Preference continuity** | Records User Profile preferences and injects them into future tasks on a configured cadence. |
 | **Procedure reuse** | Records reusable task procedures and reminds future agents to apply them. |
 | **Background Repo Memory maintenance** | Automatically organizes repository structure, entry points, and history evidence in the background, then updates them according to policy to reduce repeated searching and summarization. |
-| **Active memory control** | Lets you search and add memory through the bundled MemoraX Code skill (`$memorax-code` in Codex or `/memorax-code` in Claude Code) or the CLI. |
-| **Hook integration** | Uses Codex and Claude Code Hooks to trigger memory retrieval, reminders, and writeback. |
+| **Active memory control** | Lets you search and add memory through the bundled MemoraX Code skill or the CLI. |
+| **Client integration** | Integrates with Codex, Claude Code, and OpenCode to trigger memory retrieval, reminders, and writeback. |
 | **Local visualization** | Uses the local Memory Viewer to summarize activity counts, retrieval, and writeback status. |
 
 ## Your Memory, Your Control
@@ -160,8 +163,8 @@ memorax-code update
 ```
 
 The command follows the installed release channel and preserves configuration.
-Restart or refresh Codex and Claude Code when a release changes plugin assets
-or skills.
+Restart or refresh Codex, Claude Code, and OpenCode when a release changes
+plugin assets or skills.
 
 ## Uninstall
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -34,15 +34,15 @@
 Coding Agent 擅长解决眼前的问题，但新会话不会自动继承此前积累的架构认知、踩坑经验、仓库规则
 和协作偏好。
 
-MemoraX Code 让 Codex 和 Claude Code 共享一套能够持续积累的记忆。它会沉淀代码任务中的工程经验，
-持续整理仓库知识，并在后续任务中找回相关的工作流程和偏好。
+MemoraX Code 让 Codex、Claude Code 和 OpenCode 共享一套能够持续积累的记忆。它会沉淀代码任务中的
+工程经验，持续整理仓库知识，并在后续任务中找回相关的工作流程和偏好。
 
 它追求的不是“记得更多”，而是在需要时带回与当前任务相关的 Memory，让 Agent 减少重复搜索和试错，
 更快进入问题定位与事实验证。
 
 ## 快速开始
 
-开始前，请确保已安装 Node.js 24 或更高版本，以及 Codex 或 Claude Code。
+开始前，请确保已安装 Node.js 24 或更高版本，以及 Codex、Claude Code 或 OpenCode 中的至少一个。
 Repo Memory 操作还需要 Python 3。
 
 ### 安装与接入
@@ -58,15 +58,16 @@ Repo Memory 操作还需要 Python 3。
 npm install -g @memorax/memorax-code --foreground-scripts
 ```
 
-请保留 `--foreground-scripts`，以便查看完整的安装过程。安装器会自动检测本机可用的 Codex
-和 Claude Code，并为检测到的客户端启用集成。按照终端提示输入 Base User ID、偏好语言和
-API Key；Codex 用户还需按提示完成 Hook 的激活和信任确认。
+请保留 `--foreground-scripts`，以便查看完整的安装过程。安装器会自动检测本机可用的 Codex、
+Claude Code 和 OpenCode，并为检测到的客户端启用集成。按照终端提示输入 Base User ID、偏好语言
+和 API Key；Codex 用户还需按提示完成 Hook 的激活和信任确认。安装完成后，请重启或刷新所有检测到的
+客户端，再开始新会话。
 
 如果跳过配置或安装过程无法交互，npm 包仍会安装，但 MemoraX 搜索、召回和写回功能无法使用。
 
 ### 体验跨会话记忆
 
-克隆示例仓库，并在项目目录中打开 Codex 或 Claude Code：
+克隆示例仓库，并在项目目录中打开 Codex、Claude Code 或 OpenCode：
 
 ```bash
 git clone https://github.com/SWE-agent/test-repo.git
@@ -74,7 +75,8 @@ cd test-repo
 ```
 
 在 Codex 中使用 `$memorax-code`，在 Claude Code 中使用 `/memorax-code` 调用该 Skill。
-下面的指令使用产品名称，两端均可直接理解。
+在 OpenCode 中，直接让 Agent 使用名为 `memorax-code` 的 Skill。下面的指令使用产品名称，三个客户端
+均可直接理解。
 
 在同一个会话中依次发送以下指令：
 
@@ -112,8 +114,8 @@ cd test-repo
 | **用户偏好延续** | 在 User Profile 中记录用户偏好，并按设定周期将其带入后续任务。 |
 | **Procedure 自动复用** | 记录可复用的任务流程，并在后续任务中自动提醒 Agent 按流程执行。 |
 | **Repo Memory 后台整理** | 在后台整理仓库结构、代码入口和历史证据，并按策略自动更新，避免反复搜索和总结。 |
-| **主动记忆控制** | 使用内置的 MemoraX Code Skill（Codex 中为 `$memorax-code`，Claude Code 中为 `/memorax-code`）或 CLI，主动查找和添加记忆。 |
-| **Hook 集成** | 借助 Codex 和 Claude Code 的 Hook 触发记忆检索、提醒和写入。 |
+| **主动记忆控制** | 使用内置的 MemoraX Code Skill 或 CLI，主动查找和添加记忆。 |
+| **客户端集成** | 与 Codex、Claude Code 和 OpenCode 集成，触发记忆检索、提醒和写入。 |
 | **本地可视化** | 通过本地 Memory Viewer 查看活动统计、召回与写入状态。 |
 
 ## 你的记忆，由你控制
@@ -140,8 +142,8 @@ MemoraX 云端不会接收模型服务商凭据或本地 Backend Token。
 memorax-code update
 ```
 
-该命令会沿用当前发布通道并保留配置。如果新版本修改了插件资产或 skill，请重启或刷新
-Codex 和 Claude Code。
+该命令会沿用当前发布通道并保留配置。如果新版本修改了插件资产或 Skill，请重启或刷新
+Codex、Claude Code 和 OpenCode。
 
 ## 卸载
 

--- a/packages/npm/memorax-code/README.md
+++ b/packages/npm/memorax-code/README.md
@@ -1,11 +1,11 @@
 # @memorax/memorax-code
 
-MemoraX Code adds persistent coding memory to Codex and Claude Code.
+MemoraX Code adds persistent coding memory to Codex, Claude Code, and OpenCode.
 
 ## Requirements
 
 - Node.js 24 or newer and npm.
-- Codex or Claude Code.
+- At least one of Codex, Claude Code, OpenCode Desktop, or the OpenCode CLI.
 - A MemoraX account, Base User ID, and API key for memory features.
 - Python 3 only for Repo Memory operations.
 
@@ -20,10 +20,10 @@ npm install -g @memorax/memorax-code --foreground-scripts
 
 Keep `--foreground-scripts` so npm displays the complete setup.
 
-The installer automatically detects the Codex and Claude Code clients available
-on the machine and configures each client it finds. Follow the prompts to enter
-your MemoraX Base User ID, preferred language, and API key. When Codex is
-detected, review and approve its Hook activation.
+The installer automatically detects available Codex, Claude Code, and OpenCode
+clients and configures each client it finds. Follow the prompts to enter your
+MemoraX Base User ID, preferred language, and API key. When Codex is detected,
+review and approve its Hook activation.
 
 Entering the MemoraX credentials after the installer's disclosure enables the
 core memory features and automatic writeback. If setup is skipped or cannot


### PR DESCRIPTION
## Change Summary
Update the public quick-start documentation so OpenCode is represented alongside Codex and Claude Code after the client integration rollout.

## Implementation Highlights
- Add OpenCode to supported-client, installer detection, refresh, and client-integration guidance in the English and Chinese root READMEs.
- Document the correct OpenCode skill invocation by name and align the npm package README support requirements.

## Validation
- `make docs-check`
- `git diff --check`

## Full End-to-End Validation Results
- Environment: macOS local documentation worktree
- Scenario or matrix: English and Chinese README synchronization plus shipped npm README documentation contracts
- Command or workflow: `make docs-check`
- Result: All 10 documentation contract tests passed; link, package-document, and language-sync checks passed.
- Evidence or artifacts: Redacted local command output recorded during validation.
- Reason not run / remaining risk: Product E2E was not rerun because this is a documentation-only change with no runtime or packaging behavior changes.