### PR TITLE
fix: require MemoraX credentials during interactive install

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,13 +67,15 @@ npm install -g @memorax/memorax-code --foreground-scripts
 Keep `--foreground-scripts` so the complete setup remains visible. The
 installer automatically detects available Codex, Claude Code, DeepSeek
 Harness, and OpenCode installations and connects those it finds. Follow the
-prompts to enter your Base User ID, preferred language, and API key. Codex
-users must also approve Hook activation and trust when prompted. Restart or
-refresh every detected coding agent after installation before starting a new
-session.
+prompts to enter your MemoraX user ID, preferred language, and API key. On an
+interactive first install, a non-empty user ID and API key are required unless
+the effective configuration already supplies both. Codex users must also
+approve Hook activation and trust when prompted. Restart or refresh every
+detected coding agent after installation before starting a new session.
 
-If setup is skipped or cannot prompt, the package remains installed but
-MemoraX-backed search, retrieval, and writeback remain unavailable.
+If installation cannot prompt and effective credentials are not already
+configured, the package remains installed but MemoraX-backed search, retrieval,
+and writeback remain unavailable.
 
 ### Try Cross-Session Memory
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -60,10 +60,12 @@ npm install -g @memorax/memorax-code --foreground-scripts
 
 请保留 `--foreground-scripts`，以便查看完整的安装过程。安装器会自动检测本机可用的 Codex、
 Claude Code、DeepSeek Harness 和 OpenCode，并为检测到的 Coding Agent 启用集成。按照终端提示输入
-Base User ID、偏好语言和 API Key；Codex 用户还需按提示完成 Hook 的激活和信任确认。安装完成后，
-请重启或刷新所有检测到的 Coding Agent，再开始新会话。
+MemoraX User ID、偏好语言和 API Key；首次交互安装时，除非有效配置已经提供 User ID 和 API Key，
+否则两者均不能为空。Codex 用户还需按提示完成 Hook 的激活和信任确认。安装完成后，请重启或刷新
+所有检测到的 Coding Agent，再开始新会话。
 
-如果跳过配置或安装过程无法交互，npm 包仍会安装，但 MemoraX 搜索、召回和写回功能无法使用。
+如果安装过程无法交互，且有效配置尚未提供凭据，npm 包仍会安装，但 MemoraX 搜索、召回和写回
+功能无法使用。
 
 ### 体验跨会话记忆
 

--- a/packages/npm/memorax-code/README.md
+++ b/packages/npm/memorax-code/README.md
@@ -24,13 +24,15 @@ Keep `--foreground-scripts` so npm displays the complete setup.
 
 The installer automatically detects available Codex, Claude Code, DeepSeek
 Harness, and OpenCode installations and configures those it finds. Follow the
-prompts to enter your MemoraX Base User ID, preferred language, and API key.
-When Codex is detected, review and approve its Hook activation.
+prompts to enter your MemoraX user ID, preferred language, and API key. On an
+interactive first install, a non-empty user ID and API key are required unless
+the effective configuration already supplies both. When Codex is detected,
+review and approve its Hook activation.
 
 Entering the MemoraX credentials after the installer's disclosure enables the
-core memory features and automatic writeback. If setup is skipped or cannot
-prompt, the package remains installed, but MemoraX-backed memory is not
-configured.
+core memory features and automatic writeback. If installation cannot prompt
+and effective credentials are not already configured, the package remains
+installed, but MemoraX-backed memory is not configured.
 
 After the first installation, restart or refresh the detected coding agents
 before opening a new session. In Codex, enable **MemoraX Code Codex Adapter**

--- a/packages/npm/memorax-code/bin/memorax-code-plugin-postinstall.mjs
+++ b/packages/npm/memorax-code/bin/memorax-code-plugin-postinstall.mjs
@@ -32,9 +32,11 @@ const HOOK_TRUST_SELECTION_ENV = "MEMORAX_CODE_CODEX_HOOK_TRUST_SELECTION_JSON";
 const PREFIX = "[MemoraX Code Install]:";
 const BACKEND_PREFIX = "[MemoraX Code Backend]:";
 const GREEN = "\x1b[32m";
+const BRIGHT_CYAN = "\x1b[96m";
 const BLUE = "\x1b[34m";
 const RED = "\x1b[31m";
 const BOLD = "\x1b[1m";
