### PR TITLE
fix: show MemoraX Code in the DSH plugin list

### DIFF
--- a/packages/ts/memorax-code-backend/test/lifecycle/client-plugin-removal.test.mjs
+++ b/packages/ts/memorax-code-backend/test/lifecycle/client-plugin-removal.test.mjs
@@ -73,8 +73,8 @@ test("package-removal cleanup is prepared before shutdown and removes all client
       updatedAt: new Date().toISOString(),
     }, null, 2)}\n`);
     await writeFile(dshProfilePath, `${JSON.stringify({
-      dependencies: { "@memorax-code/dsh-adapter": `file:${dshAdapterRoot}` },
-      dsh: { profile: { bundles: ["@memorax-code/dsh-adapter"] } },
+      dependencies: { "@memorax-code/dsh-memorax-code": `file:${dshAdapterRoot}` },
+      dsh: { profile: { bundles: ["@memorax-code/dsh-memorax-code"] } },
     }, null, 2)}\n`);
     await writeFile(join(claudeHome, "settings.json"), `${JSON.stringify({
       extraKnownMarketplaces: {
@@ -107,8 +107,8 @@ const args = process.argv.slice(2);
 const profile = args[args.indexOf("--profile") + 1];
 const path = join(process.env.DSH_HOME, "profiles", profile, "package.json");
 const manifest = JSON.parse(readFileSync(path, "utf8"));
-delete manifest.dependencies["@memorax-code/dsh-adapter"];
-manifest.dsh.profile.bundles = manifest.dsh.profile.bundles.filter((name) => name !== "@memorax-code/dsh-adapter");
+delete manifest.dependencies["@memorax-code/dsh-memorax-code"];
+manifest.dsh.profile.bundles = manifest.dsh.profile.bundles.filter((name) => name !== "@memorax-code/dsh-memorax-code");
 writeFileSync(path, JSON.stringify(manifest, null, 2) + "\\n");
 `);
     await chmod(dshCommand, 0o755);
@@ -149,7 +149,7 @@ writeFileSync(path, JSON.stringify(manifest, null, 2) + "\\n");
       ["plugin", "marketplace", "remove", "memorax-code-local"],
     ]);
     assert.equal(
-      Object.hasOwn(JSON.parse(await readFile(dshProfilePath, "utf8")).dependencies, "@memorax-code/dsh-adapter"),
+      Object.hasOwn(JSON.parse(await readFile(dshProfilePath, "utf8")).dependencies, "@memorax-code/dsh-memorax-code"),
       false,
     );
   } finally {

--- a/packages/ts/memorax-code-backend/test/lifecycle/dsh-participant.test.mjs
+++ b/packages/ts/memorax-code-backend/test/lifecycle/dsh-participant.test.mjs
@@ -291,7 +291,7 @@ const operation = args[3];
 const profileRoot = join(process.env.DSH_HOME, "profiles", profile);
 const manifestPath = join(profileRoot, "package.json");
 const adapterScope = join(profileRoot, "node_modules", "@memorax-code");
-const installedAdapterRoot = join(adapterScope, "dsh-adapter");
+const installedAdapterRoot = join(adapterScope, "dsh-memorax-code");
 const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
 if (operation === "add") {
   appendFileSync(process.env.FAKE_DSH_LOG, "add-begin enabled=" + enabled() + "\\n");
@@ -300,15 +300,15 @@ if (operation === "add") {
   rmSync(installedAdapterRoot, { recursive: true, force: true });
   mkdirSync(adapterScope, { recursive: true });
   cpSync(args[4].slice("file:".length), installedAdapterRoot, { recursive: true });
-  manifest.dependencies["@memorax-code/dsh-adapter"] = args[4];
-  if (!manifest.dsh.profile.bundles.includes("@memorax-code/dsh-adapter")) manifest.dsh.profile.bundles.push("@memorax-code/dsh-adapter");
+  manifest.dependencies["@memorax-code/dsh-memorax-code"] = args[4];
+  if (!manifest.dsh.profile.bundles.includes("@memorax-code/dsh-memorax-code")) manifest.dsh.profile.bundles.push("@memorax-code/dsh-memorax-code");
   appendFileSync(process.env.FAKE_DSH_LOG, "add-end enabled=" + enabled() + "\\n");
 } else if (operation === "remove") {
   appendFileSync(process.env.FAKE_DSH_LOG, "remove enabled=" + enabled() + "\\n");
   if (profile === process.env.FAKE_DSH_REMOVE_FAIL_PROFILE) process.exit(1);
   rmSync(installedAdapterRoot, { recursive: true, force: true });
-  delete manifest.dependencies["@memorax-code/dsh-adapter"];
-  manifest.dsh.profile.bundles = manifest.dsh.profile.bundles.filter((name) => name !== "@memorax-code/dsh-adapter");
+  delete manifest.dependencies["@memorax-code/dsh-memorax-code"];
+  manifest.dsh.profile.bundles = manifest.dsh.profile.bundles.filter((name) => name !== "@memorax-code/dsh-memorax-code");
 } else process.exit(2);
 writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + "\\n");
 `);
@@ -405,8 +405,8 @@ function readFileIfExists(path) {
 
 function profileHasAdapter(path) {
   const manifest = readJson(path);
-  return Object.hasOwn(manifest.dependencies, "@memorax-code/dsh-adapter")
-    && manifest.dsh.profile.bundles.includes("@memorax-code/dsh-adapter");
+  return Object.hasOwn(manifest.dependencies, "@memorax-code/dsh-memorax-code")
+    && manifest.dsh.profile.bundles.includes("@memorax-code/dsh-memorax-code");
 }
 
 function readJson(path) {

--- a/packages/ts/memorax-code-dsh-adapter/cordis.patch.yml
+++ b/packages/ts/memorax-code-dsh-adapter/cordis.patch.yml
@@ -5,6 +5,6 @@
         providerName: memorax-code-bundled
         includeDefaultRoots: false
         watch: false
-        bundledSkillDir: !!js "process.getBuiltinModule('node:url').fileURLToPath(new URL('node_modules/@memorax-code/dsh-adapter/skills/', baseUrl))"
+        bundledSkillDir: !!js "process.getBuiltinModule('node:url').fileURLToPath(new URL('node_modules/@memorax-code/dsh-memorax-code/skills/', baseUrl))"
     - id: memorax-code
-      name: '@memorax-code/dsh-adapter'
+      name: '@memorax-code/dsh-memorax-code'

--- a/packages/ts/memorax-code-dsh-adapter/hooks/repo-memory-job.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/hooks/repo-memory-job.mjs
@@ -6,7 +6,7 @@ import { runRepoMemoryJob } from "../memorax-code-adapter-common/src/repo-memory
 import { evaluateRepository } from "../memorax-code-adapter-common/src/repo-memory/repo-memory-update-policy-evaluator.mjs";
 import { requireEnabledDshRuntime } from "../src/runtime-state.mjs";
 
-const ADAPTER_PACKAGE_NAME = "@memorax-code/dsh-adapter";
+const ADAPTER_PACKAGE_NAME = "@memorax-code/dsh-memorax-code";
 const HEADLESS_BUNDLE_NAME = "@deepseek-ai/dsh-headless";
 const hookDir = dirname(fileURLToPath(import.meta.url));
 const pluginRoot = dirname(hookDir);

--- a/packages/ts/memorax-code-dsh-adapter/package.json
+++ b/packages/ts/memorax-code-dsh-adapter/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@memorax-code/dsh-adapter",
+  "name": "@memorax-code/dsh-memorax-code",
   "version": "0.1.2",
   "private": true,
   "type": "module",

--- a/packages/ts/memorax-code-dsh-adapter/src/profile-lifecycle.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/src/profile-lifecycle.mjs
@@ -616,7 +616,6 @@ function rollbackDshPluginReconciliation(paths, options, state, mutatedProfiles,
         profile.profile,
         state.runtimeBundleRoot,
         verificationState,
-        previousPackageName,
       )
       && !replacementPackageNames.some((packageName) => (
         profileMentionsPackage(profile.profile, packageName)
@@ -1167,14 +1166,13 @@ function profileHasInstalledAdapter(
   profile,
   runtimeBundleRoot,
   state,
-  packageName = ADAPTER_PACKAGE_NAME,
 ) {
-  if (!profileHasAdapter(profile, packageName) || !state || !nonEmpty(runtimeBundleRoot)) {
-    return false;
-  }
+  if (!state || !nonEmpty(runtimeBundleRoot)) return false;
   try {
     const sourceManifest = readJsonObject(join(runtimeBundleRoot, "package.json"));
-    if (sourceManifest?.name !== packageName
+    const packageName = sourceManifest?.name;
+    if (!MANAGED_ADAPTER_PACKAGE_NAMES.includes(packageName)
+      || !profileHasAdapter(profile, packageName)
       || !nonEmpty(sourceManifest.version)) return false;
 
     const requireFromProfile = createRequire(join(profile.path, "package.json"));

--- a/packages/ts/memorax-code-dsh-adapter/src/profile-lifecycle.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/src/profile-lifecycle.mjs
@@ -49,7 +49,12 @@ const { resolveWindowsCliInvocation } = await import(
 
 const STATE_VERSION = 1;
 const RUNTIME = "dsh";
-const ADAPTER_PACKAGE_NAME = "@memorax-code/dsh-adapter";
+const ADAPTER_PACKAGE_NAME = "@memorax-code/dsh-memorax-code";
+const LEGACY_ADAPTER_PACKAGE_NAMES = Object.freeze(["@memorax-code/dsh-adapter"]);
+const MANAGED_ADAPTER_PACKAGE_NAMES = Object.freeze([
+  ADAPTER_PACKAGE_NAME,
+  ...LEGACY_ADAPTER_PACKAGE_NAMES,
+]);
 const DSH_VERSION_TIMEOUT_MS = 10_000;
 const DEFAULT_COMMAND_TIMEOUT_MS = 120_000;
 const DEFAULT_LIFECYCLE_LOCK_TIMEOUT_MS = 600_000;
@@ -392,40 +397,69 @@ function ensureDshPluginInstalledUnlocked(paths, options) {
   const failedProfiles = [];
   const mutatedProfiles = [];
   for (const profile of profiles) {
-    const before = inspectProfile(profile.name, profile.path);
-    if (before.status !== "valid") {
-      failedProfiles.push(before.status === "directory_missing"
+    let current = inspectProfile(profile.name, profile.path);
+    if (current.status !== "valid") {
+      failedProfiles.push(current.status === "directory_missing"
         ? { name: profile.name, reason: "profile_disappeared" }
         : profileManifestFailure(profile.name));
       continue;
     }
-    if (profileHasInstalledAdapter(before.profile, runtimeBundleRoot, pendingState)) {
-      installedProfiles.push(profile.name);
-      continue;
+    if (!profileHasInstalledAdapter(current.profile, runtimeBundleRoot, pendingState)) {
+      const result = runDsh(options, paths, [
+        "plugin",
+        "--profile",
+        profile.name,
+        "add",
+        `file:${runtimeBundleRoot}`,
+      ], dshCommand);
+      current = inspectProfile(profile.name, profile.path);
+      if (previouslyManaged.has(profile.name)
+        || (current.status === "valid" && profileMentionsAdapter(current.profile))) {
+        mutatedProfiles.push(profile.name);
+      }
+      if (result.status !== 0
+        || result.error
+        || current.status !== "valid"
+        || !profileHasInstalledAdapter(current.profile, runtimeBundleRoot, pendingState)) {
+        failedProfiles.push(profileMutationFailure(
+          profile.name,
+          result,
+          current,
+          "dsh_bundle_not_activated",
+        ));
+        continue;
+      }
     }
-    const result = runDsh(options, paths, [
-      "plugin",
-      "--profile",
-      profile.name,
-      "add",
-      `file:${runtimeBundleRoot}`,
-    ], dshCommand);
-    const after = inspectProfile(profile.name, profile.path);
-    if (previouslyManaged.has(profile.name)
-      || (after.status === "valid" && profileMentionsAdapter(after.profile))) {
+
+    if (LEGACY_ADAPTER_PACKAGE_NAMES.some((packageName) => (
+      profileMentionsPackage(current.profile, packageName)
+    ))) {
       mutatedProfiles.push(profile.name);
+      const cleanup = removeProfileAdapterPackages(
+        paths,
+        options,
+        profile.name,
+        LEGACY_ADAPTER_PACKAGE_NAMES,
+        dshCommand,
+      );
+      current = cleanup.profile;
+      if (cleanup.failure) {
+        failedProfiles.push(cleanup.failure);
+        continue;
+      }
     }
-    const installed = result.status === 0
-      && !result.error
-      && after.status === "valid"
-      && profileHasInstalledAdapter(after.profile, runtimeBundleRoot, pendingState);
-    if (installed) installedProfiles.push(profile.name);
-    else failedProfiles.push(profileMutationFailure(
-      profile.name,
-      result,
-      after,
-      "dsh_bundle_not_activated",
-    ));
+
+    if (current.status === "valid"
+      && profileHasInstalledAdapter(current.profile, runtimeBundleRoot, pendingState)) {
+      installedProfiles.push(profile.name);
+    } else {
+      failedProfiles.push(profileMutationFailure(
+        profile.name,
+        { status: 0 },
+        current,
+        "dsh_bundle_not_activated",
+      ));
+    }
   }
 
   const finalProfiles = pendingState.profiles.map((name) => (
@@ -505,9 +539,18 @@ function ensureDshPluginInstalledUnlocked(paths, options) {
 
 function rollbackDshPluginReconciliation(paths, options, state, mutatedProfiles, dshCommand) {
   const previouslyManaged = new Set(state.profiles);
+  const previousPackageName = runtimeAdapterPackageName(state.runtimeBundleRoot)
+    ?? ADAPTER_PACKAGE_NAME;
+  const replacementPackageNames = MANAGED_ADAPTER_PACKAGE_NAMES
+    .filter((packageName) => packageName !== previousPackageName);
   const rollbackFailedProfiles = [];
   const residualProfiles = [];
   const managedMutationResults = new Map();
+  const recordFailure = (failure) => {
+    if (!rollbackFailedProfiles.some(({ name }) => name === failure.name)) {
+      rollbackFailedProfiles.push(failure);
+    }
+  };
   for (const name of [...new Set(mutatedProfiles)]) {
     const profilePath = join(paths.profilesRoot, name);
     const before = inspectProfile(name, profilePath);
@@ -520,38 +563,39 @@ function rollbackDshPluginReconciliation(paths, options, state, mutatedProfiles,
         `file:${state.runtimeBundleRoot}`,
       ], dshCommand);
       managedMutationResults.set(name, result);
+      const restored = inspectProfile(name, profilePath);
+      if (result.status === 0
+        && !result.error
+        && restored.status === "valid"
+        && profileHasAdapter(restored.profile, previousPackageName)) {
+        const cleanup = removeProfileAdapterPackages(
+          paths,
+          options,
+          name,
+          replacementPackageNames,
+          dshCommand,
+        );
+        if (cleanup.failure) recordFailure(cleanup.failure);
+      }
       continue;
     }
     if (before.status === "directory_missing"
       || (before.status === "valid" && !profileMentionsAdapter(before.profile))) {
       continue;
     }
-    const result = runDsh(options, paths, [
-      "plugin",
-      "--profile",
+    const cleanup = removeProfileAdapterPackages(
+      paths,
+      options,
       name,
-      "remove",
-      ADAPTER_PACKAGE_NAME,
-    ], dshCommand);
-    const after = inspectProfile(name, profilePath);
-    if (after.status !== "directory_missing"
-      && (result.status !== 0
-        || result.error
-        || after.status !== "valid"
-        || profileMentionsAdapter(after.profile))) {
+      MANAGED_ADAPTER_PACKAGE_NAMES,
+      dshCommand,
+    );
+    if (cleanup.profile.status !== "directory_missing"
+      && (cleanup.profile.status !== "valid"
+        || profileMentionsAdapter(cleanup.profile.profile))) {
       residualProfiles.push(name);
     }
-    if (result.status !== 0
-      || result.error
-      || (after.status !== "directory_missing"
-        && (after.status !== "valid" || profileMentionsAdapter(after.profile)))) {
-      rollbackFailedProfiles.push(profileMutationFailure(
-        name,
-        result,
-        after,
-        "dsh_bundle_not_removed",
-      ));
-    }
+    if (cleanup.failure) recordFailure(cleanup.failure);
   }
   const rollbackState = residualProfiles.length > 0
     ? {
@@ -568,11 +612,19 @@ function rollbackDshPluginReconciliation(paths, options, state, mutatedProfiles,
   for (const name of state.profiles) {
     const profile = inspectProfile(name, join(paths.profilesRoot, name));
     if (profile.status === "valid"
-      && profileHasInstalledAdapter(profile.profile, state.runtimeBundleRoot, verificationState)) {
+      && profileHasInstalledAdapter(
+        profile.profile,
+        state.runtimeBundleRoot,
+        verificationState,
+        previousPackageName,
+      )
+      && !replacementPackageNames.some((packageName) => (
+        profileMentionsPackage(profile.profile, packageName)
+      ))) {
       continue;
     }
     authorityRestored = false;
-    rollbackFailedProfiles.push(profileMutationFailure(
+    recordFailure(profileMutationFailure(
       name,
       managedMutationResults.get(name) ?? { status: 0 },
       profile,
@@ -661,24 +713,15 @@ function disableDshPluginInstallationUnlocked(paths, options, removeState) {
       removedProfiles.push(name);
       continue;
     }
-    const result = runDsh(
-      options,
+    const cleanup = removeProfileAdapterPackages(
       paths,
-      ["plugin", "--profile", name, "remove", ADAPTER_PACKAGE_NAME],
+      options,
+      name,
+      MANAGED_ADAPTER_PACKAGE_NAMES,
       dshCommand,
     );
-    const after = inspectProfile(name, before.profile.path);
-    const removed = result.status === 0
-      && !result.error
-      && (after.status === "directory_missing"
-        || (after.status === "valid" && !profileMentionsAdapter(after.profile)));
-    if (removed) removedProfiles.push(name);
-    else failedProfiles.push(profileMutationFailure(
-      name,
-      result,
-      after,
-      "dsh_bundle_not_removed",
-    ));
+    if (cleanup.failure) failedProfiles.push(cleanup.failure);
+    else removedProfiles.push(name);
   }
 
   if (failedProfiles.length > 0) {
@@ -710,6 +753,48 @@ function disableDshPluginInstallationUnlocked(paths, options, removeState) {
     managed: !removeState,
     removedProfiles,
   };
+}
+
+function removeProfileAdapterPackages(paths, options, name, packageNames, dshCommand) {
+  const profilePath = join(paths.profilesRoot, name);
+  let profile = inspectProfile(name, profilePath);
+  let failure;
+  for (const packageName of packageNames) {
+    if (profile.status === "directory_missing") break;
+    if (profile.status !== "valid") {
+      failure ??= profileManifestFailure(name);
+      break;
+    }
+    if (!profileMentionsPackage(profile.profile, packageName)) continue;
+    const result = runDsh(
+      options,
+      paths,
+      ["plugin", "--profile", name, "remove", packageName],
+      dshCommand,
+    );
+    profile = inspectProfile(name, profilePath);
+    if (result.status !== 0
+      || result.error
+      || (profile.status !== "directory_missing"
+        && (profile.status !== "valid"
+          || profileMentionsPackage(profile.profile, packageName)))) {
+      failure ??= profileMutationFailure(
+        name,
+        result,
+        profile,
+        "dsh_bundle_not_removed",
+      );
+    }
+  }
+  if (!failure
+    && profile.status !== "directory_missing"
+    && (profile.status !== "valid"
+      || packageNames.some((packageName) => (
+        profileMentionsPackage(profile.profile, packageName)
+      )))) {
+    failure = profileMutationFailure(name, { status: 0 }, profile, "dsh_bundle_not_removed");
+  }
+  return { profile, failure };
 }
 
 function materializeRuntimeBundle(paths, metadata) {
@@ -826,7 +911,7 @@ function resolvePaths(options) {
   const runtimeRoot = join(memoraxCodeHome, "adapters", RUNTIME, "runtime", "generations");
   const configuredDshHome = options.dshHome ?? nonEmpty(env.DSH_HOME);
   const dshHome = configuredDshHome === undefined
-    ? persistedDshHome({ statePath, memoraxCodeHome, adapterRoot }, homeDir)
+    ? persistedDshHome({ statePath, memoraxCodeHome, adapterRoot, runtimeRoot }, homeDir)
       ?? resolveHomePath(join(homeDir, ".dsh"), homeDir)
     : resolveHomePath(configuredDshHome, homeDir);
   return {
@@ -1061,33 +1146,46 @@ function inspectProfile(name, path) {
 }
 
 function profileMentionsAdapter(profile) {
-  return Boolean(profile
-    && (Object.hasOwn(profile.dependencies, ADAPTER_PACKAGE_NAME)
-      || profile.bundles.includes(ADAPTER_PACKAGE_NAME)));
+  return MANAGED_ADAPTER_PACKAGE_NAMES.some((packageName) => (
+    profileMentionsPackage(profile, packageName)
+  ));
 }
 
-function profileHasAdapter(profile) {
+function profileMentionsPackage(profile, packageName) {
   return Boolean(profile
-    && Object.hasOwn(profile.dependencies, ADAPTER_PACKAGE_NAME)
-    && profile.bundles.includes(ADAPTER_PACKAGE_NAME));
+    && (Object.hasOwn(profile.dependencies, packageName)
+      || profile.bundles.includes(packageName)));
 }
 
-function profileHasInstalledAdapter(profile, runtimeBundleRoot, state) {
-  if (!profileHasAdapter(profile) || !state || !nonEmpty(runtimeBundleRoot)) return false;
+function profileHasAdapter(profile, packageName = ADAPTER_PACKAGE_NAME) {
+  return Boolean(profile
+    && Object.hasOwn(profile.dependencies, packageName)
+    && profile.bundles.includes(packageName));
+}
+
+function profileHasInstalledAdapter(
+  profile,
+  runtimeBundleRoot,
+  state,
+  packageName = ADAPTER_PACKAGE_NAME,
+) {
+  if (!profileHasAdapter(profile, packageName) || !state || !nonEmpty(runtimeBundleRoot)) {
+    return false;
+  }
   try {
     const sourceManifest = readJsonObject(join(runtimeBundleRoot, "package.json"));
-    if (sourceManifest?.name !== ADAPTER_PACKAGE_NAME
+    if (sourceManifest?.name !== packageName
       || !nonEmpty(sourceManifest.version)) return false;
 
     const requireFromProfile = createRequire(join(profile.path, "package.json"));
-    const packageRoot = (requireFromProfile.resolve.paths(ADAPTER_PACKAGE_NAME) ?? [])
-      .map((searchPath) => join(searchPath, ADAPTER_PACKAGE_NAME))
+    const packageRoot = (requireFromProfile.resolve.paths(packageName) ?? [])
+      .map((searchPath) => join(searchPath, packageName))
       .find((candidate) => existsSync(join(candidate, "package.json")));
     if (!packageRoot) return false;
 
     const installedManifest = readJsonObject(join(packageRoot, "package.json"));
     const sourcePatch = sourceManifest?.dsh?.bundle?.patch;
-    if (installedManifest?.name !== ADAPTER_PACKAGE_NAME
+    if (installedManifest?.name !== packageName
       || installedManifest.version !== sourceManifest.version
       || installedManifest.main !== sourceManifest.main
       || !isDeepStrictEqual(installedManifest.exports, sourceManifest.exports)
@@ -1096,7 +1194,7 @@ function profileHasInstalledAdapter(profile, runtimeBundleRoot, state) {
       || installedManifest?.dsh?.bundle?.patch !== sourcePatch) return false;
 
     readFileSync(join(packageRoot, sourcePatch), "utf8");
-    readFileSync(requireFromProfile.resolve(ADAPTER_PACKAGE_NAME), "utf8");
+    readFileSync(requireFromProfile.resolve(packageName), "utf8");
     const authority = requireDshRuntimeAuthority(packageRoot);
     return authority.enabled === state.enabled
       && authority.sourceAdapterRoot === resolve(state.adapterRoot)
@@ -1119,6 +1217,15 @@ function readJsonObject(path) {
   return value !== null && typeof value === "object" && !Array.isArray(value)
     ? value
     : undefined;
+}
+
+function runtimeAdapterPackageName(runtimeBundleRoot) {
+  try {
+    const packageName = readJsonObject(join(runtimeBundleRoot, "package.json"))?.name;
+    return MANAGED_ADAPTER_PACKAGE_NAMES.includes(packageName) ? packageName : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 function projectProfileStatus(

--- a/packages/ts/memorax-code-dsh-adapter/test/profile-lifecycle.test.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/test/profile-lifecycle.test.mjs
@@ -65,18 +65,18 @@ test("failed reconciliation restores the prior authority and removes newly insta
   ]);
   const webManifest = JSON.parse(readFileSync(join(profilesRoot, "web", "package.json"), "utf8"));
   assert.equal(
-    webManifest.dependencies["@memorax-code/dsh-adapter"],
+    webManifest.dependencies["@memorax-code/dsh-memorax-code"],
     `file:${priorState.runtimeBundleRoot}`,
   );
   const alphaManifest = JSON.parse(readFileSync(join(profilesRoot, "alpha", "package.json"), "utf8"));
-  assert.equal(Object.hasOwn(alphaManifest.dependencies, "@memorax-code/dsh-adapter"), false);
-  assert.equal(alphaManifest.dsh.profile.bundles.includes("@memorax-code/dsh-adapter"), false);
+  assert.equal(Object.hasOwn(alphaManifest.dependencies, "@memorax-code/dsh-memorax-code"), false);
+  assert.equal(alphaManifest.dsh.profile.bundles.includes("@memorax-code/dsh-memorax-code"), false);
   assert.equal(existsSync(join(
     profilesRoot,
     "alpha",
     "node_modules",
     "@memorax-code",
-    "dsh-adapter",
+    "dsh-memorax-code",
   )), false);
   const generations = readdirSync(join(
     memoraxCodeHome,
@@ -144,7 +144,7 @@ test("failed rollback removal retains ownership of the residual Profile", async 
   assert.deepEqual(state.profiles, ["alpha", "web"]);
   const alphaManifest = JSON.parse(readFileSync(join(profilesRoot, "alpha", "package.json"), "utf8"));
   assert.equal(
-    alphaManifest.dependencies["@memorax-code/dsh-adapter"],
+    alphaManifest.dependencies["@memorax-code/dsh-memorax-code"],
     `file:${newRuntimeBundleRoot}`,
   );
 
@@ -182,8 +182,8 @@ test("quiesce publishes the inert authority without invoking DSH or removing Pro
   mkdirSync(join(dshHome, "profiles", "web"), { recursive: true });
   mkdirSync(join(memoraxCodeHome, "adapters", "dsh"), { recursive: true });
   writeFileSync(profileManifestPath, `${JSON.stringify({
-    dependencies: { "@memorax-code/dsh-adapter": `file:${runtimeBundleRoot}` },
-    dsh: { profile: { bundles: ["@memorax-code/dsh-adapter"] } },
+    dependencies: { "@memorax-code/dsh-memorax-code": `file:${runtimeBundleRoot}` },
+    dsh: { profile: { bundles: ["@memorax-code/dsh-memorax-code"] } },
   })}\n`);
   writeFileSync(statePath, `${JSON.stringify({
     version: 1,
@@ -222,7 +222,7 @@ test("quiesce publishes the inert authority without invoking DSH or removing Pro
   assert.deepEqual(state.profiles, ["web"]);
   assert.equal(
     JSON.parse(readFileSync(profileManifestPath, "utf8"))
-      .dependencies["@memorax-code/dsh-adapter"],
+      .dependencies["@memorax-code/dsh-memorax-code"],
     `file:${runtimeBundleRoot}`,
   );
 
@@ -234,7 +234,7 @@ test("quiesce publishes the inert authority without invoking DSH or removing Pro
     runDsh: (invocation) => {
       removalInvocation = invocation;
       const manifest = JSON.parse(readFileSync(profileManifestPath, "utf8"));
-      delete manifest.dependencies["@memorax-code/dsh-adapter"];
+      delete manifest.dependencies["@memorax-code/dsh-memorax-code"];
       manifest.dsh.profile.bundles = [];
       writeFileSync(profileManifestPath, `${JSON.stringify(manifest)}\n`);
       return { status: 0 };
@@ -266,6 +266,157 @@ test("quiesce preserves the not-managed lifecycle result", async (t) => {
     skipped: true,
     reason: "not_managed",
   });
+});
+
+test("restores the persisted DSH home when DSH_HOME is not configured", async (t) => {
+  const root = mkdtempSync(join(tmpdir(), "memorax-code-dsh-persisted-home-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const homeDir = join(root, "home");
+  const memoraxCodeHome = join(homeDir, ".memorax-code");
+  const dshHome = join(root, "persisted-dsh-home");
+  const adapterRoot = join(root, "adapter");
+  const runtimeBundleRoot = join(
+    memoraxCodeHome,
+    "adapters",
+    "dsh",
+    "runtime",
+    "generations",
+    "generation-1",
+  );
+  const statePath = join(memoraxCodeHome, "adapters", "dsh", "state.json");
+  writeProfile(join(dshHome, "profiles"), "web");
+  mkdirSync(dirname(statePath), { recursive: true });
+  writeJson(statePath, {
+    version: 1,
+    runtime: "dsh",
+    integration: "plugin",
+    enabled: false,
+    dshHome,
+    memoraxCodeHome,
+    adapterRoot,
+    runtimeBundleRoot,
+    memoraxCodeCommand: "memorax-code",
+    dshCommand: "dsh",
+    dshVersion: "0.1.0-rc.6",
+    profiles: ["web"],
+    updatedAt: "2026-08-15T12:00:00.000Z",
+  });
+
+  const report = await withDshPluginLifecycleLock({
+    adapterRoot,
+    env: {},
+    homeDir,
+    memoraxCodeHome,
+  }, (lifecycle) => lifecycle.status());
+
+  assert.equal(report.ok, true);
+  assert.equal(report.managed, true);
+  assert.deepEqual(report.profiles, [{ name: "web", exists: true, installed: false }]);
+});
+
+test("migrates the managed legacy package identity and restores it if reconciliation fails", async (t) => {
+  const fixture = await createReconciliationFixture(t);
+  const {
+    profilesRoot,
+    statePath,
+    initialOptions,
+    installAdapter,
+    removeAdapter,
+    priorState,
+  } = fixture;
+  const legacyPackageName = "@memorax-code/dsh-adapter";
+  const currentPackageName = "@memorax-code/dsh-memorax-code";
+
+  removeAdapter("web", currentPackageName);
+  const legacyRuntimeBundleRoot = join(dirname(priorState.runtimeBundleRoot), "legacy-generation");
+  cpSync(priorState.runtimeBundleRoot, legacyRuntimeBundleRoot, { recursive: true });
+  const legacyRuntimeManifestPath = join(legacyRuntimeBundleRoot, "package.json");
+  writeJson(legacyRuntimeManifestPath, {
+    ...JSON.parse(readFileSync(legacyRuntimeManifestPath, "utf8")),
+    name: legacyPackageName,
+  });
+  const legacyMetadataPath = join(legacyRuntimeBundleRoot, ".memorax-code-package.json");
+  writeJson(legacyMetadataPath, {
+    ...JSON.parse(readFileSync(legacyMetadataPath, "utf8")),
+    runtimeBundleRoot: legacyRuntimeBundleRoot,
+  });
+  installAdapter("web", legacyRuntimeBundleRoot);
+  writeProfile(profilesRoot, "headless");
+  installAdapter("headless", legacyRuntimeBundleRoot);
+  const legacyState = {
+    ...priorState,
+    runtimeBundleRoot: legacyRuntimeBundleRoot,
+    profiles: ["headless", "web"],
+    updatedAt: "2026-08-15T13:00:00.000Z",
+  };
+  writeJson(statePath, legacyState);
+
+  let failWeb = true;
+  const migrationOptions = {
+    ...initialOptions,
+    runDsh(invocation) {
+      if (invocation.args[0] === "--version") return { status: 0, stdout: "0.1.0-rc.6\n" };
+      const profileName = invocation.args[2];
+      const operation = invocation.args[3];
+      if (operation === "add") {
+        if (failWeb
+          && profileName === "web"
+          && invocation.args[4] !== `file:${legacyState.runtimeBundleRoot}`) {
+          return { status: 1 };
+        }
+        installAdapter(profileName, invocation.args[4].slice("file:".length));
+      } else {
+        removeAdapter(profileName, invocation.args[4]);
+      }
+      return { status: 0 };
+    },
+  };
+
+  const failed = await withDshPluginLifecycleLock(migrationOptions, (lifecycle) => (
+    lifecycle.ensureInstalled()
+  ));
+  assert.equal(failed.ok, false);
+  assert.deepEqual(failed.failedProfiles, [
+    { name: "web", reason: "dsh_command_failed", status: 1 },
+  ]);
+  assert.equal(failed.rollbackFailedProfiles, undefined);
+  assert.deepEqual(JSON.parse(readFileSync(statePath, "utf8")), legacyState);
+  for (const profileName of legacyState.profiles) {
+    const manifest = JSON.parse(readFileSync(
+      join(profilesRoot, profileName, "package.json"),
+      "utf8",
+    ));
+    assert.equal(Object.hasOwn(manifest.dependencies, legacyPackageName), true);
+    assert.equal(Object.hasOwn(manifest.dependencies, currentPackageName), false);
+  }
+
+  failWeb = false;
+  const migrated = await withDshPluginLifecycleLock(migrationOptions, (lifecycle) => (
+    lifecycle.ensureInstalled()
+  ));
+  assert.equal(migrated.ok, true);
+  assert.equal(migrated.installed, true);
+  assert.equal(migrated.enabled, true);
+  for (const profileName of legacyState.profiles) {
+    const profileRoot = join(profilesRoot, profileName);
+    const manifest = JSON.parse(readFileSync(join(profileRoot, "package.json"), "utf8"));
+    assert.equal(Object.hasOwn(manifest.dependencies, legacyPackageName), false);
+    assert.equal(Object.hasOwn(manifest.dependencies, currentPackageName), true);
+    assert.equal(existsSync(join(
+      profileRoot,
+      "node_modules",
+      ...legacyPackageName.split("/"),
+    )), false);
+    assert.equal(existsSync(join(
+      profileRoot,
+      "node_modules",
+      ...currentPackageName.split("/"),
+    )), true);
+  }
+  const status = await withDshPluginLifecycleLock(initialOptions, (lifecycle) => lifecycle.status());
+  assert.equal(status.ok, true);
+  assert.equal(status.installed, true);
+  assert.equal(status.enabled, true);
 });
 
 test("managed DSH discovery failures are not optional skips", async (t) => {
@@ -439,7 +590,7 @@ test("materializes, packs, installs, and reuses one per-home runtime generation"
       ], { cwd: profileRoot, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
       assert.equal(install.status, 0, install.stderr);
       const manifest = JSON.parse(readFileSync(profileManifestPath, "utf8"));
-      manifest.dsh.profile.bundles = ["@memorax-code/dsh-adapter"];
+      manifest.dsh.profile.bundles = ["@memorax-code/dsh-memorax-code"];
       writeJson(profileManifestPath, manifest);
       return { status: 0 };
     },
@@ -465,7 +616,7 @@ test("materializes, packs, installs, and reuses one per-home runtime generation"
     "windows-cli-invocation.mjs",
   )), true);
   assert.deepEqual(packedFiles, ["package.json", ...adapterManifest.files].sort());
-  const installedRoot = join(profileRoot, "node_modules", "@memorax-code", "dsh-adapter");
+  const installedRoot = join(profileRoot, "node_modules", "@memorax-code", "dsh-memorax-code");
   const installed = await import(pathToFileURL(join(installedRoot, "src", "index.mjs")).href);
   assert.equal(installed.name, "memorax-code");
   let contextRead = false;
@@ -510,29 +661,30 @@ async function createReconciliationFixture(t) {
 
   const installAdapter = (profileName, runtimeBundleRoot) => {
     const profileRoot = join(profilesRoot, profileName);
-    const installedRoot = join(profileRoot, "node_modules", "@memorax-code", "dsh-adapter");
+    const packageName = JSON.parse(readFileSync(join(runtimeBundleRoot, "package.json"), "utf8")).name;
+    const installedRoot = join(profileRoot, "node_modules", ...packageName.split("/"));
     rmSync(installedRoot, { recursive: true, force: true });
     mkdirSync(dirname(installedRoot), { recursive: true });
     cpSync(runtimeBundleRoot, installedRoot, { recursive: true });
     const manifestPath = join(profileRoot, "package.json");
     const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
-    manifest.dependencies["@memorax-code/dsh-adapter"] = `file:${runtimeBundleRoot}`;
-    if (!manifest.dsh.profile.bundles.includes("@memorax-code/dsh-adapter")) {
-      manifest.dsh.profile.bundles.push("@memorax-code/dsh-adapter");
+    manifest.dependencies[packageName] = `file:${runtimeBundleRoot}`;
+    if (!manifest.dsh.profile.bundles.includes(packageName)) {
+      manifest.dsh.profile.bundles.push(packageName);
     }
     writeJson(manifestPath, manifest);
   };
-  const removeAdapter = (profileName) => {
+  const removeAdapter = (profileName, packageName = "@memorax-code/dsh-memorax-code") => {
     const profileRoot = join(profilesRoot, profileName);
-    rmSync(join(profileRoot, "node_modules", "@memorax-code", "dsh-adapter"), {
+    rmSync(join(profileRoot, "node_modules", ...packageName.split("/")), {
       recursive: true,
       force: true,
     });
     const manifestPath = join(profileRoot, "package.json");
     const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
-    delete manifest.dependencies["@memorax-code/dsh-adapter"];
+    delete manifest.dependencies[packageName];
     manifest.dsh.profile.bundles = manifest.dsh.profile.bundles
-      .filter((name) => name !== "@memorax-code/dsh-adapter");
+      .filter((name) => name !== packageName);
     writeJson(manifestPath, manifest);
   };
   const initialOptions = {

--- a/packages/ts/memorax-code-dsh-adapter/test/profile-lifecycle.test.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/test/profile-lifecycle.test.mjs
@@ -15,7 +15,10 @@ import { dirname, join, resolve } from "node:path";
 import test from "node:test";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
-import { withDshPluginLifecycleLock } from "../src/profile-lifecycle.mjs";
+import {
+  collectDshAdapterStatus,
+  withDshPluginLifecycleLock,
+} from "../src/profile-lifecycle.mjs";
 
 test("failed reconciliation restores the prior authority and removes newly installed Profiles", async (t) => {
   const fixture = await createReconciliationFixture(t);
@@ -343,7 +346,7 @@ test("migrates the managed legacy package identity and restores it if reconcilia
   installAdapter("web", legacyRuntimeBundleRoot);
   writeProfile(profilesRoot, "headless");
   installAdapter("headless", legacyRuntimeBundleRoot);
-  const legacyState = {
+  let legacyState = {
     ...priorState,
     runtimeBundleRoot: legacyRuntimeBundleRoot,
     profiles: ["headless", "web"],
@@ -371,6 +374,20 @@ test("migrates the managed legacy package identity and restores it if reconcilia
       return { status: 0 };
     },
   };
+
+  const statusBeforeMigration = collectDshAdapterStatus(migrationOptions);
+  assert.equal(statusBeforeMigration.ok, true);
+  assert.equal(statusBeforeMigration.installed, true);
+  assert.equal(statusBeforeMigration.enabled, true);
+  const reactivated = await withDshPluginLifecycleLock(migrationOptions, (lifecycle) => {
+    const quiesced = lifecycle.quiesce();
+    assert.equal(quiesced.previouslyEnabled, true);
+    assert.equal(lifecycle.status().installed, true);
+    return lifecycle.activate();
+  });
+  assert.equal(reactivated.ok, true);
+  assert.equal(reactivated.enabled, true);
+  legacyState = JSON.parse(readFileSync(statePath, "utf8"));
 
   const failed = await withDshPluginLifecycleLock(migrationOptions, (lifecycle) => (
     lifecycle.ensureInstalled()

--- a/packages/ts/memorax-code-dsh-adapter/test/runtime-state.test.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/test/runtime-state.test.mjs
@@ -12,7 +12,7 @@ import {
 test("re-reads durable DSH authority without pinning the host version", (t) => {
   const root = mkdtempSync(join(tmpdir(), "memorax-code-dsh-state-"));
   t.after(() => rmSync(root, { recursive: true, force: true }));
-  const pluginRoot = join(root, "profile", "node_modules", "@memorax-code", "dsh-adapter");
+  const pluginRoot = join(root, "profile", "node_modules", "@memorax-code", "dsh-memorax-code");
   const sourceAdapterRoot = join(root, "installed-package", "lib", "memorax-code-dsh-adapter");
   const memoraxCodeHome = join(root, "memorax-home");
   const runtimeBundleRoot = join(

--- a/scripts/dsh-npm-package-e2e.mjs
+++ b/scripts/dsh-npm-package-e2e.mjs
@@ -220,7 +220,7 @@ async function main() {
   assert.equal(await exists(join(sourceRoot, "runtime")), false);
   assert.equal(await exists(join(sourceRoot, "state.json")), false);
   const profilePackage = await realpath(join(headless, "node_modules",
-    "@memorax-code", "dsh-adapter"));
+    "@memorax-code", "dsh-memorax-code"));
   const profileMetadata = await readJson(join(profilePackage, ".memorax-code-package.json"));
   const sourceManifest = await readJson(join(sourceRoot, "package.json"));
   assert.deepEqual(
@@ -473,8 +473,8 @@ async function main() {
   assert.equal(await exists(generationsRoot), false);
   await assertProfile(headless, false);
   await assertProfile(web, false);
-  assert.equal(await exists(join(headless, "node_modules", "@memorax-code", "dsh-adapter")), false);
-  assert.equal(await exists(join(web, "node_modules", "@memorax-code", "dsh-adapter")), false);
+  assert.equal(await exists(join(headless, "node_modules", "@memorax-code", "dsh-memorax-code")), false);
+  assert.equal(await exists(join(web, "node_modules", "@memorax-code", "dsh-memorax-code")), false);
   assert.equal(await readFile(headlessSentinel, "utf8"), "preserve headless\n");
   assert.equal(await readFile(webSentinel, "utf8"), "preserve web\n");
   assert.deepEqual(await snapshotFiles(sessionsRoot), sessions);
@@ -753,10 +753,10 @@ function turnForPrompt(events, prompt) {
 
 async function assertProfile(root, integrated) {
   const manifest = await readJson(join(root, "package.json"));
-  assert.equal(Object.hasOwn(manifest.dependencies || {}, "@memorax-code/dsh-adapter"),
+  assert.equal(Object.hasOwn(manifest.dependencies || {}, "@memorax-code/dsh-memorax-code"),
     integrated);
   assert.equal(Boolean(manifest.dsh?.profile?.bundles?.includes(
-    "@memorax-code/dsh-adapter")), integrated);
+    "@memorax-code/dsh-memorax-code")), integrated);
 }
 
 async function startMemoraxMock() {


### PR DESCRIPTION
## Change Summary
Present MemoraX Code as memorax-code in the DSH plugin list while preserving lifecycle ownership and migration safety for existing managed Profiles.

## Implementation Highlights
- Rename the private DSH Profile package identity to @memorax-code/dsh-memorax-code while keeping the public Cordis plugin id memorax-code.
- Reconcile and remove the legacy @memorax-code/dsh-adapter identity, with rollback to the prior package generation when migration fails.
- Restore the persisted custom DSH home when DSH_HOME is absent so status and removal continue to target the managed Profiles.

## Validation
- npm test --prefix packages/ts/memorax-code-dsh-adapter: 26 passed.
- npm run typecheck --prefix packages/ts/memorax-code-backend: passed.
- npm test --prefix packages/ts/memorax-code-backend: 537 passed, 2 skipped.
- scripts/npm-package-check.sh dist/npm-0.1.3-dev.1: 179 passed; 364 packaged files passed allowlist validation.

## Full End-to-End Validation Results
- Environment: macOS; real @deepseek-ai/dsh 0.1.0-rc.6 and Cordis; isolated homes for automated validation; local prerelease package 0.1.3-dev.1 for manual verification.
- Scenario or matrix: fresh install, managed Profile reconciliation, legacy package migration and rollback, disable/uninstall, and DSH plugin-list presentation.
- Command or workflow: MEMORAX_CODE_DSH_E2E=1 node scripts/dsh-npm-package-e2e.mjs, followed by installation of the local prerelease tarball into the local DSH environment.
- Result: the real-client lifecycle completed successfully; the DSH UI lists memorax-code as enabled with Cordis mounted, without exposing the adapter package name.
- Evidence or artifacts: automated terminal summaries and a redacted manual DSH plugin-list screenshot.
- Reason not run / remaining risk: Windows shim contracts remain covered by automated package validation; this presentation check was performed on macOS.
- 
<img width="1654" height="866" alt="image" src="https://github.com/user-attachments/assets/6db5a628-8a7a-4241-883c-ce610e2d8ccb" />
