### PR TITLE
fix: enforce request-language memory add output

### DIFF
--- a/packages/ts/memorax-code-codex-adapter/skills/memorax-code/references/memorax-add.md
+++ b/packages/ts/memorax-code-codex-adapter/skills/memorax-code/references/memorax-add.md
@@ -17,15 +17,46 @@ Do not add positive repair lessons based only on unverified edits or assistant s
 
 ## Add Workflow
 
-For a proactive add, write all generated prose in `--memory`, `--reason`, and the confirmation in the language of the user's current request; preserve exact code, API, path, workflow, and project identifiers.
+Before composing a proactive add, determine `memory_output_language` as exactly `zh` or `en` from the natural-language instructions in the user's current request:
+
+- Choose `zh` when the request is primarily Chinese, even when it contains English code, API, path, test, workflow, or project identifiers.
+- Choose `en` when the request is primarily English.
+- If the request genuinely uses both languages equally, use the language of its final explicit instruction.
+
+Use only the current user request for this decision. Do not substitute the language of server responses, retrieved memories, configuration, surrounding documentation, examples, or technical identifiers. Then use exactly one matching language branch below; never combine the Chinese and English examples.
+
+Write all generated prose in `--memory`, `--reason`, and the confirmation in `memory_output_language`; preserve exact code, API, path, workflow, and project identifiers, as well as field-name and enum identifiers. In a `CODE_AGENT_MEMORY` card, keep fixed keys such as `repo`, `scope`, `status`, `signal`, and `problem` in English, but write their natural-language values in `memory_output_language`.
+
+Immediately before each `memorax-cli add` invocation, emit exactly one shell audit comment in the same shell input:
+
+```text
+# memorax-memory-language: <zh|en>; source=current_user_request
+```
+
+Replace `<zh|en>` with the selected value. The comment records the decision only: do not include the user's text, memory content, repository path, identity, or other private data. It is not the user-facing confirmation.
+
+Before execution, compare the audit comment, `--memory`, `--reason`, and planned confirmation. If the comment says `zh` but multi-sentence natural-language prose in `--memory` contains no meaningful Chinese, rewrite it before invoking the CLI. Apply the equivalent check for `en`; ignore preserved identifiers and fixed card keys when checking consistency.
 
 Run from the active task workspace. Pass the memory and reason directly. Put every dynamically generated `--memory` and `--reason` value in single quotes, never double quotes. Treat `$HOME`, backticks, and `$(command)` as literal text inside those quotes. Replace each literal single quote in a value with the exact POSIX sequence `'\''`.
 
+For a Chinese request, use only the Chinese branch:
+
 ```bash
+# memorax-memory-language: zh; source=current_user_request
 memorax-cli add \
-  --memory 'Concise reusable memory.' \
+  --memory '解析器处理空数组时，应先检查长度再访问元素。' \
   --type procedural \
-  --reason 'Capture reusable coding memory.'
+  --reason '记录经过验证、可复用的解析器边界检查。'
+```
+
+For an English request, use only the English branch:
+
+```bash
+# memorax-memory-language: en; source=current_user_request
+memorax-cli add \
+  --memory 'When a parser handles an empty array, check its length before accessing an element.' \
+  --type procedural \
+  --reason 'Capture a verified, reusable parser boundary check.'
 ```
 
 Use an appropriate supported type such as `core`, `semantic`, `procedural`, `episodic`, or `unclassified`. Use `preference` only for an engineering convention owned by MemoraX Code coding memory, not for a personal interaction preference.
@@ -34,39 +65,61 @@ For a complex verified repair or failed approach, use this compact card when it 
 
 ```text
 CODE_AGENT_MEMORY
-repo: <repository or product area>
-scope: <module/path::symbol/API or lifecycle boundary>
+repo: <repo>
+scope: <scope>
 status: <verified|failed_attempt|candidate>
-signal: <test, CI, review, reproduction, deployment, failure, or unknown>
-problem: <small behavioral symptom or engineering situation>
-technical_context: <stable API, lifecycle, state owner, or data-shape detail>
-surfaces: <observable producer/consumer or setup/runtime/cleanup boundaries>
-failed_shape: <reusable wrong assumption or unsafe patch shape, or none>
-validation: <small reusable check contract>
-principle: <abstract invariant or decision rule>
-anchors: <stable repository source, tests, or public docs>
+signal: <signal>
+problem: <problem>
+technical_context: <technical context>
+surfaces: <surfaces>
+failed_shape: <failed shape or none>
+validation: <validation>
+principle: <principle>
+anchors: <anchors>
 ```
 
 Keep the card under 1,100 characters when practical. It must guide future investigation while still requiring live-code inspection.
 
