### PR TITLE
feat: surface automatic quota reminders in OpenCode

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -310,10 +310,12 @@ Important distinctions:
   coordination does not parse, mix, or guess those formats.
 - OpenCode's awaited `chat.message` plugin event supplies the correlated user
   prompt and injects accepted retrieval plus shared Skill reminder, User
-  Profile, and Procedure Memory context into that message's system context. Its
-  stable `session.compacted` event marks a durable supplemental reminder for
-  the next real user message; synthetic and compaction messages do not consume
-  that pending state. Local reminder evaluation remains independent of Backend
+  Profile, and Procedure Memory context into that message's system context.
+  Claimed Search and Add quota notices are dispatched through best-effort TUI
+  toasts without entering model context or blocking the prompt path. Its stable
+  `session.compacted` event marks a durable supplemental reminder for the next
+  real user message; synthetic and compaction messages do not consume that
+  pending state. Local reminder evaluation remains independent of Backend
   recovery. Its `shell.env` event binds the native session identity and makes
   the packaged memory CLI available to agent-run shell commands.
 

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ writing when the durable intent or target is unclear.
 | **Procedure reuse** | Records reusable task procedures and reminds future agents to apply them. |
 | **Background Repo Memory maintenance** | Automatically organizes repository structure, entry points, and history evidence in the background, then updates them according to policy to reduce repeated searching and summarization. |
 | **Active memory control** | Lets you search and add memory through the bundled MemoraX Code skill or the CLI. |
-| **Client integration** | Integrates with Codex, Claude Code, DeepSeek Harness, and OpenCode to trigger memory retrieval, reminders, and writeback. |
+| **Client integration** | Integrates with Codex, Claude Code, DeepSeek Harness, and OpenCode to trigger memory retrieval, reminders, and writeback. Automatic quota reminders are currently available in Codex, Claude Code, and OpenCode. |
 | **Local visualization** | Uses the local Memory Viewer to summarize activity counts, retrieval, and writeback status. |
 
 ## Your Memory, Your Control

--- a/README.zh.md
+++ b/README.zh.md
@@ -139,7 +139,7 @@ MemoraX Code 会先比较含义：语义相同的请求不重复写入；长期�
 | **Procedure 自动复用** | 记录可复用的任务流程，并在后续任务中自动提醒 Agent 按流程执行。 |
 | **Repo Memory 后台整理** | 在后台整理仓库结构、代码入口和历史证据，并按策略自动更新，避免反复搜索和总结。 |
 | **主动记忆控制** | 使用内置的 MemoraX Code Skill 或 CLI，主动查找和添加记忆。 |
-| **客户端集成** | 与 Codex、Claude Code、DeepSeek Harness 和 OpenCode 集成，触发记忆检索、提醒和写入。 |
+| **客户端集成** | 与 Codex、Claude Code、DeepSeek Harness 和 OpenCode 集成，触发记忆检索、提醒和写入。目前 Codex、Claude Code 和 OpenCode 支持自动额度提醒。 |
 | **本地可视化** | 通过本地 Memory Viewer 查看活动统计、召回与写入状态。 |
 
 ## 你的记忆，由你控制

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -114,6 +114,9 @@ Memory write and memory search reminders are tracked independently. A reminder
 is emitted when the corresponding remaining quota reaches 10% or less and
 again at 0%; raw quota counts are not shown.
 
+Automatic quota reminders are currently supported in Codex, Claude Code, and
+OpenCode. DeepSeek Harness does not currently surface these reminders.
+
 Routine reminders do not include a complete Mark ID. If this device uses an
 unregistered anonymous identity and the MemoraX account page requires its Mark
 ID, run this command yourself in a local terminal:

--- a/packages/ts/memorax-code-backend/src/clients/opencode/memory-hook-runtime.ts
+++ b/packages/ts/memorax-code-backend/src/clients/opencode/memory-hook-runtime.ts
@@ -5,6 +5,12 @@ import {
   type AutomaticMemoryWritebackRuntime,
 } from "../../memory/automatic-writeback.js";
 import { retrieveAutomaticMemoryContext } from "../../memory/automatic-retrieval.js";
