### PR TITLE
fix: provision a DSH Repo Memory worker for web-only installs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -190,13 +190,16 @@ process's in-memory serialization.
 DSH lifecycle discovery reads valid Profiles under `DSH_HOME`. The globally
 staged adapter source is immutable; the adapter materializes a content-addressed
 runtime generation under the selected `MEMORAX_CODE_HOME` and asks DSH's native
-plugin command to install that generation into each managed Profile. The
-Backend lifecycle lock is acquired before the DSH state lock. Start quiesces
-the old authority, prepares Profile artifacts with authority disabled, and
-activates them only after Backend readiness. Stop, update, and uninstall
-publish disabled authority before Profile mutation. A disabled or invalid
-runtime stays inert inside DSH rather than registering listeners or recovering
-the Backend.
+plugin command to install that generation into each managed Profile. When DSH
+has an existing Profile but none can run headless work, the same native command
+initializes the standard `headless` Profile and brings it under adapter
+ownership so supervised Repo Memory always has a worker. Removal uninstalls the
+adapter without deleting DSH Profiles. The Backend lifecycle lock is acquired
+before the DSH state lock. Start quiesces the old authority, prepares Profile
+artifacts with authority disabled, and activates them only after Backend
+readiness. Stop, update, and uninstall publish disabled authority before
+Profile mutation. A disabled or invalid runtime stays inert inside DSH rather
+than registering listeners or recovering the Backend.
 
 OpenCode lifecycle discovery accepts either its configuration directory or an
 `opencode` executable on `PATH`, so Desktop-only, CLI-only, and combined

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -96,7 +96,11 @@ $DSH_HOME/profiles/<profile-name>/
 under `$MEMORAX_CODE_HOME/adapters/dsh/runtime/generations/` and installed into
 Profiles through DSH's native plugin command. The globally installed npm
 package remains immutable; do not copy or edit the generated state or runtime
-directories by hand.
+directories by hand. When at least one valid Profile exists but none provides
+a loadable `@deepseek-ai/dsh-headless` bundle, MemoraX Code asks the same native
+plugin command to initialize the standard `headless` Profile when that name is
+available. Stop and uninstall remove the MemoraX Code adapter from this Profile
+but preserve the Profile and its native data.
 
 MemoraX Code is tested with DSH `0.1.0-rc.6`. Other valid semantic versions are
 accepted but appear as untested in status output; compatibility is not

--- a/packages/ts/memorax-code-dsh-adapter/src/profile-lifecycle.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/src/profile-lifecycle.mjs
@@ -144,7 +144,8 @@ export function collectDshAdapterStatus(options = {}) {
     );
     const managed = Boolean(state) && !stateProblem;
     const installed = profiles.length > 0