-Pass a completed multi-line card as one single-quoted `--memory` argument:
+Pass a completed multi-line card as one single-quoted `--memory` argument. For a Chinese request:
 
 ```bash
+# memorax-memory-language: zh; source=current_user_request
+memorax-cli add \
+  --memory 'CODE_AGENT_MEMORY
+repo: owner/name
+scope: module/path::symbol
+status: verified
+signal: 聚焦测试通过
+problem: 解析器在空数组上发生越界
+technical_context: 读取首个元素前必须检查数组长度
+surfaces: 输入校验与元素读取边界
+failed_shape: 假设数组至少包含一个元素
+validation: 空数组和单元素数组的聚焦测试均通过
+principle: 访问集合元素前先验证边界
+anchors: stable/source/path' \
+  --type procedural \
+  --reason '记录经过验证、可复用的解析器边界规则。'
+```
+
+For an English request:
+
+```bash
+# memorax-memory-language: en; source=current_user_request
 memorax-cli add \
   --memory 'CODE_AGENT_MEMORY
 repo: owner/name
 scope: module/path::symbol
 status: verified
 signal: focused test passed
-problem: concise reusable symptom
-technical_context: stable implementation fact
-surfaces: affected boundary
-failed_shape: reusable pitfall or none
-validation: smallest reusable check
-principle: reusable invariant
+problem: the parser reads past an empty array
+technical_context: check array length before reading the first element
+surfaces: input validation and element-access boundary
+failed_shape: assuming every array contains an element
+validation: focused tests pass for empty and single-element arrays
+principle: validate collection bounds before element access
 anchors: stable/source/path' \
   --type procedural \
-  --reason 'Capture verified reusable coding memory.'
+  --reason 'Capture a verified, reusable parser boundary rule.'
 ```
 
 If add fails, report the exact failure and do not retry automatically, bypass the CLI, or call MemoraX directly.

