### PR TITLE
fix: support Repo Memory in standalone OpenCode

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -397,9 +397,13 @@ A relevant repo-read can invoke supervised maintenance in all four clients.
 The runner validates the bundle and selects a background build, update, or
 no-op according to policy. DSH maintenance runs through an enabled, managed
 headless-capable Profile. For OpenCode, both on-demand maintenance and
-first-eligible-prompt initialization run through a short-lived subagent session
-on the active OpenCode server; Desktop-only installations do not require a
-standalone OpenCode CLI.
+first-eligible-prompt initialization run through a short-lived subagent session.
+The detached worker reuses the active OpenCode server when it is reachable.
+Because standalone `opencode run` exposes only process-local server authority,
+the worker owns an authenticated, loopback-only `opencode serve` process when
+session creation cannot reach that authority, and closes it afterward.
+Desktop-only installations with a reachable server do not require a standalone
+OpenCode CLI.
 
 ## 4. Backend Modular Monolith
 

--- a/packages/ts/memorax-code-opencode-adapter/src/plugin.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/src/plugin.mjs
@@ -254,6 +254,8 @@ export function createMemoraxOpenCodePlugin(options = {}) {
         output.env.MEMORAX_CODE_MEMORY_CLI_TRACE_CLIENT = "opencode";
         if (openCodeServerUrl) {
           output.env.MEMORAX_CODE_OPENCODE_SERVER_URL = openCodeServerUrl;
+          output.env.MEMORAX_CODE_OPENCODE_COMMAND = stringValue(options.openCodeCommand)
+            ?? process.execPath;
         }
         const sessionId = stringValue(input?.sessionID);
         delete output.env.MEMORAX_CODE_MEMORY_CLI_TRACE_SESSION_ID;
@@ -441,6 +443,7 @@ function openCodeRepoMemoryEnv(options, serverUrl, sessionId) {
     ...process.env,
     MEMORAX_CODE_HOME: memoraxCodeHome,
     MEMORAX_CODE_MEMORY_CLI_SESSION_ID: sessionId,
+    MEMORAX_CODE_OPENCODE_COMMAND: stringValue(options.openCodeCommand) ?? process.execPath,
     MEMORAX_CODE_OPENCODE_SERVER_URL: serverUrl,
   };
 }

--- a/packages/ts/memorax-code-opencode-adapter/src/repo-memory-server-runner.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/src/repo-memory-server-runner.mjs
@@ -1,39 +1,103 @@
 #!/usr/bin/env node
+import { spawn } from "node:child_process";
+import { randomBytes } from "node:crypto";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 export const OPENCODE_REPO_MEMORY_AGENT = "memorax-code-repo-memory";
 
