### PR TITLE
feat: refine coding-memory query workflow

### DIFF
--- a/packages/ts/memorax-code-codex-adapter/skills/memorax-code/references/memorax-search.md
+++ b/packages/ts/memorax-code-codex-adapter/skills/memorax-code/references/memorax-search.md
@@ -34,23 +34,47 @@ If the user asks for commit, PR, MR, issue, or repository architecture evidence,
 
 ## Query Workflow
 
-Run at most one focused search before answering or editing. A development task may run one additional materially different search only after a failed test or dead-end investigation.
+Before searching, identify the user's current action, target, concrete behavior or symptom, and the historical knowledge that could change the next action. When the request is fragmented, derive one narrow working intent from only its explicit target, condition, and requested or implied outcome. Do not add generic security, authorization, concurrency, auditing, reliability, or best-practice concerns unless the request names that boundary or it is necessary to resolve the working intent. Ask one focused question when no actionable intent can be named.
 
-Write each query as one short natural-language question or intent statement, not a keyword list. Derive it from the user's retrieval goal instead of copying or concatenating nouns from the prompt. Follow the user's language for the prose while preserving exact code, API, path, workflow, and project identifiers. State what prior knowledge is needed and the relationship, decision, constraint, behavior, or risk being investigated. Include 2-5 stable exact identifiers when they are relevant and known, but integrate them grammatically instead of appending search tags or filler.
+Run up to two focused first-round searches before answering or editing: a primary query for the smallest user-facing decision, and a materially different complementary query only when a second independent fact can change the action. Keep one query when the request describes one strongly coupled calculation, diagnosis, ownership question, or lifecycle decision; do not split it merely to create coverage. Run independent first-round searches in parallel by default. If parallel execution encounters a transport, rate-limit, or caller-environment failure, run any remaining searches serially; do not switch solely because a successful search returns an unexpected number of items. After merging the first-round results, run at most one follow-up query only when one named residual gap can change implementation, localization, risk, or validation. Do not use the follow-up merely because results are few, generic, or incomplete.
+
+Write each query as one short natural-language question or intent statement, not a keyword list. Derive it from the user's retrieval goal instead of copying or concatenating nouns from the prompt. Follow the user's language for the prose while preserving exact code, API, path, workflow, and project identifiers. Retain at least one distinctive noun phrase from the user's wording as an anchor, together with any explicit negation, time/order, quantity, or scope qualifier. Also retain one stable task entity explicitly established by the current conversation or live code/documentation when it is needed to resolve that anchor or make the target decidable; do not drop it merely because it is absent from the newest fragmented user message. Do not replace an anchor or stable entity with a more abstract mechanism, a more specific implementation guess, or an unverified term. Preserve whether a retained detail is an observed symptom, desired outcome, disputed field or hypothesis, or explicit exclusion; do not turn an observation into a required invariant or replace a named disputed field with a generic reference.
+
+Preserve the user's requested answer shape as well as the target: for example, whether a value was introduced by a prior code change, which failed experiments require rerun, how a negative case differs, what source boundary applies, or which existing plan remains current. Encode an explicit exclusion, source boundary, or qualifier such as only, previous, failed, negative, not, latest, or before/after when it changes the answer. Do not turn an imperative, URL, copied log, or full task request into the query verbatim; extract the smallest reusable historical fact that could change the next action. When the user explicitly names several independent deliverables and their respective historical facts could change different next actions, use the existing two-query allowance for complementary coverage: let the primary query cover the central implementation or decision, and let the complementary query cover the separate validation, artifact, reporting, or boundary question. Do not split one tightly coupled task or create a second query merely to enumerate every noun.
+
+State a fact-sized relationship that can change the next action: a target under a condition, and the decision, invariant, consequence, root cause, ownership, compatibility, validation question, or requested answer at issue. For behavior, data, and lifecycle work, every query must use this visible shape: `<target>: <condition>，<decision / invariant / consequence / validation question>?`. Keep the colon in both Chinese and English so the target, condition, and decision boundary remain explicit. Do not emit a generic topic, a keyword list, a label such as `primary query`, or an explanation around the query.
+
+For a complementary first-round pair, each query must stand alone and cover a different decision boundary. Use a complementary pair only when the provided context gives each decision boundary a distinct exact code, API, path, workflow, or project identifier; otherwise keep one focused combined query that preserves both user-stated facts. Do not merely restate the same question with synonyms. If the user describes only one tightly coupled decision, emit exactly one query. Use one or two stable exact identifiers when they sharpen the query, and integrate them grammatically instead of appending search tags or filler. Use only user-provided anchors and stable terms from live code or documentation; do not reconstruct unseen fact wording from recalled memory.
 
 Pass the query directly with `--query`. Put every dynamically generated query in single quotes, never double quotes. Treat `$HOME`, backticks, and `$(command)` as literal text inside those quotes. Replace each literal single quote in the value with the exact POSIX sequence `'\''`.
 
