### PR TITLE
chore: release 0.1.4

### DIFF
--- a/packages/npm/memorax-code/package.json
+++ b/packages/npm/memorax-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax/memorax-code",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Persistent coding memory for Codex, Claude Code, DeepSeek Harness, and OpenCode.",
   "license": "MIT",
   "type": "module",

--- a/packages/ts/memorax-code-backend/package-lock.json
+++ b/packages/ts/memorax-code-backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@memorax-code/backend",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@memorax-code/backend",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "dependencies": {
         "smol-toml": "^1.7.0"
       },

--- a/packages/ts/memorax-code-backend/package.json
+++ b/packages/ts/memorax-code-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/backend",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "type": "module",
   "description": "Local memory integration, lifecycle, trace, and diagnostics for MemoraX Code.",

--- a/packages/ts/memorax-code-claude-adapter/.claude-plugin/plugin.json
+++ b/packages/ts/memorax-code-claude-adapter/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorax-code-claude-adapter",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Memory skill and local hooks for MemoraX Code in Claude Code.",
   "author": {
     "name": "MemoraX Code Maintainers"

--- a/packages/ts/memorax-code-claude-adapter/hooks/runtime-shell.json
+++ b/packages/ts/memorax-code-claude-adapter/hooks/runtime-shell.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
-  "shellVersion": "0.1.3",
+  "shellVersion": "0.1.4",
   "runtimeAbi": 1
 }

--- a/packages/ts/memorax-code-claude-adapter/package.json
+++ b/packages/ts/memorax-code-claude-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/claude-adapter",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "type": "module",
   "description": "Claude Code Hook adapter for MemoraX Code memory services.",

--- a/packages/ts/memorax-code-codex-adapter/.codex-plugin/plugin.json
+++ b/packages/ts/memorax-code-codex-adapter/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorax-code-codex-adapter",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Codex adapter, memory skill, and local hooks for MemoraX Code.",
   "author": {
     "name": "MemoraX AI"

--- a/packages/ts/memorax-code-codex-adapter/hooks/runtime-shell.json
+++ b/packages/ts/memorax-code-codex-adapter/hooks/runtime-shell.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
-  "shellVersion": "0.1.3",
+  "shellVersion": "0.1.4",
   "runtimeAbi": 1
 }

--- a/packages/ts/memorax-code-codex-adapter/package.json
+++ b/packages/ts/memorax-code-codex-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/codex-adapter",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "type": "module",
   "description": "Codex Hook and memory integration for MemoraX Code.",

--- a/packages/ts/memorax-code-dsh-adapter/package.json
+++ b/packages/ts/memorax-code-dsh-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/dsh-memorax-code",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "type": "module",
   "description": "DeepSeek Harness native memory adapter for MemoraX Code.",

--- a/packages/ts/memorax-code-opencode-adapter/package.json
+++ b/packages/ts/memorax-code-opencode-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/opencode-adapter",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "type": "module",
   "description": "OpenCode plugin adapter for MemoraX Code memory services.",


### PR DESCRIPTION
## Change Summary

Release MemoraX Code 0.1.4 with the latest OpenCode standalone Repo Memory and DSH web-only Repo Memory worker fixes now present on `main`.

## Implementation Highlights

- Synchronize the npm package, Backend, four harness adapters, and packaged runtime metadata to version 0.1.4.
- Keep this release change version-only; production behavior comes from the already-reviewed commits on `main`.

## Validation

- `node scripts/sync-release-version.mjs --check`
- `make test`
- `make npm-package-check`
- `make npm-publish-dry-run`
- Registry before release: `@memorax/memorax-code@0.1.3`, with `latest` pointing to 0.1.3.
- Dry-run artifact: 364 files, 454.9 kB package size, 2.9 MB unpacked, shasum `cbbbbf0c14610bc698ef9d1f551a9b5067ac9a0e`.

## Full End-to-End Validation Results

- Environment: macOS, Node.js 24, isolated repository and package fixtures.
- Scenario or matrix: Backend, Codex, Claude Code, DeepSeek Harness, OpenCode, npm install/update, package allowlist, and local-only trace contracts.
- Command or workflow: full `make test`, staged `make npm-package-check`, and registry-safe `make npm-publish-dry-run`.
- Result: all required release gates passed; Backend 537 passed / 2 environment skips, Codex 226 passed, Claude 65 passed, DSH 28 passed, OpenCode 30 passed, npm/trace 179 passed.
- Evidence or artifacts: npm dry-run reported `@memorax/memorax-code@0.1.4`, integrity `sha512-V0Bw2dwXZDS+4[...]CMAZ9hMwRkSRg==`; no generated artifacts are committed.
- Reason not run / remaining risk: real-client E2E was not rerun for this version-only commit; the underlying feature PRs were validated separately. The formal publish will be rebuilt from final `main` only after this PR merges.