+const OWNED_SERVER_USERNAME = "memorax-code";
+const DEFAULT_SERVER_START_TIMEOUT_MS = 20_000;
+const DEFAULT_SERVER_STOP_TIMEOUT_MS = 5_000;
+const MAX_SERVER_START_OUTPUT = 8_192;
+
+class OpenCodeTransportError extends Error {
+  constructor(operation, cause) {
+    super(`OpenCode ${operation} request failed: ${errorMessage(cause)}`);
+    this.name = "OpenCodeTransportError";
+    this.operation = operation;
+    this.cause = cause;
+  }
+}
+
 export async function runOpenCodeRepoMemory(input, options = {}) {
   const env = options.env ?? process.env;
   const managedServerUrl = stringValue(env.MEMORAX_CODE_OPENCODE_SERVER_URL);
   const serverUrl = stringValue(input?.serverUrl) ?? managedServerUrl;
-  if (!serverUrl) {
-    throw new Error(
-      "OpenCode repo memory runner requires --server-url or MEMORAX_CODE_OPENCODE_SERVER_URL",
-    );
-  }
   const repo = stringValue(input?.repo);
   if (!repo) throw new Error("OpenCode repo memory runner requires --repo");
   const prompt = stringValue(input?.prompt);
   if (!prompt) throw new Error("OpenCode repo memory runner requires --prompt");
 
-  const baseUrl = normalizedServerUrl(serverUrl);
-  const authorization = serverAuthorization(env, baseUrl, managedServerUrl);
   const directory = resolve(repo);
   const parentID = stringValue(input?.parentID)
     ?? stringValue(env.MEMORAX_CODE_MEMORY_CLI_SESSION_ID);
   const fetchImpl = options.fetchImpl ?? fetch;
+  let inheritedError;
+  if (serverUrl) {
+    const baseUrl = normalizedServerUrl(serverUrl);
+    try {
+      return await runOpenCodeRepoMemorySession({
+        authorization: serverAuthorization(env, baseUrl, managedServerUrl),
+        baseUrl,
+        directory,
+        fetchImpl,
+        parentID,
+        prompt,
+      });
+    } catch (error) {
+      if (!isSessionCreationTransportError(error)) throw error;
+      inheritedError = error;
+    }
+  } else {
+    inheritedError = new Error(
+      "OpenCode repo memory runner requires --server-url or MEMORAX_CODE_OPENCODE_SERVER_URL",
+    );
+  }
+
+  const openCodeCommand = stringValue(env.MEMORAX_CODE_OPENCODE_COMMAND);
+  if (!openCodeCommand) throw inheritedError;
+
+  let ownedServer;
+  try {
+    ownedServer = await startOwnedOpenCodeServer({
+      command: openCodeCommand,
+      directory,
+      env,
+      options,
+    });
+  } catch (error) {
+    throw new Error(
+      `${errorMessage(inheritedError)}; managed OpenCode server fallback failed: ${errorMessage(error)}`,
+    );
+  }
+
+  try {
+    return await runOpenCodeRepoMemorySession({
+      authorization: ownedServer.authorization,
+      baseUrl: ownedServer.baseUrl,
+      directory,
+      fetchImpl,
+      parentID,
+      prompt,
+      signal: ownedServer.signal,
+    });
+  } finally {
+    await ownedServer.close();
+  }
+}
+
+async function runOpenCodeRepoMemorySession(input) {
   let sessionID;
   try {
-    const session = await requestJson(fetchImpl, endpoint(baseUrl, "/session", directory), {
+    const session = await requestJson(input.fetchImpl, endpoint(input.baseUrl, "/session", input.directory), {
       method: "POST",
       headers: {
         "content-type": "application/json",
-        ...(authorization ? { authorization } : {}),
+        ...(input.authorization ? { authorization: input.authorization } : {}),
       },
       body: JSON.stringify({
-        ...(parentID ? { parentID } : {}),
+        ...(input.parentID ? { parentID: input.parentID } : {}),
         title: "MemoraX Code Repo Memory",
         permission: [
           { permission: "edit", pattern: "*", action: "allow" },
@@ -43,23 +107,25 @@ export async function runOpenCodeRepoMemory(input, options = {}) {
           { permission: "external_directory", pattern: "*", action: "allow" },
         ],
       }),
+      ...(input.signal ? { signal: input.signal } : {}),
     }, "session creation");
     sessionID = stringValue(session?.id);
     if (!sessionID) throw new Error("OpenCode session creation returned no session id");
 
     const message = await requestJson(
-      fetchImpl,
-      endpoint(baseUrl, `/session/${encodeURIComponent(sessionID)}/message`, directory),
+      input.fetchImpl,
+      endpoint(input.baseUrl, `/session/${encodeURIComponent(sessionID)}/message`, input.directory),
       {
         method: "POST",
         headers: {
           "content-type": "application/json",
-          ...(authorization ? { authorization } : {}),
+          ...(input.authorization ? { authorization: input.authorization } : {}),
         },
         body: JSON.stringify({
           agent: OPENCODE_REPO_MEMORY_AGENT,
-          parts: [{ type: "text", text: prompt }],
+          parts: [{ type: "text", text: input.prompt }],
         }),
+        ...(input.signal ? { signal: input.signal } : {}),
       },
       "blocking prompt",
     );
@@ -69,12 +135,168 @@ export async function runOpenCodeRepoMemory(input, options = {}) {
   } finally {
     if (sessionID) {
       await bestEffortDelete(
-        fetchImpl,
-        endpoint(baseUrl, `/session/${encodeURIComponent(sessionID)}`, directory),
-        authorization,
+        input.fetchImpl,
+        endpoint(input.baseUrl, `/session/${encodeURIComponent(sessionID)}`, input.directory),
+        input.authorization,
       );
     }
   }
+}
+
+async function startOwnedOpenCodeServer(input) {
+  const username = OWNED_SERVER_USERNAME;
+  const password = randomBytes(24).toString("base64url");
+  const spawnImpl = input.options.spawnImpl ?? spawn;
+  const child = spawnImpl(input.command, [
+    "serve",
+    "--hostname=127.0.0.1",
+    "--port=0",
+  ], {
+    cwd: input.directory,
+    env: {
+      ...input.env,
+      OPENCODE_SERVER_USERNAME: username,
+      OPENCODE_SERVER_PASSWORD: password,
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+    windowsHide: true,
+  });
+  const lifecycle = ownedServerLifecycle(child);
+  let closePromise;
+  const close = () => {
+    closePromise ??= stopOwnedServer(
+      child,
+      positiveInteger(input.options.serverStopTimeoutMs, DEFAULT_SERVER_STOP_TIMEOUT_MS),
+    ).finally(lifecycle.dispose);
+    return closePromise;
+  };
+  try {
+    const baseUrl = await waitForOwnedServer(
+      child,
+      positiveInteger(input.options.serverStartTimeoutMs, DEFAULT_SERVER_START_TIMEOUT_MS),
+    );
+    return {
+      authorization: basicAuthorization(username, password),
+      baseUrl,
+      close,
+      signal: lifecycle.signal,
+    };
+  } catch (error) {
+    await close();
+    throw error;
+  }
+}
+
+function waitForOwnedServer(child, timeoutMs) {
+  return new Promise((resolveReady, rejectReady) => {
+    let output = "";
+    let settled = false;
+    let timer;
+    const finish = (error, value) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      child.off("error", onError);
+      child.off("exit", onExit);
+      child.stdout?.off("data", onOutput);
+      child.stderr?.off("data", onOutput);
+      child.stdout?.resume();
+      child.stderr?.resume();
+      if (error) rejectReady(error);
+      else resolveReady(value);
+    };
+    const onOutput = (chunk) => {
+      output = `${output}${String(chunk)}`.slice(-MAX_SERVER_START_OUTPUT);
+      const match = output.match(/opencode server listening on (https?:\/\/[^\s\u001b]+)/i);
+      if (!match) return;
+      let url;
+      try {
+        url = normalizedOwnedServerUrl(match[1]);
+      } catch (error) {
+        finish(error);
+        return;
+      }
+      finish(undefined, url);
+    };
+    const onError = (error) => finish(error);
+    const onExit = (code, signal) => finish(new Error(
+      `OpenCode managed server exited before readiness${code === null ? "" : ` with code ${code}`}`
+      + `${signal ? ` after ${signal}` : ""}${output.trim() ? `: ${output.trim().slice(-500)}` : ""}`,
+    ));
+    timer = setTimeout(() => finish(new Error(
+      `timed out waiting for OpenCode managed server readiness after ${timeoutMs} ms`,
+    )), timeoutMs);
+    child.once("error", onError);
+    child.once("exit", onExit);
+    child.stdout?.on("data", onOutput);
+    child.stderr?.on("data", onOutput);
+  });
+}
+
+function normalizedOwnedServerUrl(value) {
+  const url = normalizedServerUrl(value);
+  if (url.protocol !== "http:" || url.hostname !== "127.0.0.1" || !url.port) {
+    throw new Error("OpenCode managed server did not bind to the requested loopback address");
+  }
+  return url;
+}
+
+function ownedServerLifecycle(child) {
+  const controller = new AbortController();
+  const handlers = new Map();
+  const onExit = (code, signal) => {
+    if (controller.signal.aborted) return;
+    controller.abort(new Error(
+      `OpenCode managed server exited${code === null ? "" : ` with code ${code}`}`
+      + `${signal ? ` after ${signal}` : ""}`,
+    ));
+  };
+  child.once("exit", onExit);
+  for (const signal of ["SIGINT", "SIGTERM"]) {
+    const handler = () => {
+      controller.abort(new Error(`OpenCode managed server interrupted by ${signal}`));
+      if (!childStopped(child)) child.kill(signal);
+    };
+    handlers.set(signal, handler);
+    process.once(signal, handler);
+  }
+  return {
+    signal: controller.signal,
+    dispose() {
+      child.off("exit", onExit);
+      for (const [signal, handler] of handlers) process.off(signal, handler);
+    },
+  };
+}
+
+async function stopOwnedServer(child, timeoutMs) {
+  if (childStopped(child)) return;
+  const exited = new Promise((resolveExit) => child.once("exit", resolveExit));
+  child.kill("SIGTERM");
+  if (await settlesWithin(exited, timeoutMs) || childStopped(child)) return;
+  child.kill("SIGKILL");
+  if (await settlesWithin(exited, timeoutMs) || childStopped(child)) return;
+  child.stdout?.destroy();
+  child.stderr?.destroy();
+  child.unref?.();
+}
+
+async function settlesWithin(promise, timeoutMs) {
+  let timer;
+  try {
+    return await Promise.race([
+      promise.then(() => true, () => true),
+      new Promise((resolveTimeout) => {
+        timer = setTimeout(() => resolveTimeout(false), timeoutMs);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function childStopped(child) {
+  return child.exitCode !== null || child.signalCode !== null;
 }
 
 function parseArgs(values) {
@@ -131,7 +353,7 @@ async function requestJson(fetchImpl, url, init, operation) {
   try {
     response = await fetchImpl(url, init);
   } catch (error) {
-    throw new Error(`OpenCode ${operation} request failed: ${errorMessage(error)}`);
+    throw new OpenCodeTransportError(operation, error);
   }
   const body = await response.text();
   if (!response.ok) {
@@ -146,6 +368,19 @@ async function requestJson(fetchImpl, url, init, operation) {
   } catch {
     throw new Error(`OpenCode ${operation} returned invalid JSON`);
   }
+}
+
+function isSessionCreationTransportError(error) {
+  return error instanceof OpenCodeTransportError && error.operation === "session creation";
+}
+
+function basicAuthorization(username, password) {
+  return `Basic ${Buffer.from(`${username}:${password}`).toString("base64")}`;
+}
+
+function positiveInteger(value, fallback) {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
 }
 
 async function bestEffortDelete(fetchImpl, url, authorization) {

--- a/packages/ts/memorax-code-opencode-adapter/test/plugin.test.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/test/plugin.test.mjs
@@ -93,6 +93,7 @@ test("chat.message starts missing Repo Memory for the Backend-authorized worktre
       "  cwd: process.cwd(),",
       "  memoraxCodeHome: process.env.MEMORAX_CODE_HOME,",
       "  parentSessionId: process.env.MEMORAX_CODE_MEMORY_CLI_SESSION_ID,",
+      "  openCodeCommand: process.env.MEMORAX_CODE_OPENCODE_COMMAND,",
       "  serverUrl: process.env.MEMORAX_CODE_OPENCODE_SERVER_URL,",
       "}));",
       "",
@@ -118,6 +119,7 @@ test("chat.message starts missing Repo Memory for the Backend-authorized worktre
       cwd: await realpath(backendRepo),
       memoraxCodeHome,
       parentSessionId: "session-auto-build",
+      openCodeCommand: join(root, "opencode"),
       serverUrl: "http://127.0.0.1:4096/",
     });
   } finally {
@@ -415,6 +417,7 @@ test("shell.env overwrites the OpenCode session identity and prepends the manage
   assert.equal(output.env.MEMORAX_CODE_MEMORY_CLI_TRACE_CLIENT, "opencode");
   assert.equal(output.env.MEMORAX_CODE_MEMORY_CLI_TRACE_SESSION_ID, "session-2");
   assert.equal(output.env.MEMORAX_CODE_MEMORY_CLI_SESSION_ID, "session-2");
+  assert.equal(output.env.MEMORAX_CODE_OPENCODE_COMMAND, process.execPath);
   assert.equal(output.env.MEMORAX_CODE_OPENCODE_SERVER_URL, "http://127.0.0.1:4096/");
   assert.equal(output.env.PATH, [cliBinDir, "/usr/bin", "/bin"].join(delimiter));
 });

--- a/packages/ts/memorax-code-opencode-adapter/test/repo-memory-server-runner.test.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/test/repo-memory-server-runner.test.mjs
@@ -1,8 +1,10 @@
 import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
 import { createServer } from "node:http";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { PassThrough } from "node:stream";
 import test from "node:test";
 import {
   OPENCODE_REPO_MEMORY_AGENT,
@@ -104,10 +106,83 @@ test("OpenCode repo memory runner preserves prompt failures and still deletes th
         serverUrl: server.url,
         repo: root,
         prompt: "Build Repo Memory.",
+      }, {
+        env: { MEMORAX_CODE_OPENCODE_COMMAND: "/opt/opencode" },
+        spawnImpl: () => assert.fail("prompt failures must not start a fallback server"),
       }),
       /OpenCode blocking prompt failed with HTTP 500: model unavailable/,
     );
     assert.equal(deleted, true);
+  } finally {
+    await server.close();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("OpenCode repo memory runner owns a temporary server when the inherited server is unreachable", async () => {
+  const root = await mkdtemp(join(tmpdir(), "opencode-repo-memory-fallback-"));
+  const requests = [];
+  const killSignals = [];
+  let spawnCall;
+  let authorization;
+  const server = await startServer(async (request, response) => {
+    requests.push({
+      method: request.method,
+      authorization: request.headers.authorization,
+      body: await requestBody(request),
+    });
+    if (request.headers.authorization !== authorization) {
+      return json(response, 401, { message: "unauthorized" });
+    }
+    if (request.method === "POST" && request.url.startsWith("/session?")) {
+      return json(response, 200, { id: "session-fallback" });
+    }
+    if (request.method === "POST") {
+      return json(response, 200, {
+        info: { role: "assistant" },
+        parts: [{ type: "text", text: "Repo Memory built through fallback." }],
+      });
+    }
+    return json(response, 200, true);
+  });
+  try {
+    const result = await runOpenCodeRepoMemory({
+      serverUrl: "http://127.0.0.1:9",
+      repo: root,
+      prompt: "Build Repo Memory.",
+    }, {
+      env: {
+        MEMORAX_CODE_MEMORY_CLI_SESSION_ID: "parent-fallback",
+        MEMORAX_CODE_OPENCODE_COMMAND: "/opt/opencode",
+      },
+      fetchImpl: async (url, init) => {
+        if (url.origin === "http://127.0.0.1:9") throw new TypeError("fetch failed");
+        return await fetch(url, init);
+      },
+      spawnImpl(command, args, options) {
+        spawnCall = { command, args, options };
+        authorization = `Basic ${Buffer.from(
+          `${options.env.OPENCODE_SERVER_USERNAME}:${options.env.OPENCODE_SERVER_PASSWORD}`,
+        ).toString("base64")}`;
+        const child = fakeServerChild(killSignals);
+        queueMicrotask(() => {
+          child.stderr.write(`\u001b[32mopencode server listening on ${server.url}\u001b[0m\n`);
+        });
+        return child;
+      },
+      serverStopTimeoutMs: 50,
+    });
+
+    assert.equal(result, "Repo Memory built through fallback.");
+    assert.deepEqual(spawnCall.args, ["serve", "--hostname=127.0.0.1", "--port=0"]);
+    assert.equal(spawnCall.command, "/opt/opencode");
+    assert.equal(spawnCall.options.cwd, root);
+    assert.equal(spawnCall.options.env.OPENCODE_SERVER_USERNAME, "memorax-code");
+    assert.match(spawnCall.options.env.OPENCODE_SERVER_PASSWORD, /^[A-Za-z0-9_-]{32}$/);
+    assert.deepEqual(requests.map((request) => request.method), ["POST", "POST", "DELETE"]);
+    assert.equal(requests.every((request) => request.authorization === authorization), true);
+    assert.equal(JSON.parse(requests[0].body).parentID, "parent-fallback");
+    assert.deepEqual(killSignals, ["SIGTERM"]);
   } finally {
     await server.close();
     await rm(root, { recursive: true, force: true });
@@ -144,4 +219,21 @@ function requestBody(request) {
 function json(response, status, body) {
   response.writeHead(status, { "content-type": "application/json" });
   response.end(JSON.stringify(body));
+}
+
+function fakeServerChild(killSignals) {
+  const child = new EventEmitter();
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  child.exitCode = null;
+  child.signalCode = null;
+  child.kill = (signal) => {
+    killSignals.push(signal);
+    queueMicrotask(() => {
+      child.signalCode = signal;
+      child.emit("exit", null, signal);
+    });
+    return true;
+  };
+  return child;
 }

--- a/scripts/opencode-e2e.mjs
+++ b/scripts/opencode-e2e.mjs
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
 import assert from "node:assert/strict";
-import { execFile, spawn } from "node:child_process";
+import { execFile } from "node:child_process";
 import { createServer } from "node:http";
 import {
   access,
   mkdir,
   mkdtemp,
+  readdir,
   readFile,
   realpath,
   rm,
@@ -19,7 +20,7 @@ import { resolveNpmInvocation } from "../packages/npm/memorax-code/lib/npm-invoc
 
 const execFileAsync = promisify(execFile);
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-const OPENCODE_VERSION = "1.18.16";
+const OPENCODE_VERSION = "1.18.18";
 const PROMPT = "Reply with exactly: OpenCode E2E completed.";
 const REPLY = "OpenCode E2E completed.";
 
@@ -35,7 +36,6 @@ const userConfigPath = join(openCodeConfigDir, "opencode.jsonc");
 const backendPort = await freePort();
 let memoryStub;
 let modelStub;
-let openCode;
 let memoraxCode;
 
 const inheritedEnv = Object.fromEntries(Object.entries(process.env).filter(([key]) => (
@@ -82,9 +82,17 @@ try {
     "-c", "user.email=e2e@memorax.invalid",
     "commit", "--quiet", "-m", "test fixture",
   ], { cwd: workspace, env });
+  const repoMemoryHead = (await run("git", ["rev-parse", "HEAD"], {
+    cwd: workspace,
+    env,
+  })).stdout.trim();
 
   memoryStub = await startMemoryStub();
-  modelStub = await startModelStub(REPLY);
+  modelStub = await startModelStub({
+    reply: REPLY,
+    repoMemoryHead,
+    workspace,
+  });
   env.MEMORAX_CODE_MEMORAX_ENDPOINT = memoryStub.url;
 
   await runNpm(["run", "build", "--prefix", "packages/ts/memorax-code-backend"], {
@@ -107,7 +115,6 @@ try {
     "install", "--prefix", prefix,
     tarball,
     `opencode-ai@${OPENCODE_VERSION}`,
-    `@opencode-ai/sdk@${OPENCODE_VERSION}`,
     "--foreground-scripts",
     "--silent",
   ], { cwd: workspace, env });
@@ -164,34 +171,35 @@ try {
       },
     },
   };
-  openCode = await startOpenCode(opencode, workspace, env, config);
-  const sdkModule = pathToFileURL(join(
-    prefix,
-    "node_modules", "@opencode-ai", "sdk", "dist", "client.js",
-  )).href;
+  const { stdout: openCodeOutput } = await run(opencode, [
+    "run",
+    "--format=json",
+    "--model=test/test-model",
+    "--print-logs",
+    ...PROMPT.split(" "),
+  ], {
+    cwd: workspace,
+    closeStdin: true,
+    env: {
+      ...env,
+      PWD: workspace,
+      OPENCODE_CONFIG_CONTENT: JSON.stringify(config),
+    },
+    timeout: 60_000,
+  });
+  const runEvents = parseJsonLines(openCodeOutput);
+  const sessionId = runEvents.find((event) => typeof event?.sessionID === "string")?.sessionID;
+  assert.equal(typeof sessionId, "string");
+  assert.ok(sessionId);
+  assert.match(openCodeRunText(runEvents), /OpenCode E2E completed/);
+  await waitFor(() => memoryStub.requests.some((request) => request.path === "/v1/memories/add"));
+
   const backendConnectionModule = pathToFileURL(join(
     prefix,
     "node_modules", "@memorax", "memorax-code", "lib",
     "memorax-code-adapter-common", "src", "backend-connection.mjs",
   )).href;
-  const { createOpencodeClient } = await import(sdkModule);
   const { resolveBackendConnection } = await import(backendConnectionModule);
-  const client = createOpencodeClient({ baseUrl: openCode.url, directory: workspace });
-  const sessionResponse = await client.session.create({ body: { title: "MemoraX Code E2E" } });
-  const sessionId = sessionResponse.data?.id;
-  assert.equal(typeof sessionId, "string");
-  assert.ok(sessionId);
-
-  const promptResponse = await client.session.prompt({
-    path: { id: sessionId },
-    body: {
-      model: { providerID: "test", modelID: "test-model" },
-      parts: [{ type: "text", text: PROMPT }],
-    },
-  });
-  assert.equal(promptResponse.data?.info?.role, "assistant");
-  assert.match(messageText(promptResponse.data), /OpenCode E2E completed/);
-  await waitFor(() => memoryStub.requests.some((request) => request.path === "/v1/memories/add"));
 
   assert.deepEqual(
     memoryStub.requests.filter((request) => request.path === "/v1/memories/search").map((request) => request.body.query),
@@ -207,6 +215,24 @@ try {
   ));
   assert.ok(promptModelRequest, "OpenCode did not send the user prompt to the model");
   assert.match(JSON.stringify(promptModelRequest.body), /E2E recalled memory/);
+
+  const repoMemoryJob = await waitFor(async () => {
+    const jobs = await readRepoMemoryJobs(memoraxCodeHome);
+    return jobs.find((job) => job.status === "succeeded" || job.status === "failed");
+  }, 60_000);
+  assert.equal(repoMemoryJob.status, "succeeded", JSON.stringify(repoMemoryJob, null, 2));
+  assert.equal(repoMemoryJob.runner, "opencode");
+  assert.equal(repoMemoryJob.mode, "build");
+  assert.equal(repoMemoryJob.validation?.ok, true);
+  const validatorPath = join(
+    openCodeConfigDir,
+    "skills", "memorax-code", "scripts", "validate_memory.py",
+  );
+  const repoMemoryValidation = JSON.parse((await run("python3", [validatorPath, workspace], {
+    cwd: workspace,
+    env,
+  })).stdout);
+  assert.equal(repoMemoryValidation.ok, true);
 
   const doctor = await runJson(memoraxOpenCode.command, [
     ...memoraxOpenCode.args,
@@ -244,6 +270,7 @@ try {
       || summary.searchOperationCount !== 1
       || summary.searchedMemoryCount !== 1
       || summary.addOperationCount !== 1
+      || candidate.projects?.[0]?.repoMemory?.status !== "ready"
     ) return undefined;
     return candidate;
   });
@@ -260,6 +287,7 @@ try {
     searchedMemoryCount: 1,
     addOperationCount: 1,
   });
+  assert.deepEqual(viewer.projects[0].repoMemory, { status: "ready", reason: "usable" });
   const viewerJson = JSON.stringify(viewer);
   for (const privateValue of [PROMPT, REPLY, "E2E recalled memory", sessionId]) {
     assert.equal(viewerJson.includes(privateValue), false);
@@ -274,8 +302,6 @@ try {
     assert.equal(traceTypes.has(type), true);
   }
 
-  await openCode.close();
-  openCode = undefined;
   const uninstall = await runJson(memoraxCode.command, [
     ...memoraxCode.args,
     "uninstall", "--json",
@@ -296,10 +322,11 @@ try {
     openCodeVersion: OPENCODE_VERSION,
     searchRequests: memoryStub.requests.filter((request) => request.path === "/v1/memories/search").length,
     addRequests: memoryStub.requests.filter((request) => request.path === "/v1/memories/add").length,
+    repoMemoryJobStatus: repoMemoryJob.status,
+    repoMemoryStatus: viewer.projects[0].repoMemory.status,
     viewerActivities: viewer.activities.length,
   }, null, 2));
 } finally {
-  await openCode?.close().catch(() => undefined);
   if (memoraxCode) {
     await run(memoraxCode.command, [
       ...memoraxCode.args,
@@ -350,7 +377,7 @@ async function startMemoryStub() {
   return await listen(server, requests);
 }
 
-async function startModelStub(reply) {
+async function startModelStub(options) {
   const requests = [];
   const server = createServer(async (request, response) => {
     const body = await requestJson(request);
@@ -358,6 +385,15 @@ async function startModelStub(reply) {
     if (request.method !== "POST" || request.url !== "/v1/chat/completions") {
       return json(response, 404, { message: "not found" });
     }
+    const isRepoMemoryBuild = JSON.stringify(body).includes(
+      "This invocation is the authorized background repo-memory worker.",
+    );
+    if (isRepoMemoryBuild) {
+      await writeValidRepoMemoryFixture(options.workspace, options.repoMemoryHead);
+    }
+    const reply = isRepoMemoryBuild
+      ? "Repo Memory built and validated."
+      : options.reply;
     response.writeHead(200, {
       "content-type": "text/event-stream",
       "cache-control": "no-cache",
@@ -378,57 +414,6 @@ async function startModelStub(reply) {
     response.end("data: [DONE]\n\n");
   });
   return await listen(server, requests, "/v1");
-}
-
-async function startOpenCode(command, cwd, childEnv, config) {
-  const port = await freePort();
-  const child = spawn(command, [
-    "serve", "--hostname=127.0.0.1", `--port=${port}`, "--print-logs",
-  ], {
-    cwd,
-    env: { ...childEnv, OPENCODE_CONFIG_CONTENT: JSON.stringify(config) },
-    stdio: ["ignore", "pipe", "pipe"],
-  });
-  const childExit = new Promise((resolveExit) => child.once("exit", resolveExit));
-  let output = "";
-  child.stdout.setEncoding("utf8");
-  child.stderr.setEncoding("utf8");
-  child.stdout.on("data", (chunk) => { output += chunk; });
-  child.stderr.on("data", (chunk) => { output += chunk; });
-  const url = `http://127.0.0.1:${port}`;
-  try {
-    await waitFor(async () => {
-      if (childStopped(child)) throw new Error(`OpenCode exited early:\n${output}`);
-      return await fetch(`${url}/global/health`).then((response) => response.ok).catch(() => false);
-    }, 20_000);
-  } catch (error) {
-    await terminateChild(child, childExit);
-    throw error;
-  }
-  return {
-    url,
-    close: () => terminateChild(child, childExit),
-  };
-}
-
-async function terminateChild(child, childExit) {
-  if (childStopped(child)) return;
-  child.kill("SIGTERM");
-  let stopTimer;
-  const stopped = await Promise.race([
-    childExit.then(() => true),
-    new Promise((resolveTimeout) => {
-      stopTimer = setTimeout(() => resolveTimeout(false), 5_000);
-    }),
-  ]);
-  clearTimeout(stopTimer);
-  if (stopped || childStopped(child)) return;
-  child.kill("SIGKILL");
-  await childExit;
-}
-
-function childStopped(child) {
-  return child.exitCode !== null || child.signalCode !== null;
 }
 
 async function listen(server, requests, suffix = "") {
@@ -487,13 +472,16 @@ function runNpm(args, options) {
 
 async function run(command, args, options) {
   try {
-    return await execFileAsync(command, args, {
-      ...options,
+    const { closeStdin, ...execOptions } = options;
+    const invocation = execFileAsync(command, args, {
+      ...execOptions,
       encoding: "utf8",
       maxBuffer: 16 * 1024 * 1024,
     });
+    if (closeStdin) invocation.child?.stdin?.end();
+    return await invocation;
   } catch (error) {
-    const detail = [error.stdout, error.stderr].filter(Boolean).join("\n");
+    const detail = [error.message, error.stdout, error.stderr].filter(Boolean).join("\n");
     throw new Error(`${command} ${args.join(" ")} failed${detail ? `:\n${detail}` : ""}`);
   }
 }
@@ -526,12 +514,78 @@ async function freePort() {
   return port;
 }
 
-function messageText(message) {
-  return (message?.parts ?? [])
-    .filter((part) => part?.type === "text" && typeof part.text === "string")
-    .map((part) => part.text)
+function parseJsonLines(output) {
+  return output.trim().split(/\r?\n/).filter(Boolean).map((line) => JSON.parse(line));
+}
+
+function openCodeRunText(events) {
+  return events
+    .filter((event) => event?.type === "text" && typeof event?.part?.text === "string")
+    .map((event) => event.part.text)
     .join("\n")
     .trim();
+}
+
+async function readRepoMemoryJobs(memoraxCodeHome) {
+  const jobsDir = join(memoraxCodeHome, "repo-memory-jobs");
+  const entries = await readdir(jobsDir, { withFileTypes: true }).catch(() => []);
+  const jobs = await Promise.all(entries
+    .filter((entry) => entry.isDirectory() && entry.name !== "in-progress")
+    .map(async (entry) => {
+      try {
+        return JSON.parse(await readFile(join(jobsDir, entry.name, "job.json"), "utf8"));
+      } catch {
+        return undefined;
+      }
+    }));
+  return jobs.filter(Boolean);
+}
+
+async function writeValidRepoMemoryFixture(workspace, head) {
+  const memory = join(workspace, ".repo_memory");
+  await Promise.all([
+    mkdir(join(memory, "raw"), { recursive: true }),
+    mkdir(join(memory, "resources"), { recursive: true }),
+  ]);
+  await Promise.all([
+    writeFile(join(memory, "PROFILE.md"), [
+      "---",
+      'schema: "repo_memory_profile.v0.1"',
+      `local_head: "${head}"`,
+      "---",
+      "",
+      "# Isolated OpenCode E2E Repo Memory",
+      "",
+    ].join("\n")),
+    writeFile(join(memory, "resources", "commits.md"), emptyRepoMemoryResource(
+      "repo_memory_commit_resource.v0.1", "git_commit_facets", "draft_resource",
+      "../raw/git-commits.json",
+    )),
+    writeFile(join(memory, "resources", "prs.md"), emptyRepoMemoryResource(
+      "repo_memory_pr_resource.v0.1", "provider_skipped_local_only",
+      "unavailable_local_only", "",
+    )),
+    writeFile(join(memory, "resources", "issues.md"), emptyRepoMemoryResource(
+      "repo_memory_issue_resource.v0.1", "provider_skipped_local_only",
+      "unavailable_local_only", "",
+    )),
+    writeFile(join(memory, "raw", "git-commits.json"), "[]\n"),
+  ]);
+}
+
+function emptyRepoMemoryResource(schema, source, trustState, rawSource) {
+  return [
+    "---",
+    `schema: "${schema}"`,
+    `source: "${source}"`,
+    "resource_count: 0",
+    `trust_state: "${trustState}"`,
+    `raw_source: "${rawSource}"`,
+    "---",
+    "",
+    `# ${schema}`,
+    "",
+  ].join("\n");
 }
 
 async function assertManagedArtifacts(configDir) {


### PR DESCRIPTION
## Change Summary
Make OpenCode Repo Memory initialization work from standalone `opencode run` sessions whose plugin-provided server URL has no network listener.

## Implementation Highlights
- Reuse the active OpenCode server when session creation can reach it; on a session-creation transport failure, launch a short-lived `opencode serve` bound to `127.0.0.1` with random Basic Auth.
- Pass the active OpenCode executable to both automatic initialization and manual Repo Memory workers, and clean up the owned server after success, failure, or interruption.
- Replace the SDK-attached OpenCode E2E path with a real npm-installed standalone request that also verifies Repo Memory validation and Viewer readiness.

## Validation
- `npm test --prefix packages/ts/memorax-code-opencode-adapter` — 30/30 passed.
- `make test-opencode-e2e` — passed with OpenCode 1.18.18.
- `make docs-check` — passed.
- `make npm-package-check` — passed, including the 179-test npm/trace suite and staged package validation.

## Full End-to-End Validation Results
- Environment: isolated macOS arm64 HOME/XDG/MemoraX Code state, Node.js 24.15.0, locally packed `@memorax/memorax-code@0.1.3`, npm-installed OpenCode 1.18.18.
- Scenario or matrix: standalone `opencode run` request with memory Search/Add and a missing Repo Memory bundle.
- Command or workflow: `make test-opencode-e2e`.
- Result: the request completed; Search=1 and Add=1; the OpenCode Repo Memory job succeeded; the packaged validator returned OK; Memory Viewer reported Repo Memory `ready`.
- Evidence or artifacts: redacted E2E summary reported `repoMemoryJobStatus: succeeded`, `repoMemoryStatus: ready`, and three content-free Viewer activities. Temporary artifacts and processes were cleaned.
- Reason not run / remaining risk: Windows real-machine standalone OpenCode E2E and the full cross-harness `make test` were not run. The affected OpenCode adapter, npm packaging, trace boundary, docs, and macOS standalone E2E checks all passed.