### PR TITLE
feat: define personal memory update semantics

### DIFF
--- a/packages/ts/memorax-code-codex-adapter/skills/memorax-code/references/personal-write.md
+++ b/packages/ts/memorax-code-codex-adapter/skills/memorax-code/references/personal-write.md
@@ -9,8 +9,6 @@ Use these instructions only to save, update, forget, or delete repository-scoped
 
 Store each part under its own authority when a request genuinely contains both. Do not persist current-task instructions or temporary plans.
 
-Keep file names, schema and script field names, type values, command options, and fixed Markdown headings in English. Write human-readable memory content in the user's current interaction language unless the user explicitly requests another storage language. This includes procedure titles and steps and user-profile descriptions, applicability, and exceptions. Preserve exact code identifiers, commands, paths, API names, and quoted literals without translation.
-
 ## Procedure Memory
 
 Before writing, ensure the repository root `.gitignore` contains `.repo_memory/`. Store each procedure topic in its own concise kebab-case file directly under:
@@ -21,27 +19,36 @@ Before writing, ensure the repository root `.gitignore` contains `.repo_memory/`
 
 Do not create a global procedures file, index, event log, generated metadata, or version history. Do not edit `.repo_memory/PROFILE.md`, `.repo_memory/resources/`, `.repo_memory/raw/`, or `.repo_memory/user-profile/`.
 
-Choose the closest existing topic file. Update it when the user refines the same procedure; create a new file only for a distinct topic. Remove superseded wording rather than preserving old versions.
+Choose the closest existing topic file before writing:
+
+- New topic: create a file.
+- Addition or refinement to the same topic: update the existing file.
+- A new rule directly conflicts with or replaces an old rule: update the existing file and remove the superseded content.
+- An old rule references a command, file, or workflow that no longer exists: update the invalid part; delete the file if the entire procedure is obsolete.
+- Equivalent content: do not add a duplicate.
+- If it is unclear whether the change is durable or only applies to the current task: ask the user.
+
+Do not modify existing memory because of a one-time instruction for the current task. Do not scan or clean up unrelated topics.
 
 Use this shape when useful:
 
 ```markdown
-# 代码审查
+# Reviewing Code
 
-Use when: 审查当前仓库中的代码变更时。
+Use when: reviewing changes in this repository.
 
 ## Procedure
 
-1. 创建 PR 前先审查变更。
-2. 解决阻塞性问题。
-3. 审查完成后再创建 PR。
+1. Review the changes before creating a PR.
+2. Resolve blocking findings.
+3. Create the PR only after review is complete.
 
 ## Exceptions
 
-- 优先遵循用户当前提出的更具体指令。
+- Follow a more specific current user instruction first.
 ```
 
-Delete only the topic file or section the user explicitly identifies. Do not retain deleted text in tombstones, backups, inactive entries, or history files.
+Do not retain deleted text in tombstones, backups, inactive entries, or history files. Apply the same rule to superseded text.
 
 ## User-Profile Memory
 
@@ -59,15 +66,26 @@ List existing preferences before adding and perform semantic matching:
 python3 <skill-dir>/scripts/user_profile_memory.py list --repo <repo>
 ```
 
-If equivalent content exists, do not add it again. Update the matching id when an existing entry expresses the same preference differently. Add only a genuinely new preference:
+Handle the semantic match before writing:
+
+- New preference: add a new preference.
+- Equivalent content: do not add a duplicate.
+- Addition or refinement to the same preference: update the existing preference.
+- A new preference directly conflicts with or replaces an old preference in the same scope: update the existing id and remove the superseded content.
+- The user explicitly says a preference no longer applies: delete that preference.
+- Its `Applies when` environment, tool, or workflow no longer exists: update the scope; delete it if the entire preference is obsolete.
+
+Do not modify or delete existing preferences because of a one-time instruction for the current task. Do not scan or clean up unrelated preferences.
+
+Use the matching id for updates. Add only a genuinely new preference:
 
 ```bash
 python3 <skill-dir>/scripts/user_profile_memory.py add \
   --repo <repo> \
   --type communication \