-      && profiles.every((profile) => profile.managed && profile.exists && profile.installed);
+      && profiles.every((profile) => profile.managed && profile.exists && profile.installed)
+      && managedProfilesHaveInstalledHeadlessBundle(discoveredProfiles, managedNames);
     const base = {
       integration: "plugin",
       managed,
@@ -285,7 +286,8 @@ function readDshPluginStatusUnlocked(paths, options) {
     state,
   );
   const installed = state.profiles.length > 0
-    && managedProfiles.every((profile) => profile.installed);
+    && managedProfiles.every((profile) => profile.installed)
+    && managedProfilesHaveInstalledHeadlessBundle(profiles, new Set(state.profiles));
   return {
     ok: true,
     action: "dsh-plugin-status",
@@ -360,7 +362,7 @@ function ensureDshPluginInstalledUnlocked(paths, options) {
     };
   }
 
-  let workerProfileName = profiles.find(profileIsHeadlessCapable)?.name;
+  let workerProfileName = profiles.find(profileHasInstalledHeadlessBundle)?.name;
   let targetProfiles = profiles;
   let initializeWorkerProfile = false;
   if (!workerProfileName) {
@@ -459,7 +461,7 @@ function ensureDshPluginInstalledUnlocked(paths, options) {
         || current.status !== "valid"
         || !profileHasInstalledAdapter(current.profile, runtimeBundleRoot, pendingState)
         || (profile.name === workerProfileName
-          && !profileIsHeadlessCapable(current.profile))) {
+          && !profileHasInstalledHeadlessBundle(current.profile))) {
         failedProfiles.push(profileMutationFailure(
           profile.name,
           result,
@@ -492,7 +494,8 @@ function ensureDshPluginInstalledUnlocked(paths, options) {
 
     if (current.status === "valid"
       && profileHasInstalledAdapter(current.profile, runtimeBundleRoot, pendingState)
-      && (profile.name !== workerProfileName || profileIsHeadlessCapable(current.profile))) {
+      && (profile.name !== workerProfileName
+        || profileHasInstalledHeadlessBundle(current.profile))) {
       installedProfiles.push(profile.name);
     } else {
       failedProfiles.push(profileMutationFailure(
@@ -517,7 +520,7 @@ function ensureDshPluginInstalledUnlocked(paths, options) {
     }
   }
   if (!finalProfiles.some((profile) => (
-    profile.status === "valid" && profileIsHeadlessCapable(profile.profile)
+    profile.status === "valid" && profileHasInstalledHeadlessBundle(profile.profile)
   )) && !failedProfiles.some((failure) => failure.name === workerProfileName)) {
     failedProfiles.push({ name: workerProfileName, reason: "headless_profile_not_capable" });
   }
@@ -691,7 +694,8 @@ function activateDshPluginInstallationUnlocked(paths, options) {
   if (state.profiles.length === 0
     || state.profiles.some((name) => (
       !profileHasInstalledAdapter(profileByName.get(name), state.runtimeBundleRoot, state)
-    ))) {
+    ))
+    || !managedProfilesHaveInstalledHeadlessBundle(profiles, new Set(state.profiles))) {
     return {
       ok: false,
       action: "dsh-plugin-activate",
@@ -1209,8 +1213,22 @@ function profileHasAdapter(profile, packageName = ADAPTER_PACKAGE_NAME) {
     && profile.bundles.includes(packageName));
 }
 
-function profileIsHeadlessCapable(profile) {
-  return Boolean(profile?.bundles.includes(HEADLESS_BUNDLE_NAME));
+function managedProfilesHaveInstalledHeadlessBundle(profiles, managedNames) {
+  return profiles.some((profile) => (
+    managedNames.has(profile.name) && profileHasInstalledHeadlessBundle(profile)
+  ));
+}
+
+function profileHasInstalledHeadlessBundle(profile) {
+  if (!profile?.bundles.includes(HEADLESS_BUNDLE_NAME)) return false;
+  try {
+    // DSH exposes built-in bundles through the Profile's shared resolution tree.
+    const requireFromProfile = createRequire(join(profile.path, "package.json"));
+    readFileSync(requireFromProfile.resolve(HEADLESS_BUNDLE_NAME), "utf8");
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function profileHasInstalledAdapter(

--- a/packages/ts/memorax-code-dsh-adapter/src/profile-lifecycle.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/src/profile-lifecycle.mjs
@@ -50,6 +50,8 @@ const { resolveWindowsCliInvocation } = await import(
 const STATE_VERSION = 1;
 const RUNTIME = "dsh";
 const ADAPTER_PACKAGE_NAME = "@memorax-code/dsh-memorax-code";
+const HEADLESS_PROFILE_NAME = "headless";
+const HEADLESS_BUNDLE_NAME = "@deepseek-ai/dsh-headless";
 const LEGACY_ADAPTER_PACKAGE_NAMES = Object.freeze(["@memorax-code/dsh-adapter"]);
 const MANAGED_ADAPTER_PACKAGE_NAMES = Object.freeze([
   ADAPTER_PACKAGE_NAME,
@@ -358,6 +360,38 @@ function ensureDshPluginInstalledUnlocked(paths, options) {
     };
   }
 
+  let workerProfileName = profiles.find(profileIsHeadlessCapable)?.name;
+  let targetProfiles = profiles;
+  let initializeWorkerProfile = false;
+  if (!workerProfileName) {
+    const headlessPath = join(paths.profilesRoot, HEADLESS_PROFILE_NAME);
+    const headless = inspectProfile(HEADLESS_PROFILE_NAME, headlessPath);
+    if (headless.status === "manifest_unreadable") {
+      return {
+        ok: false,
+        action: "dsh-plugin-install",
+        runtime: RUNTIME,
+        reason: "profile_manifest_unreadable",
+        profiles: [HEADLESS_PROFILE_NAME],
+      };
+    }
+    if (headless.status === "valid") {
+      return {
+        ok: false,
+        action: "dsh-plugin-install",
+        runtime: RUNTIME,
+        reason: "headless_profile_not_capable",
+        profiles: [HEADLESS_PROFILE_NAME],
+      };
+    }
+    workerProfileName = HEADLESS_PROFILE_NAME;
+    initializeWorkerProfile = true;
+    targetProfiles = [
+      ...profiles,
+      { name: HEADLESS_PROFILE_NAME, path: headlessPath },
+    ].sort((left, right) => left.name.localeCompare(right.name));
+  }
+
   const memoraxCodeCommand = resolveMemoraxCodeCommand(options.memoraxCodeCommand);
   const metadata = {
     version: 1,
@@ -387,7 +421,7 @@ function ensureDshPluginInstalledUnlocked(paths, options) {
     // interrupted or partial native add remains repairable and removable.
     profiles: [...new Set([
       ...previouslyManaged,
-      ...profiles.map((profile) => profile.name),
+      ...targetProfiles.map((profile) => profile.name),
     ])].sort(),
     updatedAt: now,
   };
@@ -396,9 +430,12 @@ function ensureDshPluginInstalledUnlocked(paths, options) {
   const installedProfiles = [];
   const failedProfiles = [];
   const mutatedProfiles = [];
-  for (const profile of profiles) {
+  for (const profile of targetProfiles) {
     let current = inspectProfile(profile.name, profile.path);
-    if (current.status !== "valid") {
+    if (current.status !== "valid"
+      && !(initializeWorkerProfile
+        && profile.name === workerProfileName
+        && current.status === "directory_missing")) {
       failedProfiles.push(current.status === "directory_missing"
         ? { name: profile.name, reason: "profile_disappeared" }
         : profileManifestFailure(profile.name));
@@ -420,12 +457,16 @@ function ensureDshPluginInstalledUnlocked(paths, options) {
       if (result.status !== 0
         || result.error
         || current.status !== "valid"
-        || !profileHasInstalledAdapter(current.profile, runtimeBundleRoot, pendingState)) {
+        || !profileHasInstalledAdapter(current.profile, runtimeBundleRoot, pendingState)
+        || (profile.name === workerProfileName
+          && !profileIsHeadlessCapable(current.profile))) {
         failedProfiles.push(profileMutationFailure(
           profile.name,
           result,
           current,
-          "dsh_bundle_not_activated",
+          profile.name === workerProfileName
+            ? "headless_profile_not_capable"
+            : "dsh_bundle_not_activated",
         ));
         continue;
       }
@@ -450,7 +491,8 @@ function ensureDshPluginInstalledUnlocked(paths, options) {
     }
 
     if (current.status === "valid"
-      && profileHasInstalledAdapter(current.profile, runtimeBundleRoot, pendingState)) {
+      && profileHasInstalledAdapter(current.profile, runtimeBundleRoot, pendingState)
+      && (profile.name !== workerProfileName || profileIsHeadlessCapable(current.profile))) {
       installedProfiles.push(profile.name);
     } else {
       failedProfiles.push(profileMutationFailure(
@@ -473,6 +515,11 @@ function ensureDshPluginInstalledUnlocked(paths, options) {
       && !profileHasInstalledAdapter(profile.profile, runtimeBundleRoot, pendingState)) {
       failedProfiles.push({ name: profile.name, reason: "dsh_bundle_not_activated" });
     }
+  }
+  if (!finalProfiles.some((profile) => (
+    profile.status === "valid" && profileIsHeadlessCapable(profile.profile)
+  )) && !failedProfiles.some((failure) => failure.name === workerProfileName)) {
+    failedProfiles.push({ name: workerProfileName, reason: "headless_profile_not_capable" });
   }
   const managedProfiles = finalProfiles
     .filter((profile) => profile.status !== "directory_missing")
@@ -1160,6 +1207,10 @@ function profileHasAdapter(profile, packageName = ADAPTER_PACKAGE_NAME) {
   return Boolean(profile
     && Object.hasOwn(profile.dependencies, packageName)
     && profile.bundles.includes(packageName));
+}
+
+function profileIsHeadlessCapable(profile) {
+  return Boolean(profile?.bundles.includes(HEADLESS_BUNDLE_NAME));
 }
 
 function profileHasInstalledAdapter(

--- a/packages/ts/memorax-code-dsh-adapter/test/profile-lifecycle.test.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/test/profile-lifecycle.test.mjs
@@ -20,6 +20,8 @@ import {
   withDshPluginLifecycleLock,
 } from "../src/profile-lifecycle.mjs";
 
+const HEADLESS_BUNDLE_NAME = "@deepseek-ai/dsh-headless";
+
 test("failed reconciliation restores the prior authority and removes newly installed Profiles", async (t) => {
   const fixture = await createReconciliationFixture(t);
   const {
@@ -344,7 +346,7 @@ test("migrates the managed legacy package identity and restores it if reconcilia
     runtimeBundleRoot: legacyRuntimeBundleRoot,
   });
   installAdapter("web", legacyRuntimeBundleRoot);
-  writeProfile(profilesRoot, "headless");
+  writeProfile(profilesRoot, "headless", [HEADLESS_BUNDLE_NAME]);
   installAdapter("headless", legacyRuntimeBundleRoot);
   let legacyState = {
     ...priorState,
@@ -532,7 +534,7 @@ test("reports pnpm missing from DSH's native Profile plugin manager", async (t) 
   const adapterRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
   const dshHome = join(root, "dsh-home");
   const memoraxCodeHome = join(root, "memorax-code-home");
-  writeProfile(join(dshHome, "profiles"), "web");
+  writeProfile(join(dshHome, "profiles"), "web", [HEADLESS_BUNDLE_NAME]);
 
   const report = await withDshPluginLifecycleLock({
     adapterRoot,
@@ -555,24 +557,28 @@ test("reports pnpm missing from DSH's native Profile plugin manager", async (t) 
   ]);
 });
 
-test("materializes, packs, installs, and reuses one per-home runtime generation", async (t) => {
+test("materializes one runtime generation and provisions a web-only headless worker", async (t) => {
   const root = mkdtempSync(join(tmpdir(), "memorax-code-dsh-runtime-bundle-"));
   t.after(() => rmSync(root, { recursive: true, force: true }));
   const adapterRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
   const adapterManifest = JSON.parse(readFileSync(join(adapterRoot, "package.json"), "utf8"));
   const memoraxCodeHome = join(root, "memorax-code-home");
   const dshHome = join(root, "dsh-home");
-  const profileRoot = join(dshHome, "profiles", "web");
-  const profileManifestPath = join(profileRoot, "package.json");
+  const profilesRoot = join(dshHome, "profiles");
+  const webRoot = join(profilesRoot, "web");
+  const webManifestPath = join(webRoot, "package.json");
   const packRoot = join(root, "packs");
-  mkdirSync(profileRoot, { recursive: true });
+  mkdirSync(webRoot, { recursive: true });
   mkdirSync(packRoot, { recursive: true });
-  writeJson(profileManifestPath, {
+  writeJson(webManifestPath, {
     name: "dsh-profile-web",
     version: "1.0.0",
     private: true,
     dependencies: {},
-    dsh: { profile: { bundles: [] } },
+    dsh: { profile: { bundles: [
+      "@deepseek-ai/dsh-base",
+      "@deepseek-ai/dsh-web-app",
+    ] } },
   });
 
   let addCalls = 0;
@@ -586,17 +592,31 @@ test("materializes, packs, installs, and reuses one per-home runtime generation"
       if (invocation.args.length === 1 && invocation.args[0] === "--version") {
         return { status: 0, stdout: "0.1.0-rc.6\n" };
       }
-      assert.deepEqual(invocation.args.slice(0, 4), ["plugin", "--profile", "web", "add"]);
+      assert.deepEqual(
+        [invocation.args[0], invocation.args[1], invocation.args[3]],
+        ["plugin", "--profile", "add"],
+      );
+      const profileName = invocation.args[2];
+      if (profileName === "headless") {
+        writeProfile(profilesRoot, profileName, [
+          "@deepseek-ai/dsh-base",
+          HEADLESS_BUNDLE_NAME,
+        ]);
+      }
+      const profileRoot = join(profilesRoot, profileName);
+      const profileManifestPath = join(profileRoot, "package.json");
       addCalls += 1;
       const runtimeBundleRoot = invocation.args[4].slice("file:".length);
-      const pack = spawnSync("npm", [
-        "pack",
-        runtimeBundleRoot,
-        "--json",
-        `--pack-destination=${packRoot}`,
-      ], { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
-      assert.equal(pack.status, 0, pack.stderr);
-      packedFiles = JSON.parse(pack.stdout)[0].files.map(({ path }) => path).sort();
+      if (packedFiles === undefined) {
+        const pack = spawnSync("npm", [
+          "pack",
+          runtimeBundleRoot,
+          "--json",
+          `--pack-destination=${packRoot}`,
+        ], { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+        assert.equal(pack.status, 0, pack.stderr);
+        packedFiles = JSON.parse(pack.stdout)[0].files.map(({ path }) => path).sort();
+      }
       const install = spawnSync("npm", [
         "install",
         "--ignore-scripts",
@@ -607,7 +627,7 @@ test("materializes, packs, installs, and reuses one per-home runtime generation"
       ], { cwd: profileRoot, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
       assert.equal(install.status, 0, install.stderr);
       const manifest = JSON.parse(readFileSync(profileManifestPath, "utf8"));
-      manifest.dsh.profile.bundles = ["@memorax-code/dsh-memorax-code"];
+      manifest.dsh.profile.bundles.push("@memorax-code/dsh-memorax-code");
       writeJson(profileManifestPath, manifest);
       return { status: 0 };
     },
@@ -619,11 +639,14 @@ test("materializes, packs, installs, and reuses one per-home runtime generation"
   assert.equal(first.ok, true);
   assert.equal(first.installed, true);
   assert.equal(first.enabled, false);
-  assert.equal(addCalls, 1);
+  assert.deepEqual(first.detectedProfiles, ["web"]);
+  assert.deepEqual(first.installedProfiles, ["headless", "web"]);
+  assert.equal(addCalls, 2);
   assert.equal(existsSync(join(adapterRoot, ".memorax-code-package.json")), false);
 
   const statePath = join(memoraxCodeHome, "adapters", "dsh", "state.json");
   const firstState = JSON.parse(readFileSync(statePath, "utf8"));
+  assert.deepEqual(firstState.profiles, ["headless", "web"]);
   assert.match(firstState.runtimeBundleRoot, /[/\\]runtime[/\\]generations[/\\][0-9a-f]{64}$/);
   assert.equal(existsSync(join(firstState.runtimeBundleRoot, "src", "profile-lifecycle.mjs")), false);
   assert.equal(existsSync(join(
@@ -633,7 +656,13 @@ test("materializes, packs, installs, and reuses one per-home runtime generation"
     "windows-cli-invocation.mjs",
   )), true);
   assert.deepEqual(packedFiles, ["package.json", ...adapterManifest.files].sort());
-  const installedRoot = join(profileRoot, "node_modules", "@memorax-code", "dsh-memorax-code");
+  const installedRoot = join(
+    profilesRoot,
+    "headless",
+    "node_modules",
+    "@memorax-code",
+    "dsh-memorax-code",
+  );
   const installed = await import(pathToFileURL(join(installedRoot, "src", "index.mjs")).href);
   assert.equal(installed.name, "memorax-code");
   let contextRead = false;
@@ -658,7 +687,7 @@ test("materializes, packs, installs, and reuses one per-home runtime generation"
   ));
   const secondState = JSON.parse(readFileSync(statePath, "utf8"));
   assert.equal(second.ok, true);
-  assert.equal(addCalls, 1);
+  assert.equal(addCalls, 2);
   assert.equal(secondState.runtimeBundleRoot, firstState.runtimeBundleRoot);
   assert.deepEqual(
     readdirSync(join(memoraxCodeHome, "adapters", "dsh", "runtime", "generations")),
@@ -674,7 +703,7 @@ async function createReconciliationFixture(t) {
   const dshHome = join(root, "dsh-home");
   const profilesRoot = join(dshHome, "profiles");
   const statePath = join(memoraxCodeHome, "adapters", "dsh", "state.json");
-  writeProfile(profilesRoot, "web");
+  writeProfile(profilesRoot, "web", [HEADLESS_BUNDLE_NAME]);
 
   const installAdapter = (profileName, runtimeBundleRoot) => {
     const profileRoot = join(profilesRoot, profileName);
@@ -738,13 +767,13 @@ function writeJson(path, value) {
   writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
 }
 
-function writeProfile(profilesRoot, name) {
+function writeProfile(profilesRoot, name, bundles = []) {
   const profileRoot = join(profilesRoot, name);
   mkdirSync(profileRoot, { recursive: true });
   writeJson(join(profileRoot, "package.json"), {
     name: `dsh-profile-${name}`,
     private: true,
     dependencies: {},
-    dsh: { profile: { bundles: [] } },
+    dsh: { profile: { bundles } },
   });
 }

--- a/packages/ts/memorax-code-dsh-adapter/test/profile-lifecycle.test.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/test/profile-lifecycle.test.mjs
@@ -319,6 +319,61 @@ test("restores the persisted DSH home when DSH_HOME is not configured", async (t
   assert.deepEqual(report.profiles, [{ name: "web", exists: true, installed: false }]);
 });
 
+test("reports drift and rejects activation when the managed worker loses its headless bundle", async (t) => {
+  const fixture = await createReconciliationFixture(t);
+  const {
+    profilesRoot,
+    initialOptions,
+  } = fixture;
+  const manifestPath = join(profilesRoot, "web", "package.json");
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+  manifest.dsh.profile.bundles = manifest.dsh.profile.bundles
+    .filter((name) => name !== HEADLESS_BUNDLE_NAME);
+  writeJson(manifestPath, manifest);
+
+  const publicStatus = collectDshAdapterStatus(initialOptions);
+  assert.equal(publicStatus.ok, true);
+  assert.equal(publicStatus.installed, false);
+  assert.equal(publicStatus.enabled, false);
+  assert.equal(publicStatus.reason, "profile_drift");
+
+  const activation = await withDshPluginLifecycleLock(initialOptions, (lifecycle) => {
+    const status = lifecycle.status();
+    assert.equal(status.installed, false);
+    assert.equal(status.enabled, false);
+    return lifecycle.activate();
+  });
+  assert.equal(activation.ok, false);
+  assert.equal(activation.reason, "managed_profiles_not_installed");
+});
+
+test("does not accept a stale headless bundle declaration without an installed module", async (t) => {
+  const fixture = await createReconciliationFixture(t);
+  const {
+    profilesRoot,
+    initialOptions,
+  } = fixture;
+  rmSync(join(profilesRoot, "node_modules", ...HEADLESS_BUNDLE_NAME.split("/")), {
+    recursive: true,
+    force: true,
+  });
+
+  const publicStatus = collectDshAdapterStatus(initialOptions);
+  assert.equal(publicStatus.ok, true);
+  assert.equal(publicStatus.installed, false);
+  assert.equal(publicStatus.enabled, false);
+  assert.equal(publicStatus.reason, "profile_drift");
+
+  const activation = await withDshPluginLifecycleLock(initialOptions, (lifecycle) => {
+    const status = lifecycle.status();
+    assert.equal(status.installed, false);
+    assert.equal(status.enabled, false);
+    return lifecycle.activate();
+  });
+  assert.equal(activation.ok, false);
+  assert.equal(activation.reason, "managed_profiles_not_installed");
+});
+
 test("migrates the managed legacy package identity and restores it if reconciliation fails", async (t) => {
   const fixture = await createReconciliationFixture(t);
   const {
@@ -776,4 +831,14 @@ function writeProfile(profilesRoot, name, bundles = []) {
     dependencies: {},
     dsh: { profile: { bundles } },
   });
+  if (bundles.includes(HEADLESS_BUNDLE_NAME)) {
+    const headlessRoot = join(profilesRoot, "node_modules", ...HEADLESS_BUNDLE_NAME.split("/"));
+    mkdirSync(headlessRoot, { recursive: true });
+    writeJson(join(headlessRoot, "package.json"), {
+      name: HEADLESS_BUNDLE_NAME,
+      version: "0.1.0-test",
+      main: "index.js",
+    });
+    writeFileSync(join(headlessRoot, "index.js"), "module.exports = {};\n");
+  }
 }

--- a/scripts/dsh-npm-package-e2e.mjs
+++ b/scripts/dsh-npm-package-e2e.mjs
@@ -176,11 +176,12 @@ async function main() {
     DSH_PERMISSION_MODE: "danger-full-access",
   };
 
-  progress("creating the first real DSH Profile");
-  await createProfile(dsh, "headless", paths, runtimeEnv, true);
+  progress("creating only the real DSH web Profile");
+  await createProfile(dsh, "web", paths, runtimeEnv, false);
+  const web = join(paths.dshHome, "profiles", "web");
+  const webSentinel = join(web, "memorax-e2e-preserve.txt");
+  await writeFile(webSentinel, "preserve web\n");
   const headless = join(paths.dshHome, "profiles", "headless");
-  const headlessSentinel = join(headless, "memorax-e2e-preserve.txt");
-  await writeFile(headlessSentinel, "preserve headless\n");
 
   const tarball = await memoraxTarball(paths, runtimeEnv);
   progress("installing the MemoraX Code tarball with real npm lifecycle scripts");
@@ -189,7 +190,7 @@ async function main() {
   { timeout: 300_000 });
   const installOutput = installed.stdout + "\n" + installed.stderr;
   assert.match(installOutput, /Detected existing DeepSeek Harness profiles/);
-  assert.match(installOutput, /DeepSeek Harness profiles: found \(headless\)/);
+  assert.match(installOutput, /DeepSeek Harness profiles: found \(web\)/);
   assert.match(installOutput, /Restart or refresh DeepSeek Harness/);
   assert.doesNotMatch(installOutput, /client adapters were skipped for this install/);
 
@@ -208,9 +209,10 @@ async function main() {
   };
 
   await assertProfile(headless, true);
+  await assertProfile(web, true);
   const initialState = await readJson(statePath);
   assert.equal(initialState.enabled, true);
-  assert.deepEqual(initialState.profiles, ["headless"]);
+  assert.deepEqual(initialState.profiles, ["headless", "web"]);
   assert.equal(initialState.dshVersion, DSH_VERSION);
   assert.equal(resolve(initialState.adapterRoot), resolve(sourceRoot));
   assert.equal(isInside(initialState.runtimeBundleRoot, generationsRoot), true);
@@ -236,6 +238,9 @@ async function main() {
   assert.equal(await readFile(join(profilePackage, "skills", "memorax-code", "SKILL.md"), "utf8"),
     canonicalSkill);
   assert.equal(await exists(join(profilePackage, "src", "profile-lifecycle.mjs")), false);
+  await createProfile(dsh, "headless", paths, runtimeEnv, true);
+  const headlessSentinel = join(headless, "memorax-e2e-preserve.txt");
+  await writeFile(headlessSentinel, "preserve headless\n");
 
   const packagedRepoMemoryHelper = join(sourceRoot, "hooks", "repo-memory-job.mjs");
   const profileRepoMemoryHelper = join(profilePackage, "hooks", "repo-memory-job.mjs");
@@ -437,17 +442,18 @@ async function main() {
   }
 
   progress("reconciling a Profile created after installation");
-  await createProfile(dsh, "web", paths, runtimeEnv, false);
-  const web = join(paths.dshHome, "profiles", "web");
-  const webSentinel = join(web, "memorax-e2e-preserve.txt");
-  await writeFile(webSentinel, "preserve web\n");
+  const auxiliary = join(paths.dshHome, "profiles", "auxiliary");
+  await run(dsh, ["plugin", "--profile", "auxiliary", "--version"], paths.workspace, runtimeEnv);
+  const auxiliarySentinel = join(auxiliary, "memorax-e2e-preserve.txt");
+  await writeFile(auxiliarySentinel, "preserve auxiliary\n");
   const drift = await lifecycle("status", 1);
   assert.equal(drift.dshAdapter?.reason, "profile_drift");
   assert.equal((await lifecycle("start")).dshAdapter?.enabled, true);
   backendPid = validPid((await readJson(backendStatePath)).pid);
+  await assertProfile(auxiliary, true);
   await assertProfile(headless, true);
   await assertProfile(web, true);
-  assert.deepEqual((await readJson(statePath)).profiles, ["headless", "web"]);
+  assert.deepEqual((await readJson(statePath)).profiles, ["auxiliary", "headless", "web"]);
 
   progress("stopping and proving a DSH Turn cannot revive the Backend");
   const trafficBeforeStop = memoraxServer.requests.length;
@@ -456,6 +462,7 @@ async function main() {
   await waitFor(() => !alive(pidBeforeStop), "stopped Backend exit");
   backendPid = undefined;
   assert.equal((await readJson(statePath)).enabled, false);
+  await assertProfile(auxiliary, false);
   await assertProfile(headless, false);
   await assertProfile(web, false);
   await runTurn(dsh, STOPPED_PROMPT, paths.workspace, runtimeEnv);
@@ -471,10 +478,13 @@ async function main() {
   assert.equal(await exists(installedRoot), false);
   assert.equal(await exists(statePath), false);
   assert.equal(await exists(generationsRoot), false);
+  await assertProfile(auxiliary, false);
   await assertProfile(headless, false);
   await assertProfile(web, false);
+  assert.equal(await exists(join(auxiliary, "node_modules", "@memorax-code", "dsh-memorax-code")), false);
   assert.equal(await exists(join(headless, "node_modules", "@memorax-code", "dsh-memorax-code")), false);
   assert.equal(await exists(join(web, "node_modules", "@memorax-code", "dsh-memorax-code")), false);
+  assert.equal(await readFile(auxiliarySentinel, "utf8"), "preserve auxiliary\n");
   assert.equal(await readFile(headlessSentinel, "utf8"), "preserve headless\n");
   assert.equal(await readFile(webSentinel, "utf8"), "preserve web\n");
   assert.deepEqual(await snapshotFiles(sessionsRoot), sessions);


### PR DESCRIPTION
## Change Summary

Provision a standard DSH headless Profile when an installation starts with only web or other non-headless Profiles, so Repo Memory background generation works without manual Profile setup.

## Implementation Highlights

- Reuse an existing headless-capable managed Profile, or initialize the standard `headless` Profile through DSH's native plugin command under the existing lifecycle locks.
- Validate both `@deepseek-ai/dsh-headless` and the MemoraX adapter before enabling lifecycle authority; fail closed for unreadable or conflicting pre-existing `headless` Profiles.
- Preserve all DSH Profiles during uninstall while removing only the adapter, and extend the existing package E2E from a web-only starting state.
- Document the stable DSH worker-Profile lifecycle contract in `ARCHITECTURE.md`.

## Validation

- `npm test --prefix packages/ts/memorax-code-dsh-adapter` — 26/26 passed.
- `make docs-check` — passed.
- `make npm-package-check` — 179/179 passed.
- `git diff --check` — passed.
- Isolated real-client Repo Memory generation with npm DSH `0.1.0-rc.7` — passed.

## Full End-to-End Validation Results

- Environment: macOS; isolated `HOME`, `DSH_HOME`, `MEMORAX_CODE_HOME`, npm prefix, and fixture Git repository; npm DSH `0.1.0-rc.7`; local MemoraX Code tarball built from this commit.
- Scenario or matrix: start with only a real `web` Profile, install MemoraX Code, provision the missing headless worker, dispatch `bundle_missing` Repo Memory maintenance, run the real DSH `/memorax-code` repo-build flow, and validate the generated bundle.
- Command or workflow: installed the package through real npm lifecycle scripts, then invoked the installed DSH adapter's `repo-memory-job maintain` entrypoint against the isolated fixture.
- Result: managed Profiles became `headless + web`; dispatch selected `action=build`, `runner=dsh`; the job succeeded in about 200 seconds; validator exited 0; seven Repo Memory files were generated; `PROFILE.md local_head` matched the triggering snapshot.
- Evidence or artifacts: terminal result was redacted to lifecycle state, validation status, file count, and snapshot match. All temporary credentials, processes, staging output, and isolated directories were removed after the run.
- Reason not run / remaining risk: Windows real-client DSH E2E was not rerun for this PR; command invocation remains covered by the existing cross-platform lifecycle and Windows shim contract tests.
