### PR TITLE
feat: support Node.js 20

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -7,7 +7,7 @@ installation. For a source checkout and contributor setup, see
 
 ## Requirements
 
-- Node.js 24 or newer and npm.
+- Node.js 20 or newer (Node.js 24 LTS recommended) and npm.
 - At least one of Codex, Claude Code, DeepSeek Harness (DSH), OpenCode Desktop,
   or the OpenCode CLI installed in the environment where MemoraX Code will
   run. DSH integration requires at least one existing Profile and `pnpm` on

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="https://code.memorax.net/"><img src="https://img.shields.io/badge/website-code.memorax.net-2563eb" alt="MemoraX Code website"></a>
   <a href="https://www.npmjs.com/package/@memorax/memorax-code"><img src="https://img.shields.io/npm/v/@memorax/memorax-code.svg" alt="npm version"></a>
   <img src="https://img.shields.io/npm/v/@memorax/memorax-code.svg?label=version&color=f59e0b" alt="npm package version">
-  <img src="https://img.shields.io/badge/node-%3E%3D24-339933?logo=node.js&logoColor=white" alt="Node.js 24 or newer">
+  <img src="https://img.shields.io/badge/node-%3E%3D20-339933?logo=node.js&logoColor=white" alt="Node.js 20 or newer">
 </p>
 
 <p align="center">
@@ -52,8 +52,9 @@ and validation sooner.
 
 ## Quick Start
 
-Prepare Node.js 24+ and at least one of Codex, Claude Code, DeepSeek Harness,
-or OpenCode. Python 3 is required for Repo Memory operations.
+Prepare Node.js 20+ (Node.js 24 LTS recommended) and at least one of Codex,
+Claude Code, DeepSeek Harness, or OpenCode. Python 3 is required for Repo
+Memory operations.
 
 ### Install and Connect
 
@@ -88,7 +89,7 @@ If the initial setup does not work as expected, check these common cases:
 
 | Symptom | Recommended fix |
 | --- | --- |
-| Installation fails with an unsupported Node.js version | Run `node --version` and upgrade to Node.js 24 or later before reinstalling MemoraX Code. |
+| Installation fails with an unsupported Node.js version | Run `node --version` and upgrade to Node.js 20 or later before reinstalling MemoraX Code. |
 | Interactive setup was skipped or could not prompt | Configure the required MemoraX values in `$MEMORAX_CODE_HOME/config.toml` or through the documented environment variables, then run `memorax-code start`. |
 | MemoraX API key is missing or not configured | Run `memorax-cli status` to check the current configuration, then add the API key through the supported configuration or environment variables. Never paste the key into chats or public issues. |
 | Search, retrieval, or writeback is unavailable after installation | Run `memorax-code status` and `memorax-cli status`. Verify the MemoraX credentials and memory settings, then restart with `memorax-code start`. |

--- a/README.zh.md
+++ b/README.zh.md
@@ -22,7 +22,7 @@
   <a href="https://code.memorax.net/"><img src="https://img.shields.io/badge/website-code.memorax.net-2563eb" alt="MemoraX Code 产品网站"></a>
   <a href="https://www.npmjs.com/package/@memorax/memorax-code"><img src="https://img.shields.io/npm/v/@memorax/memorax-code.svg" alt="npm 版本"></a>
   <img src="https://img.shields.io/npm/v/@memorax/memorax-code.svg?label=version&color=f59e0b" alt="npm 包版本">
-  <img src="https://img.shields.io/badge/node-%3E%3D24-339933?logo=node.js&logoColor=white" alt="Node.js 24 或更高版本">
+  <img src="https://img.shields.io/badge/node-%3E%3D20-339933?logo=node.js&logoColor=white" alt="Node.js 20 或更高版本">
 </p>
 
 <p align="center">
@@ -47,8 +47,8 @@ MemoraX Code 让 Codex、Claude Code、DeepSeek Harness 和 OpenCode 共享一�
 
 ## 快速开始
 
-开始前，请确保已安装 Node.js 24 或更高版本，以及 Codex、Claude Code、DeepSeek Harness 或 OpenCode
-中的至少一个。Repo Memory 操作还需要 Python 3。
+开始前，请确保已安装 Node.js 20 或更高版本（推荐 Node.js 24 LTS），以及 Codex、Claude Code、
+DeepSeek Harness 或 OpenCode 中的至少一个。Repo Memory 操作还需要 Python 3。
 
 ### 安装与接入
 