+const UNDERLINE = "\x1b[4m";
 const RESET = "\x1b[0m";
 
 if (truthyEnv(process.env.MEMORAX_CODE_SKIP_POSTINSTALL)) process.exit(0);
@@ -244,19 +246,19 @@ async function maybeConfigureMemoraxMemory(scriptedAnswers) {
   if (scriptedAnswers) {
     return await configureMemoraxMemoryFromAnswers(scriptedAnswers);
   }
+  printMemoraxRegistrationLink();
+  printMemoraxUserIdGuidance();
   let rl = createInterface({ input: process.stdin, output: process.stderr });
   try {
-    const configureNow = await rl.question(`${PREFIX} Connect MemoraX Code to MemoraX now? [Y/n] `);
-    if (/^n(?:o)?$/i.test(configureNow.trim())) {
-      log("MemoraX connection skipped. MemoraX Code memory is not fully configured until valid credentials are supplied.");
-      return "skipped";
-    }
-    log(`If you do not have a MemoraX account/API key, register at ${MEMORAX_ACCOUNT_URL}.`);
-    const userId = (await rl.question(`${PREFIX} MemoraX base user ID: `)).trim();
+    const userId = await questionRequiredLine(
+      rl,
+      `${PREFIX} Your MemoraX user ID (required, e.g. your-name): `,
+      "MemoraX user ID is required.",
+    );
     const outputLanguage = await questionPreferredLanguage(rl);
     rl.close();
     rl = undefined;
-    const apiKey = (await questionMasked(`${PREFIX} MemoraX API key: `)).trim();
+    const apiKey = await questionRequiredMasked(`${PREFIX} MemoraX API key (required): `);
     return await writeMemoraxConfigFromInput({
       userId,
       apiKey,
@@ -308,28 +310,27 @@ async function chooseUpdateClients(previousClients, detectedClients, scriptedAns
 }
 
 async function configureMemoraxMemoryFromAnswers(answers) {
-  if (answers.length === 0) {
-    log(`No MemoraX connection response was received. Register at ${MEMORAX_ACCOUNT_URL}, then edit \`~/.memorax-code/config.toml\` or rerun interactively with \`--foreground-scripts\`.`);
-    return "skipped";
-  }
-  log("Connect MemoraX Code to MemoraX now? [Y/n]");
-  const configureNow = String(answers.shift() ?? "").trim();
-  if (/^n(?:o)?$/i.test(configureNow)) {
-    log("MemoraX connection skipped. MemoraX Code memory is not fully configured until valid credentials are supplied.");
-    return "skipped";
-  }
-  log(`If you do not have a MemoraX account/API key, register at ${MEMORAX_ACCOUNT_URL}.`);
-  log("MemoraX base user ID: <provided>");
-  const userId = String(answers.shift() ?? "").trim();
-  const outputLanguageAnswer = String(answers.shift() ?? "").trim();
-  log(`Preferred language [ZH/en] (used for Memory extraction): ${outputLanguageAnswer ? "<provided>" : "<default>"}`);
-  log("MemoraX API key: <provided>");
-  const apiKey = String(answers.shift() ?? "").trim();
+  printMemoraxRegistrationLink();
+  printMemoraxUserIdGuidance();
+  const userId = requiredScriptedAnswer(answers, {
+    prompt: "Your MemoraX user ID (required, e.g. your-name)",
+    requiredMessage: "MemoraX user ID is required.",
+    missingMessage: "No MemoraX user ID response was received; MemoraX configuration is incomplete.",
+  });
+  if (!userId) return "skipped";
+  const outputLanguage = scriptedPreferredLanguage(answers);
+  if (!outputLanguage) return "skipped";
+  const apiKey = requiredScriptedAnswer(answers, {
+    prompt: "MemoraX API key (required)",
+    requiredMessage: "MemoraX API key is required.",
+    missingMessage: "No MemoraX API key response was received; MemoraX configuration is incomplete.",
+  });
+  if (!apiKey) return "skipped";
   return await writeMemoraxConfigFromInput({
     userId,
     apiKey,
     endpoint: memoraxInstallEndpoint(),
-    outputLanguage: preferredLanguage(outputLanguageAnswer),
+    outputLanguage,
   });
 }
 
@@ -339,9 +340,19 @@ function printMemoraxDisclosure() {
   log("Newly generated configuration enables automatic writeback. Existing configuration is never enabled implicitly; disable it with `[memory.writeback] enabled = false` or `MEMORAX_CODE_MEMORAX_WRITEBACK_ENABLED=false`.");
 }
 
+function printMemoraxUserIdGuidance() {
+  log("MemoraX uses one user ID to keep your coding memories consistent across supported agents and devices.");
+  log("Choose a stable ID and use the same value everywhere; MemoraX Code separates repositories automatically.");
+}
+
+function printMemoraxRegistrationLink() {
+  log("No MemoraX account or API key yet?");
+  log(`→ Register here: ${BRIGHT_CYAN}${BOLD}${UNDERLINE}${MEMORAX_ACCOUNT_URL}${RESET}`);
+}
+
 async function writeMemoraxConfigFromInput({ userId, apiKey, endpoint, outputLanguage }) {
   if (!userId || !apiKey) {
-    logRed("MemoraX config was not written because base user ID or API key was empty.");
+    logRed("MemoraX config was not written because MemoraX user ID or API key was empty.");
     return "skipped";
   }
   if (!outputLanguage) {
@@ -355,6 +366,45 @@ async function writeMemoraxConfigFromInput({ userId, apiKey, endpoint, outputLan
   logGreen(`MemoraX config written to ${memoraxCodeConfigPath()}.`);
   log("MemoraX network access will be checked by the first workspace-scoped memory request from a trusted workspace.");
   return "configured";
+}
+
+async function questionRequiredLine(rl, prompt, requiredMessage) {
+  while (true) {
+    const answer = (await rl.question(prompt)).trim();
+    if (answer) return answer;
+    logRed(requiredMessage);
+  }
+}
+
+async function questionRequiredMasked(prompt) {
+  while (true) {
+    const answer = (await questionMasked(prompt)).trim();
+    if (answer) return answer;
+    logRed("MemoraX API key is required.");
+  }
+}
+
+function requiredScriptedAnswer(answers, { prompt, requiredMessage, missingMessage }) {
+  while (answers.length > 0) {
+    const answer = String(answers.shift() ?? "").trim();
+    log(`${prompt}: ${answer ? "<provided>" : "<empty>"}`);
+    if (answer) return answer;
+    logRed(requiredMessage);
+  }
+  logRed(missingMessage);
+  return undefined;
+}
+
+function scriptedPreferredLanguage(answers) {
+  while (answers.length > 0) {
+    const answer = String(answers.shift() ?? "").trim();
+    log(`Preferred language [ZH/en] (used for Memory extraction): ${answer ? "<provided>" : "<default>"}`);
+    const language = preferredLanguage(answer);
+    if (language) return language;
+    logRed("Preferred language must be zh or en.");
+  }
+  logRed("No preferred language response was received; MemoraX configuration is incomplete.");
+  return undefined;
 }
 
 async function questionPreferredLanguage(rl) {

--- a/packages/npm/memorax-code/bin/memorax-code-plugin-postinstall.mjs
+++ b/packages/npm/memorax-code/bin/memorax-code-plugin-postinstall.mjs
@@ -239,7 +239,12 @@ process.exit(0);
 
 async function maybeConfigureMemoraxMemory(scriptedAnswers) {
   printMemoraxDisclosure();
-  if (!canPrompt()) {
+  const promptAvailable = canPrompt();
+  if (promptAvailable && readMemoraxInstallStatus()?.configured) {
+    log("Existing MemoraX credentials detected; keeping the effective configuration unchanged.");
+    return "preserved";
+  }
+  if (!promptAvailable) {
     log(`This install cannot prompt for a MemoraX ID and key. Register at ${MEMORAX_ACCOUNT_URL}, then edit \`~/.memorax-code/config.toml\` or rerun interactively with \`--foreground-scripts\`.`);
     return "skipped";
   }

--- a/packages/npm/memorax-code/test/postinstall.test.mjs
+++ b/packages/npm/memorax-code/test/postinstall.test.mjs
@@ -28,6 +28,7 @@ const vscodeExtensionCommandPath = fileURLToPath(new URL("../lib/vscode-extensio
 const windowsCliInvocationPath = fileURLToPath(new URL("../lib/windows-cli-invocation.mjs", import.meta.url));
 const smolTomlPath = fileURLToPath(new URL("../../../ts/memorax-code-backend/node_modules/smol-toml", import.meta.url));
 const memoraxCodePluginId = "memorax-code-codex-adapter@memorax-code";
+const memoraxSetupInput = "memorax-user\nzh\nmemorax-secret\n";
 
 function pathWithoutCommand(command, pathValue) {
   return String(pathValue ?? "")
@@ -1268,7 +1269,7 @@ test("postinstall auto-detected Claude-only setup does not inspect Codex login s
     officialMode: true,
     codexAvailable: false,
     interactive: true,
-    input: "n\n",
+    input: memoraxSetupInput,
   });
   try {
     assert.equal(run.result.code, 0, run.result.stderr);
@@ -1371,7 +1372,7 @@ test("postinstall enables Codex shared Hooks without inspecting the Codex login 
     emptyClaudeSettings: true,
     claudeAvailable: false,
     interactive: true,
-    input: "n\nn\n",
+    input: `${memoraxSetupInput}n\n`,
   });
   try {
     assert.equal(run.result.code, 0, run.result.stderr);
@@ -1408,7 +1409,7 @@ test("postinstall uses the same Codex Hook lifecycle for a custom provider confi
     codexConfig,
     claudeAvailable: false,
     interactive: true,
-    input: "n\nn\n",
+    input: `${memoraxSetupInput}n\n`,
   });
   try {
     assert.equal(run.result.code, 0, run.result.stderr);
@@ -1448,7 +1449,7 @@ test("postinstall uses the Codex App bundled runtime when no standalone CLI is i
     codexAppOnly: true,
     claudeAvailable: false,
     interactive: true,
-    input: "n\ny\n",
+    input: `${memoraxSetupInput}y\n`,
   });
   try {
     assert.equal(run.result.code, 0, run.result.stderr);
@@ -1498,13 +1499,12 @@ test("postinstall accepts VS Code bundled runtimes when no standalone CLI is ins
   }
 });
 
-test("postinstall seeds default MemoraX Code config on first install when memory setup is skipped", async () => {
-  const run = await runPostinstall({ interactive: true, input: "n\nn\n" });
+test("postinstall seeds default MemoraX Code config during first interactive setup", async () => {
+  const run = await runPostinstall({ interactive: true, input: `${memoraxSetupInput}n\n` });
   try {
     assert.equal(run.result.code, 0, run.result.stderr);
     assert.match(run.result.stderr, /MemoraX Code requires MemoraX for its core remote-memory functionality/);
-    assert.match(run.result.stderr, /MemoraX memory: Not configured/);
-    assert.match(run.result.stderr, /Package installed, MemoraX not configured/);
+    assert.match(run.result.stderr, /MemoraX memory: .*Configured/);
     const config = await readFile(join(run.memoraxCodeHome, "config.toml"), "utf8");
     assert.match(tomlSectionText(config, "clients"), /^dsh = true(?:\s+#.*)?$/m);
     assert.doesNotMatch(config, /profile\s*=/);
@@ -1564,7 +1564,7 @@ test("postinstall can configure only Claude Code", async () => {
     claudeSettingsText,
     codexAvailable: false,
     interactive: true,
-    input: "n\n",
+    input: memoraxSetupInput,
   });
   try {
     assert.equal(run.result.code, 0, run.result.stderr);
@@ -1589,7 +1589,7 @@ test("postinstall can configure only Codex", async () => {
     claudeSettingsText,
     claudeAvailable: false,
     interactive: true,
-    input: "n\ny\n",
+    input: `${memoraxSetupInput}y\n`,
   });
   try {
     assert.equal(run.result.code, 0, run.result.stderr);
@@ -1613,7 +1613,7 @@ test("postinstall can configure only Codex", async () => {
 test("postinstall can write MemoraX memory config before backend start", async () => {
   const run = await runPostinstall({
     interactive: true,
-    input: "y\nmemorax-user\nen\nmemorax-secret\nn\n",
+    input: "memorax-user\nen\nmemorax-secret\nn\n",
     memoraxVerify: {},
   });
   try {
@@ -1621,13 +1621,14 @@ test("postinstall can write MemoraX memory config before backend start", async (
     assert.match(run.result.stderr, /MemoraX Code requires MemoraX for its core remote-memory functionality/);
     assert.match(run.result.stderr, /automatically send selected user prompts and final assistant answers to MemoraX/);
     assert.match(run.result.stderr, /Newly generated configuration enables automatic writeback/);
-    assert.match(run.result.stderr, /If you do not have a MemoraX account\/API key, register at https:\/\/platform\.memorax\.net\//);
-    assert.match(run.result.stderr, /Connect MemoraX Code to MemoraX now/);
-    assert.equal((run.result.stderr.match(/Connect MemoraX Code to MemoraX now/g) ?? []).length, 1);
+    assert.match(run.result.stderr, /\x1b\[96m\x1b\[1m\x1b\[4mhttps:\/\/platform\.memorax\.net\/\x1b\[0m/);
+    assert.doesNotMatch(run.result.stderr, /Connect MemoraX Code to MemoraX now/);
     assert.doesNotMatch(run.result.stderr, /Enable automatic writeback|Enable writeback now/);
-    assert.match(run.result.stderr, /MemoraX base user ID: <provided>/);
+    assert.match(run.result.stderr, /MemoraX uses one user ID to keep your coding memories consistent across supported agents and devices/);
+    assert.match(run.result.stderr, /Choose a stable ID and use the same value everywhere; MemoraX Code separates repositories automatically/);
+    assert.match(run.result.stderr, /Your MemoraX user ID \(required, e\.g\. your-name\): <provided>/);
     assert.match(run.result.stderr, /Preferred language \[ZH\/en\] \(used for Memory extraction\): <provided>/);
-    assert.match(run.result.stderr, /MemoraX API key: <provided>/);
+    assert.match(run.result.stderr, /MemoraX API key \(required\): <provided>/);
     assert.doesNotMatch(run.result.stderr, /MemoraX endpoint/);
     assert.match(run.result.stderr, /MemoraX config written to/);
     assert.match(run.result.stderr, /first workspace-scoped memory request from a trusted workspace/);
@@ -1806,11 +1807,10 @@ test("postinstall reports the global automatic writeback kill switch", async () 
 test("postinstall writes the platform endpoint when no override is supplied", async () => {
   const run = await runPostinstall({
     interactive: true,
-    input: "y\nmemorax-user\n\nmemorax-secret\nn\n",
+    input: "memorax-user\n\nmemorax-secret\nn\n",
   });
   try {
     assert.equal(run.result.code, 0, run.result.stderr);
-    assert.match(run.result.stderr, /register at https:\/\/platform\.memorax\.net\//);
     const config = await readFile(join(run.memoraxCodeHome, "config.toml"), "utf8");
     assert.match(config, /endpoint = "https:\/\/platform\.memorax\.net" # MemoraX service URL\./);
     assert.match(config, /output_language = "zh" # Language for newly generated MemoraX memories\./);
@@ -1819,33 +1819,34 @@ test("postinstall writes the platform endpoint when no override is supplied", as
   }
 });
 
-test("postinstall does not report empty MemoraX credentials as configured", async () => {
+test("postinstall requires non-empty MemoraX credentials", async () => {
   const run = await runPostinstall({
     interactive: true,
-    input: "y\n\nzh\nmemorax-secret\nn\n",
+    input: "\nmemorax-user\nzh\n\nmemorax-secret\nn\n",
   });
   try {
     assert.equal(run.result.code, 0, run.result.stderr);
-    assert.match(run.result.stderr, /MemoraX config was not written because base user ID or API key was empty/);
-    assert.match(run.result.stderr, /MemoraX memory: Not configured/);
-    assert.doesNotMatch(run.result.stderr, /MemoraX memory: .*Configured/);
+    assert.match(run.result.stderr, /MemoraX user ID is required/);
+    assert.equal((run.result.stderr.match(/Your MemoraX user ID \(required, e\.g\. your-name\)/g) ?? []).length, 2);
+    assert.match(run.result.stderr, /MemoraX API key is required/);
+    assert.equal((run.result.stderr.match(/MemoraX API key \(required\)/g) ?? []).length, 2);
+    assert.match(run.result.stderr, /MemoraX memory: .*Configured/);
   } finally {
     await rm(run.root, { recursive: true, force: true });
   }
 });
 
-test("postinstall rejects an unsupported preferred language", async () => {
+test("postinstall retries an unsupported preferred language", async () => {
   const run = await runPostinstall({
     interactive: true,
-    input: "y\nmemorax-user\nfr\nmemorax-secret\nn\n",
+    input: "memorax-user\nfr\nen\nmemorax-secret\nn\n",
   });
   try {
     assert.equal(run.result.code, 0, run.result.stderr);
     assert.match(run.result.stderr, /preferred language must be zh or en/i);
-    assert.match(run.result.stderr, /MemoraX memory: Not configured/);
+    assert.match(run.result.stderr, /MemoraX memory: .*Configured/);
     const config = await readFile(join(run.memoraxCodeHome, "config.toml"), "utf8");
-    assert.match(config, /output_language = "zh" # Language for newly generated MemoraX memories\./);
-    assert.doesNotMatch(config, /memorax-user|memorax-secret/);
+    assert.match(config, /output_language = "en" # Language for newly generated MemoraX memories\./);
   } finally {
     await rm(run.root, { recursive: true, force: true });
   }
@@ -1874,7 +1875,7 @@ test("postinstall preserves existing optional config instead of backfilling defa
   const run = await runPostinstall({
     memoraxCodeConfig: existingConfig,
     interactive: true,
-    input: "y\nmemorax-user\nen\nmemorax-secret\nn\n",
+    input: "memorax-user\nen\nmemorax-secret\nn\n",
     memoraxVerify: {},
   });
   try {
@@ -1942,7 +1943,7 @@ test("postinstall preserves existing config mode and owner while updating manage
     memoraxCodeConfig: '[memorax]\nuser_id = "mode-user"\n',
     memoraxCodeConfigMode: 0o640,
     interactive: true,
-    input: "n\nn\n",
+    input: `${memoraxSetupInput}n\n`,
   });
   try {
     assert.equal(run.result.code, 0, run.result.stderr);
@@ -1958,7 +1959,7 @@ test("postinstall preserves existing config mode and owner while updating manage
 test("postinstall does not probe an unscoped MemoraX namespace", async () => {
   const run = await runPostinstall({
     interactive: true,
-    input: "y\nmemorax-user\nzh\nbad-secret\nn\n",
+    input: "memorax-user\nzh\nbad-secret\nn\n",
     memoraxVerify: { status: 401, body: { error: "invalid key" } },
   });
   try {

--- a/packages/npm/memorax-code/test/postinstall.test.mjs
+++ b/packages/npm/memorax-code/test/postinstall.test.mjs
@@ -1716,7 +1716,8 @@ test("postinstall does not trust configured JSON from a failed memory status com
 
 test("postinstall reports existing credentials without implicitly enabling writeback", async () => {
   const run = await runPostinstall({
-    npmCommand: "update",
+    interactive: true,
+    input: "n\n",
     memoraxCodeConfig: [
       "[clients]",
       "codex = true",
@@ -1731,8 +1732,10 @@ test("postinstall reports existing credentials without implicitly enabling write
   });
   try {
     assert.equal(run.result.code, 0, run.result.stderr);
+    assert.match(run.result.stderr, /Existing MemoraX credentials detected; keeping the effective configuration unchanged/);
     assert.doesNotMatch(run.result.stderr, /Connect MemoraX Code to MemoraX now/);
     assert.doesNotMatch(run.result.stderr, /Preferred language/);
+    assert.doesNotMatch(run.result.stderr, /Your MemoraX user ID|MemoraX API key \(required\)/);
     assert.match(run.result.stderr, /MemoraX memory: .*Configured/);
     assert.match(run.result.stderr, /Automatic writeback: Disabled by effective configuration/);
     assert.doesNotMatch(run.result.stderr, /existing-secret|existing-user/);
@@ -1745,6 +1748,8 @@ test("postinstall reports existing credentials without implicitly enabling write
 
 test("postinstall recognizes environment-only MemoraX credentials", async () => {
   const run = await runPostinstall({
+    interactive: true,
+    input: "n\n",
     memoraxEnv: {
       MEMORAX_CODE_MEMORAX_API_KEY: "environment-secret",
       MEMORAX_CODE_MEMORAX_USER_ID: "environment-user",
@@ -1752,9 +1757,13 @@ test("postinstall recognizes environment-only MemoraX credentials", async () => 
   });
   try {
     assert.equal(run.result.code, 0, run.result.stderr);
+    assert.match(run.result.stderr, /Existing MemoraX credentials detected; keeping the effective configuration unchanged/);
+    assert.doesNotMatch(run.result.stderr, /Your MemoraX user ID|MemoraX API key \(required\)|Preferred language/);
     assert.match(run.result.stderr, /MemoraX memory: .*Configured/);
     assert.match(run.result.stderr, /Automatic writeback: .*Enabled/);
     assert.doesNotMatch(run.result.stderr, /environment-secret|environment-user/);
+    const config = await readFile(join(run.memoraxCodeHome, "config.toml"), "utf8");
+    assert.doesNotMatch(config, /environment-secret|environment-user/);
   } finally {
     await rm(run.root, { recursive: true, force: true });
   }
@@ -1875,28 +1884,29 @@ test("postinstall preserves existing optional config instead of backfilling defa
   const run = await runPostinstall({
     memoraxCodeConfig: existingConfig,
     interactive: true,
-    input: "memorax-user\nen\nmemorax-secret\nn\n",
+    input: "n\n",
     memoraxVerify: {},
   });
   try {
     assert.equal(run.result.code, 0, run.result.stderr);
+    assert.match(run.result.stderr, /Existing MemoraX credentials detected; keeping the effective configuration unchanged/);
+    assert.doesNotMatch(run.result.stderr, /Your MemoraX user ID|MemoraX API key \(required\)|Preferred language/);
     const config = await readFile(join(run.memoraxCodeHome, "config.toml"), "utf8");
     assert.match(config, /\[custom\]\nkeep = true/);
     assert.deepEqual(activeTomlSections(config), [
       "clients",
       "custom",
       "memorax",
-      "memory.add",
       "memory.repo_update",
     ]);
     assert.match(tomlSectionText(config, "memory.repo_update"), /^policy = "daily"$/m);
     assert.match(tomlSectionText(config, "memory.repo_update"), /^commit_threshold = 9$/m);
     assert.match(tomlSectionText(config, "memory.repo_update"), /^cooldown_hours = 48$/m);
     assert.doesNotMatch(config, /top_k|buffer_max_turns|retention_days/);
-    assert.ok(config.includes(`endpoint = "${run.memoraxEndpoint}" # MemoraX service URL.`));
-    assert.match(config, /api_key = "memorax-secret" # MemoraX API key used by the local Backend\./);
-    assert.match(config, /user_id = "memorax-user" # MemoraX base user ID; requests derive a workspace-scoped namespace\./);
-    assert.match(config, /\[memory\.add\]\noutput_language = "en" # Language for newly generated MemoraX memories\./);
+    assert.match(config, /endpoint = "http:\/\/old-memorax\.test"/);
+    assert.match(config, /api_key = "old-secret"/);
+    assert.match(config, /user_id = "old-user"/);
+    assert.doesNotMatch(config, /\[memory\.add\]|output_language/);
   } finally {
     await rm(run.root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Change Summary

Require MemoraX credentials during interactive first-install setup, with clearer user ID guidance and a more visible registration link.

## Implementation Highlights

- Remove the optional MemoraX connection gate and retry empty user IDs, empty API keys, and unsupported language values during interactive setup.
- Explain how the stable MemoraX user ID is shared across supported agents and devices, and render the registration URL on its own highlighted line.
- Preserve non-interactive and update behavior so npm lifecycle scripts never block waiting for credentials.

## Validation

- `make npm-package-check`
- Focused postinstall checks for required credentials, language retry, config ordering, endpoint defaults, and highlighted registration URL.
- Manual global installation from a local test tarball with foreground scripts.

## Full End-to-End Validation Results

- Environment: macOS, Node.js 24+, local prerelease npm tarball.
- Scenario or matrix: Interactive global install with Codex, Claude Code, DeepSeek Harness Profiles, and OpenCode detected; required MemoraX configuration and registration-link presentation.
- Command or workflow: `npm install -g <local-test-tarball> --foreground-scripts`
- Result: Passed. The complete package check passed 179/179 tests, package allowlist validation, isolated install/update checks, and local-only trace checks. Manual terminal verification also passed.
- Evidence or artifacts: User-reviewed terminal output from the local prerelease package; no credentials or private paths included in this PR.
- Reason not run / remaining risk: No additional risk identified for the scoped interactive-install change.