### PR TITLE
test: install DSH headless bundle in lifecycle fixture

### DIFF
--- a/packages/ts/memorax-code-backend/test/lifecycle/dsh-participant.test.mjs
+++ b/packages/ts/memorax-code-backend/test/lifecycle/dsh-participant.test.mjs
@@ -268,8 +268,22 @@ async function createFixture() {
   const pidPath = join(memoraxCodeHome, "runtime", "backend", "backend.pid.json");
   const dshCommand = join(root, "fake-dsh.mjs");
   const dshLog = join(root, "dsh.log");
+  const headlessBundleRoot = join(
+    dshHome,
+    "profiles",
+    "node_modules",
+    "@deepseek-ai",
+    "dsh-headless",
+  );
   mkdirSync(profileRoot, { recursive: true });
+  mkdirSync(headlessBundleRoot, { recursive: true });
   mkdirSync(codexHome, { recursive: true });
+  writeJson(join(headlessBundleRoot, "package.json"), {
+    name: "@deepseek-ai/dsh-headless",
+    version: "0.1.0-test",
+    main: "index.js",
+  });
+  writeFileSync(join(headlessBundleRoot, "index.js"), "module.exports = {};\n");
   writeFileSync(profilePath, `${JSON.stringify({
     name: "dsh-profile-headless",
     private: true,


### PR DESCRIPTION
## Change Summary

Keep the Backend DSH lifecycle integration fixture aligned with the production headless-worker health contract by installing a resolvable mock `@deepseek-ai/dsh-headless` bundle.

## Implementation Highlights

- Materialize the mock headless package in the isolated DSH Profile resolution tree.
- Leave production behavior unchanged; this only repairs the stale test fixture introduced by the stricter PR #76 validation.

## Validation

- `node --test --test-timeout=5000 --test-force-exit packages/ts/memorax-code-backend/test/lifecycle/dsh-participant.test.mjs` — 7 passed.
- `make test` — Backend 537 passed / 2 skipped; Codex 226 passed; Claude 65 passed; DSH 28 passed; OpenCode 30 passed; npm and trace 179 passed.

## Full End-to-End Validation Results

- Environment: isolated macOS test fixtures on Node.js 24.
- Scenario or matrix: Backend-owned DSH lifecycle with a headless-capable Profile.
- Command or workflow: full repository `make test` verification.
- Result: all executable test profiles passed.
- Evidence or artifacts: terminal test reports only; no private or generated artifacts retained.
- Reason not run / remaining risk: real-client E2E was not rerun because this change only corrects an isolated mock package installation and does not change production code.