@@ -78,7 +78,7 @@ MemoraX User ID、偏好语言和 API Key；首次交互安装时，除非有效
 
 | 现象 | 建议处理方式 |
 | --- | --- |
-| 因 Node.js 版本不受支持导致安装失败 | 运行 `node --version` 检查版本，并升级到 Node.js 24 或更高版本后重新安装 MemoraX Code。 |
+| 因 Node.js 版本不受支持导致安装失败 | 运行 `node --version` 检查版本，并升级到 Node.js 20 或更高版本后重新安装 MemoraX Code。 |
 | 跳过了交互式配置，或安装过程无法显示配置提示 | 在 `$MEMORAX_CODE_HOME/config.toml` 中配置所需的 MemoraX 参数，或使用文档支持的环境变量，然后运行 `memorax-code start`。 |
 | MemoraX API Key 缺失或尚未配置 | 运行 `memorax-cli status` 检查当前配置，然后通过支持的配置文件或环境变量添加 API Key。不要将 API Key 粘贴到聊天记录或公开 Issue 中。 |
 | 安装完成后搜索、召回或写回仍不可用 | 运行 `memorax-code status` 和 `memorax-cli status`，检查 MemoraX 凭据和 Memory 配置，然后运行 `memorax-code start` 重新启动。 |

--- a/packages/npm/memorax-code/README.md
+++ b/packages/npm/memorax-code/README.md
@@ -5,7 +5,7 @@ Harness, and OpenCode.
 
 ## Requirements
 
-- Node.js 24 or newer and npm.
+- Node.js 20 or newer (Node.js 24 LTS recommended) and npm.
 - At least one of Codex, Claude Code, DeepSeek Harness, OpenCode Desktop, or
   the OpenCode CLI.
 - A MemoraX account, Base User ID, and API key for memory features.