+import {
+  claimQuotaNotice,
+  createPendingQuotaNoticeRuntime,
+  type PendingQuotaNoticeRuntime,
+  type QuotaNoticeClaimer,
+} from "../../memory/quota-notice.js";
 import type {
   MemoryHookTurnStartResult,
   OpenCodeTurnStartCommand,
@@ -52,12 +58,14 @@ export type OpenCodeMemoryHookRuntimeOptions = {
   diagnosticLogger?: MemoryDiagnosticLogger;
   env?: Record<string, string | undefined>;
   fetchImpl?: typeof fetch;
+  claimQuotaNotice?: QuotaNoticeClaimer;
   now?: () => number;
   ttlMs?: number;
   maxEntries?: number;
   cleanupIntervalMs?: number;
   memoryObservability?: MemoryObservabilityHook;
   memoraxCodeHome?: string;
+  pendingQuotaNotice?: PendingQuotaNoticeRuntime;
   repositoryMemorySession?: RepositoryMemorySessionRuntime;
   turnCoordinator?: MemoryTurnCoordinator;
 };
@@ -75,6 +83,12 @@ export function createOpenCodeMemoryHookRuntime(
   options: OpenCodeMemoryHookRuntimeOptions = {},
 ): OpenCodeMemoryHookRuntime {
   const now = options.now ?? (() => Date.now());
+  const pendingQuotaNotice = options.pendingQuotaNotice ?? createPendingQuotaNoticeRuntime({
+    claimQuotaNotice: options.claimQuotaNotice,
+    diagnosticLogger: options.diagnosticLogger,
+    env: options.env,
+  });
+  const ownsPendingQuotaNotice = options.pendingQuotaNotice === undefined;
   const automaticWritebackRuntime: {
     enqueue: AutomaticMemoryWritebackEnqueue;
     discardForScopeUpgrade?: AutomaticMemoryWritebackRuntime["discardForScopeUpgrade"];
@@ -83,7 +97,10 @@ export function createOpenCodeMemoryHookRuntime(
     ? undefined
     : options.automaticWriteback
       ? { enqueue: options.automaticWriteback }
-      : createAutomaticMemoryWritebackRuntime({ diagnosticLogger: options.diagnosticLogger });
+      : createAutomaticMemoryWritebackRuntime({
+        diagnosticLogger: options.diagnosticLogger,
+        queueQuotaNotice: pendingQuotaNotice.queue,
+      });
   const turnCoordinator = options.turnCoordinator ?? createMemoryTurnCoordinator({
     automaticWriteback: automaticWritebackRuntime!.enqueue,
     now,
@@ -164,8 +181,12 @@ export function createOpenCodeMemoryHookRuntime(
         if (typeof oldest !== "string") break;
         retrievalTurns.delete(oldest);
       }
+      const pendingUserNotice = repositoryMemory.ok
+        ? await pendingQuotaNotice.claim(repositoryMemory.memory.config)
+        : undefined;
       const retrieval = await retrieveAutomaticMemoryContext({
         diagnosticLogger: options.diagnosticLogger,
+        claimQuotaNotice: options.claimQuotaNotice ?? claimQuotaNotice,
         env: options.env ?? process.env,
         fetchImpl: options.fetchImpl,
         memoryObservability: options.memoryObservability,
@@ -175,10 +196,12 @@ export function createOpenCodeMemoryHookRuntime(
         sessionKey: command.sessionId,
         traceContext,
       });
+      const userNotice = [pendingUserNotice, retrieval.userNotice].filter(Boolean).join("\n");
       return {
         ok: true,
         ...(repoMemoryWorktree ? { repoMemoryWorktree } : {}),
         ...(retrieval.context ? { additionalContext: retrieval.context } : {}),
+        ...(userNotice ? { userNotice } : {}),
       };
     },
     async writeback(command) {
@@ -319,6 +342,7 @@ export function createOpenCodeMemoryHookRuntime(
       if (ownsTurnCoordinator) turnCoordinator.close();
       if (ownsRepositoryMemorySession) repositoryMemorySession.close();
       automaticWritebackRuntime?.close?.();
+      if (ownsPendingQuotaNotice) pendingQuotaNotice.close();
     },
   };
 }

--- a/packages/ts/memorax-code-backend/src/memory/service.ts
+++ b/packages/ts/memorax-code-backend/src/memory/service.ts
@@ -80,6 +80,7 @@ export function createMemoryService(options: MemoryServiceOptions = {}): MemoryS
   });
   const openCodeHook = createOpenCodeMemoryHookRuntime({
     ...options,
+    pendingQuotaNotice,
     repositoryMemorySession,
     turnCoordinator,
   });

--- a/packages/ts/memorax-code-backend/test/clients/opencode/opencode-memory-hook.test.mjs
+++ b/packages/ts/memorax-code-backend/test/clients/opencode/opencode-memory-hook.test.mjs
@@ -175,9 +175,10 @@ test("OpenCode finalizes an explicit MessageAbortedError without writeback", asy
   }
 });
 
-test("OpenCode runtime reuses retrieval, scope, and automatic writeback", async () => {
+test("OpenCode runtime reuses retrieval, scope, writeback, and quota notices", async () => {
   const memoraxCodeHome = await mkdtemp(join(tmpdir(), "memorax-code-opencode-runtime-"));
   const requests = [];
+  let searchCalls = 0;
   const runtime = createOpenCodeMemoryHookRuntime({
     memoraxCodeHome,
     env: {
@@ -190,10 +191,12 @@ test("OpenCode runtime reuses retrieval, scope, and automatic writeback", async 
       MEMORAX_CODE_MEMORAX_API_KEY: "secret",
       MEMORAX_CODE_MEMORAX_USER_ID: "user-1",
     },
+    claimQuotaNotice: async (_config, quota) => `${quota.featureCode}: ${quota.remaining}`,
     fetchImpl: async (url, init) => {
       const request = { url: String(url), body: JSON.parse(init.body) };
       requests.push(request);
       const searching = request.url.endsWith("/v1/memories/search");
+      if (searching) searchCalls += 1;
       return new Response(JSON.stringify(searching ? {
         success: true,
         data: {
@@ -205,10 +208,15 @@ test("OpenCode runtime reuses retrieval, scope, and automatic writeback", async 
             score: 0.9,
             metadata: { memory_type: "core" },
           }],
+          ...(searchCalls === 1 ? { balances: [quotaBalance("memory_search", 10)] } : {}),
         },
       } : {
         success: true,
-        data: { task_id: "writeback-1", status: "queued" },
+        data: {
+          task_id: "writeback-1",
+          status: "queued",
+          balances: [quotaBalance("memory_write", 9)],
+        },
       }), {
         status: 200,
         headers: { "content-type": "application/json" },
@@ -226,6 +234,8 @@ test("OpenCode runtime reuses retrieval, scope, and automatic writeback", async 
       workspaceKind: "project",
     });
     assert.match(start.additionalContext, /shared retrieval runtime/);
+    assert.equal(start.userNotice, "memory_search: 10");
+    assert.doesNotMatch(start.additionalContext, /memory_search/);
 
     assert.deepEqual(await runtime.writeback({
       version: 1,
@@ -246,6 +256,18 @@ test("OpenCode runtime reuses retrieval, scope, and automatic writeback", async 
       { role: "user", content: "OpenCode user prompt." },
       { role: "assistant", content: "OpenCode assistant reply." },
     ]);
+
+    const next = await runtime.recordTurnStart({
+      version: 1,
+      client: "opencode",
+      sessionId: "session-1",
+      userMessageId: "user-2",
+      prompt: "OpenCode second prompt.",
+      cwd: TEST_WORKSPACE,
+      workspaceKind: "project",
+    });
+    assert.equal(next.userNotice, "memory_write: 9");
+    assert.doesNotMatch(next.additionalContext, /memory_write/);
   } finally {
     runtime.close();
     await rm(memoraxCodeHome, { recursive: true, force: true });
@@ -274,6 +296,19 @@ function openCodeMessages() {
       parts: [textPart("assistant-1", "OpenCode assistant reply.")],
     },
   ];
+}
+
+function quotaBalance(featureCode, remaining) {
+  return {
+    product_code: "memory_api",
+    feature_code: featureCode,
+    spec_key: "calls",
+    quota_unit: "times",
+    quota_limit: 100,
+    reserved: 0,
+    consumed: 0,
+    remaining,
+  };
 }
 
 function textPart(messageID, text) {

--- a/packages/ts/memorax-code-backend/test/memory/memory-service.test.mjs
+++ b/packages/ts/memorax-code-backend/test/memory/memory-service.test.mjs
@@ -93,7 +93,7 @@ test("memory service exposes a sealed Hook facade and closes idempotently", asyn
   }
 });
 
-test("memory service surfaces automatic Add quota on the next Codex or Claude turn", async () => {
+test("memory service surfaces automatic Add quota on the next supported client turn", async () => {
   const root = await mkdtemp(join(tmpdir(), "memorax-code-service-quota-"));
   const memoraxCodeHome = join(root, "home");
   const workspace = join(root, "workspace");
@@ -104,7 +104,6 @@ test("memory service surfaces automatic Add quota on the next Codex or Claude tu
   const turns = [
     { turnId: "turn-quota-1", prompt: "Store the first turn.", reply: "First turn stored." },
     { turnId: "turn-quota-2", prompt: "Store the second turn.", reply: "Second turn stored." },
-    { turnId: "turn-quota-3", prompt: "Show the pending warning.", reply: "Warning shown." },
   ];
   const transcriptPath = await writeRollout(root, "session-service-quota", turns);
   const diagnosticEvents = [];
@@ -196,10 +195,18 @@ test("memory service surfaces automatic Add quota on the next Codex or Claude tu
     });
     await waitForAcceptedWritebacks(diagnosticEvents, 2);
 
-    const codexNotice = await service.recordTurnStart(codexTurnStart(turns[2]));
-    assert.equal(codexNotice.userNotice, "Quota notice: 9998 remaining.");
-    assert.equal("additionalContext" in codexNotice, false);
-    assert.deepEqual(await service.recordTurnStart(codexTurnStart(turns[2])), { ok: true });
+    const openCodeTurn = {
+      version: 1,
+      client: "opencode",
+      sessionId: "session-opencode-service-quota",
+      userMessageId: "user-opencode-service-quota",
+      prompt: "Show the second pending warning.",
+      cwd: workspace,
+    };
+    const openCodeNotice = await service.recordTurnStart(openCodeTurn);
+    assert.equal(openCodeNotice.userNotice, "Quota notice: 9998 remaining.");
+    assert.equal("additionalContext" in openCodeNotice, false);
+    assert.deepEqual(await service.recordTurnStart(openCodeTurn), { ok: true });
     assert.equal(requests.length, 2);
   } finally {
     await service.drain();

--- a/packages/ts/memorax-code-opencode-adapter/src/plugin.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/src/plugin.mjs
@@ -210,6 +210,7 @@ export function createMemoraxOpenCodePlugin(options = {}) {
           }, TURN_START_TIMEOUT_MS);
           turnStartAccepted = true;
           if (!pluginEnabled(options)) return;
+          await showUserNotice(client, directory, result?.userNotice, options);
           repositoryWorktree = stringValue(result?.repoMemoryWorktree);
           const repoMemoryEnv = openCodeRepoMemoryEnv(options, openCodeServerUrl, sessionId);
           if (repoMemoryEnv) {
@@ -382,6 +383,25 @@ function appendSystemContexts(output, ...contexts) {
   if (additions.length === 0) return;
   const existing = stringValue(output?.message?.system);
   output.message.system = [existing, ...additions].filter(Boolean).join("\n\n");
+}
+
+async function showUserNotice(client, directory, notice, options) {
+  const message = stringValue(notice);
+  if (!message || typeof client?.tui?.showToast !== "function") return;
+  try {
+    await client.tui.showToast({
+      body: {
+        title: "MemoraX Code",
+        message,
+        variant: "warning",
+        duration: 10_000,
+      },
+      query: { directory },
+      throwOnError: true,
+    });
+  } catch (error) {
+    debug(options, "opencode quota reminder failed", error);
+  }
 }
 
 function recordReminder(options, reminder) {

--- a/packages/ts/memorax-code-opencode-adapter/src/plugin.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/src/plugin.mjs
@@ -210,7 +210,7 @@ export function createMemoraxOpenCodePlugin(options = {}) {
           }, TURN_START_TIMEOUT_MS);
           turnStartAccepted = true;
           if (!pluginEnabled(options)) return;
-          await showUserNotice(client, directory, result?.userNotice, options);
+          void showUserNotice(client, directory, result?.userNotice, options);
           repositoryWorktree = stringValue(result?.repoMemoryWorktree);
           const repoMemoryEnv = openCodeRepoMemoryEnv(options, openCodeServerUrl, sessionId);
           if (repoMemoryEnv) {

--- a/packages/ts/memorax-code-opencode-adapter/test/plugin.test.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/test/plugin.test.mjs
@@ -40,7 +40,7 @@ test("chat.message retrieves memory and injects it into the system prompt", asyn
   });
 });
 
-test("chat.message shows userNotice as a TUI toast without injecting it into model context", async () => {
+test("chat.message shows userNotice without blocking or injecting it into model context", async () => {
   const toastCalls = [];
   const plugin = createPluginWithoutReminders({
     backendConnection: { url: "http://127.0.0.1:8787" },
@@ -53,7 +53,12 @@ test("chat.message shows userNotice as a TUI toast without injecting it into mod
   const hooks = await plugin(pluginInput({
     client: {
       session: { async messages() { return { data: [] }; } },
-      tui: { async showToast(options) { toastCalls.push(options); } },
+      tui: {
+        showToast(options) {
+          toastCalls.push(options);
+          return new Promise(() => {});
+        },
+      },
     },
   }));
   const output = promptOutput("user-quota", "Recall memory.", "Existing system context");

--- a/packages/ts/memorax-code-opencode-adapter/test/plugin.test.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/test/plugin.test.mjs
@@ -40,6 +40,40 @@ test("chat.message retrieves memory and injects it into the system prompt", asyn
   });
 });
 
+test("chat.message shows userNotice as a TUI toast without injecting it into model context", async () => {
+  const toastCalls = [];
+  const plugin = createPluginWithoutReminders({
+    backendConnection: { url: "http://127.0.0.1:8787" },
+    fetchImpl: responseSequence([], [{
+      ok: true,
+      additionalContext: "Retrieved memory context.",
+      userNotice: "Quota reminder: Memory search has 10% or less remaining.",
+    }]),
+  });
+  const hooks = await plugin(pluginInput({
+    client: {
+      session: { async messages() { return { data: [] }; } },
+      tui: { async showToast(options) { toastCalls.push(options); } },
+    },
+  }));
+  const output = promptOutput("user-quota", "Recall memory.", "Existing system context");
+
+  await hooks["chat.message"]({ sessionID: "session-quota" }, output);
+
+  assert.equal(output.message.system, "Existing system context\n\nRetrieved memory context.");
+  assert.doesNotMatch(output.message.system, /Quota reminder/);
+  assert.deepEqual(toastCalls, [{
+    body: {
+      title: "MemoraX Code",
+      message: "Quota reminder: Memory search has 10% or less remaining.",
+      variant: "warning",
+      duration: 10_000,
+    },
+    query: { directory: "/repo/directory" },
+    throwOnError: true,
+  }]);
+});
+
 test("repo-scoped reminder builders require a Backend-authorized worktree", async () => {
   const evaluations = [];
   const plugin = createMemoraxOpenCodePlugin({

--- a/scripts/opencode-e2e.mjs
+++ b/scripts/opencode-e2e.mjs
@@ -23,6 +23,8 @@ const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const OPENCODE_VERSION = "1.18.18";
 const PROMPT = "Reply with exactly: OpenCode E2E completed.";
 const REPLY = "OpenCode E2E completed.";
+const SECOND_PROMPT = "Reply with exactly: OpenCode E2E second turn completed.";
+const SECOND_REPLY = "OpenCode E2E second turn completed.";
 
 const root = await mkdtemp(join(tmpdir(), "memorax-code-opencode-e2e-"));
 const home = join(root, "home");
@@ -127,7 +129,6 @@ try {
   const opencode = process.platform === "win32"
     ? join(prefix, "node_modules", "opencode-ai", "bin", "opencode.exe")
     : join(binDir, "opencode");
-  await assertManagedArtifacts(openCodeConfigDir);
 
   const startReport = await runJson(memoraxCode.command, [
     ...memoraxCode.args,
@@ -139,6 +140,7 @@ try {
   ], { cwd: workspace, env });
   assert.equal(startReport.ok, true);
   assert.equal(startReport.opencodeAdapter?.enabled, true);
+  await assertManagedArtifacts(openCodeConfigDir);
 
   const config = {
     formatter: false,
@@ -171,7 +173,7 @@ try {
       },
     },
   };
-  const { stdout: openCodeOutput } = await run(opencode, [
+  const { stdout: openCodeOutput, stderr: openCodeError } = await run(opencode, [
     "run",
     "--format=json",
     "--model=test/test-model",
@@ -192,7 +194,32 @@ try {
   assert.equal(typeof sessionId, "string");
   assert.ok(sessionId);
   assert.match(openCodeRunText(runEvents), /OpenCode E2E completed/);
+  assert.doesNotMatch(openCodeError, /opencode quota reminder failed/);
   await waitFor(() => memoryStub.requests.some((request) => request.path === "/v1/memories/add"));
+
+  const { stdout: secondOpenCodeOutput, stderr: secondOpenCodeError } = await run(opencode, [
+    "run",
+    `--session=${sessionId}`,
+    "--format=json",
+    "--model=test/test-model",
+    "--print-logs",
+    ...SECOND_PROMPT.split(" "),
+  ], {
+    cwd: workspace,
+    closeStdin: true,
+    env: {
+      ...env,
+      PWD: workspace,
+      OPENCODE_CONFIG_CONTENT: JSON.stringify(config),
+    },
+    timeout: 60_000,
+  });
+  const secondRunEvents = parseJsonLines(secondOpenCodeOutput);
+  assert.match(openCodeRunText(secondRunEvents), /OpenCode E2E second turn completed/);
+  assert.doesNotMatch(secondOpenCodeError, /opencode quota reminder failed/);
+  await waitFor(() => (
+    memoryStub.requests.filter((request) => request.path === "/v1/memories/add").length === 2
+  ));
 
   const backendConnectionModule = pathToFileURL(join(
     prefix,
@@ -203,18 +230,33 @@ try {
 
   assert.deepEqual(
     memoryStub.requests.filter((request) => request.path === "/v1/memories/search").map((request) => request.body.query),
-    [PROMPT],
+    [PROMPT, SECOND_PROMPT],
   );
-  const add = memoryStub.requests.find((request) => request.path === "/v1/memories/add");
-  assert.deepEqual(add.body.messages.map(({ role, content }) => ({ role, content })), [
-    { role: "user", content: PROMPT },
-    { role: "assistant", content: REPLY },
+  const adds = memoryStub.requests.filter((request) => request.path === "/v1/memories/add");
+  assert.deepEqual(adds.map((request) => (
+    request.body.messages.map(({ role, content }) => ({ role, content }))
+  )), [
+    [
+      { role: "user", content: PROMPT },
+      { role: "assistant", content: REPLY },
+    ],
+    [
+      { role: "user", content: SECOND_PROMPT },
+      { role: "assistant", content: SECOND_REPLY },
+    ],
   ]);
   const promptModelRequest = modelStub.requests.find((request) => (
     JSON.stringify(request.body).includes(PROMPT)
   ));
   assert.ok(promptModelRequest, "OpenCode did not send the user prompt to the model");
   assert.match(JSON.stringify(promptModelRequest.body), /E2E recalled memory/);
+  const secondPromptModelRequest = modelStub.requests.find((request) => (
+    JSON.stringify(request.body).includes(SECOND_PROMPT)
+  ));
+  assert.ok(secondPromptModelRequest, "OpenCode did not send the second user prompt to the model");
+  for (const request of [promptModelRequest, secondPromptModelRequest]) {
+    assert.doesNotMatch(JSON.stringify(request.body), /Quota reminder|额度提醒/);
+  }
 
   const repoMemoryJob = await waitFor(async () => {
     const jobs = await readRepoMemoryJobs(memoraxCodeHome);
@@ -266,10 +308,10 @@ try {
     const candidate = await response.json();
     const summary = candidate.summary;
     if (
-      summary?.turnCount !== 1
-      || summary.searchOperationCount !== 1
-      || summary.searchedMemoryCount !== 1
-      || summary.addOperationCount !== 1
+      summary?.turnCount !== 2
+      || summary.searchOperationCount !== 2
+      || summary.searchedMemoryCount !== 2
+      || summary.addOperationCount !== 2
       || candidate.projects?.[0]?.repoMemory?.status !== "ready"
     ) return undefined;
     return candidate;
@@ -282,14 +324,14 @@ try {
     searchedMemoryCount: viewer.summary.searchedMemoryCount,
     addOperationCount: viewer.summary.addOperationCount,
   }, {
-    turnCount: 1,
-    searchOperationCount: 1,
-    searchedMemoryCount: 1,
-    addOperationCount: 1,
+    turnCount: 2,
+    searchOperationCount: 2,
+    searchedMemoryCount: 2,
+    addOperationCount: 2,
   });
   assert.deepEqual(viewer.projects[0].repoMemory, { status: "ready", reason: "usable" });
   const viewerJson = JSON.stringify(viewer);
-  for (const privateValue of [PROMPT, REPLY, "E2E recalled memory", sessionId]) {
+  for (const privateValue of [PROMPT, REPLY, SECOND_PROMPT, SECOND_REPLY, "E2E recalled memory", sessionId]) {
     assert.equal(viewerJson.includes(privateValue), false);
   }
   for (const field of ["prompt", "answer", "query", "results", "details", "sessionId", "turnId"]) {
@@ -348,6 +390,7 @@ try {
 
 async function startMemoryStub() {
   const requests = [];
+  let addCount = 0;
   const server = createServer(async (request, response) => {
     const body = await requestJson(request);
     requests.push({ method: request.method, path: request.url, body });
@@ -363,13 +406,19 @@ async function startMemoryStub() {
             score: 0.99,
             metadata: { memory_type: "procedural" },
           }],
+          balances: [quotaBalance("memory_search", 10)],
         },
       });
     }
     if (request.method === "POST" && request.url === "/v1/memories/add") {
+      addCount += 1;
       return json(response, 202, {
         success: true,
-        data: { task_id: "opencode-e2e-add", status: "accepted" },
+        data: {
+          task_id: `opencode-e2e-add-${addCount}`,
+          status: "accepted",
+          balances: [quotaBalance("memory_write", 10 - addCount)],
+        },
       });
     }
     return json(response, 404, { message: "not found" });
@@ -393,7 +442,9 @@ async function startModelStub(options) {
     }
     const reply = isRepoMemoryBuild
       ? "Repo Memory built and validated."
-      : options.reply;
+      : JSON.stringify(body).includes(SECOND_PROMPT)
+        ? SECOND_REPLY
+        : options.reply;
     response.writeHead(200, {
       "content-type": "text/event-stream",
       "cache-control": "no-cache",
@@ -450,6 +501,19 @@ function requestJson(request) {
 function json(response, status, body) {
   response.writeHead(status, { "content-type": "application/json" });
   response.end(JSON.stringify(body));
+}
+
+function quotaBalance(featureCode, remaining) {
+  return {
+    product_code: "memory_api",
+    feature_code: featureCode,
+    spec_key: "calls",
+    quota_unit: "times",
+    quota_limit: 100,
+    reserved: 1,
+    consumed: 0,
+    remaining,
+  };
 }
 
 function installedMemoraxCli(binDir, packageRoot, name) {


### PR DESCRIPTION
## Change Summary
Surface MemoraX quota reminders in the OpenCode TUI without adding reminder text to model context, and document that DSH does not yet support automatic quota reminders.

## Implementation Highlights
- Deliver Search quota reminders as current-turn OpenCode toasts and carry Add quota reminders into the next turn.
- Keep reminder delivery on the UI-only path; model request content is not modified.
- Extend isolated OpenCode coverage for Search and Add reminder delivery, and document the current DSH support boundary.

## Validation
- Backend suite: 555 passed, 2 skipped.
- OpenCode adapter suite: 31 passed.
- npm package check: 220 passed, 2 skipped.
- Documentation check passed.
- Isolated real-client OpenCode E2E passed.

## Full End-to-End Validation Results
- Environment: OpenCode 1.18.18 in an isolated local configuration with a staged package.
- Scenario or matrix: Repo Memory readiness, two Search operations, two Add operations, current-turn Search toast delivery, next-turn Add toast delivery, and model-request isolation.
- Command or workflow: make test-opencode-e2e
- Result: Passed. Repo Memory became ready; both Search and Add flows completed; quota reminders were surfaced in the TUI; captured model requests contained no quota reminder text.
- Evidence or artifacts: A redacted local TUI screenshot was captured for review but intentionally not committed.
- Reason not run / remaining risk: DSH automatic quota reminder validation is not applicable because DSH currently has no supported UI-only Host-to-Client notification path; this limitation is documented.
<img width="1600" height="990" alt="image" src="https://github.com/user-attachments/assets/d0717a1d-885a-41cc-ab0d-1eed51db4f24" />