-  --description "用户希望在当前仓库中使用简洁的中文回答。" \
-  --applies-when "回答当前仓库相关问题时。" \
-  --do-not-apply-when "用户明确要求使用其他语言或格式。"
+  --description "User prefers concise Chinese answers for this repository." \
+  --applies-when "Answering questions in this repository." \
+  --do-not-apply-when "The user explicitly requests another language or format."
 ```
 
 Allowed script types are `communication`, `workflow`, `environment`, and `profile`. These type names do not expand this authority: never use `workflow` or `environment` to store an executable repository procedure.
@@ -83,7 +101,7 @@ python3 <skill-dir>/scripts/user_profile_memory.py update \
   --do-not-apply-when <exception>
 ```
 
-If multiple preferences may match, ask the user to choose before updating. Delete only an explicitly identified preference:
+If multiple preferences may match, or it is unclear whether the change is durable, ask the user. Delete only an explicitly identified preference:
 
 ```bash
 python3 <skill-dir>/scripts/user_profile_memory.py delete \

--- a/packages/ts/memorax-code-codex-adapter/test/repo-procedure-memory-skill.test.mjs
+++ b/packages/ts/memorax-code-codex-adapter/test/repo-procedure-memory-skill.test.mjs
@@ -26,10 +26,17 @@ test("memorax-code routes personal procedure reads and writes", () => {
   assert.match(writeReference, /each procedure topic in its own concise kebab-case file/);
   assert.match(writeReference, /Do not create a global procedures file/);
   assert.match(writeReference, /Do not persist current-task instructions or temporary plans/);
-  assert.match(writeReference, /Write human-readable memory content in the user's current interaction language/);
-  assert.match(writeReference, /procedure titles and steps and user-profile descriptions, applicability, and exceptions/);
-  assert.match(writeReference, /Preserve exact code identifiers, commands, paths, API names, and quoted literals without translation/);
+  assert.match(writeReference, /Choose the closest existing topic file before writing/);
+  assert.match(writeReference, /New topic: create a file/);
+  assert.match(writeReference, /Addition or refinement to the same topic: update the existing file/);
+  assert.match(writeReference, /directly conflicts with or replaces an old rule: update the existing file and remove the superseded content/);
+  assert.match(writeReference, /command, file, or workflow that no longer exists: update the invalid part; delete the file if the entire procedure is obsolete/);
+  assert.match(writeReference, /Equivalent content: do not add a duplicate/);
+  assert.match(writeReference, /unclear whether the change is durable or only applies to the current task: ask the user/);
+  assert.match(writeReference, /Do not modify existing memory because of a one-time instruction/);
+  assert.match(writeReference, /Do not scan or clean up unrelated topics/);
   assert.match(writeReference, /Do not retain deleted text in tombstones/);
+  assert.match(writeReference, /Apply the same rule to superseded text/);
 
   assert.equal(existsSync(join(skillRoot, "scripts", "user_profile_memory.py")), true);
 });

--- a/packages/ts/memorax-code-codex-adapter/test/repo-user-profile-memory-skill.test.mjs
+++ b/packages/ts/memorax-code-codex-adapter/test/repo-user-profile-memory-skill.test.mjs
@@ -75,8 +75,16 @@ test("repo memory skills route user-profile reads and writes", () => {
   assert.match(skill, /personal profile write/);
   assert.match(reference, /\.repo_memory\/user-profile\/preferences\.md/);
   assert.match(reference, /may be saved implicitly/);
-  assert.match(reference, /Keep file names, schema and script field names, type values, command options, and fixed Markdown headings in English/);
-  assert.match(reference, /unless the user explicitly requests another storage language/);
+  assert.match(reference, /Handle the semantic match before writing/);
+  assert.match(reference, /New preference: add a new preference/);
+  assert.match(reference, /Equivalent content: do not add a duplicate/);
+  assert.match(reference, /Addition or refinement to the same preference: update the existing preference/);
+  assert.match(reference, /directly conflicts with or replaces an old preference in the same scope: update the existing id and remove the superseded content/);
+  assert.match(reference, /explicitly says a preference no longer applies: delete that preference/);
+  assert.match(reference, /environment, tool, or workflow no longer exists: update the scope; delete it if the entire preference is obsolete/);
+  assert.match(reference, /Do not modify or delete existing preferences because of a one-time instruction/);
+  assert.match(reference, /Do not scan or clean up unrelated preferences/);
+  assert.match(reference, /multiple preferences may match, or it is unclear whether the change is durable, ask the user/);
   assert.match(reference, /never use `workflow` or `environment` to store an executable repository procedure/);
   assert.match(reference, /python3 <skill-dir>\/scripts\/user_profile_memory\.py/);
   assert.match(reference, /Do not preserve deleted text elsewhere/);
@@ -371,7 +379,7 @@ test("repo-user-profile-memory script rejects oversized writes without changing 
   }
 });
 
-test("repo-user-profile-memory semantic merge path updates one preference instead of adding a similar one", () => {
+test("documented user-profile lifecycle updates the selected id and physically removes obsolete content", () => {
   const root = mkdtempSync(join(tmpdir(), "memorax-code-user-profile-semantic."));
   try {
     const repo = createRepo(root);
@@ -383,24 +391,66 @@ test("repo-user-profile-memory semantic merge path updates one preference instea
       "--applies-when", "回答当前 repo 的问题。",
       "--do-not-apply-when", "用户明确要求其他语言。",
     ]);
-    const candidates = runProfile("list", repo);
-    assert.equal(candidates.active_count, 1);
-    assert.equal(candidates.preferences[0].id, first.id);
+    const unrelated = runProfile("add", repo, [
+      "--type", "profile",
+      "--description", "用户希望在这个 repo 中被称为 Alex。",
+      "--applies-when", "在这个 repo 中称呼用户。",
+    ]);
+    const duplicate = runProfile("add", repo, [
+      "--type", "communication",
+      "--description", "用户偏好：我喜欢用中文回答。",
+      "--applies-when", "回答当前 repo 的问题。",
+    ]);
+    assert.equal(duplicate.status, "duplicate");
+    assert.equal(duplicate.id, first.id);
+    assert.equal(duplicate.active_count, 2);
 
-    const merged = runProfile("update", repo, [
-      "--id", candidates.preferences[0].id,
+    const candidates = runProfile("list", repo);
+    assert.equal(candidates.active_count, 2);
+    const selected = candidates.preferences.find((preference) => preference.id === first.id);
+    assert.equal(selected?.description, "用户偏好：我喜欢用中文回答。");
+
+    const refined = runProfile("update", repo, [
+      "--id", selected.id,
       "--description", "用户偏好：在这个 repo 里希望我用中文回答，除非明确要求其他语言。",
       "--applies-when", "回答当前 repo 的设计、实现、review 或调试问题。",
       "--do-not-apply-when", "用户明确要求英文或其他语言。",
     ]);
-    assert.equal(merged.id, first.id);
-    assert.equal(merged.active_count, 1);
+    assert.equal(refined.id, first.id);
+    assert.equal(refined.active_count, 2);
 
-    const text = readFileSync(preferences, "utf8");
-    assert.equal((text.match(/^## Preference /gm) ?? []).length, 1);
-    assert.match(text, /active_count: 1/);
+    let text = readFileSync(preferences, "utf8");
+    assert.equal((text.match(/^## Preference /gm) ?? []).length, 2);
+    assert.match(text, /active_count: 2/);
     assert.match(text, /在这个 repo 里希望我用中文回答/);
     assert.doesNotMatch(text, /我喜欢用中文回答/);
+    assert.match(text, /被称为 Alex/);
+
+    const replaced = runProfile("update", repo, [
+      "--id", first.id,
+      "--description", "用户偏好：在这个 repo 里默认使用英文回答。",
+      "--applies-when", "回答当前 repo 的问题。",
+      "--do-not-apply-when", "用户明确要求其他语言。",
+    ]);
+    assert.equal(replaced.id, first.id);
+    assert.equal(replaced.active_count, 2);
+
+    text = readFileSync(preferences, "utf8");
+    assert.match(text, /默认使用英文回答/);
+    assert.doesNotMatch(text, /在这个 repo 里希望我用中文回答/);
+    assert.match(text, /被称为 Alex/);
+
+    const deleted = runProfile("delete", repo, ["--id", first.id]);
+    assert.equal(deleted.status, "deleted");
+    assert.equal(deleted.active_count, 1);
+
+    text = readFileSync(preferences, "utf8");
+    assert.match(text, /active_count: 1/);
+    assert.match(text, new RegExp(unrelated.id));
+    assert.match(text, /被称为 Alex/);
+    assert.doesNotMatch(text, new RegExp(first.id));
+    assert.doesNotMatch(text, /默认使用英文回答/);
+    assert.doesNotMatch(text, /- Status: `(deleted|superseded)`/);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Change Summary
Define explicit create, update, delete, no-write, and clarification semantics for Personal Memory procedure and profile updates. This reapplies the exact three-file change from #41 on the current `main` through an internal repository branch because the cross-fork PR could not satisfy the base-branch merge policy.

## Implementation Highlights
- Define semantic-match behavior for new, equivalent, refined, conflicting, obsolete, one-time, and ambiguous procedure memory.
- Apply the same lifecycle to user-profile preferences while preserving the selected preference id and physically removing superseded content.
- Extend contract assertions and real storage-CLI coverage for duplicate, refinement, replacement, deletion, and unrelated-preference isolation.

## Validation
- Fresh verification on current `main`: focused deterministic tests 10/10 passed.
- Fresh `git diff --check`: passed.
- The same three-file patch was previously validated in #41 with 15 scenarios x 2 model samples (30/30), Codex adapter 202/202, Claude Code adapter 65/65, docs 10/10, and npm package checks 165/165. Those broader suites were not rerun for this replacement branch.

## Full End-to-End Validation Results
- Environment:
  - Isolated temporary worktree at current `main` commit `1ea70d3b78e66e1f145d7866057aa5fd11cb9727`.
  - Internal branch head `eb24541d68d4ff602d3a0e397c12d9279717ccab`.
- Scenario or matrix:

| Scope | Scenario | Result |
| --- | --- | --- |
| Procedure contract | create, update, conflict replacement, obsolete deletion, duplicate suppression, one-time exclusion, ambiguity | PASS |
| Profile storage | add, duplicate, update, delete, isolated entries, concurrent adds, corrupt-store fail-closed, size limit | PASS |
| Lifecycle integration | selected-id refinement, replacement, physical deletion, unrelated preference preserved | PASS |

- Command or workflow:
  - `node --test packages/ts/memorax-code-codex-adapter/test/repo-procedure-memory-skill.test.mjs packages/ts/memorax-code-codex-adapter/test/repo-user-profile-memory-skill.test.mjs`
  - `git diff --check`
- Result:
  - 10 tests passed, 0 failed, 0 skipped.
  - Exactly 3 intended files changed, +105/-30.
- Evidence or artifacts:
  - Original cross-fork validation and full 15-scenario matrix: #41.
  - Current fresh command output was observed from the isolated worktree and was not committed.
- Reason not run / remaining risk:
  - Broader adapter, documentation, packaging, and model-simulation suites were not rerun on this replacement branch; their earlier #41 results are historical evidence for the same patch.
  - Semantic matching remains model-driven; the earlier 30/30 samples are useful evidence, not a deterministic CI guarantee.