-For example:
+Use these actual output shapes as examples. They are queries themselves, not full user prompts or instructions for the user. Each Chinese/English pair is a language variant: choose the one matching the user, never run both merely because both are shown. The comments explain the example only and are not part of emitted query text.
 
 ```bash
-memorax-cli search --query 'What prior decisions define the memorax-code parser API failure boundary for malformed input?'
-memorax-cli search --query 'What prior review policies and regression risks apply to the memorax-code parser API cleanup boundary?'
-memorax-cli search --query 'memorax-code 中 Backend、Codex adapter 与 memory 层的职责如何衔接，之前为什么这样划分？'
+# One tightly coupled decision: emit one query.
+memorax-cli search --query 'Trace 生产版本：升级后到达的记录中，应以哪个客户端版本字段判断由旧插件产生，而非新版本上传进程？'
+memorax-cli search --query 'Trace producer version: after an upgrade, which client-version field shows that an event came from the old plugin rather than the new uploader?'
+
+# Two independent boundaries: emit a complementary pair.
+memorax-cli search --query '任务上下文：升级新包后已打开任务仍按旧提示，是否绑定旧版本且必须新开对话？'
+memorax-cli search --query '包缓存版本冲突：本地新包与缓存冲突时，已打开任务为何仍使用旧提示，如何确认实际加载版本？'
+memorax-cli search --query 'Task context after upgrade: can an already-open task keep old injected context, and must validation use a fresh task?'
+memorax-cli search --query 'Package-cache version collision: how do we confirm which version the active task actually loaded?'
+
+# Preserve an explicit lifecycle condition and the required invariant.
+memorax-cli search --query '自动写回：事件回调不等待 Promise 时，如何在消息终态后执行并防止重复？'
+memorax-cli search --query 'Automatic writeback: when an event callback does not await a Promise, how should it run after message terminal state without duplicates?'
+
+# Preserve a source boundary rather than turning it into a generic SDK question.
+memorax-cli search --query '桌面 SDK 数据权威：无原生命令行时，应从哪些规范化消息和会话生命周期事件获取数据？'
+memorax-cli search --query 'Desktop SDK authority: without a native CLI, which normalized messages and session lifecycle events are authoritative?'
 ```
 
 Keep queries under 25 words when practical for the language, but do not shorten them into ungrammatical fragments. Exclude secrets, private URLs, full prompts, raw transcripts, copied files, long logs, stack traces, and one-off task details.
 
-Read or summarize at most two relevant items. Prefer memories matching the current repository, module, API, lifecycle surface, ownership boundary, behavior, and failure mode. Treat verified memories as routing and validation hints, not patch recipes. Treat failed-attempt memories as negative evidence. Ignore stale or unrelated items and anything conflicting with current source, tests, or durable documentation.
+Do not use abstract query facets such as "state", "fix", "safety", or "best practice" unless they are the concrete target. Do not use generic security or safety queries as complementary queries; bind every query to an exact target, condition, and behavior boundary.
+
+Merge and deduplicate first-round results by item identity when available, otherwise by matching scope, condition, claim, and consequence. Accept a memory only when all three checks pass: it has the same component, API, workflow, or ownership boundary; it has the same behavior, symptom, condition, or change; and it supplies a condition, conclusion, consequence, fix, or validation idea that can change the current action. Read or summarize at most two accepted direct hits. Prefer memories matching the current repository, module, API, lifecycle surface, ownership boundary, behavior, and failure mode. Treat verified memories as routing and validation hints, not patch recipes. Treat failed-attempt memories as negative evidence. Ignore stale or unrelated items and anything conflicting with current source, tests, or durable documentation. For application questions, reject retrieval-strategy, evaluation, prompting, or workflow-process memories as domain evidence even if they repeat application terms. If no memory passes all three checks, say that memory is insufficient for the requested decision rather than filling the gap with a generic principle.
 
 ## Transport Failures
 

