### PR TITLE
fix: restore active clients during package replacement

### DIFF
--- a/packages/ts/memorax-code-backend/src/lifecycle/orchestrator.ts
+++ b/packages/ts/memorax-code-backend/src/lifecycle/orchestrator.ts
@@ -194,8 +194,9 @@ async function startMemoraxCodeServiceLocked(
   if (serviceStateFailure) {
     return { ok: false, action: "start", backend: serviceStateFailure };
   }
-  const config = loadManagedClientsConfig(memoraxCodeHome);
-  const requestedClients = resolveManagedClients(argv, config);
+  const requestedClients = managedClientsFor(argv, serviceOptions, {
+    preferActive: isPackageReplacement(),
+  });
   const clients = isDshAdapterRecovery()
     ? { ...requestedClients, dsh: true }
     : requestedClients;

--- a/packages/ts/memorax-code-backend/src/lifecycle/orchestrator.ts
+++ b/packages/ts/memorax-code-backend/src/lifecycle/orchestrator.ts
@@ -194,8 +194,11 @@ async function startMemoraxCodeServiceLocked(
   if (serviceStateFailure) {
     return { ok: false, action: "start", backend: serviceStateFailure };
   }
+  const packageReplacement = isPackageReplacement();
+  // Active client intent must not bypass strict lifecycle config validation.
+  if (packageReplacement) loadManagedClientsConfig(memoraxCodeHome);
   const requestedClients = managedClientsFor(argv, serviceOptions, {
-    preferActive: isPackageReplacement(),
+    preferActive: packageReplacement,
   });
   const clients = isDshAdapterRecovery()
     ? { ...requestedClients, dsh: true }
@@ -574,7 +577,9 @@ async function executeMemoraxCodeStop(
       ...(dshAdapter ? { dshAdapter } : {}),
       ...(opencodeAdapter ? { opencodeAdapter } : {}),
     },
-    remainingClients: remaining && hasRemainingClients ? remaining : undefined,
+    remainingClients: packageReplacement
+      ? activeClients
+      : remaining && hasRemainingClients ? remaining : undefined,
   };
 }
 

--- a/packages/ts/memorax-code-backend/test/lifecycle/dsh-participant.test.mjs
+++ b/packages/ts/memorax-code-backend/test/lifecycle/dsh-participant.test.mjs
@@ -17,7 +17,7 @@ import { freePort } from "../support/helpers.mjs";
 
 const cliPath = fileURLToPath(new URL("../../dist/memorax-code.js", import.meta.url));
 
