### PR TITLE
feat: add source-only DSH native Turn bridge

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -29,9 +29,14 @@ Backend. The Backend is a capability-oriented modular monolith. The clients
 retain ownership of models, model-provider credentials, native tools,
 model-provider traffic, and native transcript or message creation.
 
+The source tree also contains a DeepSeek Harness (DSH) native Turn bridge.
+It consumes DSH's persisted Session Event Log through a Cordis listener and
+the same versioned local Backend protocol; its deployment lifecycle is kept
+separate from this request-time integration.
+
 Around the Backend are:
 
-- three client deployment adapters;
+- three client deployment adapters and one source-only DSH Turn bridge;
 - one lower-level shared runtime source layer;
 - one npm assembly and installed-CLI layer; and
 - repository automation that builds, validates, stages, and tests artifacts.
@@ -41,12 +46,14 @@ flowchart LR
   subgraph Clients["Client-owned runtimes"]
     Codex["Codex"]
     Claude["Claude Code"]
+    DSH["DeepSeek Harness"]
     OpenCode["OpenCode"]
   end
 
-  subgraph Adapters["Client deployment adapters"]
+  subgraph Adapters["Client integrations"]
     CodexAdapter["Codex adapter<br/>plugin, Hooks, canonical skill"]
     ClaudeAdapter["Claude adapter<br/>plugin, Hooks, installer"]
+    DshAdapter["DSH adapter<br/>Cordis Turn bridge"]
     OpenCodeAdapter["OpenCode adapter<br/>plugin, installer, skill artifact"]
   end
 
@@ -74,9 +81,11 @@ flowchart LR
 
   Codex --> CodexAdapter
   Claude --> ClaudeAdapter
+  DSH --> DshAdapter
   OpenCode --> OpenCodeAdapter
   CodexAdapter -. "versioned local Hook HTTP" .-> Backend
   ClaudeAdapter -. "versioned local Hook HTTP" .-> Backend
+  DshAdapter -. "versioned local plugin HTTP" .-> Backend
   OpenCodeAdapter -. "versioned local plugin HTTP" .-> Backend
 
   Backend --> MemoraX
@@ -94,6 +103,7 @@ relationships; the arrow labels distinguish them. It is not an import graph.
 | `packages/ts/memorax-code-adapter-common` | Shared source for Backend connection authority, private runtime records, cross-process locking and configuration, Hook generations, Hook launch helpers, and Repo/Personal Memory helpers | Backend composition, native transcript interpretation, MemoraX request execution, or client plugin policy | `packages/ts/memorax-code-adapter-common/src/backend-connection.mjs`, `src/runtime-record.mjs`, `src/hooks`, and `src/repo-memory` |
 | `packages/ts/memorax-code-codex-adapter` | Codex plugin artifact, Hook shells and runtimes, session/workspace observation, diagnostics, and the canonical shared skill | Codex rollout semantics or Backend-side writeback authority | `.codex-plugin`, `hooks`, `runtime-hooks`, `src`, and `skills/memorax-code` |
 | `packages/ts/memorax-code-claude-adapter` | Claude Code plugin artifact, Hook shells and runtimes, configuration, installer, marketplace source, and diagnostics | Claude transcript semantics or Backend memory orchestration | `.claude-plugin`, `hooks`, `runtime-hooks`, `scripts`, and `src/plugin-install.mjs` |
+| `packages/ts/memorax-code-dsh-adapter` | DSH Cordis Turn listener, exact persisted-event interval validation, and the local Backend wire protocol | DSH Profile mutation, Backend-side event interpretation, or MemoraX request execution | `src/plugin.mjs`, `src/protocol.mjs`, and `test/plugin-integration.test.mjs` |
 | `packages/ts/memorax-code-opencode-adapter` | OpenCode plugin runtime, managed thin-loader installation, automatic retrieval, SDK-backed writeback, shell-session identity, workspace runtime evidence and diagnostics, a materialized shared skill, and supervised Repo Memory maintenance and missing-bundle initialization | OpenCode message interpretation inside the Backend or model-provider configuration | `src/plugin.mjs`, `src/plugin-install.mjs`, `src/cli.mjs`, `src/repo-memory-server-runner.mjs`, and the OpenCode materialization mapping in `scripts/npm-source-files.mjs` |
 | `packages/npm/memorax-code` | Installed executable wrappers, update, preinstall/postinstall, npm manifest, and release-package source | Backend lifecycle semantics, uninstall orchestration, or artifact staging | `bin`, `lib/run-entrypoint.mjs`, and `package.json` |
 | `scripts` | Backend build orchestration, staging/materialization, package layout, documentation, and local-only data gates | Product runtime authority | Package-build/check scripts and executable contract scripts |
@@ -106,8 +116,9 @@ the owner of their behavior.
 
 ### 2.2 Physical dependency directions
 
-- The Backend and all three adapters may import adapter-common. Adapter-common must
-  not import those higher-level components back.
+- The Backend and the Codex, Claude Code, and OpenCode deployment adapters may
+  import adapter-common. Adapter-common must not import those higher-level
+  components back.
 - Adapter Hook and plugin runtimes do not import Backend implementation. They
   communicate through versioned, client-qualified local HTTP commands.
 - Backend lifecycle may load adapter configuration or installers through
@@ -232,8 +243,9 @@ Important distinctions:
   input. Their prompt or event text is not automatic writeback content
   authority; OpenCode's separately supplied SDK records are validated as
   client-native content.
-- Codex rollout JSONL, Claude Code transcript JSONL, and OpenCode SDK session
-  message records are the content authorities for their respective clients.
+- Codex rollout JSONL, Claude Code transcript JSONL, DSH's exact persisted
+  Session Event Log interval, and OpenCode SDK session message records are the
+  content authorities for their respective clients.
 - Required client/session/turn identity and repository scope fail closed when
   incomplete, conflicting, or unprovable.
 - A malformed or incomplete direct `.git` directory is the sole documented
@@ -291,6 +303,10 @@ sequenceDiagram
     Integration->>Authority: fetch session messages through the client SDK
     Authority-->>Integration: matching user and completed assistant records
     Integration->>Service: correlation and SDK message records
+  else DSH
+    Integration->>Authority: flush and read exact startSeq..endSeq interval
+    Authority-->>Integration: persisted Session header and events
+    Integration->>Service: correlation and exact persisted interval
   else Codex or Claude Code
     Integration->>Service: client-qualified writeback correlation
     Service->>Authority: read the exact rollout or transcript Turn
@@ -302,20 +318,34 @@ sequenceDiagram
   Coordinator->>Runtime: enqueue the materialized Turn
   Runtime-->>Coordinator: local scheduling accepted or rejected
   Runtime->>Provider: later flush buffered or chunked writeback
