### PR TITLE
feat: reconcile DSH writeback tasks after restart

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -331,19 +331,13 @@ sequenceDiagram
   Runtime-->>Coordinator: local scheduling accepted or rejected
   Runtime->>Provider: later flush buffered or chunked writeback
   Provider-->>Runtime: accepted task identity
-  alt reconciliation-enabled client
-    Runtime->>Obs: emit accepted task event and identity
-    Obs->>Projection: update the live task projection
-    Obs->>Trace: persist the same writeback event
-    Reconciler->>Projection: list live and persisted pending tasks
-    Projection->>Trace: read persisted writeback history
-    Reconciler->>Provider: query writeback status
-    Reconciler->>Trace: append terminal status when completed
-  else DSH trace-only bridge
-    Runtime->>Obs: emit accepted task event and identity
-    Obs->>Trace: persist the same writeback event
-    Note over Projection,Reconciler: no DSH task projection or reconciliation in this layer
-  end
+  Runtime->>Obs: emit accepted task event and identity
+  Obs->>Projection: update the live task projection
+  Obs->>Trace: persist the same writeback event
+  Reconciler->>Projection: list live and persisted pending tasks
+  Projection->>Trace: read persisted writeback history
+  Reconciler->>Provider: query writeback status
+  Reconciler->>Trace: append terminal status when completed
 ```
 
 - Retrieval events do not enter reconciliation.
@@ -360,8 +354,9 @@ sequenceDiagram
   resolved and validated from the persisted Session workspace.
 - DSH uses the shared retrieval, buffering, chunking, redaction, provider, and
   client-qualified trace paths. Its normalized Search and Add operations enter
-  DSH trace, while task reconciliation and Memory Viewer remain intentionally
-  disabled until those capabilities are added explicitly.
+  DSH trace and pending Add tasks use the shared writeback-reconciliation
+  projection. Its Viewer projection remains intentionally disabled until that
+  capability is added explicitly.
 - OpenCode terminal handling accepts only matching SDK user and completed
   assistant records for the correlated session and parent message. An exact
   `MessageAbortedError` closes the Turn as interrupted without writeback; other
@@ -375,11 +370,9 @@ sequenceDiagram
   buffer runtime cancels and discards pending fallback turns for the same
   client and session before buffering under the Git scope. It does not migrate
   or flush those turns across namespaces.
-- For clients with writeback reconciliation enabled, pending status can be
-  reconstructed from persisted local trace after Backend restart. A
-  still-pending provider status updates in-memory reconciliation policy rather
-  than appending a new trace event. DSH trace retains the accepted task event,
-  but DSH pending tasks are not yet reconstructed by this projection.
+- Pending writeback status can be reconstructed from client-qualified local
+  trace after Backend restart. A still-pending provider status updates
+  in-memory reconciliation policy rather than appending a new trace event.
 
 ### 3.5 Repo Memory coordination
 

--- a/packages/ts/memorax-code-backend/src/app/backend-server.ts
+++ b/packages/ts/memorax-code-backend/src/app/backend-server.ts
@@ -39,14 +39,13 @@ type BackendShutdownResources = {
 };
 
 const DEFAULT_BACKEND_SHUTDOWN_TIMEOUT_MS = 4_000;
-const WRITEBACK_RECONCILIATION_CLIENTS = ["codex", "claude", "opencode"] as const;
 
 export function createBackendServer(
   state = createBackendState(),
   options: BackendServerOptions = {},
 ): BackendServer {
   const memoryEnv = { ...process.env, MEMORAX_CODE_HOME: state.sessionHome };
-  const memoryWritebackTaskProjections = WRITEBACK_RECONCILIATION_CLIENTS.map((client) => createMemoryWritebackTaskProjection({
+  const memoryWritebackTaskProjections = TRACE_CLIENTS.map((client) => createMemoryWritebackTaskProjection({
     memoraxCodeHome: state.sessionHome,
     client,
   }));

--- a/packages/ts/memorax-code-backend/test/app/server-shutdown.test.mjs
+++ b/packages/ts/memorax-code-backend/test/app/server-shutdown.test.mjs
@@ -55,21 +55,19 @@ test("Backend close is idempotent and waits for observability drain", async () =
   }
 });
 
-test("Backend starts isolated writeback reconcilers for Codex and Claude", { concurrency: false }, async () => {
+test("Backend starts isolated writeback reconcilers for every traced client", { concurrency: false }, async () => {
   const memoraxCodeHome = await mkdtemp(join(tmpdir(), "memorax-code-backend-client-reconcilers-"));
   const traces = await Promise.all([
     writePendingWritebackTrace(memoraxCodeHome, "codex", "codex-reconcile-task"),
     writePendingWritebackTrace(memoraxCodeHome, "claude", "claude-reconcile-task"),
+    writePendingWritebackTrace(memoraxCodeHome, "dsh", "dsh-reconcile-task"),
+    writePendingWritebackTrace(memoraxCodeHome, "opencode", "opencode-reconcile-task"),
   ]);
-  const dshTrace = await writePendingWritebackTrace(
-    memoraxCodeHome,
-    "dsh",
-    "dsh-trace-only-task",
-  );
   const restoreEnv = withEnv({
     MEMORAX_CODE_CODEX_TRACE_ENABLED: "true",
     MEMORAX_CODE_CLAUDE_TRACE_ENABLED: "true",
     MEMORAX_CODE_DSH_TRACE_ENABLED: "true",
+    MEMORAX_CODE_OPENCODE_TRACE_ENABLED: "true",
     MEMORAX_CODE_MEMORAX_ENDPOINT: "http://memorax.test",
     MEMORAX_CODE_MEMORAX_API_KEY: "secret",
     MEMORAX_CODE_MEMORAX_USER_ID: "user-1",
@@ -77,14 +75,14 @@ test("Backend starts isolated writeback reconcilers for Codex and Claude", { con
   });
   const originalFetch = globalThis.fetch;
   const requests = [];
-  let notifyBothPolled;
-  const bothPolled = new Promise((resolve) => {
-    notifyBothPolled = resolve;
+  let notifyAllPolled;
+  const allPolled = new Promise((resolve) => {
+    notifyAllPolled = resolve;
   });
   globalThis.fetch = async (url) => {
     const taskId = new URL(String(url)).pathname.split("/").at(-1);
     requests.push(taskId);
-    if (requests.length === 2) notifyBothPolled();
+    if (requests.length === 4) notifyAllPolled();
     return new Response(JSON.stringify({
       status: "success",
       memory: {
@@ -98,14 +96,17 @@ test("Backend starts isolated writeback reconcilers for Codex and Claude", { con
   );
   try {
     await Promise.race([
-      bothPolled,
-      new Promise((_, reject) => setTimeout(() => reject(new Error("both client tasks were not polled")), 1_000)),
+      allPolled,
+      new Promise((_, reject) => setTimeout(() => reject(new Error("traced client tasks were not polled")), 1_000)),
     ]);
     await server.shutdown();
 
+    assert.equal(requests.length, 4);
     assert.deepEqual(new Set(requests), new Set([
       "codex-reconcile-task",
       "claude-reconcile-task",
+      "dsh-reconcile-task",
+      "opencode-reconcile-task",
     ]));
     for (const trace of traces) {
       const events = (await readFile(trace.eventsPath, "utf8"))
@@ -118,11 +119,6 @@ test("Backend starts isolated writeback reconcilers for Codex and Claude", { con
       assert.equal(events[1].response.outcome, "saved");
       assert.equal(events[1].response.savedMemoryCount, 1);
     }
-    const dshEvents = (await readFile(dshTrace.eventsPath, "utf8"))
-      .trim()
-      .split("\n")
-      .map((line) => JSON.parse(line));
-    assert.equal(dshEvents.length, 1, "DSH Trace must not activate reconciliation in this batch");
   } finally {
     await server.shutdown();
     globalThis.fetch = originalFetch;

--- a/packages/ts/memorax-code-backend/test/clients/dsh/dsh-memory-hook.test.mjs
+++ b/packages/ts/memorax-code-backend/test/clients/dsh/dsh-memory-hook.test.mjs
@@ -194,7 +194,7 @@ test("Backend runs DSH Search, normalized Trace, and Add from one native Turn in
   }
 });
 
-test("Backend recovers DSH Trace and writeback from the native log after restart", async () => {
+test("Backend recovers DSH Trace, writeback, and task status across restarts", async () => {
   const sessionHome = await mkdtemp(join(tmpdir(), "memorax-code-dsh-recovery-"));
   const interval = dshTurnInterval({
     sessionId: "session-dsh-recovered",
@@ -202,7 +202,15 @@ test("Backend recovers DSH Trace and writeback from the native log after restart
     turn: 2,
     startSeq: 20,
   });
-  const { fetchImpl, requests } = memoraxAddFetch();
+  const { fetchImpl: addFetch, requests } = memoraxAddFetch();
+  const fetchImpl = async (url, init) => (
+    new URL(String(url)).pathname.includes("/v1/memories/add/status/")
+      ? new Response(JSON.stringify({ status: "processing" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+      : addFetch(url, init)
+  );
   const restoreEnv = withEnv({
     MEMORAX_CODE_HOME: sessionHome,
     MEMORAX_CODE_CODEX_TRACE_ENABLED: "false",
@@ -220,6 +228,7 @@ test("Backend recovers DSH Trace and writeback from the native log after restart
   globalThis.fetch = fetchImpl;
   let firstServer;
   let secondServer;
+  let thirdServer;
   try {
     firstServer = createBackendServer(createBackendState("127.0.0.1", { sessionHome }));
     const firstUrl = await listen(firstServer);
@@ -249,7 +258,10 @@ test("Backend recovers DSH Trace and writeback from the native log after restart
     });
     assert.equal(writeback.status, 200);
     assert.deepEqual(await writeback.json(), { ok: true, scheduled: true });
-    await waitFor(() => requests.length === 1, "recovered DSH writeback did not call MemoraX Add");
+    await waitFor(
+      () => requests.some((request) => request.url.endsWith("/v1/memories/add")),
+      "recovered DSH writeback did not call MemoraX add",
+    );
 
     const traceEventsPath = join(
       sessionHome,
@@ -265,6 +277,26 @@ test("Backend recovers DSH Trace and writeback from the native log after restart
       /"type":"memory_writeback"/,
       "recovered DSH writeback did not reach its trace",
     );
+    await secondServer.shutdown();
+    const statusRequests = [];
+    globalThis.fetch = async (url) => {
+      statusRequests.push(String(url));
+      return new Response(JSON.stringify({
+        status: "success",
+        memory: {
+          summary: "Reconciled DSH memory.",
+          events: [{ id: "dsh-reconciled-memory", event: "ADD" }],
+        },
+      }), { status: 200, headers: { "content-type": "application/json" } });
+    };
+    thirdServer = createBackendServer(createBackendState("127.0.0.1", { sessionHome }));
+    await listen(thirdServer);
+    await waitForFile(
+      traceEventsPath,
+      /"type":"memory_writeback_status"/,
+      "restarted Backend did not reconcile the DSH writeback task",
+    );
+
     const traceEvents = (await readFile(traceEventsPath, "utf8"))
       .trim()
       .split("\n")
@@ -274,10 +306,18 @@ test("Backend recovers DSH Trace and writeback from the native log after restart
       "turn_end",
       "turn_materialized",
       "memory_writeback",
+      "memory_writeback_status",
     ]);
     assert.equal(traceEvents[0].trace.context_origin, "dsh-cordis-turn-start");
     assert.equal(traceEvents[1].trace.context_origin, "dsh-session-event-log");
     assert.equal(traceEvents[2].request.prompt, "Implement the DSH adapter.");
+    assert.equal(statusRequests.length, 1);
+    assert.match(new URL(statusRequests[0]).pathname, /\/v1\/memories\/add\/status\/hook-memory-add$/);
+    assert.equal(traceEvents[4].trace.client, "dsh");
+    assert.equal(traceEvents[4].source, "writeback_reconciler");
+    assert.equal(traceEvents[4].request.original_event_id, traceEvents[3].event_id);
+    assert.equal(traceEvents[4].response.outcome, "saved");
+    assert.equal(traceEvents[4].response.savedMemoryCount, 1);
     const currentTurn = JSON.parse(await readFile(join(
       sessionHome,
       "debug",
@@ -287,6 +327,7 @@ test("Backend recovers DSH Trace and writeback from the native log after restart
     ), "utf8"));
     assert.equal(currentTurn.turn_state, "completed");
   } finally {
+    await thirdServer?.shutdown();
     await secondServer?.shutdown();
     await firstServer?.shutdown();
     globalThis.fetch = originalFetch;


### PR DESCRIPTION
## Change Summary

Recover pending DSH memory writeback tasks from local trace after Backend restart and reconcile their terminal MemoraX status through the shared client-qualified task pipeline.

## Implementation Highlights

- Build writeback task projections and reconcilers from the canonical TRACE_CLIENTS list, adding DSH without a harness-specific reconciliation implementation.
- Restore accepted DSH Add tasks from persisted trace, poll their task status, and append a client-isolated memory_writeback_status event when they complete.
- Exercise projection isolation across Codex, Claude Code, DSH, and OpenCode while keeping DSH Memory Viewer support outside this PR.

## Validation

- Focused Backend reconciliation and DSH recovery tests: 6 passed.
- npm run typecheck --prefix packages/ts/memorax-code-backend: passed.
- npm test --prefix packages/ts/memorax-code-backend: 537 passed, 2 skipped.
- make test-npm-package: 179 passed; local-only trace contract passed.
- make docs-check: passed.
- git diff --check: passed.

## Full End-to-End Validation Results

- Environment: isolated macOS homes with the pinned DSH 0.1.0-rc.6 release and a locally staged MemoraX Code package. DSH, Cordis, npm lifecycle scripts, Profiles, and the Backend were real; only LLM and MemoraX HTTP endpoints were mocked.
- Scenario or matrix:
  - Install and start with a real DSH Profile.
  - Run a real DSH Turn through Search, personal context, Skill Reminder, Repo Memory initialization, and Add.
  - SIGKILL and resume one DSH session.
  - SIGKILL and recover the managed Backend.
  - Reconcile a Profile created after installation, then stop and uninstall.
- Command or workflow: MEMORAX_CODE_DSH_E2E=1 make test-dsh-e2e.
- Result: passed with 4 Search requests and 3 Add requests; canonical Skill round-trip, native reminder, personal context, Repo Memory dispatch, interrupted-Turn recovery, Backend recovery, later-Profile reconciliation, stop, and uninstall assertions all succeeded.
- Evidence or artifacts: the assertion-driven workflow returned ok: true; all homes and runtime artifacts were isolated and removed by cleanup.
- Reason not run / remaining risk: real Windows DSH E2E and a live MemoraX service were not used. Exact pending-task recovery across Backend restarts is covered by the Backend integration test.