--- a/packages/ts/memorax-code-codex-adapter/test/memorax-code-skill.test.mjs
+++ b/packages/ts/memorax-code-codex-adapter/test/memorax-code-skill.test.mjs
@@ -64,7 +64,8 @@ test("memorax-code references keep authority and operation boundaries explicit",
 
   assert.match(memoraxSearch, /memorax-cli search/);
   assert.match(memoraxSearch, /In OpenCode, ask the agent to use the `memorax-code` skill by name/);
-  assert.match(memoraxSearch, /at most one focused search/);
+  assert.match(memoraxSearch, /Run up to two focused first-round searches/);
+  assert.match(memoraxSearch, /only when a second independent fact can change the action/);
   assert.match(memoraxSearch, /Do not call MemoraX HTTP endpoints directly/);
   assert.match(memoraxSearch, /memorax-cli search --query '/);
   assert.match(memoraxSearch, /Linked worktrees share one repository scope/);
@@ -105,20 +106,22 @@ test("memorax-code references keep authority and operation boundaries explicit",
   assert.match(personalWrite, /may be saved implicitly/);
 });
 
-test("memorax-code search guidance combines semantic intent with exact anchors", () => {
+test("memorax-code search guidance preserves semantic roles and exact anchors", () => {
   const memoraxSearch = readSkillFile("references/memorax-search.md");
 
   assert.match(memoraxSearch, /one short natural-language question or intent statement, not a keyword list/);
   assert.match(memoraxSearch, /instead of copying or concatenating nouns from the prompt/);
   assert.match(memoraxSearch, /Follow the user's language/);
-  assert.match(memoraxSearch, /relationship, decision, constraint, behavior, or risk/);
-  assert.match(memoraxSearch, /Include 2-5 stable exact identifiers/);
+  assert.match(memoraxSearch, /Retain at least one distinctive noun phrase/);
+  assert.match(memoraxSearch, /observed symptom, desired outcome, disputed field or hypothesis, or explicit exclusion/);
+  assert.match(memoraxSearch, /every query must use this visible shape/);
+  assert.match(memoraxSearch, /one or two stable exact identifiers/);
   assert.match(memoraxSearch, /integrate them grammatically/);
   assert.match(memoraxSearch, /do not shorten them into ungrammatical fragments/);
 
-  assert.match(memoraxSearch, /What prior decisions define the memorax-code parser API failure boundary/);
-  assert.match(memoraxSearch, /What prior review policies and regression risks apply/);
-  assert.match(memoraxSearch, /Backend、Codex adapter 与 memory 层的职责如何衔接/);
+  assert.match(memoraxSearch, /Trace producer version: after an upgrade/);
+  assert.match(memoraxSearch, /Task context after upgrade: can an already-open task keep old injected context/);
+  assert.match(memoraxSearch, /Desktop SDK authority: without a native CLI/);
 });
 
 test("memorax-code retries read-only search once after transport or sandbox failure", () => {


### PR DESCRIPTION
## Change Summary

Improve coding-memory recall and reduce unnecessary query generation by grounding each search in the user's explicit target, constraints, semantic roles, and decision boundaries.

## Implementation Highlights

- Normalize behavior, data, and lifecycle queries into the explicit `<target>: <condition>, <decision / invariant / consequence / validation question>?` structure instead of allowing topic labels, keyword lists, or free-form restatements.
- Preserve distinctive noun phrases and exact code, API, path, workflow, or project identifiers together with relevant negation, ordering, quantity, and scope qualifiers.
- Preserve whether a retained detail is an observed symptom, desired outcome, disputed field or hypothesis, or explicit exclusion so query rewriting does not change the user's meaning.
- Keep strongly coupled questions in one focused query. Generate a complementary query only for a separate actionable decision boundary with its own concrete anchor.
- Allow one follow-up search only when a named residual gap can change implementation, localization, risk, or validation, rather than because the first results are merely sparse or generic.
- Merge and deduplicate results, then accept only memories that match the component or workflow, behavior or condition, and an actionable conclusion. Use at most two accepted direct hits in the final response.

## Validation

The evaluation used 140 coding-memory retrieval scenarios derived from daily Codex interactions and memories within the same repository. Each scenario contained a fragmented user request and its target memory.

- Every search used `memorax-cli search --limit 6`, and only each query's Top-6 results were evaluated.
- `complete`: the allowed searches jointly retrieved all target memories directly.
- `partial`: at least one target memory was retrieved directly, but coverage was incomplete.
- `miss`: no target memory was retrieved directly.

| Dataset | Current workflow | New workflow |
| --- | ---: | ---: |
| C01-C56 | 35 complete / 19 partial / 2 miss | 50 complete / 6 partial / 0 miss |
| C01-C140 | - | 122 complete / 18 partial / 0 miss |

Repository checks:

- `make docs-check`: passed (10 tests and documentation/README contract checks).
- `node --test packages/ts/memorax-code-codex-adapter/test/memorax-code-skill.test.mjs`: passed (7 tests).
- `git diff --check`: passed.
- `npm test --prefix packages/ts/memorax-code-codex-adapter`: the full suite was attempted but did not complete cleanly in this checkout; unrelated Hook/runtime cases failed and Node terminated on a native assertion. The focused skill contract above passes.

## Full End-to-End Validation Results

- Environment: isolated query authors against the same coding-memory scope and retrieval window.
- Scenario or matrix: paired current/new workflow comparison for C01-C56, plus new-workflow coverage across C01-C140.
- Command or workflow: generate queries under each workflow, execute them with `memorax-cli search --limit 6`, and label the Top-6 results against each scenario's target memories.
- Result: the new workflow increased complete retrieval in the paired comparison and produced no misses across the 140-scenario coverage run.
- Evidence or artifacts: aggregate results are included above; raw evaluation records remain local because they contain source interaction and memory text and are not part of this one-file PR.
- Reason not run / remaining risk: effectiveness still needs validation across more diverse repositories, languages, and task types.