-test("Backend lifecycle stages, activates, retains, and package-retires the DSH participant", async () => {
+test("Backend lifecycle stages, activates, retains, package-retires, and restores the DSH participant", async () => {
   const fixture = await createFixture();
   try {
     const started = runCli(fixture, "start", ["--clients", "dsh"]);
@@ -75,6 +75,21 @@ test("Backend lifecycle stages, activates, retains, and package-retires the DSH 
     assert.equal(profileHasAdapter(fixture.profilePath), false);
     assert.equal(existsSync(fixture.pidPath), false);
     assert.match(readFileSync(fixture.dshLog, "utf8"), /^remove enabled=false$/m);
+
+    const activeClientsPath = join(fixture.memoraxCodeHome, "runtime", "backend", "managed-clients.json");
+    assert.deepEqual(readJson(activeClientsPath), {
+      codex: false,
+      claude: false,
+      dsh: true,
+      opencode: false,
+    });
+    const restored = runCli(fixture, "start", [], {
+      MEMORAX_CODE_PACKAGE_REPLACEMENT: "1",
+    });
+    assert.equal(restored.status, 0, `${restored.stdout}\n${restored.stderr}`);
+    assert.equal(JSON.parse(restored.stdout).dshAdapter.enabled, true);
+    assert.equal(readJson(fixture.statePath).enabled, true);
+    assert.equal(profileHasAdapter(fixture.profilePath), true);
   } finally {
     runCli(fixture, "stop", ["--clients", "none"]);
     rmSync(fixture.root, { recursive: true, force: true });

--- a/packages/ts/memorax-code-backend/test/lifecycle/management-cli.test.mjs
+++ b/packages/ts/memorax-code-backend/test/lifecycle/management-cli.test.mjs
@@ -672,6 +672,18 @@ test("memorax-code lifecycle rejects invalid config before mutating clients or B
     assert.equal(await readFile(join(codexHome, "config.toml"), "utf8"), originalCodexConfig);
     assert.equal(await readFile(join(claudeHome, "settings.json"), "utf8"), originalClaudeSettings);
     assert.equal(await pathExists(pluginCli.callsPath), false);
+
+    const activeClientsPath = join(home, "runtime", "backend", "managed-clients.json");
+    const activeClients = { codex: false, claude: true, dsh: false, opencode: false };
+    await mkdir(join(home, "runtime", "backend"), { recursive: true });
+    await writeFile(activeClientsPath, `${JSON.stringify(activeClients)}\n`);
+    const replacement = await runCli(cliPath, ["start", "--json", ...commonArgs], {
+      env: { ...env, MEMORAX_CODE_PACKAGE_REPLACEMENT: "1" },
+    });
+    assert.equal(replacement.code, 1, `${replacement.stdout}\n${replacement.stderr}`);
+    assert.match(replacement.stderr, /failed to parse MemoraX Code lifecycle config/);
+    assert.deepEqual(JSON.parse(await readFile(activeClientsPath, "utf8")), activeClients);
+    assert.equal(await pathExists(join(home, "runtime", "backend", "backend.pid.json")), false);
   } finally {
     await runCli(cliPath, ["stop", "--json", ...commonArgs, "--clients", "none"], { env });
     await rm(home, { recursive: true, force: true });

--- a/packages/ts/memorax-code-backend/test/lifecycle/orchestrator.test.mjs
+++ b/packages/ts/memorax-code-backend/test/lifecycle/orchestrator.test.mjs
@@ -576,6 +576,41 @@ test("memorax-code start leaves Codex config unchanged before the plugin is inst
   }
 });
 
+test("package replacement restores only previously active clients", async () => {
+  const home = await mkdtemp(join(tmpdir(), "memorax-code-package-replacement-home-"));
+  const codexHome = await mkdtemp(join(tmpdir(), "memorax-code-package-replacement-codex-"));
+  const port = await freePort();
+  const cliPath = fileURLToPath(new URL("../../dist/memorax-code.js", import.meta.url));
+  const activeClientsPath = join(home, "runtime", "backend", "managed-clients.json");
+  const inactiveClients = { codex: false, claude: false, dsh: false, opencode: false };
+  await writeManagedClientsConfig(home, { codex: true, claude: false });
+  await mkdir(join(home, "runtime", "backend"), { recursive: true });
+  await writeFile(activeClientsPath, `${JSON.stringify(inactiveClients)}\n`);
+  try {
+    const started = await runCli(cliPath, [
+      "start", "--json",
+      "--home", home,
+      "--port", String(port),
+      "--codex-home", codexHome,
+    ], { env: { MEMORAX_CODE_PACKAGE_REPLACEMENT: "1" } });
+
+    assert.equal(started.code, 0, `${started.stdout}\n${started.stderr}`);
+    const report = JSON.parse(started.stdout);
+    assert.equal(report.ok, true);
+    assert.equal(report.codexAdapter, undefined);
+    assert.deepEqual(JSON.parse(await readFile(activeClientsPath, "utf8")), inactiveClients);
+  } finally {
+    await runCli(cliPath, [
+      "stop", "--json",
+      "--home", home,
+      "--port", String(port),
+      "--clients", "none",
+    ]);
+    await rm(home, { recursive: true, force: true });
+    await rm(codexHome, { recursive: true, force: true });
+  }
+});
+
 test("memorax-code start --yes registers a missing Codex plugin but requires activation", async () => {
   const home = await mkdtemp(join(tmpdir(), "memorax-code-lifecycle-prompt-plugin-home-"));
   const codexHome = await mkdtemp(join(tmpdir(), "memorax-code-lifecycle-prompt-plugin-codex-"));


### PR DESCRIPTION
## Change Summary
Restore previously active client intent during npm package replacement so configured-but-inactive integrations do not make postinstall restoration fail.

## Implementation Highlights
- Make package-replacement start prefer the persisted active-client record while preserving explicit `--clients` selection behavior.
- Add one lifecycle regression scenario where configuration enables Codex but the active-client record excludes it; no per-client matrix is required.

## Validation
- `npm run typecheck --prefix packages/ts/memorax-code-backend`
- `npm test --prefix packages/ts/memorax-code-backend`: 556 passed, 2 skipped
- `make npm-package-check`: 220 passed, 2 skipped

## Full End-to-End Validation Results
- Environment: macOS arm64, Node.js v24.15.0, npm 11.12.1
- Scenario or matrix: package replacement with a configured but previously inactive client
- Command or workflow: focused lifecycle test followed by the complete Backend and npm artifact verification profiles
- Result: replacement start restored only the persisted active-client set; all relevant checks passed
- Evidence or artifacts: regression test in `packages/ts/memorax-code-backend/test/lifecycle/orchestrator.test.mjs` and successful local command output
- Reason not run / remaining risk: a real global npm replacement was not repeated because it would mutate the current global package and local lifecycle state; platform-specific global npm behavior remains for follow-up manual validation
