### PR TITLE
feat: clarify coding-memory routing boundaries

### DIFF
--- a/packages/ts/memorax-code-codex-adapter/skills/memorax-code/SKILL.md
+++ b/packages/ts/memorax-code-codex-adapter/skills/memorax-code/SKILL.md
@@ -21,6 +21,11 @@ description: >-
 
 Classify the requested memory authority first, then its operation. Load only the matching reference unless the request genuinely spans authorities or operations.
 
+After selecting an operation reference, read it completely in a standalone
+tool call and wait for the full result before constructing or executing that
+operation. Never combine reading a required reference with the command or
+action it governs in the same shell command or tool call.
+
 ## Authority Router
 
 ### MemoraX Code Coding Memory
@@ -51,8 +56,11 @@ Use personal memory for user-owned repository procedures and durable profile or 
 - Route ordered actions, checklists, prerequisites, gates, exceptions, and validation rules to personal procedure memory, even when phrased as "I prefer", "I like", "我的习惯", or "我喜欢".
 - Route preferred name, answer language, tone, verbosity, explanation style, and result presentation to personal profile memory.
 - Route task-learned repairs, coding pitfalls, project engineering conventions, and reusable design lessons to MemoraX Code coding memory.
+- Route prior project discussions, experiment conclusions, saved engineering findings, earlier fixes, and reusable project lessons to MemoraX Code coding memory. Do not route them to repo memory merely because they concern a project. Use repo memory for repository identity, architecture, module maps, commits, PRs, MRs, and issues.
 - Route repository architecture, module maps, commit history, PRs, MRs, and issues to repo memory. Verify claims about current behavior against live code.
+- Use both repo memory and MemoraX Code coding memory only when a request genuinely needs distinct repository evidence and reusable engineering lessons. This can apply to implementation, debugging, refactoring, migration planning, or validation when the answer may depend on repository module maps, commit/PR/issue evidence, and prior fixes, pitfalls, conventions, validation patterns, or design rationale. Do not use both authorities just because a request mentions a repository, file, module, or "previous".
 - Route current-task instructions and temporary plans to the current task only; do not persist them.
+- Current-task-only applies only when completing the request does not depend on prior project state. Do not select it merely because the requested action happens in the current turn. When implementation, debugging, review, experiment continuation, or validation depends on earlier project decisions, results, fixes, constraints, or plans that the user has not explicitly and completely supplied, route to MemoraX Code coding memory.
 - Do not infer an authority from verbs such as "remember", "recall", "refresh", or "update" alone. Ask one focused question when the target remains ambiguous.
 
 Examples:

--- a/packages/ts/memorax-code-codex-adapter/skills/memorax-code/references/memorax-search.md
+++ b/packages/ts/memorax-code-codex-adapter/skills/memorax-code/references/memorax-search.md
@@ -21,8 +21,12 @@ Search when prior coding memory may change localization, implementation, review,
 - a request for a previous fix, failed approach, coding convention, design decision, or reusable lesson;
 - implementation, review, planning, API, schema, parser, workflow-contract, or migration work where prior project guidance may matter;
 - explicit instructions to follow previous agreements or remembered engineering conventions.
+- a request to recover, verify, or apply prior project discussions, experiment results, saved memory, earlier decisions, previous changes, or historical constraints, unless the needed facts are fully present in the current visible context.
+- a requested action that depends on prior project state, results, fixes, constraints, or plans when the exact evidence needed is not explicitly present in the current user-provided material.
 
-Skip search for simple current-code facts, tiny edits, typo fixes, one-shot commands, or behavior directly established by a clear live source.
+Skip search for simple current-code facts, tiny edits, typo fixes, one-shot commands, or behavior directly established by a clear live source. Do not skip merely by saying the current conversation is sufficient or a relevant result was already retrieved; skip only when the current user message, selected text, or nearby visible context fully contains the facts needed for the answer. A nearby summary is sufficient for explaining that summary, but not automatically sufficient for diagnosing a regression, continuing an experiment, reviewing consistency with prior behavior, or claiming a complete historical account. A word such as "previous", "earlier", "remember", or "history" is not enough by itself to search when the visible context already contains the requested prior facts.
+
+Do not search merely because a prior result or fix might exist. For an exact calculation from currently available data, or a current screenshot or reproducible symptom with sufficient live evidence, use the current evidence first. Search only when the user request or visible context establishes a concrete historical dependency.
 
 Choose the closest coding scene to shape the query:
 


### PR DESCRIPTION
## Change Summary

Clarify when prior project context belongs to coding memory versus repository memory, and require an explicit historical dependency before coding-memory Search is triggered.

## Implementation Highlights

- Require the selected operation reference to be read completely in a standalone tool call before constructing or executing the operation.
- Route prior project discussions, experiment conclusions, earlier fixes, and reusable engineering findings to coding memory while keeping repository identity, architecture, commits, PRs, MRs, and issues under repo memory.
- Use both authorities only when a request genuinely needs distinct repository evidence and reusable engineering knowledge.
- Refine Search and skip boundaries so visible context must fully contain the needed facts, while concrete historical dependencies still trigger retrieval.

## Validation

- `git diff --check`: passed.
- `node --test test/memorax-code-skill.test.mjs`: passed, 7/7 tests.
- Relevant Hook/profile/procedure files with `--test-concurrency=1`: passed, 30/30 tests.
- Full Codex adapter suite: 201/205 tests passed. The four failing reminder/profile Hook cases use a 100 ms test Backend timeout; each passed when rerun individually, and all 30 related tests passed serially. No failure asserted against the changed skill guidance.

## Full End-to-End Validation Results

- Environment: local macOS checkout on the feature branch, using isolated test homes and local test Backends supplied by the adapter suite.
- Scenario or matrix: coding-memory authority routing, operation-reference loading, Search trigger boundaries, and existing Hook/profile/procedure reminder behavior.
- Command or workflow: focused skill contract tests, serial related Hook tests, the full Codex adapter suite, and staged diff validation.
- Result: skill contracts passed 7/7; related serial tests passed 30/30; the concurrent full suite passed 201/205 with four load-sensitive 100 ms timeout failures that pass in isolation.
- Evidence or artifacts: test output only; no private transcripts, memory content, credentials, or local trace artifacts are included.
- Reason not run / remaining risk: no MemoraX-backed end-to-end call was run because this change only updates packaged routing guidance. Remaining risk is interpretation consistency across different agent clients and task phrasings.