--- a/packages/npm/memorax-code/lib/node-version.mjs
+++ b/packages/npm/memorax-code/lib/node-version.mjs
@@ -1,4 +1,4 @@
-export const MINIMUM_NODE_MAJOR = 24;
+export const MINIMUM_NODE_MAJOR = 20;
 
 export function unsupportedNodeVersionMessage(version = process.versions.node) {
   const value = String(version ?? "").trim();

--- a/packages/npm/memorax-code/package.json
+++ b/packages/npm/memorax-code/package.json
@@ -37,7 +37,7 @@
     "README.md"
   ],
   "engines": {
-    "node": ">=24"
+    "node": ">=20"
   },
   "dependencies": {
     "smol-toml": "^1.7.0"

--- a/packages/npm/memorax-code/test/memorax-code-update.test.mjs
+++ b/packages/npm/memorax-code/test/memorax-code-update.test.mjs
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { chmod, cp, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { chmod, cp, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { delimiter, dirname, join } from "node:path";
+import { basename, delimiter, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
 
@@ -95,7 +95,8 @@ test("memorax-code update propagates an explicit home to npm lifecycle scripts",
   try {
     await mkdir(fakeBin, { recursive: true });
     const npmStub = join(fakeBin, "npm");
-    await writeFile(npmStub, [
+    const npmStubModule = `${npmStub}.mjs`;
+    await writeFile(npmStubModule, [
       "#!/usr/bin/env node",
       "import { writeFileSync } from 'node:fs';",
       "writeFileSync(process.env.MEMORAX_CODE_UPDATE_CAPTURE, JSON.stringify({",
@@ -105,7 +106,8 @@ test("memorax-code update propagates an explicit home to npm lifecycle scripts",
       "}));",
       "",
     ].join("\n"));
-    await chmod(npmStub, 0o755);
+    await chmod(npmStubModule, 0o755);
+    await symlink(basename(npmStubModule), npmStub);
 
     const result = spawnSync(
       process.execPath,

--- a/packages/npm/memorax-code/test/node-version.test.mjs
+++ b/packages/npm/memorax-code/test/node-version.test.mjs
@@ -14,18 +14,18 @@ test("published Node engine matches the enforced runtime minimum", async () => {
   assert.equal(manifest.engines?.node, `>=${MINIMUM_NODE_MAJOR}`);
 });
 
-test("runtime version guard accepts Node 24 and newer", () => {
-  assert.equal(unsupportedNodeVersionMessage("24.0.0"), undefined);
-  assert.equal(unsupportedNodeVersionMessage("25.1.0"), undefined);
+test("runtime version guard accepts Node 20 and newer", () => {
+  assert.equal(unsupportedNodeVersionMessage("20.0.0"), undefined);
+  assert.equal(unsupportedNodeVersionMessage("24.1.0"), undefined);
 });
 
 test("runtime version guard rejects older or unreadable versions", () => {
   assert.match(
-    unsupportedNodeVersionMessage("23.11.1") ?? "",
-    /requires Node\.js 24 or newer.*Node\.js 23\.11\.1/,
+    unsupportedNodeVersionMessage("19.11.1") ?? "",
+    /requires Node\.js 20 or newer.*Node\.js 19\.11\.1/,
   );
   assert.match(
     unsupportedNodeVersionMessage("unknown") ?? "",
-    /requires Node\.js 24 or newer.*Node\.js unknown/,
+    /requires Node\.js 20 or newer.*Node\.js unknown/,
   );
 });

--- a/packages/npm/memorax-code/test/postinstall.test.mjs
+++ b/packages/npm/memorax-code/test/postinstall.test.mjs
@@ -3,7 +3,7 @@ import { spawn } from "node:child_process";
 import { chmod, copyFile, mkdir, mkdtemp, readFile, readdir, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { createServer } from "node:http";
 import { tmpdir } from "node:os";
-import { delimiter, dirname, join } from "node:path";
+import { basename, delimiter, dirname, join } from "node:path";
 import test from "node:test";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { commandOnPath } from "../lib/vscode-extension-command.mjs";
@@ -29,6 +29,19 @@ const windowsCliInvocationPath = fileURLToPath(new URL("../lib/windows-cli-invoc
 const smolTomlPath = fileURLToPath(new URL("../../../ts/memorax-code-backend/node_modules/smol-toml", import.meta.url));
 const memoraxCodePluginId = "memorax-code-codex-adapter@memorax-code";
 const memoraxSetupInput = "memorax-user\nzh\nmemorax-secret\n";
+
+async function writeMockNodeCommand(command, source) {
+  const contents = Array.isArray(source) ? source.join("\n") : source;
+  if (process.platform === "win32") {
+    await writeFile(command, contents, { mode: 0o755 });
+    await chmod(command, 0o755);
+    return;
+  }
+  const modulePath = `${command}.mjs`;
+  await writeFile(modulePath, contents, { mode: 0o755 });
+  await chmod(modulePath, 0o755);
+  await symlink(basename(modulePath), command);
+}
 
 function pathWithoutCommand(command, pathValue) {
   return String(pathValue ?? "")
@@ -344,15 +357,14 @@ async function runPostinstall({ existingCache = false, explicitCache = false, ho
     "",
   ].join("\n"), { mode: 0o755 });
   if (codexAvailable) {
-    await writeFile(join(fakeBin, "codex"), [
+    await writeMockNodeCommand(join(fakeBin, "codex"), [
       "#!/usr/bin/env node",
       "import { appendFileSync } from 'node:fs';",
       `appendFileSync(${JSON.stringify(logPath)}, 'codex ' + process.argv.slice(2).join(' ') + '\\n');`,
       "if (process.argv[2] === '--version') console.log('codex 9.9.9-test');",
       "process.exit(0);",
       "",
-    ].join("\n"), { mode: 0o755 });
-    await chmod(join(fakeBin, "codex"), 0o755);
+    ]);
   }
   if (codexAppOnly) {
     const appCodex = process.platform === "win32"
@@ -362,35 +374,32 @@ async function runPostinstall({ existingCache = false, explicitCache = false, ho
     if (process.platform === "win32") {
       await copyFile(process.execPath, appCodex);
     } else {
-      await writeFile(appCodex, [
+      await writeMockNodeCommand(appCodex, [
         "#!/usr/bin/env node",
         "import { appendFileSync } from 'node:fs';",
         `appendFileSync(${JSON.stringify(logPath)}, 'app-codex ' + process.argv.slice(2).join(' ') + '\\n');`,
         "if (process.argv[2] === '--version') console.log('codex-app 9.9.9-test');",
         "process.exit(0);",
         "",
-      ].join("\n"), { mode: 0o755 });
-      await chmod(appCodex, 0o755);
+      ]);
     }
   }
   if (vscodeOnly) {
     await writeMockVsCodeRuntimes({ home, logPath });
   }
   if (claudeAvailable) {
-    await writeFile(join(fakeBin, "claude"), [
+    await writeMockNodeCommand(join(fakeBin, "claude"), [
       "#!/usr/bin/env node",
       "import { appendFileSync } from 'node:fs';",
       `appendFileSync(${JSON.stringify(logPath)}, 'claude ' + process.argv.slice(2).join(' ') + '\\n');`,
       `if (process.argv[2] === '--version') { ${claudeVersionFails ? "console.error('broken Claude CLI'); process.exit(7);" : "console.log('claude 9.9.9-test');"} }`,
       "process.exit(0);",
       "",
-    ].join("\n"), { mode: 0o755 });
-    await chmod(join(fakeBin, "claude"), 0o755);
+    ]);
   }
   if (opencodeCliAvailable) {
     const executable = join(fakeBin, process.platform === "win32" ? "opencode.cmd" : "opencode");
-    await writeFile(executable, "#!/usr/bin/env node\nprocess.exit(0);\n", { mode: 0o755 });
-    await chmod(executable, 0o755);
+    await writeMockNodeCommand(executable, "#!/usr/bin/env node\nprocess.exit(0);\n");
   }
   const cacheMarketplace = existingCache ? "personal" : explicitCache ? "memorax-code" : undefined;
   if (cacheMarketplace) {
@@ -572,24 +581,22 @@ async function writeMockVsCodeRuntimes({ home, logPath }) {
     await copyFile(process.execPath, claudeCommand);
     return;
   }
-  await writeFile(codexCommand, [
+  await writeMockNodeCommand(codexCommand, [
     "#!/usr/bin/env node",
     "import { appendFileSync } from 'node:fs';",
     `appendFileSync(${JSON.stringify(logPath)}, 'vscode-codex ' + process.argv.slice(2).join(' ') + '\\n');`,
     "if (process.argv[2] === '--version') console.log('codex-vscode 9.9.9-test');",
     "process.exit(0);",
     "",
-  ].join("\n"), { mode: 0o755 });
-  await chmod(codexCommand, 0o755);
-  await writeFile(claudeCommand, [
+  ]);
+  await writeMockNodeCommand(claudeCommand, [
     "#!/usr/bin/env node",
     "import { appendFileSync } from 'node:fs';",
     `appendFileSync(${JSON.stringify(logPath)}, 'vscode-claude ' + process.argv.slice(2).join(' ') + '\\n');`,
     "if (process.argv[2] === '--version') console.log('claude-vscode 9.9.9-test');",
     "process.exit(0);",
     "",
-  ].join("\n"), { mode: 0o755 });
-  await chmod(claudeCommand, 0o755);
+  ]);
 }
 
 function vscodeTargetPlatform() {

--- a/packages/ts/memorax-code-backend/package-lock.json
+++ b/packages/ts/memorax-code-backend/package-lock.json
@@ -15,18 +15,18 @@
         "memorax-code-backend": "dist/server.js"
       },
       "devDependencies": {
-        "@types/node": "^24.13.2",
+        "@types/node": "^20.0.0",
         "typescript": "^5.9.0"
       }
     },
     "node_modules/@types/node": {
-      "version": "24.13.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
-      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.18.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/smol-toml": {
@@ -56,9 +56,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     }

--- a/packages/ts/memorax-code-backend/package.json
+++ b/packages/ts/memorax-code-backend/package.json
@@ -17,7 +17,7 @@
     "test:memory-viewer": "npm run build && node --test --test-timeout=5000 --test-force-exit test/viewer/http/memory-viewer-routes.test.mjs"
   },
   "devDependencies": {
-    "@types/node": "^24.13.2",
+    "@types/node": "^20.0.0",
     "typescript": "^5.9.0"
   },
   "dependencies": {

--- a/scripts/build-npm-packages.mjs
+++ b/scripts/build-npm-packages.mjs
@@ -136,8 +136,8 @@ async function validateSourceManifest() {
   if (typeof manifest.version !== "string" || !manifest.version) {
     throw new Error("main npm package version is required");
   }
-  if (manifest.engines?.node !== ">=24") {
-    throw new Error("main npm package must require Node.js 24 or newer");
+  if (manifest.engines?.node !== ">=20") {
+    throw new Error("main npm package must require Node.js 20 or newer");
   }
 }
 

--- a/scripts/npm-package-check.sh
+++ b/scripts/npm-package-check.sh
@@ -59,7 +59,7 @@ assert "npm install -g @memorax/memorax-code --foreground-scripts" in readme
 assert license_text == Path("LICENSE").read_text()
 assert package_manifest["name"] == "@memorax/memorax-code"
 assert package_manifest["license"] == "MIT"
-assert package_manifest.get("engines", {}).get("node") == ">=24"
+assert package_manifest.get("engines", {}).get("node") == ">=20"
 assert "LICENSE" in package_manifest["files"]
 expected_bins = {
     "memorax-code": "bin/memorax-code.mjs",

--- a/scripts/validate-npm-pack-json.mjs
+++ b/scripts/validate-npm-pack-json.mjs
@@ -158,8 +158,8 @@ try {
   const packedManifest = JSON.parse(
     await readFile(join(extracted, "package", "package.json"), "utf8"),
   );
-  if (packedManifest.engines?.node !== ">=24") {
-    throw new Error("npm pack must require Node.js 24 or newer");
+  if (packedManifest.engines?.node !== ">=20") {
+    throw new Error("npm pack must require Node.js 20 or newer");
   }
   const packedDshSkill = await readFile(
     join(extracted, "package", "lib/memorax-code-dsh-adapter/skills/memorax-code/SKILL.md"),


### PR DESCRIPTION
## Change Summary

Lower the MemoraX Code system runtime requirement from Node.js 24 to Node.js 20 so enterprise environments on Node.js 20 can install and run the package, while keeping Node.js 24 as the recommended development baseline.

## Implementation Highlights

- Align the npm engine, runtime guard, build/pack validation, backend Node typings, and public installation documentation on Node.js 20 or newer.
- Make generated npm, Codex, Claude, OpenCode, Codex App, and VS Code test CLI fixtures use explicit `.mjs` targets behind POSIX command symlinks, avoiding version-dependent extensionless ESM loading.

## Validation

- `make docs-check`: passed.
- `make npm-package-check`: passed, including 179 package tests and the 364-file tarball allowlist.
- `make test`: passed across Backend, Codex, Claude Code, DSH, OpenCode, and npm package suites.
- Full npm source suite under Node.js 20.0.0, 20.18.0, and 24.15.0: 179/179 passed for each runtime.
- Backend TypeScript typecheck against `@types/node@20`: passed.

## Full End-to-End Validation Results

- Environment: macOS arm64; official Node.js 20.0.0 and 20.18.0 distributions; npm 10.8.2 for the final Node.js 20.18 run; fully isolated npm prefix/cache and MemoraX Code, Codex, Claude Code, DSH, and OpenCode homes.
- Scenario or matrix:
  - Node.js 20.0.0: build package, global tarball installation with lifecycle scripts, CLI version, Backend start/status, HTTP health, and stop.
  - Node.js 20.18.0: rebuild and pack the current branch, global installation with preinstall/postinstall, isolated Codex Hook activation, Backend start/status/health/stop, and self-uninstall.
- Command or workflow: local npm tarball installed with `npm install -g <tarball> --foreground-scripts` under isolated environment variables; lifecycle exercised through the installed `memorax-code` binary.
- Result: passed. The Backend returned HTTP 200, available Codex and OpenCode integrations reported healthy after explicit Hook authorization, and uninstall removed the npm package and managed plugin artifacts.
- Evidence or artifacts: console output was reviewed and contained no real MemoraX credentials or private transcripts; temporary test artifacts were moved to Trash after verification.
- Reason not run / remaining risk: no real Windows Node.js 20 installation was run in this change; existing Windows npm-shim and lifecycle contract tests passed as part of the package suite.