--- a/packages/ts/memorax-code-codex-adapter/test/memorax-code-skill.test.mjs
+++ b/packages/ts/memorax-code-codex-adapter/test/memorax-code-skill.test.mjs
@@ -82,8 +82,8 @@ test("memorax-code references keep authority and operation boundaries explicit",
   assert.match(memoraxAdd, /CODE_AGENT_MEMORY/);
   assert.match(memoraxAdd, /In OpenCode, ask the agent to use the `memorax-code` skill by name/);
   assert.match(memoraxAdd, /Route user-owned ordered actions/);
-  assert.match(memoraxAdd, /For a proactive add, write all generated prose/);
-  assert.match(memoraxAdd, /language of the user's current request/);
+  assert.match(memoraxAdd, /Before composing a proactive add, determine `memory_output_language`/);
+  assert.match(memoraxAdd, /natural-language instructions in the user's current request/);
   assert.match(memoraxAdd, /preserve exact code, API, path, workflow, and project identifiers/);
   assert.match(memoraxAdd, /memorax-cli add[\s\S]*--memory '/);
   assert.match(memoraxAdd, /`workspace_scope_mismatch` or `workspace_scope_unavailable`/);
@@ -122,6 +122,41 @@ test("memorax-code search guidance preserves semantic roles and exact anchors", 
   assert.match(memoraxSearch, /Trace producer version: after an upgrade/);
   assert.match(memoraxSearch, /Task context after upgrade: can an already-open task keep old injected context/);
   assert.match(memoraxSearch, /Desktop SDK authority: without a native CLI/);
+});
+
+test("memorax-code add guidance selects one audited request-language branch", () => {
+  const memoraxAdd = readSkillFile("references/memorax-add.md");
+  const bashBlocks = [...memoraxAdd.matchAll(/```bash\n([\s\S]*?)\n```/g)].map((match) => match[1]);
+  const zhBlocks = bashBlocks.filter((block) => block.startsWith("# memorax-memory-language: zh; source=current_user_request\n"));
+  const enBlocks = bashBlocks.filter((block) => block.startsWith("# memorax-memory-language: en; source=current_user_request\n"));
+
+  assert.match(memoraxAdd, /determine `memory_output_language` as exactly `zh` or `en`/);
+  assert.match(memoraxAdd, /Use only the current user request for this decision/);
+  assert.match(memoraxAdd, /use exactly one matching language branch below/);
+  assert.match(memoraxAdd, /never combine the Chinese and English examples/);
+  assert.match(memoraxAdd, /If the comment says `zh`[\s\S]*contains no meaningful Chinese, rewrite it before invoking the CLI/);
+  assert.match(memoraxAdd, /keep fixed keys such as `repo`, `scope`, `status`, `signal`, and `problem` in English/);
+  assert.equal(bashBlocks.length, 4);
+  assert.equal(zhBlocks.length, 2);
+  assert.equal(enBlocks.length, 2);
+
+  for (const block of bashBlocks) {
+    const lines = block.split("\n");
+    assert.match(lines[0], /^# memorax-memory-language: (?:zh|en); source=current_user_request$/);
+    assert.equal(lines[1], "memorax-cli add \\");
+    assert.match(block, /--memory '/);
+    assert.match(block, /--type procedural/);
+    assert.match(block, /--reason '/);
+  }
+
+  for (const block of zhBlocks) {
+    assert.match(block, /--memory '[^']*[\p{Script=Han}]/u);
+    assert.match(block, /--reason '[^']*[\p{Script=Han}]/u);
+  }
+
+  for (const block of enBlocks) {
+    assert.doesNotMatch(block, /[\p{Script=Han}]/u);
+  }
 });
 
 test("memorax-code retries read-only search once after transport or sandbox failure", () => {


### PR DESCRIPTION
## Change Summary

让 `memorax-cli add` 生成的记忆、原因说明和确认语明确跟随当前用户请求语言，避免复杂记忆卡片被全英文示例或英文技术材料带偏，并增加可审计的执行前语言检查。

## Implementation Highlights

- 仅依据当前用户请求选择 `zh` 或 `en`；中文请求中出现代码、API、路径、测试名或英文技术标识时仍选择中文。
- 中文和英文示例改为互斥分支，简单记忆和 `CODE_AGENT_MEMORY` 复杂卡片均提供两种语言版本。
- 每次调用前要求输出固定注释 `# memorax-memory-language: <zh|en>; source=current_user_request`，并在执行前检查注释、`--memory`、`--reason` 和确认语是否一致。
- 固定字段名、枚举、代码、API 和路径保持原样，自然语言字段值跟随所选语言。
- 新增静态契约测试，覆盖分支数量、注释位置、CLI 参数格式和中英文正文。

## Validation

- `node --test test/memorax-code-skill.test.mjs`：8/8 通过。
- `npm test --prefix packages/ts/memorax-code-codex-adapter`：226/226 通过。
- `make docs-check`：10/10 通过，文档契约和 README 同步检查通过。
- `make npm-package-check`：179/179 通过，npm staging、打包清单和 local-only trace 检查通过。
- `git diff --check`：通过。
- 三组消融实验：45/45 个独立 Codex 会话正常完成；完整新规则语言结果 15/15 通过、固定注释 15/15、CLI 契约 15/15、工具调用 0/15。
- `npm test --prefix packages/ts/memorax-code-claude-adapter`：64/65 通过；唯一失败为既有 `Claude repo memory worker captures stdout and validates the generated bundle`，验证器报告测试夹具缺少 `source` / `trust_state`，且该路径不在本 PR 的两个改动文件中。

## Full End-to-End Validation Results

- Environment: macOS 26.5.2；Node.js v24.15.0；Codex CLI v0.142.5；模型 `gpt-5.5`；默认推理强度 `none`；独立、临时、只读会话。
- Scenario or matrix:
  - 在看到结果前固定 15 个合成案例：3 个纯中文复杂修复、3 个中文夹大量英文技术标识、3 个中文指令夹英文失败材料、3 个中英接近且最后指令为中文、3 个英文对照。
  - 每个案例分别运行三组：修改前原始规则、仅增加中英文简单/复杂示例、完整新规则（双语示例 + 请求语言判定 + 审计注释 + 一致性检查）。共 15 × 3 = 45 个独立会话，使用固定种子打乱执行顺序。
  - 每个中文复杂卡片检查 `signal`、`problem`、`technical_context`、`surfaces`、`failed_shape`、`validation`、`principle` 7 个字段及 `--reason`。只有路径、API、测试名等标识的字段不算英文泄漏；含英文自然语言且没有中文的字段才算泄漏。
- Command or workflow:
  - 将 `HEAD^` 中的修改前 `memorax-add.md`、由旧文件仅替换双语示例得到的消融版本、以及当前 `memorax-add.md` 分别直接注入相同评测提示。
  - 每格使用一个新的 `codex exec --ephemeral --ignore-user-config -s read-only -m gpt-5.5` 会话，只生成 Shell 输入，明确禁止使用工具或执行命令。
  - 记录 45 个唯一提示哈希、最终输出和 JSONL 事件，再自动评分并人工复核所有失败项。
- Result:

  | 指标 | 修改前 | 仅双语示例 | 完整新规则 |
  | --- | ---: | ---: | ---: |
  | 全部案例语言通过 | 7/15 | 11/15 | 15/15 |
  | 中文高风险案例语言通过 | 4/12 | 8/12 | 12/12 |
  | 中文字段合规 | 48/84 | 57/84 | 84/84 |
  | 英文自然语言泄漏字段 | 36/84 | 27/84 | 0/84 |
  | 英文对照组语言通过 | 3/3 | 3/3 | 3/3 |
  | 正确审计注释 | 0/15 | 0/15 | 15/15 |
  | CLI 参数契约 | 15/15 | 15/15 | 15/15 |
  | 未调用任何工具 | 15/15 | 15/15 | 15/15 |

  | 场景 | 修改前 | 仅双语示例 | 完整新规则 |
  | --- | ---: | ---: | ---: |
  | 纯中文复杂修复 | 3/3 | 3/3 | 3/3 |
  | 中文夹英文技术标识 | 0/3 | 1/3 | 3/3 |
  | 中文指令夹英文失败材料 | 1/3 | 2/3 | 3/3 |
  | 中英接近，最后指令为中文 | 0/3 | 2/3 | 3/3 |
  | 英文对照 | 3/3 | 3/3 | 3/3 |

  从修改前到完整新规则，12 个中文案例中有 8 个由失败变为通过、0 个由通过变为失败。纯中文场景三组均为 3/3，说明此前容易案例看不出差异；旧规则的主要弱点出现在英文技术材料会与全英文复杂卡片示例共同形成错误语言锚点时。仅补双语示例能改善结果，但仍有 27/84 个英文泄漏字段；完整规则的显式判定与执行前检查进一步消除了本组样本中的泄漏。

- Evidence or artifacts:

  代表案例输入是中文请求，但含较多英文标识：

  > 请把这个已验证的修复保存为复杂编码记忆：在 packages/ts/config/src/parse-config.ts 的 parseConfig() 中，empty input 必须返回 Result.empty()，不能 fall through 到 JSON.parse()；vitest 的 parseConfig handles empty input 和 preserves sourcePath 都通过。repo 是 owner/config-kit，anchors 用 packages/ts/config/test/parse-config.test.ts。

  <details>
  <summary>修改前原始输出：整张复杂卡片及 reason 均被英文示例带成英文</summary>

  ```bash
  memorax-cli add \
    --memory 'CODE_AGENT_MEMORY
  repo: owner/config-kit
  scope: packages/ts/config/src/parse-config.ts::parseConfig()
  status: verified
  signal: vitest parseConfig handles empty input and preserves sourcePath passed
  problem: empty input must produce an empty successful config result instead of trying to parse JSON
  technical_context: parseConfig() has a dedicated empty-input contract: return Result.empty() before any JSON.parse() path
  surfaces: config text input -> parseConfig() result; sourcePath behavior must remain preserved
  failed_shape: letting empty input fall through to JSON.parse() breaks the empty-config contract
  validation: run vitest coverage for parseConfig handles empty input and preserves sourcePath
  principle: validate and return the explicit empty-input result before invoking parsers that require content
  anchors: packages/ts/config/test/parse-config.test.ts' \
    --type procedural \
    --reason 'Capture verified reusable coding memory for parseConfig empty-input handling.'
  ```

  </details>

  <details>
  <summary>完整新规则原始输出：自然语言为中文，技术标识保持原样，并带审计注释</summary>

  ```bash
  # memorax-memory-language: zh; source=current_user_request
  memorax-cli add \
    --memory 'CODE_AGENT_MEMORY
  repo: owner/config-kit
  scope: packages/ts/config/src/parse-config.ts::parseConfig()
  status: verified
  signal: vitest 的 parseConfig handles empty input 和 preserves sourcePath 均通过
  problem: empty input 不能继续落到 JSON.parse()
  technical_context: parseConfig() 收到空输入时必须直接返回 Result.empty()，避免把空内容当作 JSON 解析
  surfaces: 配置解析入口、空输入处理、sourcePath 保留行为
  failed_shape: 空输入没有提前返回，继续 fall through 到 JSON.parse()
  validation: vitest 覆盖 empty input 返回 Result.empty()，并确认 preserves sourcePath 仍通过
  principle: 解析入口先处理空输入等边界情况，再进入 JSON.parse() 这类严格解析步骤
  anchors: packages/ts/config/test/parse-config.test.ts' \
    --type procedural \
    --reason '记录经过验证、可复用的配置解析边界规则：空输入应返回 Result.empty()，不能进入 JSON.parse()。'
  ```

  </details>

  运行完整性检查：45/45 会话退出码为 0，45 个提示哈希均唯一，JSONL 中命令/MCP/网页工具调用为 0，也没有 WebSocket 重试；因此没有执行任何真实 `memorax-cli add`。

- Reason not run / remaining risk:
  - 为避免产生测试垃圾记忆，未真正向 MemoraX 提交 Add；本实验验证的是提示规则对模型输出的影响，不是服务器端行为。
  - 每个“案例 × 规则版本”只生成一次，案例均为合成数据；结果显示清晰方向，但不能直接当作线上英文泄漏率。
  - Codex CLI 启动时出现本地模型缓存/会话索引/临时 shell snapshot 的非致命警告；45 个会话仍均正常返回且输出事件完整。
  - GitHub 当前未上报自动 checks；Claude 适配器既有夹具失败如上，需由独立修复处理。