-  Provider-->>Obs: accepted task event and identity
-  Obs->>Projection: update the live task projection
-  Obs->>Trace: persist the same writeback event
-  Reconciler->>Projection: list live and persisted pending tasks
-  Projection->>Trace: read persisted writeback history
-  Reconciler->>Provider: query writeback status
-  Reconciler->>Trace: append terminal status when completed
+  Provider-->>Runtime: accepted task identity
+  alt integration supplies trace observability
+    Runtime->>Obs: emit accepted task event and identity
+    Obs->>Projection: update the live task projection
+    Obs->>Trace: persist the same writeback event
+    Reconciler->>Projection: list live and persisted pending tasks
+    Projection->>Trace: read persisted writeback history
+    Reconciler->>Provider: query writeback status
+    Reconciler->>Trace: append terminal status when completed
+  else DSH native bridge
+    Note over Runtime,Trace: no Trace, task projection, or reconciliation in this layer
+  end
 ```
 
 - Retrieval events do not enter reconciliation.
 - Local enqueue acceptance is the metadata-consumption point; provider I/O may
   occur later through the automatic writeback runtime.
 - Buffering and chunking belong to the memory capability; rollout, transcript,
-  and SDK message parsing remains client-specific.
+  DSH event-interval, and SDK message parsing remains client-specific.
+- DSH accepts only a contiguous native interval bounded by the matching
+  `turn/start` and completed `turn/end`. The Backend materializes direct user
+  text and visible model-assistant text; plugin recall, tools, reasoning, and
+  incomplete Turns are excluded. Only non-delegated sessions are eligible.
+- A valid persisted DSH interval can restore automatic writeback after a
+  Backend restart without cached Turn metadata; repository scope is still
+  resolved and validated from the persisted Session workspace.
+- DSH Search and Add intentionally stay outside Trace, task reconciliation,
+  and Memory Viewer in this source-only bridge layer.
 - OpenCode terminal handling accepts only matching SDK user and completed
   assistant records for the correlated session and parent message. An exact
   `MessageAbortedError` closes the Turn as interrupted without writeback; other
@@ -329,9 +359,10 @@ sequenceDiagram
   buffer runtime cancels and discards pending fallback turns for the same
   client and session before buffering under the Git scope. It does not migrate
   or flush those turns across namespaces.
-- Pending writeback status can be reconstructed from persisted local trace
-  after Backend restart. A still-pending provider status updates in-memory
-  reconciliation policy rather than appending a new trace event.
+- For trace-enabled clients, pending writeback status can be reconstructed
+  from persisted local trace after Backend restart. A still-pending provider
+  status updates in-memory reconciliation policy rather than appending a new
+  trace event.
 
 ### 3.5 Repo Memory coordination
 
@@ -380,6 +411,7 @@ src/
   clients/
     codex/                Codex native interpretation and lifecycle adapters
     claude/               Claude native interpretation and lifecycle participant
+    dsh/                  DSH native event-interval interpretation
     opencode/             OpenCode retrieval, SDK message interpretation, and lifecycle participant
   config/                 Backend and proxy/config interpretation
   entrypoints/            process and management-CLI orchestration
@@ -416,6 +448,7 @@ entrypoints and compatibility facades. It is not another implementation area.
 | `src/lifecycle/backend` | Managed process, PID/token/connection records, status probing, cleanup, and shutdown requests | Helper contracts do not depend back on the full service implementation |
 | `src/clients/codex` | Codex rollout, prompt, turn-index, and workspace interpretation; Hook memory runtime; plugin integration glue; and lifecycle participant | No Claude format fallback; request runtime remains HTTP-composition independent |
 | `src/clients/claude` | Claude transcript/turn interpretation, Hook memory runtime, and lifecycle participant | No Codex format fallback; request runtime remains HTTP-composition independent |
+| `src/clients/dsh` | DSH Session header and exact persisted event-interval interpretation plus its request-time memory runtime | No Hook-text, rollout, transcript, SDK-message, or latest-Turn fallback; request runtime remains HTTP-composition independent |
 | `src/clients/opencode` | OpenCode SDK message validation and text materialization, plugin memory runtime, and lifecycle participant | No Hook-text, database, rollout, or transcript fallback; request runtime remains HTTP-composition independent |
 | `src/memory` | Memory commands, retrieval, writeback, turn coordination, repository session pinning, manual CLI, buffering/chunking, task projection, and reconciliation | Client-neutral modules do not parse native transcript formats |
 | `src/repository` | Read-only repository identity and Repo Memory readiness | Scope derivation does not execute Git or use synchronous filesystem reads |
@@ -519,9 +552,9 @@ and
 
 | Concern | Authority | Derived or non-authoritative views |
 | --- | --- | --- |
-| Models, model-provider credentials, native tools, and model-provider traffic | Codex, Claude Code, or OpenCode | Backend and adapters must not proxy or persist this authority |
+| Models, model-provider credentials, native tools, and model-provider traffic | Codex, Claude Code, DeepSeek Harness, or OpenCode | Backend and adapters must not proxy or persist this authority |
 | Hook command identity | Versioned, client-qualified command plus validated required session/turn fields | Parsed HTTP request objects |
-| Automatic writeback content | Codex rollout JSONL, Claude Code transcript JSONL, or OpenCode SDK session messages for the matching client and Turn | Hook or plugin text, trace, latest-Turn guesses, local database guesses, and another client's format are not fallbacks |
+| Automatic writeback content | Codex rollout JSONL, Claude Code transcript JSONL, DSH's exact persisted Session Event Log interval, or OpenCode SDK session messages for the matching client and Turn | Hook or plugin text, trace, latest-Turn guesses, local database guesses, and another client's format are not fallbacks |
 | Workspace and repository identity | Backend read-only resolution held by the live repository-session runtime; its only permitted scope transition is the same-root degraded-direct-`.git` to verified-Git upgrade | Project labels, Viewer catalog entries, and Hook `cwd` |
 | Backend connection and managed-process ownership | Versioned private connection/token/PID records plus lifecycle lock/version validation | In-memory state in any one process |
 | MemoraX memory result and asynchronous task state | Normalized response from `provider/memorax` | Observability, trace, Viewer, and task projections |

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-ts test-codex-adapter test-claude-adapter test-opencode-adapter test-opencode-e2e test-npm-package docs-check npm-package-build npm-package-check npm-publish-dry-run release-version-check clean
+.PHONY: test test-ts test-codex-adapter test-claude-adapter test-dsh-adapter test-opencode-adapter test-opencode-e2e test-npm-package docs-check npm-package-build npm-package-check npm-publish-dry-run release-version-check clean
 
 NPM ?= npm
 
@@ -10,6 +10,7 @@ test-ts:
 	$(NPM) test --prefix packages/ts/memorax-code-backend
 	$(MAKE) test-codex-adapter
 	$(MAKE) test-claude-adapter
+	$(MAKE) test-dsh-adapter
 	$(MAKE) test-opencode-adapter
 
 test-codex-adapter:
@@ -17,6 +18,9 @@ test-codex-adapter:
 
 test-claude-adapter:
 	$(NPM) test --prefix packages/ts/memorax-code-claude-adapter
+
+test-dsh-adapter:
+	$(NPM) test --prefix packages/ts/memorax-code-dsh-adapter
 
 test-opencode-adapter:
 	$(NPM) test --prefix packages/ts/memorax-code-opencode-adapter

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,6 +4,8 @@ MemoraX Code is a local-first integration for Codex, Claude Code, and OpenCode
 with an optional external bind mode and required communication with MemoraX
 for cloud-backed memory. Security reports should distinguish the local
 Backend, client-owned provider traffic, and MemoraX memory traffic.
+The source tree also contains a DeepSeek Harness (DSH) native Turn bridge whose
+request-time authority is covered by the same trust boundaries.
 
 ## Supported Versions
 
@@ -28,9 +30,9 @@ Please allow time for triage and remediation before public disclosure.
 
 ### Client and local Backend
 
-- Codex, Claude Code, and OpenCode own provider credentials, models, native
-  tools, and provider traffic. MemoraX Code does not proxy model-provider
-  traffic and does not need client provider credentials.
+- Codex, Claude Code, DeepSeek Harness, and OpenCode own provider credentials,
+  models, native tools, and provider traffic. MemoraX Code does not proxy
+  model-provider traffic and does not need client provider credentials.
 - The managed Backend binds to loopback by default. External binding requires
   explicit opt-in and a Backend token; deployment operators must provide an
   appropriate authenticated and encrypted network boundary.
@@ -71,14 +73,15 @@ the generated configuration's automatic writeback; automatic retrieval remains
 disabled until explicitly enabled.
 
 Memory searches send the query and repository-scoped identity to MemoraX.
-When OpenCode automatic retrieval is enabled, each eligible user prompt is
-used as the search query.
+When DSH or OpenCode automatic retrieval is enabled, each eligible direct user
+prompt is used as the search query.
 Active adds and automatic writeback send the selected content needed to create
 memory. Automatic writeback may include selected user instructions and the
 matching final assistant response from an exact Codex rollout, Claude Code
-transcript, or OpenCode SDK session-message turn. It does not send the retained
-trace file, raw transcript path, SDK message records, or trace-only provenance
-as part of that payload.
+transcript, DSH persisted Session Event Log interval, or OpenCode SDK
+session-message turn. It does not send the retained trace file, raw transcript
+path, raw DSH interval, SDK message records, or trace-only provenance as part
+of that payload.
 
 Automatic writeback bounds each selected message to its configured Add limit,
 then applies a local best-effort detector before hashing, buffering, chunking,

--- a/packages/ts/memorax-code-backend/src/clients/dsh/memory-hook-runtime.ts
+++ b/packages/ts/memorax-code-backend/src/clients/dsh/memory-hook-runtime.ts
@@ -1,0 +1,243 @@
+import type {
+  AutomaticMemoryWritebackRejectionReason,
+} from "../../memory/automatic-writeback.js";
+import { retrieveAutomaticMemoryContext } from "../../memory/automatic-retrieval.js";
+import type {
+  DshTurnStartCommand,
+  DshWritebackCommand,
+  MemoryHookTurnStartResult,
+} from "../../memory/hook-command.js";
+import type { MemoryDiagnosticLogger } from "../../memory/observability.js";
+import {
+  type ConfiguredRepositoryMemoryResult,
+  type RepositoryMemorySessionRuntime,
+} from "../../memory/repository-session.js";
+import type {
+  MemoryTurnCoordinator,
+  MemoryTurnState,
+} from "../../memory/turn-coordinator.js";
+import type { RepositoryMemoryScopeFailureReason } from "../../repository/scope.js";
+import {
+  dshSessionEventTurn,
+  type DshSessionTurnFailureReason,
+} from "./session-turn.js";
+
+export type DshMemoryHookWritebackSkipReason =
+  | "turn_metadata_mismatch"
+  | "config_missing"
+  | DshSessionTurnFailureReason
+  | RepositoryMemoryScopeFailureReason
+  | AutomaticMemoryWritebackRejectionReason;
+
+export type DshMemoryHookWritebackResult =
+  | { ok: true; scheduled: true }
+  | { ok: true; scheduled: false; reason: DshMemoryHookWritebackSkipReason };
+
+export type DshMemoryHookRuntimeOptions = {
+  diagnosticLogger?: MemoryDiagnosticLogger;
+  env?: Record<string, string | undefined>;
+  fetchImpl?: typeof fetch;
+  now?: () => number;
+  maxEntries?: number;
+  memoraxCodeHome?: string;
+  repositoryMemorySession: RepositoryMemorySessionRuntime;
+  turnCoordinator: MemoryTurnCoordinator;
+};
+
+export type DshMemoryHookRuntime = {
+  recordTurnStart(command: DshTurnStartCommand): Promise<MemoryHookTurnStartResult>;
+  writeback(command: DshWritebackCommand): Promise<DshMemoryHookWritebackResult>;
+  close(): void;
+};
+
+const DSH_MEMORY_TURN_CLIENT = "dsh" as const;
+
+export function createDshMemoryHookRuntime(
+  options: DshMemoryHookRuntimeOptions,
+): DshMemoryHookRuntime {
+  const now = options.now ?? (() => Date.now());
+  const { repositoryMemorySession, turnCoordinator } = options;
+  const retrievalTurns = new Set<string>();
+  const retrievalTurnLimit = positiveInteger(options.maxEntries, 256);
+
+  return {
+    async recordTurnStart(command) {
+      turnCoordinator.pruneExpired();
+      const repositoryMemory = await resolveHookRepositoryMemory(
+        command,
+        options,
+        repositoryMemorySession,
+      );
+      turnCoordinator.recordTurnStart({
+        client: DSH_MEMORY_TURN_CLIENT,
+        sessionId: command.sessionId,
+        clientTurnId: String(command.turn),
+        cwd: command.cwd,
+        eventStartSeq: command.startSeq,
+        createdAt: now(),
+        repositoryMemory,
+      });
+      options.diagnosticLogger?.("dsh_memory.turn_start", {
+        sessionId: command.sessionId,
+        turn: command.turn,
+        startSeq: command.startSeq,
+        cacheSize: turnCoordinator.size(DSH_MEMORY_TURN_CLIENT),
+        workspace: repositoryMemory.ok ? repositoryMemory.memory.scope?.repositorySlug : undefined,
+        workspaceScopeReason: repositoryMemory.ok ? undefined : repositoryMemory.reason,
+      });
+
+      const retrievalKey = JSON.stringify([command.sessionId, command.turn, command.startSeq]);
+      if (retrievalTurns.has(retrievalKey)) {
+        return { ok: true };
+      }
+      retrievalTurns.add(retrievalKey);
+      while (retrievalTurns.size > retrievalTurnLimit) {
+        const oldest = retrievalTurns.values().next().value;
+        if (typeof oldest !== "string") break;
+        retrievalTurns.delete(oldest);
+      }
+      const retrieval = await retrieveAutomaticMemoryContext({
+        diagnosticLogger: options.diagnosticLogger,
+        env: options.env ?? process.env,
+        fetchImpl: options.fetchImpl,
+        // DSH receives its own trace identity in a later capability layer.
+        query: command.prompt,
+        repositoryMemory,
+        sessionKey: command.sessionId,
+      });
+      return {
+        ok: true,
+        ...(retrieval.context ? { additionalContext: retrieval.context } : {}),
+      };
+    },
+    async writeback(command) {
+      turnCoordinator.pruneExpired();
+      const key = dshTurnKey(command.sessionId, command.turn);
+      const entry = turnCoordinator.getTurn(key);
+      if (
+        entry
+        && (entry.eventStartSeq !== command.startSeq || entry.cwd !== command.cwd)
+      ) return skippedWriteback(command, "turn_metadata_mismatch", options);
+      const materialized = dshSessionEventTurn(command);
+      if (!materialized.ok) {
+        if (materialized.reason === "turn_not_completed") {
+          const discarded = turnCoordinator.discardTurn(key, "interrupted");
+          return skippedWriteback(
+            command,
+            materialized.reason,
+            options,
+            discarded ? "consumed" : "absent",
+          );
+        }
+        return skippedWriteback(command, materialized.reason, options);
+      }
+
+      const writeback = await turnCoordinator.completeMaterializedTurn({
+        key,
+        metadata: entry,
+        resolveRepositoryMemory: () => resolveCurrentHookRepositoryMemory(
+          entry,
+          command,
+          options,
+          repositoryMemorySession,
+        ),
+        userText: materialized.turn.userPrompt,
+        assistantText: materialized.turn.assistantReply,
+        writeback: {
+          client: DSH_MEMORY_TURN_CLIENT,
+          sessionKey: command.sessionId,
+          env: options.env ?? process.env,
+          fetchImpl: options.fetchImpl,
+          // DSH Search and Add remain outside Trace, reconciliation, and Viewer in this layer.
+        },
+      });
+      if (!writeback.scheduled) {
+        return skippedWriteback(
+          command,
+          writeback.reason,
+          options,
+          writeback.metadataDisposition,
+        );
+      }
+      options.diagnosticLogger?.("dsh_memory.writeback", {
+        scheduled: true,
+        metadataDisposition: writeback.metadataDisposition,
+        sessionId: command.sessionId,
+        turn: command.turn,
+        startSeq: command.startSeq,
+        endSeq: command.endSeq,
+        outcome: materialized.turn.outcome,
+        promptChars: materialized.turn.userPrompt.length,
+        assistantChars: materialized.turn.assistantReply.length,
+        contentSource: "dsh_session_event_interval",
+      });
+      return { ok: true, scheduled: true };
+    },
+    close() {
+      retrievalTurns.clear();
+    },
+  };
+}
+
+function dshTurnKey(sessionId: string, turn: number) {
+  return {
+    client: DSH_MEMORY_TURN_CLIENT,
+    sessionId,
+    clientTurnId: String(turn),
+  } as const;
+}
+
+async function resolveHookRepositoryMemory(
+  command: DshTurnStartCommand,
+  options: DshMemoryHookRuntimeOptions,
+  repositoryMemorySession: RepositoryMemorySessionRuntime,
+): Promise<ConfiguredRepositoryMemoryResult> {
+  return await repositoryMemorySession.resolve({
+    client: DSH_MEMORY_TURN_CLIENT,
+    sessionId: command.sessionId,
+    workspaceRoot: command.cwd,
+    memoraxCodeHome: options.memoraxCodeHome ?? options.env?.MEMORAX_CODE_HOME,
+    env: options.env,
+  });
+}
+
+async function resolveCurrentHookRepositoryMemory(
+  entry: MemoryTurnState | undefined,
+  command: DshWritebackCommand,
+  options: DshMemoryHookRuntimeOptions,
+  repositoryMemorySession: RepositoryMemorySessionRuntime,
+): Promise<ConfiguredRepositoryMemoryResult> {
+  return await repositoryMemorySession.resolve({
+    client: DSH_MEMORY_TURN_CLIENT,
+    sessionId: command.sessionId,
+    workspaceRoot: command.cwd,
+    // The persisted session header and exact event interval remain native
+    // authority after a Backend restart, when the in-memory binding is gone.
+    requireBoundScope: entry !== undefined,
+    memoraxCodeHome: options.memoraxCodeHome ?? options.env?.MEMORAX_CODE_HOME,
+    env: options.env,
+  });
+}
+
+function skippedWriteback(
+  command: DshWritebackCommand,
+  reason: DshMemoryHookWritebackSkipReason,
+  options: DshMemoryHookRuntimeOptions,
+  metadataDisposition: "consumed" | "retained" | "absent" = "retained",
+): DshMemoryHookWritebackResult {
+  options.diagnosticLogger?.("dsh_memory.writeback", {
+    scheduled: false,
+    reason,
+    metadataDisposition,
+    sessionId: command.sessionId,
+    turn: command.turn,
+    startSeq: command.startSeq,
+    endSeq: command.endSeq,
+  });
+  return { ok: true, scheduled: false, reason };
+}
+
+function positiveInteger(value: unknown, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}

--- a/packages/ts/memorax-code-backend/src/clients/dsh/session-turn.ts
+++ b/packages/ts/memorax-code-backend/src/clients/dsh/session-turn.ts
@@ -1,0 +1,308 @@
+import { isRecord } from "../../shared/record.js";
+
+export type DshSessionTurn = Readonly<{
+  sessionId: string;
+  turn: number;
+  startSeq: number;
+  endSeq: number;
+  userPrompt: string;
+  assistantReply: string;
+  outcome: string;
+}>;
+
+export type DshSessionTurnFailureReason =
+  | "session_header_invalid"
+  | "session_identity_mismatch"
+  | "workspace_identity_mismatch"
+  | "subagent_session"
+  | "interval_length_mismatch"
+  | "event_invalid"
+  | "event_sequence_mismatch"
+  | "turn_boundary_mismatch"
+  | "turn_identity_mismatch"
+  | "turn_not_completed"
+  | "unknown_required_event"
+  | "user_prompt_missing"
+  | "assistant_message_missing";
+
+type DshSessionTurnValidationFailureReason = Exclude<
+  DshSessionTurnFailureReason,
+  "turn_not_completed"
+>;
+
+export type DshSessionTurnResult =
+  | { ok: true; turn: DshSessionTurn }
+  | { ok: false; reason: DshSessionTurnValidationFailureReason }
+  | { ok: false; reason: "turn_not_completed"; outcome: string };
+
+type DshSessionTurnInput = Readonly<{
+  sessionId: string;
+  turn: number;
+  startSeq: number;
+  endSeq: number;
+  cwd: string;
+  sessionHeader: Readonly<Record<string, unknown>>;
+  events: readonly unknown[];
+}>;
+
+const DSH_SESSION_FORMAT_VERSION = 0;
+// Mirrors the supported DSH persistence catalog. Events outside this
+// vocabulary are safe to skip only when their envelope explicitly says so.
+const KNOWN_SESSION_EVENT_TYPES = new Set([
+  "agent-preset/selected",
+  "agent/inbox/spliced",
+  "approval/asked",
+  "approval/decided",
+  "approval/policy",
+  "turn/start",
+  "turn/end",
+  "step/start",
+  "step/end",
+  "user/message",
+  "assistant/chunk",
+  "assistant/message",
+  "command/done",
+  "command/run",
+  "compaction/end",
+  "compaction/prune",
+  "compaction/start",
+  "compaction/summary",
+  "feedback/record",
+  "goal/change",
+  "hook/invoked",
+  "hook/result",
+  "llm/retry",
+  "llm/retry-started",
+  "permission/preset",
+  "plan/mode",
+  "tool/call",
+  "tool/code-dispatch",
+  "tool/code-dispatch-start",
+  "tool/result",
+  "todo/write",
+  "request/header",
+  "request/context",
+  "sandbox/mode",
+  "schedule/change",
+  "session/end-seed",
+  "session/title",
+  "session/title-llm-request",
+  "subagent/descriptor",
+  "tool-workflow/agent-end",
+  "tool-workflow/agent-start",
+  "tool-workflow/run-end",
+  "tool-workflow/run-start",
+  "web/deepseek-search-llm-request",
+]);
+const TURN_IDENTITY_REQUIRED_EVENT_TYPES = new Set([
+  "turn/start",
+  "turn/end",
+  "assistant/message",
+]);
+
+export function dshSessionEventTurn(input: DshSessionTurnInput): DshSessionTurnResult {
+  const header = validateSessionHeader(input);
+  if (header) return { ok: false, reason: header };
+  if (
+    input.events.length === 0
+    || input.endSeq - input.startSeq !== input.events.length - 1
+  ) {
+    return { ok: false, reason: "interval_length_mismatch" };
+  }
+  const first = input.events[0];
+  const last = input.events[input.events.length - 1];
+  if (
+    !isRecord(first)
+    || first.type !== "turn/start"
+    || !isRecord(last)
+    || last.type !== "turn/end"
+  ) return { ok: false, reason: "turn_boundary_mismatch" };
+
+  const userParts: string[] = [];
+  const assistantParts: string[] = [];
+  let outcome: string | undefined;
+
+  for (const [index, value] of input.events.entries()) {
+    if (!isRecord(value)) return { ok: false, reason: "event_invalid" };
+    const type = stringField(value, "type");
+    const seq = safeIntegerField(value, "seq", 0);
+    if (!type || seq === undefined) {
+      return { ok: false, reason: "event_invalid" };
+    }
+    if (seq !== input.startSeq + index) {
+      return { ok: false, reason: "event_sequence_mismatch" };
+    }
+    if (Object.prototype.hasOwnProperty.call(value, "ignorable") && value.ignorable !== true) {
+      return { ok: false, reason: "event_invalid" };
+    }
+    if (!KNOWN_SESSION_EVENT_TYPES.has(type)) {
+      if (value.ignorable === true) continue;
+      return { ok: false, reason: "unknown_required_event" };
+    }
+
+    const data = isRecord(value.data) ? value.data : undefined;
+    const carriesTurn = data ? Object.prototype.hasOwnProperty.call(data, "turn") : false;
+    const eventTurn = data && carriesTurn ? safeIntegerField(data, "turn", 1) : undefined;
+    if (
+      (carriesTurn && eventTurn === undefined)
+      || (TURN_IDENTITY_REQUIRED_EVENT_TYPES.has(type) && eventTurn === undefined)
+    ) return { ok: false, reason: "event_invalid" };
+    if (eventTurn !== undefined && eventTurn !== input.turn) {
+      return { ok: false, reason: "turn_identity_mismatch" };
+    }
+    if (
+      (type === "turn/start" && index !== 0)
+      || (type === "turn/end" && index !== input.events.length - 1)
+    ) {
+      return { ok: false, reason: "turn_boundary_mismatch" };
+    }
+
+    switch (type) {
+      case "turn/start":
+        break;
+      case "turn/end": {
+        const reason = data && isRecord(data.reason) ? stringField(data.reason, "kind") : undefined;
+        if (!reason) return { ok: false, reason: "event_invalid" };
+        outcome = reason;
+        break;
+      }
+      case "user/message": {
+        if (!data) return { ok: false, reason: "event_invalid" };
+        const message = messageEnvelope(data, "user");
+        if (!message || !validSurfaceOp(value.surfaceOp)) {
+          return { ok: false, reason: "event_invalid" };
+        }
+        if (message.source.kind === "user") {
+          if (value.surfaceOp !== "append") {
+            return { ok: false, reason: "event_invalid" };
+          }
+          const text = textContent(message.content);
+          if (text === undefined) return { ok: false, reason: "event_invalid" };
+          if (text) userParts.push(text);
+        }
+        break;
+      }
+      case "assistant/message": {
+        if (!data || value.surfaceOp !== "append" || !isRecord(data.message)) {
+          return { ok: false, reason: "event_invalid" };
+        }
+        const message = messageEnvelope(data.message, "assistant");
+        if (
+          !message
+          || message.source.kind !== "model"
+          || !stringField(message.source, "provider")
+          || !stringField(message.source, "model")
+        ) return { ok: false, reason: "event_invalid" };
+        const text = textContent(message.content);
+        if (text === undefined) return { ok: false, reason: "event_invalid" };
+        if (text) assistantParts.push(text);
+        break;
+      }
+    }
+  }
+
+  if (!outcome) return { ok: false, reason: "turn_boundary_mismatch" };
+  if (outcome !== "completed") {
+    return { ok: false, reason: "turn_not_completed", outcome };
+  }
+  const userPrompt = userParts.join("\n\n").trim();
+  if (!userPrompt) return { ok: false, reason: "user_prompt_missing" };
+  const assistantReply = assistantParts.join("\n\n").trim();
+  if (!assistantReply) return { ok: false, reason: "assistant_message_missing" };
+  return {
+    ok: true,
+    turn: {
+      sessionId: input.sessionId,
+      turn: input.turn,
+      startSeq: input.startSeq,
+      endSeq: input.endSeq,
+      userPrompt,
+      assistantReply,
+      outcome,
+    },
+  };
+}
+
+function validateSessionHeader(
+  input: DshSessionTurnInput,
+): DshSessionTurnValidationFailureReason | undefined {
+  const header = input.sessionHeader;
+  if (
+    header.version !== DSH_SESSION_FORMAT_VERSION
+    || safeIntegerField(header, "createdAt", 0) === undefined
+  ) return "session_header_invalid";
+  if (stringField(header, "id") !== input.sessionId) return "session_identity_mismatch";
+  if (stringField(header, "cwd") !== input.cwd) return "workspace_identity_mismatch";
+  if (Object.prototype.hasOwnProperty.call(header, "parentSession")) {
+    if (!stringField(header, "parentSession")) return "session_header_invalid";
+  }
+  if (Object.prototype.hasOwnProperty.call(header, "origin")) {
+    if (header.origin !== "subagent") return "session_header_invalid";
+    return "subagent_session";
+  }
+  const delegationDepth = optionalSafeIntegerField(header, "delegationDepth", 0);
+  if (!delegationDepth.ok) return "session_header_invalid";
+  if ((delegationDepth.value ?? 0) > 0) return "subagent_session";
+  return undefined;
+}
+
+type MessageEnvelope = Readonly<{
+  content: readonly unknown[];
+  source: Record<string, unknown>;
+}>;
+
+function messageEnvelope(value: Record<string, unknown>, role: "user" | "assistant"): MessageEnvelope | undefined {
+  if (
+    value.role !== role
+    || !Array.isArray(value.content)
+    || !isRecord(value.source)
+    || !stringField(value.source, "kind")
+  ) return undefined;
+  return { content: value.content, source: value.source };
+}
+
+function textContent(content: readonly unknown[]): string | undefined {
+  const parts: string[] = [];
+  for (const block of content) {
+    if (!isRecord(block) || !stringField(block, "type")) return undefined;
+    if (block.type !== "text") continue;
+    if (typeof block.text !== "string") return undefined;
+    if (block.text.trim()) parts.push(block.text);
+  }
+  return parts.join("\n").trim();
+}
+
+function validSurfaceOp(value: unknown): boolean {
+  if (value === "append") return true;
+  return isRecord(value)
+    && Object.keys(value).length === 3
+    && value.op === "replace"
+    && safeIntegerField(value, "start", 0) !== undefined
+    && safeIntegerField(value, "end", 0) !== undefined;
+}
+
+function stringField(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function safeIntegerField(
+  record: Record<string, unknown>,
+  key: string,
+  minimum: number,
+): number | undefined {
+  const value = record[key];
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= minimum
+    ? value
+    : undefined;
+}
+
+function optionalSafeIntegerField(
+  record: Record<string, unknown>,
+  key: string,
+  minimum: number,
+): { ok: true; value?: number } | { ok: false } {
+  if (!Object.prototype.hasOwnProperty.call(record, key)) return { ok: true };
+  const value = safeIntegerField(record, key, minimum);
+  return value === undefined ? { ok: false } : { ok: true, value };
+}

--- a/packages/ts/memorax-code-backend/src/memory/automatic-writeback.ts
+++ b/packages/ts/memorax-code-backend/src/memory/automatic-writeback.ts
@@ -36,7 +36,7 @@ import {
   type MemoryPayloadRedactionKind,
 } from "./payload-redaction.js";
 
-export type AutomaticMemoryWritebackClient = "codex" | "claude-code" | "opencode";
+export type AutomaticMemoryWritebackClient = "codex" | "claude-code" | "opencode" | "dsh";
 
 export type AutomaticMemoryWritebackOptions = {
   client: AutomaticMemoryWritebackClient;

--- a/packages/ts/memorax-code-backend/src/memory/hook-command.ts
+++ b/packages/ts/memorax-code-backend/src/memory/hook-command.ts
@@ -3,7 +3,7 @@ import { isRecord } from "../shared/record.js";
 export const MEMORY_HOOK_COMMAND_VERSION = 1 as const;
 export const INVALID_MEMORY_HOOK_COMMAND = "invalid memory Hook command";
 
-export type MemoryHookClient = "codex" | "claude-code" | "opencode";
+export type MemoryHookClient = "codex" | "claude-code" | "opencode" | "dsh";
 
 const BASE_COMMAND_KEYS = [
   "version",
@@ -16,6 +16,7 @@ const TURN_START_KEYS: Readonly<Record<MemoryHookClient, ReadonlySet<string>>> =
   codex: new Set([...BASE_COMMAND_KEYS, "turnId", "prompt", "transcriptPath"]),
   "claude-code": new Set([...BASE_COMMAND_KEYS, "promptId", "prompt", "transcriptPath"]),
   opencode: new Set([...BASE_COMMAND_KEYS, "userMessageId", "prompt"]),
+  dsh: new Set(["version", "client", "sessionId", "turn", "startSeq", "cwd", "prompt"]),
 };
 const WRITEBACK_KEYS: Readonly<Record<MemoryHookClient, ReadonlySet<string>>> = {
   codex: new Set([...BASE_COMMAND_KEYS, "turnId", "lastAssistantMessage", "transcriptPath"]),
@@ -30,6 +31,17 @@ const WRITEBACK_KEYS: Readonly<Record<MemoryHookClient, ReadonlySet<string>>> = 
     "userMessageId",
     "assistantMessageId",
     "messages",
+  ]),
+  dsh: new Set([
+    "version",
+    "client",
+    "sessionId",
+    "turn",
+    "startSeq",
+    "endSeq",
+    "cwd",
+    "sessionHeader",
+    "events",
   ]),
 };
 const SKILL_REMINDER_KEYS: Readonly<Partial<Record<MemoryHookClient, ReadonlySet<string>>>> = {
@@ -63,7 +75,18 @@ export type OpenCodeTurnStartCommand = MemoryHookCommandBase<"opencode"> & Reado
   prompt: string;
 }>;
 
-export type TurnStartCommand = CodexTurnStartCommand | ClaudeTurnStartCommand | OpenCodeTurnStartCommand;
+export type DshTurnStartCommand = MemoryHookCommandBase<"dsh"> & Readonly<{
+  turn: number;
+  startSeq: number;
+  cwd: string;
+  prompt: string;
+}>;
+
+export type TurnStartCommand =
+  | CodexTurnStartCommand
+  | ClaudeTurnStartCommand
+  | OpenCodeTurnStartCommand
+  | DshTurnStartCommand;
 
 export type MemoryHookTurnStartResult = Readonly<{
   ok: true;
@@ -89,7 +112,20 @@ export type OpenCodeWritebackCommand = MemoryHookCommandBase<"opencode"> & Reado
   messages: readonly unknown[];
 }>;
 
-export type WritebackCommand = CodexWritebackCommand | ClaudeWritebackCommand | OpenCodeWritebackCommand;
+export type DshWritebackCommand = MemoryHookCommandBase<"dsh"> & Readonly<{
+  turn: number;
+  startSeq: number;
+  endSeq: number;
+  cwd: string;
+  sessionHeader: Readonly<Record<string, unknown>>;
+  events: readonly unknown[];
+}>;
+
+export type WritebackCommand =
+  | CodexWritebackCommand
+  | ClaudeWritebackCommand
+  | OpenCodeWritebackCommand
+  | DshWritebackCommand;
 
 export type SkillReminderTrigger = "cadence" | "post_compaction";
 
@@ -130,6 +166,22 @@ export function parseTurnStartCommand(
   if (!base) return invalidCommand();
   const prompt = requiredStringField(value, "prompt");
   if (!prompt) return invalidCommand();
+  if (base.client === "dsh") {
+    const turn = positiveSafeIntegerField(value, "turn");
+    const startSeq = nonNegativeSafeIntegerField(value, "startSeq");
+    if (!turn || startSeq === undefined || !base.cwd) return invalidCommand();
+    return {
+      ok: true,
+      command: {
+        ...base,
+        client: "dsh",
+        turn,
+        startSeq,
+        cwd: base.cwd,
+        prompt,
+      },
+    };
+  }
   if (base.client === "codex") {
     const transcriptPath = requiredStringField(value, "transcriptPath");
     const turnId = optionalStringField(value, "turnId");
@@ -179,6 +231,33 @@ export function parseWritebackCommand(
   if (!isRecord(value)) return invalidCommand();
   const base = parseCommandBase(value, WRITEBACK_KEYS);
   if (!base) return invalidCommand();
+  if (base.client === "dsh") {
+    const turn = positiveSafeIntegerField(value, "turn");
+    const startSeq = nonNegativeSafeIntegerField(value, "startSeq");
+    const endSeq = nonNegativeSafeIntegerField(value, "endSeq");
+    if (
+      !turn
+      || startSeq === undefined
+      || endSeq === undefined
+      || endSeq < startSeq
+      || !base.cwd
+      || !isRecord(value.sessionHeader)
+      || !Array.isArray(value.events)
+    ) return invalidCommand();
+    return {
+      ok: true,
+      command: {
+        ...base,
+        client: "dsh",
+        turn,
+        startSeq,
+        endSeq,
+        cwd: base.cwd,
+        sessionHeader: value.sessionHeader,
+        events: value.events,
+      },
+    };
+  }
   if (base.client === "opencode") {
     const userMessageId = requiredStringField(value, "userMessageId");
     const assistantMessageId = requiredStringField(value, "assistantMessageId");
@@ -290,7 +369,12 @@ function parseCommandBase(
 ): MemoryHookCommandBase<MemoryHookClient> | undefined {
   if (value.version !== MEMORY_HOOK_COMMAND_VERSION) return undefined;
   const client = value.client;
-  if (client !== "codex" && client !== "claude-code" && client !== "opencode") return undefined;
+  if (
+    client !== "codex"
+    && client !== "claude-code"
+    && client !== "opencode"
+    && client !== "dsh"
+  ) return undefined;
   const clientKeys = allowedKeys[client];
   if (!clientKeys || Object.keys(value).some((key) => !clientKeys.has(key))) return undefined;
   const sessionId = requiredStringField(value, "sessionId");
@@ -305,6 +389,26 @@ function parseCommandBase(
     ...(cwd.value ? { cwd: cwd.value } : {}),
     ...(workspaceKind.value ? { workspaceKind: workspaceKind.value } : {}),
   };
+}
+
+function positiveSafeIntegerField(
+  value: Record<string, unknown>,
+  key: string,
+): number | undefined {
+  const field = value[key];
+  return typeof field === "number" && Number.isSafeInteger(field) && field > 0
+    ? field
+    : undefined;
+}
+
+function nonNegativeSafeIntegerField(
+  value: Record<string, unknown>,
+  key: string,
+): number | undefined {
+  const field = value[key];
+  return typeof field === "number" && Number.isSafeInteger(field) && field >= 0
+    ? field
+    : undefined;
 }
 
 function requiredStringField(

--- a/packages/ts/memorax-code-backend/src/memory/service.ts
+++ b/packages/ts/memorax-code-backend/src/memory/service.ts
@@ -10,6 +10,10 @@ import {
   type ClaudeMemoryHookWritebackResult,
 } from "../clients/claude/memory-hook-runtime.js";
 import {
+  createDshMemoryHookRuntime,
+  type DshMemoryHookWritebackResult,
+} from "../clients/dsh/memory-hook-runtime.js";
+import {
   createOpenCodeMemoryHookRuntime,
   type OpenCodeMemoryHookWritebackResult,
 } from "../clients/opencode/memory-hook-runtime.js";
@@ -31,7 +35,8 @@ export type MemoryServiceOptions = Omit<
 type MemoryHookWritebackResult =
   | CodexMemoryHookWritebackResult
   | ClaudeMemoryHookWritebackResult
-  | OpenCodeMemoryHookWritebackResult;
+  | OpenCodeMemoryHookWritebackResult
+  | DshMemoryHookWritebackResult;
 
 export type MemoryService = {
   recordTurnStart(command: TurnStartCommand): Promise<MemoryHookTurnStartResult>;
@@ -69,6 +74,11 @@ export function createMemoryService(options: MemoryServiceOptions = {}): MemoryS
     repositoryMemorySession,
     turnCoordinator,
   });
+  const dshHook = createDshMemoryHookRuntime({
+    ...options,
+    repositoryMemorySession,
+    turnCoordinator,
+  });
   let closed = false;
   return {
     async recordTurnStart(command) {
@@ -79,6 +89,8 @@ export function createMemoryService(options: MemoryServiceOptions = {}): MemoryS
           return await claudeHook.recordTurnStart(command);
         case "opencode":
           return await openCodeHook.recordTurnStart(command);
+        case "dsh":
+          return await dshHook.recordTurnStart(command);
       }
       return unsupportedMemoryHookCommand(command);
     },
@@ -90,6 +102,8 @@ export function createMemoryService(options: MemoryServiceOptions = {}): MemoryS
           return await claudeHook.writeback(command);
         case "opencode":
           return await openCodeHook.writeback(command);
+        case "dsh":
+          return await dshHook.writeback(command);
       }
       return unsupportedMemoryHookCommand(command);
     },
@@ -102,6 +116,7 @@ export function createMemoryService(options: MemoryServiceOptions = {}): MemoryS
       codexHook.close();
       claudeHook.close();
       openCodeHook.close();
+      dshHook.close();
       turnCoordinator.close();
       repositoryMemorySession.close();
       automaticWriteback.close();

--- a/packages/ts/memorax-code-backend/src/memory/turn-coordinator.ts
+++ b/packages/ts/memorax-code-backend/src/memory/turn-coordinator.ts
@@ -25,6 +25,7 @@ export type MemoryTurnStart = MemoryTurnKey & Readonly<{
   cwd?: string;
   workspaceKind?: string;
   transcriptPath?: string;
+  eventStartSeq?: number;
   createdAt: number;
   sessionTurnIndex?: number;
   traceContext?: TraceContext;
@@ -109,6 +110,7 @@ export function createMemoryTurnCoordinator(options: MemoryTurnCoordinatorOption
         cwd: input.cwd,
         workspaceKind: input.workspaceKind,
         transcriptPath: input.transcriptPath,
+        eventStartSeq: input.eventStartSeq,
         createdAt: input.createdAt,
         sessionTurnIndex: input.sessionTurnIndex,
         traceContext: input.traceContext,

--- a/packages/ts/memorax-code-backend/src/memory/writeback-buffer.ts
+++ b/packages/ts/memorax-code-backend/src/memory/writeback-buffer.ts
@@ -12,7 +12,7 @@ import {
 import type { TraceContext } from "../trace/context.js";
 
 export type MemoryWritebackBufferDecision = {
-  client: "codex" | "claude-code" | "opencode";
+  client: "codex" | "claude-code" | "opencode" | "dsh";
   sessionKey: string;
   idempotencyKey: string;
   messages: WritebackMessage[];

--- a/packages/ts/memorax-code-backend/test/architecture/source-boundaries.test.mjs
+++ b/packages/ts/memorax-code-backend/test/architecture/source-boundaries.test.mjs
@@ -40,6 +40,8 @@ const rules = [
       "clients/claude/memory-hook-runtime.ts",
       "clients/claude/transcript-turn.ts",
       "clients/codex/memory-hook-runtime.ts",
+      "clients/dsh/memory-hook-runtime.ts",
+      "clients/dsh/session-turn.ts",
       "clients/opencode/memory-hook-runtime.ts",
       "clients/opencode/message-turn.ts",
       "memory/turn-coordinator.ts",
@@ -61,6 +63,7 @@ const rules = [
       "memory/automatic-writeback.ts",
       "clients/claude/memory-hook-runtime.ts",
       "clients/codex/memory-hook-runtime.ts",
+      "clients/dsh/memory-hook-runtime.ts",
       "clients/opencode/memory-hook-runtime.ts",
       "provider/memorax/adapter.ts",
       "memory/turn-coordinator.ts",
@@ -83,6 +86,7 @@ const rules = [
     importers: [
       "clients/claude/memory-hook-runtime.ts",
       "clients/codex/memory-hook-runtime.ts",
+      "clients/dsh/memory-hook-runtime.ts",
       "clients/opencode/memory-hook-runtime.ts",
       "memory/turn-coordinator.ts",
     ],
@@ -104,9 +108,14 @@ const rules = [
     forbidden: ["node:http", "server-", "entrypoints/", "transport/http/", "app/state"],
   },
   {
+    name: "DSH memory hook runtime stays independent from HTTP and Backend composition",
+    importers: ["clients/dsh/memory-hook-runtime.ts", "clients/dsh/session-turn.ts"],
+    forbidden: ["node:http", "server-", "entrypoints/", "transport/http/", "app/state"],
+  },
+  {
     name: "memory turn coordinator stays independent from HTTP, Backend composition, and client transcripts",
     importers: ["memory/turn-coordinator.ts"],
-    forbidden: ["node:http", "server-", "entrypoints/", "transport/http/", "app/state", "clients/codex/rollout", "clients/claude/", "clients/opencode/"],
+    forbidden: ["node:http", "server-", "entrypoints/", "transport/http/", "app/state", "clients/codex/rollout", "clients/claude/", "clients/dsh/", "clients/opencode/"],
   },
   {
     name: "writeback reconciliation stays independent from HTTP, Backend composition, and Viewer models",

--- a/packages/ts/memorax-code-backend/test/clients/dsh/dsh-memory-hook.test.mjs
+++ b/packages/ts/memorax-code-backend/test/clients/dsh/dsh-memory-hook.test.mjs
@@ -1,0 +1,188 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+import { createBackendState } from "../../../dist/app/state.js";
+import { createBackendServer } from "../../../dist/server.js";
+import { listen } from "../../support/helpers.mjs";
+import { createHttpBackendClient } from "../../../../memorax-code-dsh-adapter/src/http-client.mjs";
+import {
+  memoraxAddFetch,
+  waitFor,
+  withEnv,
+} from "../codex/support/memory-hook-fixtures.mjs";
+import { dshTurnInterval } from "./support/dsh-session-fixtures.mjs";
+
+const TEST_WORKSPACE = fileURLToPath(new URL("../../..", import.meta.url));
+
+test("Backend runs a DSH native Turn through retrieval and automatic writeback", async () => {
+  const sessionHome = await mkdtemp(join(tmpdir(), "memorax-code-dsh-hook-"));
+  const interval = dshTurnInterval({
+    sessionId: "session-dsh-http",
+    cwd: TEST_WORKSPACE,
+    turn: 3,
+    startSeq: 40,
+  });
+  const requests = [];
+  const fetchImpl = async (url, init) => {
+    const request = { url: String(url), body: JSON.parse(init.body) };
+    requests.push(request);
+    const searching = request.url.endsWith("/v1/memories/search");
+    return new Response(JSON.stringify(searching ? {
+      success: true,
+      data: {
+        task_id: "dsh-search",
+        status: "completed",
+        data: [{
+          id: "memory-1",
+          memory: "Use DSH's durable Session Event Log.",
+          score: 0.95,
+          metadata: { memory_type: "core" },
+        }],
+      },
+    } : {
+      success: true,
+      data: { task_id: "dsh-add", status: "queued" },
+    }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  };
+  const restoreEnv = withEnv({
+    MEMORAX_CODE_HOME: sessionHome,
+    MEMORAX_CODE_CODEX_TRACE_ENABLED: "false",
+    MEMORAX_CODE_CLAUDE_TRACE_ENABLED: "false",
+    MEMORAX_CODE_OPENCODE_TRACE_ENABLED: "false",
+    MEMORAX_CODE_MEMORY_RETRIEVAL_ENABLED: "true",
+    MEMORAX_CODE_MEMORY_WRITEBACK_ENABLED: "true",
+    MEMORAX_CODE_MEMORY_WRITEBACK_BUFFER_ENABLED: "false",
+    MEMORAX_CODE_MEMORAX_ENDPOINT: "http://memorax.test",
+    MEMORAX_CODE_MEMORAX_API_KEY: "secret",
+    MEMORAX_CODE_MEMORAX_USER_ID: "user-1",
+  });
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = fetchImpl;
+  const state = createBackendState("127.0.0.1", {
+    sessionHome,
+    authToken: "backend-token",
+  });
+  const server = createBackendServer(state);
+  const url = await listen(server);
+  const backendClient = createHttpBackendClient({
+    env: {},
+    fetchImpl: originalFetch,
+    resolveConnection: () => ({ url, token: "backend-token" }),
+  });
+  const turnStart = {
+    version: 1,
+    client: "dsh",
+    sessionId: interval.sessionId,
+    turn: interval.turn,
+    startSeq: interval.startSeq,
+    cwd: interval.cwd,
+    prompt: "Implement the DSH adapter.",
+  };
+  try {
+    const startBody = await backendClient.recordTurnStart(turnStart);
+    assert.equal(startBody.ok, true);
+    assert.match(startBody.additionalContext, /durable Session Event Log/);
+
+    const mismatched = structuredClone(interval);
+    mismatched.sessionHeader.cwd = resolve(TEST_WORKSPACE, "other");
+    const rejectedWriteback = await backendClient.writebackTurn({
+      version: 1,
+      client: "dsh",
+      ...mismatched,
+    });
+    assert.deepEqual(rejectedWriteback, {
+      ok: true,
+      scheduled: false,
+      reason: "workspace_identity_mismatch",
+    });
+
+    const shiftedInterval = dshTurnInterval({
+      sessionId: interval.sessionId,
+      cwd: interval.cwd,
+      turn: interval.turn,
+      startSeq: interval.startSeq + 1,
+    });
+    const mismatchedMetadata = await backendClient.writebackTurn({
+      version: 1,
+      client: "dsh",
+      ...shiftedInterval,
+    });
+    assert.deepEqual(mismatchedMetadata, {
+      ok: true,
+      scheduled: false,
+      reason: "turn_metadata_mismatch",
+    });
+
+    const writeback = await backendClient.writebackTurn({
+      version: 1,
+      client: "dsh",
+      ...interval,
+    });
+    assert.deepEqual(writeback, { ok: true, scheduled: true });
+    await waitFor(() => requests.length === 2, "DSH writeback did not call MemoraX Add");
+    assert.deepEqual(requests.map((request) => new URL(request.url).pathname), [
+      "/v1/memories/search",
+      "/v1/memories/add",
+    ]);
+    assert.deepEqual(requests[1].body.messages.map(({ role, content }) => ({ role, content })), [
+      { role: "user", content: "Implement the DSH adapter." },
+      { role: "assistant", content: "I will inspect.\n\nThe adapter is ready." },
+    ]);
+    assert.equal(JSON.stringify(requests[1].body).includes("recalled memory"), false);
+    assert.equal(JSON.stringify(requests[1].body).includes("private tool result"), false);
+  } finally {
+    await server.shutdown();
+    globalThis.fetch = originalFetch;
+    restoreEnv();
+    await rm(sessionHome, { recursive: true, force: true });
+  }
+});
+
+test("Backend recovers DSH writeback from the native log without cached turn metadata", async () => {
+  const sessionHome = await mkdtemp(join(tmpdir(), "memorax-code-dsh-recovery-"));
+  const interval = dshTurnInterval({
+    sessionId: "session-dsh-recovered",
+    cwd: TEST_WORKSPACE,
+    turn: 2,
+    startSeq: 20,
+  });
+  const { fetchImpl, requests } = memoraxAddFetch();
+  const restoreEnv = withEnv({
+    MEMORAX_CODE_HOME: sessionHome,
+    MEMORAX_CODE_CODEX_TRACE_ENABLED: "false",
+    MEMORAX_CODE_CLAUDE_TRACE_ENABLED: "false",
+    MEMORAX_CODE_OPENCODE_TRACE_ENABLED: "false",
+    MEMORAX_CODE_MEMORY_RETRIEVAL_ENABLED: "false",
+    MEMORAX_CODE_MEMORY_WRITEBACK_ENABLED: "true",
+    MEMORAX_CODE_MEMORY_WRITEBACK_BUFFER_ENABLED: "false",
+    MEMORAX_CODE_MEMORAX_ENDPOINT: "http://memorax.test",
+    MEMORAX_CODE_MEMORAX_API_KEY: "secret",
+    MEMORAX_CODE_MEMORAX_USER_ID: "user-1",
+  });
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = fetchImpl;
+  const state = createBackendState("127.0.0.1", { sessionHome });
+  const server = createBackendServer(state);
+  const url = await listen(server);
+  try {
+    const writeback = await originalFetch(`${url}/memory/writeback`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ version: 1, client: "dsh", ...interval }),
+    });
+    assert.equal(writeback.status, 200);
+    assert.deepEqual(await writeback.json(), { ok: true, scheduled: true });
+    await waitFor(() => requests.length === 1, "recovered DSH writeback did not call MemoraX Add");
+  } finally {
+    await server.shutdown();
+    globalThis.fetch = originalFetch;
+    restoreEnv();
+    await rm(sessionHome, { recursive: true, force: true });
+  }
+});

--- a/packages/ts/memorax-code-backend/test/clients/dsh/dsh-session-turn.test.mjs
+++ b/packages/ts/memorax-code-backend/test/clients/dsh/dsh-session-turn.test.mjs
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { dshSessionEventTurn } from "../../../dist/clients/dsh/session-turn.js";
+import { dshTurnInterval } from "./support/dsh-session-fixtures.mjs";
+
+const CWD = "/workspace/project";
+
+test("DSH turn materialization accepts one exact native interval and excludes plugin and tool content", () => {
+  const result = dshSessionEventTurn(dshTurnInterval({ cwd: CWD }));
+  assert.deepEqual(result, {
+    ok: true,
+    turn: {
+      sessionId: "session-dsh",
+      turn: 1,
+      startSeq: 0,
+      endSeq: 10,
+      userPrompt: "Implement the DSH adapter.",
+      assistantReply: "I will inspect.\n\nThe adapter is ready.",
+      outcome: "completed",
+    },
+  });
+  assert.equal(JSON.stringify(result).includes("recalled memory"), false);
+  assert.equal(JSON.stringify(result).includes("private tool result"), false);
+
+  const ordinaryFork = dshTurnInterval({ cwd: CWD });
+  ordinaryFork.sessionHeader.parentSession = "ordinary-parent";
+  assert.equal(
+    dshSessionEventTurn(ordinaryFork).ok,
+    true,
+    "an ordinary fork is not a delegated subagent",
+  );
+});
+
+test("DSH turn materialization fails closed across session, workspace, interval, and event identities", () => {
+  const base = dshTurnInterval({ cwd: CWD });
+  const cases = [
+    ["session header version", (value) => { value.sessionHeader.version = 1; }, "session_header_invalid"],
+    ["session id", (value) => { value.sessionHeader.id = "other-session"; }, "session_identity_mismatch"],
+    ["workspace", (value) => { value.sessionHeader.cwd = "/workspace/other"; }, "workspace_identity_mismatch"],
+    ["subagent", (value) => { value.sessionHeader.delegationDepth = 1; }, "subagent_session"],
+    ["interval length", (value) => { value.endSeq += 1; }, "interval_length_mismatch"],
+    ["event sequence", (value) => { value.events[4].seq += 1; }, "event_sequence_mismatch"],
+    ["surface operation", (value) => { value.events[2].surfaceOp = { op: "replace", start: 1 }; }, "event_invalid"],
+    ["first boundary", (value) => { value.events[0].type = "step/start"; }, "turn_boundary_mismatch"],
+    ["turn identity", (value) => { value.events[4].data.turn = 2; }, "turn_identity_mismatch"],
+    [
+      "interrupted turn",
+      (value) => { value.events.at(-1).data.reason = { kind: "interrupted" }; },
+      "turn_not_completed",
+      "interrupted",
+    ],
+    ["unknown required event", (value) => { delete value.events[9].ignorable; }, "unknown_required_event"],
+  ];
+  for (const [name, mutate, reason, outcome] of cases) {
+    const value = structuredClone(base);
+    mutate(value);
+    assert.deepEqual(dshSessionEventTurn(value), {
+      ok: false,
+      reason,
+      ...(outcome ? { outcome } : {}),
+    }, name);
+  }
+});
+
+test("DSH turn materialization never treats plugin recall as the user prompt", () => {
+  const value = dshTurnInterval({ cwd: CWD });
+  value.events[1].data.source = { kind: "plugin", plugin: "memorax-code", form: "recall" };
+  assert.deepEqual(dshSessionEventTurn(value), {
+    ok: false,
+    reason: "user_prompt_missing",
+  });
+});
+
+test("DSH turn materialization ignores compaction replacement messages", () => {
+  const value = dshTurnInterval({ cwd: CWD });
+  value.events[2].data.source = {
+    kind: "plugin",
+    plugin: "compact",
+    compactionId: "compaction-1",
+  };
+  value.events[2].surfaceOp = { op: "replace", start: 1, end: 1 };
+
+  const result = dshSessionEventTurn(value);
+  assert.equal(result.ok, true);
+  assert.equal(result.turn.userPrompt, "Implement the DSH adapter.");
+  assert.equal(JSON.stringify(result).includes("recalled memory"), false);
+});
+
+test("DSH interrupted intervals do not require completed-Turn content", () => {
+  const value = dshTurnInterval({ cwd: CWD });
+  value.events[1].data.source = { kind: "plugin", plugin: "memorax-code", form: "recall" };
+  value.events.at(-1).data.reason = { kind: "interrupted" };
+  assert.deepEqual(dshSessionEventTurn(value), {
+    ok: false,
+    reason: "turn_not_completed",
+    outcome: "interrupted",
+  });
+});

--- a/packages/ts/memorax-code-backend/test/clients/dsh/support/dsh-session-fixtures.mjs
+++ b/packages/ts/memorax-code-backend/test/clients/dsh/support/dsh-session-fixtures.mjs
@@ -1,0 +1,94 @@
+export function dshTurnInterval({
+  sessionId = "session-dsh",
+  cwd,
+  turn = 1,
+  startSeq = 0,
+} = {}) {
+  if (!cwd) throw new Error("fixture cwd is required");
+  const events = [];
+  const append = (type, data, extra = {}) => {
+    events.push({
+      type,
+      seq: startSeq + events.length,
+      time: 1_700_000_000_000 + events.length,
+      data,
+      ...extra,
+    });
+  };
+  append("turn/start", { turn });
+  append("user/message", {
+    id: "user-message-1",
+    role: "user",
+    content: [{ type: "text", text: "Implement the DSH adapter." }],
+    source: { kind: "user" },
+  }, { surfaceOp: "append" });
+  append("user/message", {
+    id: "memory-recall-1",
+    role: "user",
+    content: [{ type: "text", text: "recalled memory must not be written back" }],
+    source: { kind: "plugin", plugin: "memorax-code", form: "recall" },
+  }, { surfaceOp: "append" });
+  append("step/start", { turn, step: 1 });
+  append("assistant/message", {
+    turn,
+    step: 1,
+    message: {
+      id: "assistant-message-1",
+      role: "assistant",
+      content: [
+        { type: "text", text: "I will inspect." },
+        { type: "tool-call", id: "call-1", name: "read", arguments: "{}" },
+      ],
+      source: { kind: "model", provider: "mock", model: "mock" },
+    },
+  }, { surfaceOp: "append" });
+  append("tool/call", {
+    turn,
+    step: 1,
+    callId: "call-1",
+    name: "read",
+    arguments: "{}",
+  });
+  append("tool/result", {
+    turn,
+    step: 1,
+    message: {
+      id: "tool-message-1",
+      role: "user",
+      content: [{
+        type: "tool-result",
+        toolCallId: "call-1",
+        content: [{ type: "text", text: "private tool result must stay local" }],
+        isError: false,
+      }],
+      source: { kind: "tool", callId: "call-1" },
+    },
+  }, { surfaceOp: "append" });
+  append("assistant/message", {
+    turn,
+    step: 1,
+    message: {
+      id: "assistant-message-2",
+      role: "assistant",
+      content: [{ type: "text", text: "The adapter is ready." }],
+      source: { kind: "model", provider: "mock", model: "mock" },
+    },
+  }, { surfaceOp: "append" });
+  append("step/end", { turn, step: 1 });
+  append("plugin/telemetry", null, { ignorable: true });
+  append("turn/end", { turn, reason: { kind: "completed" } });
+  return {
+    sessionId,
+    turn,
+    startSeq,
+    endSeq: startSeq + events.length - 1,
+    cwd,
+    sessionHeader: {
+      version: 0,
+      id: sessionId,
+      createdAt: 1_700_000_000_000,
+      cwd,
+    },
+    events,
+  };
+}

--- a/packages/ts/memorax-code-backend/test/transport/http/memory-hook.test.mjs
+++ b/packages/ts/memorax-code-backend/test/transport/http/memory-hook.test.mjs
@@ -132,6 +132,26 @@ test("Backend memory hook endpoints reject commands outside the closed schema", 
     assistantMessageId: "assistant-opencode-writeback",
     messages: [],
   };
+  const dshTurnStart = {
+    version: 1,
+    client: "dsh",
+    sessionId: "session-dsh-turn-start",
+    turn: 1,
+    startSeq: 0,
+    cwd: "/workspace/dsh",
+    prompt: "DSH turn start.",
+  };
+  const dshWriteback = {
+    version: 1,
+    client: "dsh",
+    sessionId: "session-dsh-writeback",
+    turn: 1,
+    startSeq: 0,
+    endSeq: 1,
+    cwd: "/workspace/dsh",
+    sessionHeader: {},
+    events: [],
+  };
   try {
     for (const [caseName, path, body] of [
       ["unversioned command", "/memory/turn-start", {
@@ -214,6 +234,18 @@ test("Backend memory hook endpoints reject commands outside the closed schema", 
       ["invalid OpenCode messages container", "/memory/writeback", {
         ...openCodeWriteback,
         messages: {},
+      }],
+      ["transcript field on DSH turn-start", "/memory/turn-start", {
+        ...dshTurnStart,
+        transcriptPath: "/tmp/dsh.jsonl",
+      }],
+      ["invalid DSH events container", "/memory/writeback", {
+        ...dshWriteback,
+        events: {},
+      }],
+      ["invalid DSH event interval", "/memory/writeback", {
+        ...dshWriteback,
+        endSeq: -1,
       }],
     ]) {
       const response = await fetch(`${url}${path}`, {

--- a/packages/ts/memorax-code-dsh-adapter/package.json
+++ b/packages/ts/memorax-code-dsh-adapter/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@memorax-code/dsh-adapter",
+  "version": "0.1.2",
+  "private": true,
+  "type": "module",
+  "description": "DeepSeek Harness native memory adapter for MemoraX Code.",
+  "scripts": {
+    "test": "node --test test/*.test.mjs"
+  }
+}

--- a/packages/ts/memorax-code-dsh-adapter/src/dsh-message.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/src/dsh-message.mjs
@@ -1,0 +1,32 @@
+import { randomUUID } from "node:crypto";
+
+/** Create the same detached, identified, deeply frozen UserMessage as DSH. */
+export function createDshUserMessage(input) {
+  if (input === null || typeof input !== "object" || Array.isArray(input)) {
+    throw new TypeError("DSH UserMessage input must be an object");
+  }
+  if (Object.hasOwn(input, "id") || Object.hasOwn(input, "role")) {
+    throw new TypeError("DSH UserMessage input must not supply id or role");
+  }
+  return deepFreeze(structuredClone({
+    ...input,
+    role: "user",
+    id: randomUUID(),
+  }));
+}
+
+// Mirrors DSH's public createUserMessage -> freezeMessage -> deepFreeze
+// construction contract without depending on DSH internals.
+function deepFreeze(value) {
+  const seen = new WeakSet();
+  const pending = [value];
+  while (pending.length > 0) {
+    const node = pending.pop();
+    if (node === null || typeof node !== "object" || node instanceof AbortSignal) continue;
+    if (seen.has(node)) continue;
+    seen.add(node);
+    Object.freeze(node);
+    for (const key of Object.keys(node)) pending.push(node[key]);
+  }
+  return value;
+}

--- a/packages/ts/memorax-code-dsh-adapter/src/http-client.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/src/http-client.mjs
@@ -1,0 +1,52 @@
+const RETRIEVAL_BACKEND_TIMEOUT_MS = 12_000;
+const DEFAULT_BACKEND_TIMEOUT_MS = 5_000;
+
+/** Create the narrow Backend port consumed by the Cordis plugin. */
+export function createHttpBackendClient(options) {
+  const resolveConnection = options?.resolveConnection;
+  const fetchImpl = options?.fetchImpl ?? globalThis.fetch;
+  const env = options?.env ?? process.env;
+  if (typeof resolveConnection !== "function") {
+    throw new TypeError("DSH Backend client requires resolveConnection");
+  }
+  if (typeof fetchImpl !== "function") throw new TypeError("DSH Backend client requires fetch");
+
+  return Object.freeze({
+    recordTurnStart(command, request = {}) {
+      return post("/memory/turn-start", command, request.signal);
+    },
+    writebackTurn(command, request = {}) {
+      return post("/memory/writeback", command, request.signal);
+    },
+  });
+
+  async function post(path, body, callerSignal) {
+    const connection = resolveConnection();
+    const timeoutMs = positiveInteger(
+      env.MEMORAX_CODE_DSH_MEMORY_HOOK_TIMEOUT_MS,
+      path === "/memory/turn-start" ? RETRIEVAL_BACKEND_TIMEOUT_MS : DEFAULT_BACKEND_TIMEOUT_MS,
+    );
+    const headers = { "content-type": "application/json", connection: "close" };
+    if (connection.token) headers["x-memorax-code-backend-token"] = connection.token;
+    const timeoutSignal = AbortSignal.timeout(timeoutMs);
+    const signal = callerSignal
+      ? AbortSignal.any([callerSignal, timeoutSignal])
+      : timeoutSignal;
+    const response = await fetchImpl(new URL(path, connection.url), {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+      signal,
+    });
+    if (!response.ok) {
+      await response.arrayBuffer().catch(() => undefined);
+      throw new Error(`MemoraX Code Backend ${path} returned HTTP ${response.status}`);
+    }
+    return await response.json().catch(() => undefined);
+  }
+}
+
+function positiveInteger(value, fallback) {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}

--- a/packages/ts/memorax-code-dsh-adapter/src/plugin.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/src/plugin.mjs
@@ -1,0 +1,281 @@
+import {
+  createTurnStartCommand,
+  createWritebackCommand,
+} from "./protocol.mjs";
+
+export const PLUGIN_NAME = "memorax-code";
+export const RECALL_SOURCE_PLUGIN = "memorax-code-dsh";
+// DSH gives the whole app five seconds to dispose; leave time for downstream
+// persistence and process cleanup after this plugin's accepted writes drain.
+const DEFAULT_WRITEBACK_DRAIN_TIMEOUT_MS = 4_000;
+
+/** Register DSH-native retrieval and durable Turn writeback listeners. */
+export function registerMemoraxCodePlugin(ctx, dependencies) {
+  const backendClient = dependencies?.backendClient;
+  const createUserMessage = dependencies?.createUserMessage;
+  const defer = dependencies?.defer ?? queueMicrotask;
+  const debug = dependencies?.debug ?? process.env.MEMORAX_CODE_DSH_DEBUG === "1";
+  const drainTimeoutMs = positiveInteger(
+    dependencies?.drainTimeoutMs,
+    DEFAULT_WRITEBACK_DRAIN_TIMEOUT_MS,
+  );
+  if (typeof backendClient?.recordTurnStart !== "function"
+    || typeof backendClient?.writebackTurn !== "function") {
+    throw new TypeError("memorax-code DSH plugin requires a Backend client");
+  }
+  if (typeof createUserMessage !== "function") {
+    throw new TypeError("memorax-code DSH plugin requires createUserMessage");
+  }
+  if (typeof ctx?.sessions?.flush !== "function"
+    || typeof ctx?.sessionPersistence?.readFrom !== "function") {
+    throw new TypeError("memorax-code DSH plugin requires sessions and sessionPersistence");
+  }
+
+  const turns = new WeakMap();
+  const writebackTails = new WeakMap();
+  const retrievalLifetime = new AbortController();
+  const writebackLifetime = new AbortController();
+  const pendingWritebacks = new Set();
+  let accepting = true;
+
+  ctx.on("session/event", (session, event) => {
+    if (!isMemoryEligibleSession(session) || !accepting) return;
+    if (event?.type === "turn/start") {
+      const turn = event.data?.turn;
+      if (!positiveSafeInteger(turn) || !nonNegativeSafeInteger(event.seq)) return;
+      const sessionTurns = turnMap(turns, session);
+      if (sessionTurns.has(turn)) {
+        sessionTurns.set(turn, { invalid: true });
+        return;
+      }
+      sessionTurns.set(turn, {
+        startSeq: event.seq,
+        retrievalAttempted: false,
+        closed: false,
+      });
+      return;
+    }
+    if (event?.type !== "turn/end") return;
+    const turn = event.data?.turn;
+    if (!positiveSafeInteger(turn) || !nonNegativeSafeInteger(event.seq)) return;
+    const state = turns.get(session)?.get(turn);
+    if (!state || state.invalid || state.closed || event.seq < state.startSeq) return;
+    state.closed = true;
+    state.endSeq = event.seq;
+    // Wait one microtask so every session/event listener, including the
+    // persistence coordinator, has admitted turn/end before the flush barrier.
+    const onFailure = (error) => debugFailure(ctx, debug, "writeback", error);
+    const pending = deferPromise(defer, () => enqueueWriteback({
+      ctx,
+      backendClient,
+      session,
+      turn,
+      state,
+      signal: writebackLifetime.signal,
+      writebackTails,
+    }), onFailure)
+      .catch(onFailure)
+      .finally(() => turns.get(session)?.delete(turn));
+    trackPending(pendingWritebacks, pending);
+  });
+
+  ctx.on("session/disposed", (session) => {
+    turns.delete(session);
+  });
+
+  ctx.on("agent/pre-step", async ({ agent, turn, step, signal }, next) => {
+    const decision = await next();
+    if (decision?.kind !== "enter" || signal?.aborted || !accepting) return decision;
+    if (step !== 1 || !isMemoryEligibleSession(agent?.session)) return decision;
+    const state = turns.get(agent.session)?.get(turn);
+    if (!state || state.invalid || state.closed || state.retrievalAttempted) return decision;
+    state.retrievalAttempted = true;
+    const prompt = userPrompt(decision.messages);
+    const cwd = sessionCwd(agent.session);
+    if (!prompt || !cwd) return decision;
+
+    try {
+      const retrievalSignal = signal
+        ? AbortSignal.any([signal, retrievalLifetime.signal])
+        : retrievalLifetime.signal;
+      const command = createTurnStartCommand({
+        sessionId: agent.session.id,
+        turn,
+        startSeq: state.startSeq,
+        cwd,
+        prompt,
+      });
+      const response = await backendClient.recordTurnStart(command, { signal: retrievalSignal });
+      if (signal?.aborted || !accepting) return decision;
+      const additionalContext = nonEmptyString(response?.additionalContext);
+      if (!additionalContext) return decision;
+      return {
+        kind: "enter",
+        messages: [
+          ...decision.messages,
+          createUserMessage({
+            content: [{ type: "text", text: additionalContext }],
+            source: { kind: "plugin", plugin: RECALL_SOURCE_PLUGIN, form: "recall" },
+          }),
+        ],
+      };
+    } catch (error) {
+      debugFailure(ctx, debug, "retrieval", error);
+      return decision;
+    }
+  });
+
+  if (typeof ctx.effect === "function") {
+    ctx.effect(() => async () => {
+      accepting = false;
+      retrievalLifetime.abort(new Error("memorax-code DSH plugin disposed"));
+      await waitForPending(pendingWritebacks, drainTimeoutMs);
+      writebackLifetime.abort(new Error("memorax-code DSH plugin disposed"));
+    }, "memorax-code.lifecycle");
+  }
+}
+
+function enqueueWriteback(options) {
+  const previous = options.writebackTails.get(options.session) ?? Promise.resolve();
+  const current = previous
+    .catch(() => undefined)
+    .then(() => captureWriteback(
+      options.ctx,
+      options.backendClient,
+      options.session,
+      options.turn,
+      options.state,
+      options.signal,
+    ));
+  options.writebackTails.set(options.session, current);
+  return current.finally(() => {
+    if (options.writebackTails.get(options.session) === current) {
+      options.writebackTails.delete(options.session);
+    }
+  });
+}
+
+async function captureWriteback(ctx, backendClient, session, turn, state, signal) {
+  signal.throwIfAborted();
+  const participated = await ctx.sessions.flush(session);
+  if (!participated) throw new Error("DSH session flush had no persistence listener");
+  signal.throwIfAborted();
+  const persisted = await ctx.sessionPersistence.readFrom(session.id, state.startSeq, signal);
+  signal.throwIfAborted();
+  const cwd = sessionCwd(session);
+  if (!cwd) throw new Error("DSH session has no authoritative cwd");
+  const command = createWritebackCommand({
+    sessionId: session.id,
+    turn,
+    startSeq: state.startSeq,
+    endSeq: state.endSeq,
+    cwd,
+    sessionHeader: persisted?.meta,
+    events: persisted?.events,
+  });
+  await backendClient.writebackTurn(command, { signal });
+}
+
+export function isMemoryEligibleSession(session) {
+  const header = session?.header;
+  return typeof session?.id === "string"
+    && header !== null
+    && typeof header === "object"
+    && header.id === session.id
+    && header.origin === undefined
+    && (header.delegationDepth === undefined || header.delegationDepth === 0);
+}
+
+function userPrompt(messages) {
+  if (!Array.isArray(messages)) return undefined;
+  const parts = [];
+  for (const message of messages) {
+    if (message?.role !== "user" || message.source?.kind !== "user") continue;
+    const text = textContent(message.content);
+    if (text) parts.push(text);
+  }
+  return parts.length > 0 ? parts.join("\n\n") : undefined;
+}
+
+function textContent(content) {
+  if (!Array.isArray(content)) return undefined;
+  const parts = content.flatMap((block) => (
+    block?.type === "text" && typeof block.text === "string" && block.text.trim()
+      ? [block.text.trim()]
+      : []
+  ));
+  return parts.length > 0 ? parts.join("\n") : undefined;
+}
+
+function sessionCwd(session) {
+  return nonEmptyString(session?.header?.cwd);
+}
+
+function turnMap(turns, session) {
+  let sessionTurns = turns.get(session);
+  if (!sessionTurns) {
+    sessionTurns = new Map();
+    turns.set(session, sessionTurns);
+  }
+  return sessionTurns;
+}
+
+function positiveSafeInteger(value) {
+  return Number.isSafeInteger(value) && value > 0;
+}
+
+function positiveInteger(value, fallback) {
+  return Number.isSafeInteger(value) && value > 0 ? value : fallback;
+}
+
+function nonNegativeSafeInteger(value) {
+  return Number.isSafeInteger(value) && value >= 0;
+}
+
+function nonEmptyString(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function debugFailure(ctx, debug, operation, error) {
+  if (!debug) return;
+  const detail = error instanceof Error ? error.message : String(error);
+  ctx.logger?.warn?.(`memorax-code ${operation} failed: ${detail}`);
+}
+
+function deferPromise(defer, operation, onFailure) {
+  return new Promise((resolve, reject) => {
+    try {
+      defer(() => {
+        const result = Promise.resolve().then(operation).catch(onFailure);
+        resolve(result);
+        return result;
+      });
+    } catch (error) {
+      reject(error);
+    }
+  });
+}
+
+function trackPending(pending, promise) {
+  pending.add(promise);
+  promise.then(
+    () => pending.delete(promise),
+    () => pending.delete(promise),
+  );
+}
+
+async function waitForPending(pending, timeoutMs) {
+  const accepted = [...pending];
+  if (accepted.length === 0) return;
+  let timer;
+  try {
+    await Promise.race([
+      Promise.allSettled(accepted),
+      new Promise((resolve) => {
+        timer = setTimeout(resolve, timeoutMs);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/packages/ts/memorax-code-dsh-adapter/src/protocol.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/src/protocol.mjs
@@ -1,0 +1,125 @@
+export const MEMORY_HOOK_COMMAND_VERSION = 1;
+export const MEMORY_HOOK_CLIENT = "dsh";
+
+const TURN_SCOPED_EVENT_TYPES = new Set([
+  "step/start",
+  "step/end",
+  "assistant/chunk",
+  "assistant/message",
+  "tool/call",
+  "tool/result",
+]);
+
+export function createTurnStartCommand(input) {
+  return {
+    version: MEMORY_HOOK_COMMAND_VERSION,
+    client: MEMORY_HOOK_CLIENT,
+    sessionId: requiredString(input?.sessionId, "sessionId"),
+    turn: positiveSafeInteger(input?.turn, "turn"),
+    startSeq: nonNegativeSafeInteger(input?.startSeq, "startSeq"),
+    cwd: requiredString(input?.cwd, "cwd"),
+    prompt: requiredString(input?.prompt, "prompt"),
+  };
+}
+
+export function createWritebackCommand(input) {
+  const sessionId = requiredString(input?.sessionId, "sessionId");
+  const turn = positiveSafeInteger(input?.turn, "turn");
+  const startSeq = nonNegativeSafeInteger(input?.startSeq, "startSeq");
+  const endSeq = nonNegativeSafeInteger(input?.endSeq, "endSeq");
+  const cwd = requiredString(input?.cwd, "cwd");
+  const sessionHeader = sessionHeaderValue(input?.sessionHeader, sessionId, cwd);
+  const events = exactTurnWindow(input?.events, { turn, startSeq, endSeq });
+  return {
+    version: MEMORY_HOOK_COMMAND_VERSION,
+    client: MEMORY_HOOK_CLIENT,
+    sessionId,
+    turn,
+    startSeq,
+    endSeq,
+    cwd,
+    sessionHeader: structuredClone(sessionHeader),
+    events: structuredClone(events),
+  };
+}
+
+/**
+ * Select and verify the exact persisted interval after readFrom(). Later Turns
+ * may already be durable, so only the inclusive requested suffix is returned.
+ */
+export function exactTurnWindow(events, expected) {
+  if (!Array.isArray(events)) throw new TypeError("DSH persisted events must be an array");
+  const turn = positiveSafeInteger(expected?.turn, "turn");
+  const startSeq = nonNegativeSafeInteger(expected?.startSeq, "startSeq");
+  const endSeq = nonNegativeSafeInteger(expected?.endSeq, "endSeq");
+  if (endSeq < startSeq) throw new Error("DSH turn endSeq precedes startSeq");
+
+  const selected = [];
+  for (const event of events) {
+    if (!record(event) || !Number.isSafeInteger(event.seq) || event.seq < 0) {
+      throw new Error("DSH persisted event has an invalid sequence number");
+    }
+    if (event.seq > endSeq) break;
+    selected.push(event);
+  }
+  const expectedLength = endSeq - startSeq + 1;
+  if (selected.length !== expectedLength) {
+    throw new Error("DSH persisted turn interval is incomplete");
+  }
+  for (let index = 0; index < selected.length; index += 1) {
+    if (selected[index].seq !== startSeq + index) {
+      throw new Error("DSH persisted turn interval is not contiguous");
+    }
+  }
+
+  const first = selected[0];
+  const last = selected.at(-1);
+  if (first.type !== "turn/start" || first.data?.turn !== turn) {
+    throw new Error("DSH persisted turn interval has no matching start boundary");
+  }
+  if (last.type !== "turn/end" || last.data?.turn !== turn) {
+    throw new Error("DSH persisted turn interval has no matching end boundary");
+  }
+  for (let index = 1; index < selected.length - 1; index += 1) {
+    const event = selected[index];
+    if (event.type === "turn/start" || event.type === "turn/end") {
+      throw new Error("DSH persisted turn interval contains a nested turn boundary");
+    }
+    if (TURN_SCOPED_EVENT_TYPES.has(event.type) && event.data?.turn !== turn) {
+      throw new Error("DSH persisted turn event belongs to another turn");
+    }
+  }
+  return selected;
+}
+
+function sessionHeaderValue(value, sessionId, cwd) {
+  if (!record(value)) throw new TypeError("DSH sessionHeader must be an object");
+  if (value.id !== sessionId) throw new Error("DSH sessionHeader id does not match sessionId");
+  if (value.cwd !== cwd) throw new Error("DSH sessionHeader cwd does not match cwd");
+  return value;
+}
+
+function requiredString(value, name) {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new TypeError(`DSH ${name} must be a non-empty string`);
+  }
+  return value.trim();
+}
+
+function positiveSafeInteger(value, name) {
+  if (!Number.isSafeInteger(value) || value < 1) {
+    throw new TypeError(`DSH ${name} must be a positive safe integer`);
+  }
+  return value;
+}
+
+function nonNegativeSafeInteger(value, name) {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new TypeError(`DSH ${name} must be a non-negative safe integer`);
+  }
+  return value;
+}
+
+function record(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}

--- a/packages/ts/memorax-code-dsh-adapter/test/plugin-integration.test.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/test/plugin-integration.test.mjs
@@ -1,0 +1,384 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createDshUserMessage } from "../src/dsh-message.mjs";
+import {
+  isMemoryEligibleSession,
+  registerMemoraxCodePlugin,
+} from "../src/plugin.mjs";
+
+test("retrieves once and writes the exact durable top-level DSH Turn", async () => {
+  const deferred = [];
+  const calls = [];
+  const turnStarts = [];
+  const writebacks = [];
+  let persisted;
+  const ctx = mockContext({
+    flush: async () => {
+      calls.push("flush");
+      return true;
+    },
+    readFrom: async (_sessionId, fromSeq) => {
+      calls.push(`read:${fromSeq}`);
+      return persisted;
+    },
+  });
+  const backendClient = {
+    async recordTurnStart(command) {
+      calls.push("backend:turn-start");
+      turnStarts.push(command);
+      return { ok: true, additionalContext: "Relevant shared memory" };
+    },
+    async writebackTurn(command) {
+      calls.push("backend:writeback");
+      writebacks.push(command);
+      return { ok: true, scheduled: true };
+    },
+  };
+  registerMemoraxCodePlugin(ctx, {
+    backendClient,
+    createUserMessage: createDshUserMessage,
+    defer: (callback) => deferred.push(callback),
+  });
+
+  const session = topLevelSession();
+  ctx.emit("session/event", session, event("turn/start", 4, { turn: 1 }));
+  const directUser = {
+    id: "user-1",
+    role: "user",
+    content: [{ type: "text", text: "How should the adapter work?" }],
+    source: { kind: "user" },
+  };
+  const downstreamContext = {
+    id: "context-1",
+    role: "user",
+    content: [{ type: "text", text: "workspace context" }],
+    source: { kind: "plugin", plugin: "workspace" },
+  };
+  const next = async () => {
+    calls.push("next");
+    return { kind: "enter", messages: [directUser, downstreamContext] };
+  };
+  const decision = await ctx.waterfall("agent/pre-step", {
+    agent: { id: session.id, session },
+    turn: 1,
+    step: 1,
+    signal: new AbortController().signal,
+  }, next);
+
+  assert.deepEqual(calls.slice(0, 2), ["next", "backend:turn-start"]);
+  assert.equal(decision.messages.length, 3);
+  assert.deepEqual(decision.messages[2].source, {
+    kind: "plugin",
+    plugin: "memorax-code-dsh",
+    form: "recall",
+  });
+  assert.deepEqual(turnStarts, [{
+    version: 1,
+    client: "dsh",
+    sessionId: "session-1",
+    turn: 1,
+    startSeq: 4,
+    cwd: "/workspace/project",
+    prompt: "How should the adapter work?",
+  }]);
+
+  await ctx.waterfall("agent/pre-step", {
+    agent: { id: session.id, session },
+    turn: 1,
+    step: 1,
+    signal: new AbortController().signal,
+  }, next);
+  assert.equal(turnStarts.length, 1, "retrieval is attempted at most once per Turn");
+
+  const recall = decision.messages[2];
+  persisted = {
+    meta: session.header,
+    events: [
+      event("turn/start", 4, { turn: 1 }),
+      event("step/start", 5, { turn: 1, step: 1 }),
+      event("user/message", 6, directUser),
+      event("user/message", 7, recall),
+      event("assistant/message", 8, {
+        turn: 1,
+        step: 1,
+        message: {
+          id: "assistant-1",
+          role: "assistant",
+          content: [{ type: "text", text: "Use the native event log." }],
+          source: { kind: "model", provider: "test", model: "test" },
+        },
+      }),
+      event("step/end", 9, { turn: 1, step: 1 }),
+      event("turn/end", 10, { turn: 1, reason: { kind: "completed" } }),
+      event("turn/start", 11, { turn: 2 }),
+    ],
+  };
+  ctx.emit("session/event", session, persisted.events[6]);
+  assert.equal(calls.includes("flush"), false, "flush waits until session/event publication completes");
+  assert.equal(deferred.length, 1);
+  await deferred.shift()();
+
+  assert.deepEqual(calls.slice(-3), ["flush", "read:4", "backend:writeback"]);
+  assert.equal(writebacks.length, 1);
+  assert.deepEqual(writebacks[0].events.map(({ seq }) => seq), [4, 5, 6, 7, 8, 9, 10]);
+  assert.equal(writebacks[0].events.find(({ seq }) => seq === 7).data.source.plugin, "memorax-code-dsh");
+  assert.equal(writebacks[0].sessionHeader.id, session.id);
+
+  const child = topLevelSession({
+    id: "child-1",
+    parentSession: session.id,
+    origin: "subagent",
+    delegationDepth: 1,
+  });
+  ctx.emit("session/event", child, event("turn/start", 0, { turn: 1 }));
+  const childDecision = await ctx.waterfall("agent/pre-step", {
+    agent: { id: child.id, session: child },
+    turn: 1,
+    step: 1,
+    signal: new AbortController().signal,
+  }, async () => ({ kind: "enter", messages: [directUser] }));
+  assert.equal(childDecision.messages.length, 1);
+  assert.equal(turnStarts.length, 1, "subagent sessions do not retrieve");
+  assert.equal(isMemoryEligibleSession(topLevelSession({ origin: "unknown" })), false);
+
+  const fork = topLevelSession({
+    id: "fork-1",
+    parentSession: session.id,
+    seedLength: 10,
+    delegationDepth: 0,
+  });
+  ctx.emit("session/event", fork, event("turn/start", 11, { turn: 2 }));
+  const forkDecision = await ctx.waterfall("agent/pre-step", {
+    agent: { id: fork.id, session: fork },
+    turn: 2,
+    step: 1,
+    signal: new AbortController().signal,
+  }, async () => ({ kind: "enter", messages: [directUser] }));
+  assert.equal(forkDecision.messages.length, 2);
+  assert.equal(turnStarts.length, 2, "an ordinary user fork remains memory eligible");
+  assert.equal(turnStarts[1].sessionId, fork.id);
+});
+
+test("fails closed when durable readFrom returns a gapped Turn", async () => {
+  const deferred = [];
+  let writebacks = 0;
+  const session = topLevelSession();
+  const ctx = mockContext({
+    flush: async () => true,
+    readFrom: async () => ({
+      meta: session.header,
+      events: [
+        event("turn/start", 0, { turn: 1 }),
+        event("user/message", 2, {
+          id: "user-1",
+          role: "user",
+          content: [{ type: "text", text: "gap" }],
+          source: { kind: "user" },
+        }),
+        event("turn/end", 3, { turn: 1, reason: { kind: "completed" } }),
+      ],
+    }),
+  });
+  registerMemoraxCodePlugin(ctx, {
+    backendClient: {
+      async recordTurnStart() { return { ok: true }; },
+      async writebackTurn() { writebacks += 1; },
+    },
+    createUserMessage: createDshUserMessage,
+    defer: (callback) => deferred.push(callback),
+  });
+
+  ctx.emit("session/event", session, event("turn/start", 0, { turn: 1 }));
+  ctx.emit("session/event", session, event("turn/end", 3, {
+    turn: 1,
+    reason: { kind: "completed" },
+  }));
+  await deferred.shift()();
+  assert.equal(writebacks, 0);
+});
+
+test("serializes same-session writeback and continues after one failure", async () => {
+  const deferred = [];
+  const order = [];
+  const firstWrite = Promise.withResolvers();
+  const session = topLevelSession();
+  const intervals = new Map([
+    [0, [
+      event("turn/start", 0, { turn: 1 }),
+      event("turn/end", 1, { turn: 1, reason: { kind: "completed" } }),
+    ]],
+    [2, [
+      event("turn/start", 2, { turn: 2 }),
+      event("turn/end", 3, { turn: 2, reason: { kind: "completed" } }),
+    ]],
+  ]);
+  const ctx = mockContext({
+    flush: async () => {
+      order.push("flush");
+      return true;
+    },
+    readFrom: async (_id, startSeq) => {
+      order.push(`read:${startSeq}`);
+      return { meta: session.header, events: intervals.get(startSeq) };
+    },
+  });
+  registerMemoraxCodePlugin(ctx, {
+    backendClient: {
+      async recordTurnStart() { return { ok: true }; },
+      async writebackTurn(command) {
+        order.push(`write:${command.turn}`);
+        if (command.turn === 1) {
+          await firstWrite.promise;
+          throw new Error("first write failed");
+        }
+      },
+    },
+    createUserMessage: createDshUserMessage,
+    defer: (callback) => deferred.push(callback),
+  });
+
+  ctx.emit("session/event", session, intervals.get(0)[0]);
+  ctx.emit("session/event", session, intervals.get(0)[1]);
+  ctx.emit("session/event", session, intervals.get(2)[0]);
+  ctx.emit("session/event", session, intervals.get(2)[1]);
+  assert.equal(deferred.length, 2);
+  const first = deferred[0]();
+  const second = deferred[1]();
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.deepEqual(order, ["flush", "read:0", "write:1"]);
+
+  firstWrite.resolve();
+  await Promise.all([first, second]);
+  assert.deepEqual(order, [
+    "flush", "read:0", "write:1",
+    "flush", "read:2", "write:2",
+  ]);
+});
+
+test("drains an accepted Turn writeback during Cordis disposal", async () => {
+  const deferred = [];
+  const write = Promise.withResolvers();
+  const session = topLevelSession();
+  const events = [
+    event("turn/start", 0, { turn: 1 }),
+    event("turn/end", 1, { turn: 1, reason: { kind: "completed" } }),
+  ];
+  const ctx = mockContext({
+    flush: async () => true,
+    readFrom: async () => ({ meta: session.header, events }),
+  });
+  registerMemoraxCodePlugin(ctx, {
+    backendClient: {
+      async recordTurnStart() { return { ok: true }; },
+      async writebackTurn() { await write.promise; },
+    },
+    createUserMessage: createDshUserMessage,
+    defer: (callback) => deferred.push(callback),
+    drainTimeoutMs: 1_000,
+  });
+
+  ctx.emit("session/event", session, events[0]);
+  ctx.emit("session/event", session, events[1]);
+  const disposing = ctx.dispose();
+  let disposed = false;
+  void disposing.then(() => { disposed = true; });
+  const scheduled = deferred.shift()();
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(disposed, false);
+
+  write.resolve();
+  await Promise.all([scheduled, disposing]);
+  assert.equal(disposed, true);
+});
+
+test("aborts in-flight retrieval during Cordis disposal", async () => {
+  const started = Promise.withResolvers();
+  const ctx = mockContext({
+    flush: async () => true,
+    readFrom: async () => undefined,
+  });
+  registerMemoraxCodePlugin(ctx, {
+    backendClient: {
+      async recordTurnStart(_command, { signal }) {
+        started.resolve(signal);
+        await new Promise((_resolve, reject) => {
+          signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+        });
+      },
+      async writebackTurn() {},
+    },
+    createUserMessage: createDshUserMessage,
+  });
+
+  const session = topLevelSession();
+  ctx.emit("session/event", session, event("turn/start", 0, { turn: 1 }));
+  const retrieving = ctx.waterfall("agent/pre-step", {
+    agent: { id: session.id, session },
+    turn: 1,
+    step: 1,
+    signal: new AbortController().signal,
+  }, async () => ({
+    kind: "enter",
+    messages: [{
+      id: "user-1",
+      role: "user",
+      content: [{ type: "text", text: "recall" }],
+      source: { kind: "user" },
+    }],
+  }));
+
+  const retrievalSignal = await started.promise;
+  await ctx.dispose();
+  assert.equal(retrievalSignal.aborted, true);
+  assert.equal((await retrieving).messages.length, 1);
+});
+
+function topLevelSession(overrides = {}) {
+  const id = overrides.id ?? "session-1";
+  return {
+    id,
+    header: {
+      version: 0,
+      id,
+      createdAt: 1,
+      cwd: "/workspace/project",
+      ...overrides,
+    },
+  };
+}
+
+function event(type, seq, data) {
+  return { type, seq, time: seq + 1, data };
+}
+
+function mockContext(runtime) {
+  const handlers = new Map();
+  const disposers = [];
+  return {
+    logger: { warn() {} },
+    sessions: { flush: runtime.flush },
+    sessionPersistence: { readFrom: runtime.readFrom },
+    on(name, callback) {
+      const registered = handlers.get(name) ?? [];
+      registered.push(callback);
+      handlers.set(name, registered);
+      return () => {};
+    },
+    effect(start) {
+      const dispose = start();
+      if (typeof dispose === "function") disposers.push(dispose);
+    },
+    emit(name, ...args) {
+      for (const callback of handlers.get(name) ?? []) callback(...args);
+    },
+    waterfall(name, payload, next) {
+      const [callback] = handlers.get(name) ?? [];
+      assert.ok(callback, `missing ${name} listener`);
+      return callback(payload, next);
+    },
+    async dispose() {
+      for (const dispose of disposers.reverse()) await dispose();
+    },
+  };
+}

--- a/scripts/check-local-trace-only.mjs
+++ b/scripts/check-local-trace-only.mjs
@@ -20,6 +20,7 @@ const productionRoots = [
   "packages/ts/memorax-code-claude-adapter/runtime-hooks/",
   "packages/ts/memorax-code-claude-adapter/scripts/",
   "packages/ts/memorax-code-claude-adapter/src/",
+  "packages/ts/memorax-code-dsh-adapter/src/",
   "packages/ts/memorax-code-opencode-adapter/src/",
 ];
 
@@ -28,6 +29,7 @@ const reviewedNetworkSources = new Set([
   "packages/ts/memorax-code-backend/src/app/backend-server.ts",
   "packages/ts/memorax-code-backend/src/clients/claude/memory-hook-runtime.ts",
   "packages/ts/memorax-code-backend/src/clients/codex/memory-hook-runtime.ts",
+  "packages/ts/memorax-code-backend/src/clients/dsh/memory-hook-runtime.ts",
   "packages/ts/memorax-code-backend/src/clients/opencode/memory-hook-runtime.ts",
   "packages/ts/memorax-code-backend/src/lifecycle/backend/service.ts",
   "packages/ts/memorax-code-backend/src/lifecycle/backend/status.ts",
@@ -51,6 +53,7 @@ const reviewedNetworkSources = new Set([
   "packages/ts/memorax-code-codex-adapter/runtime-hooks/memory-writeback.mjs",
   "packages/ts/memorax-code-codex-adapter/src/cli.mjs",
   "packages/ts/memorax-code-codex-adapter/skills/memorax-code/scripts/detect_updates.py",
+  "packages/ts/memorax-code-dsh-adapter/src/http-client.mjs",
   "packages/ts/memorax-code-opencode-adapter/src/cli.mjs",
   "packages/ts/memorax-code-opencode-adapter/src/plugin.mjs",
   "packages/ts/memorax-code-opencode-adapter/src/repo-memory-server-runner.mjs",

--- a/scripts/sync-release-version.mjs
+++ b/scripts/sync-release-version.mjs
@@ -18,6 +18,7 @@ export const RELEASE_VERSION_TARGETS = Object.freeze([
   { file: "packages/ts/memorax-code-claude-adapter/package.json", field: ["version"] },
   { file: "packages/ts/memorax-code-claude-adapter/.claude-plugin/plugin.json", field: ["version"] },
   { file: "packages/ts/memorax-code-claude-adapter/hooks/runtime-shell.json", field: ["shellVersion"] },
+  { file: "packages/ts/memorax-code-dsh-adapter/package.json", field: ["version"] },
   { file: "packages/ts/memorax-code-opencode-adapter/package.json", field: ["version"] },
 ]);
 


### PR DESCRIPTION
## Change Summary

Add a source-only DeepSeek Harness (DSH) native Turn bridge that uses DSH's persisted Session Event Log for repository-scoped automatic memory retrieval and writeback. This establishes the request-time integration layer only; deployment and Profile lifecycle are intentionally deferred.

## Implementation Highlights

- Add a Cordis Turn listener that retrieves memory once from the direct user prompt, waits for `turn/end`, flushes persistence, and reads the exact `startSeq..endSeq` interval before writeback.
- Extend the versioned local Backend protocol with closed DSH schemas and validate sequence continuity, Turn boundaries, session/Turn/workspace identity, completion state, and required event types. Only direct user text and visible model-assistant text become Add content; plugin recall, tools, reasoning, delegated sessions, and incomplete Turns fail closed or are excluded.
- Reuse the existing repository-session, automatic retrieval, Turn coordination, buffering, and MemoraX provider paths. A fresh Backend can recover writeback from a valid persisted DSH interval without cached Turn metadata.
- Handle DSH compaction replacement messages without losing valid automatic Add, serialize same-session writeback, drain accepted writes during Cordis disposal, and cancel in-flight retrieval on disposal.
- Document the DSH event-log authority and trust boundary, and include the new source package in architecture, release-version, test, and local-network contracts.
- Keep deployment deliberately outside this PR: there is no production Cordis entrypoint, npm staging, DSH Profile mutation, install/start/stop/uninstall lifecycle, Trace, task reconciliation, Memory Viewer, or skill reminder integration.

## Validation

- `npm run typecheck --prefix packages/ts/memorax-code-backend` — passed.
- `npm test --prefix packages/ts/memorax-code-dsh-adapter` — 5/5 passed.
- Targeted DSH Backend, event-materialization, and local HTTP integration suites — 11/11 passed.
- `npm test --prefix packages/ts/memorax-code-backend` — 523 passed, 2 skipped, 0 failed.
- Existing adapter suites — Codex 204/204, Claude Code 65/65, and OpenCode 29/29 passed.
- `make test-npm-package` — 170/170 passed, including the local-only network gate.
- `make docs-check`, `make release-version-check`, and `git diff --check` — passed.

## Full End-to-End Validation Results

- Environment: macOS 26.5.1 arm64, Node.js 24.15.0, npm 11.12.1; DSH `0.1.0-rc.5` source at `47f943859bef`; loopback Backend with synthetic DSH Session Event Log fixtures and mocked MemoraX Search/Add responses.
- Scenario or matrix:

  | Scenario | Result |
  | --- | --- |
  | Direct top-level user prompt → Backend Search → DSH plugin recall injection | Passed; retrieval occurred once and retained plugin provenance |
  | Completed Turn → persistence flush → exact event interval → Backend Add | Passed; Add contained only direct user and visible assistant text |
  | Fresh Backend without cached Turn metadata → valid persisted interval | Passed; writeback was reconstructed and scheduled |
  | DSH compaction replacement inside a Turn | Passed; compacted plugin context was ignored without suppressing Add |
  | Gapped, mismatched, delegated, interrupted, or unknown-required-event intervals | Passed; processing failed closed without invalid Add content |
  | Concurrent same-session writeback and Cordis disposal | Passed; writes remained serialized, accepted writeback drained, and in-flight retrieval was cancelled |

- Command or workflow: Ran the DSH adapter suite, focused Backend DSH/event-materialization and HTTP suites, full Backend and existing-adapter regression suites, npm package tests, documentation checks, release-version checks, and the local-only network gate.
- Result: All exercised source-layer and local HTTP scenarios passed with no regression in Codex, Claude Code, or OpenCode.
- Evidence or artifacts: Node test-runner output only. Test sessions and MemoraX responses were synthetic; no credentials, private transcripts, retained traces, or user paths were captured.
- Reason not run / remaining risk: A real installed-DSH E2E, Profile reconciliation, packaging lifecycle, and Windows client run were not performed because this PR intentionally does not provide the deployment layer. The bridge follows the current DSH `0.1.0-rc.5` Cordis and Session Event Log contracts, so upstream pre-release API changes remain a compatibility risk. Trace, task reconciliation, Memory Viewer, and skill reminders remain unavailable for DSH until follow-up PRs add those layers.
