### PR TITLE
fix: migrate configured legacy setups after update

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -185,9 +185,14 @@ lifecycle never detects new clients, accepts credentials, or authorizes Hooks.
 `memorax-code setup` owns disclosure, memory preferences, credential creation
 or entry, client discovery, Hook review, Backend reconciliation, and final
 verification. It requires an interactive terminal. A versioned completion
-record is committed only after setup succeeds; the no-argument CLI uses that
-record solely to choose between setup guidance and current status. Invalid or
-unsupported completion and package-transition records fail closed.
+record is committed only after setup succeeds; the no-argument CLI normally
+uses that record to choose between setup guidance and current status. For a
+legacy installation with a ready effective configuration but no completion
+record, an interactive no-argument invocation validates and reuses that
+configuration, then runs the same foreground setup and reconciliation once to
+commit the record. Without a ready configuration or interactive terminal, it
+continues to show setup guidance. Invalid or unsupported completion and
+package-transition records fail closed.
 
 The principal control-plane locations are:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -104,11 +104,14 @@ Successful setup writes a private versioned record at:
 $MEMORAX_CODE_HOME/runtime/setup/setup-completion.json
 ```
 
-The record controls only no-argument CLI routing. When it is absent,
-`memorax-code` points to `memorax-code setup`; when valid, the command shows
-status. Invalid and unsupported records fail closed. A complete product
-uninstall removes this marker while retaining `config.toml`; stop and partial
-client uninstall preserve it.
+The record controls only no-argument CLI routing. When it is valid, the command
+shows status. When it is absent and an interactive terminal is available,
+`memorax-code` validates and reuses a complete effective configuration, then
+runs setup and reconciliation once to write the record. If the configuration
+is incomplete or no interactive terminal is available, it points to
+`memorax-code setup`. Invalid and unsupported records fail closed. A complete
+product uninstall removes this marker while retaining `config.toml`; stop and
+partial client uninstall preserve it.
 
 Replacing a running managed Backend uses a separate private record:
 

--- a/packages/npm/memorax-code/bin/memorax-code.mjs
+++ b/packages/npm/memorax-code/bin/memorax-code.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -251,6 +251,10 @@ async function runSetupCommand(args, { updateMode = false } = {}) {
     const { withSetupCompletionLock } = await loadSetupCompletionApi();
     return await withSetupCompletionLock(memoraxCodeHome, async (completion) => {
       if (updateMode && completion.status === "absent") {
+        if (hasReadyMemoraxConfiguration(memoraxCodeHome)) {
+          console.error("memorax-code update: existing configuration detected; completing the one-time setup migration");
+          return await spawnSetupProcess(memoraxCodeHome, { setupMode });
+        }
         console.error("memorax-code update: package updated; setup has not been completed; run `memorax-code setup` from an interactive terminal");
         return 0;
       }
@@ -274,6 +278,10 @@ async function routeDefaultCommand() {
     const { readSetupCompletionRecord, setupCompletionPath } = await loadSetupCompletionApi();
     const state = readSetupCompletionRecord(memoraxCodeHome);
     if (state.status === "absent") {
+      if (setupCanPrompt() && hasReadyMemoraxConfiguration(memoraxCodeHome)) {
+        console.error("memorax-code: existing configuration detected; completing the one-time setup migration");
+        return await runSetupCommand(["--home", memoraxCodeHome]);
+      }
       console.error("memorax-code: setup has not been completed. Run `memorax-code setup` from an interactive terminal.");
       return 1;
     }
@@ -351,6 +359,22 @@ async function loadSetupCompletionApi() {
 
 async function loadTrialSetupApi() {
   return await import(pathToFileURL(join(packageRoot(), "lib", "trial-setup.mjs")).href);
+}
+
+function hasReadyMemoraxConfiguration(memoraxCodeHome) {
+  const result = spawnSync(process.execPath, [
+    join(packageRoot(), "bin", "memorax-cli.mjs"),
+    "status",
+    "--json",
+    "--config-only",
+  ], {
+    encoding: "utf8",
+    env: { ...process.env, MEMORAX_CODE_HOME: memoraxCodeHome },
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: 10_000,
+    windowsHide: true,
+  });
+  return !result.error && !result.signal && result.status === 0;
 }
 
 async function spawnSetupProcess(memoraxCodeHome, { updateMode = false, setupMode = "automatic" } = {}) {

--- a/packages/npm/memorax-code/test/memorax-code-entrypoint.test.mjs
+++ b/packages/npm/memorax-code/test/memorax-code-entrypoint.test.mjs
@@ -139,11 +139,12 @@ test("setup propagates the setup process exit code", async () => {
   }
 });
 
-test("update reviews clients and Hooks only after foreground setup has completed", {
+test("update reviews clients and Hooks or migrates a configured legacy install", {
   skip: process.platform === "win32",
 }, async (t) => {
-  for (const [name, completed] of [
+  for (const [name, completed, configured = false] of [
     ["setup incomplete", false],
+    ["configured legacy install", false, true],
     ["setup complete", true],
   ]) {
     await t.test(name, async () => {
@@ -171,13 +172,21 @@ test("update reviews clients and Hooks only after foreground setup has completed
           assumeInteractive: true,
           extraEnv: {
             PATH: `${fakeBin}${delimiter}${process.env.PATH ?? ""}`,
+            ...(configured ? { MEMORAX_CODE_TEST_CONFIGURED: "1" } : {}),
           },
         });
 
         assert.equal(result.status, 0, result.stderr);
-        if (!completed) {
+        if (!completed && !configured) {
           assert.match(result.stderr, /package updated; setup has not been completed; run `memorax-code setup` from an interactive terminal/);
           assert.equal(await pathExists(fixture.setupLogPath), false);
+        } else if (configured) {
+          assert.match(result.stderr, /existing configuration detected; completing the one-time setup migration/);
+          assert.deepEqual(await readJsonLines(fixture.setupLogPath), [{
+            args: [],
+            home: fixture.memoraxCodeHome,
+            setupMode: "automatic",
+          }]);
         } else {
           assert.match(result.stderr, /reviewing client and Hook changes in the foreground/);
           assert.deepEqual(await readJsonLines(fixture.setupLogPath), [{
@@ -347,6 +356,17 @@ async function createPackageFixture() {
     version: "0.0.0-test",
     type: "module",
   }, null, 2)}\n`);
+  await writeFile(join(root, "bin", "memorax-cli.mjs"), [
+    "const configured = process.env.MEMORAX_CODE_TEST_CONFIGURED === '1';",
+    "console.log(JSON.stringify({",
+    "  ok: configured,",
+    "  action: 'memory.status',",
+    "  provider: 'memory.memorax',",
+    "  config: { configured },",
+    "}));",
+    "process.exit(configured ? 0 : 1);",
+    "",
+  ].join("\n"));
   await writeFile(join(root, "lib", "trial-setup.mjs"), [
     "export async function loadReadyTrialSetupCredential(options = {}) {",
     "  if (options.memoraxCodeHome !== process.env.MEMORAX_CODE_TEST_EXPECTED_ACCOUNT_HOME) {",

--- a/scripts/npm-package-check.sh
+++ b/scripts/npm-package-check.sh
@@ -529,6 +529,16 @@ assert (home / ".memorax-code" / "runtime" / "backend" / "backend.pid.json").exi
 assert not (home / ".memorax-code" / "runtime" / "install" / "package-transition.json").exists()
 PY_SETUP
 
+cp "$MEMORAX_CODE_HOME/config.toml" "$home_dir/legacy-config-before-migration.toml"
+rm "$MEMORAX_CODE_HOME/runtime/setup/setup-completion.json"
+MEMORAX_CODE_SETUP_ASSUME_INTERACTIVE=1 \
+MEMORAX_CODE_SKIP_CODEX_PLUGIN_INSTALL=1 \
+MEMORAX_CODE_SKIP_CLAUDE_ADAPTER_INSTALL=1 \
+MEMORAX_CODE_SKIP_OPENCODE_ADAPTER_INSTALL=1 \
+"$prefix/bin/memorax-code" >/dev/null 2>&1
+cmp "$home_dir/legacy-config-before-migration.toml" "$MEMORAX_CODE_HOME/config.toml"
+test -f "$MEMORAX_CODE_HOME/runtime/setup/setup-completion.json"
+
 "$prefix/bin/memorax-code" >/dev/null
 
 cp "$MEMORAX_CODE_HOME/runtime/setup/setup-completion.json" "$home_dir/setup-completion-before-update.json"


### PR DESCRIPTION
## Change Summary

Migrate already-configured installations created before setup-completion records were introduced, so users upgrading from earlier 0.1.x releases do not need to re-enter their MemoraX configuration.

## Implementation Highlights

- Treat a missing setup-completion record as migratable only when `memorax-cli status --json --config-only` confirms that the existing MemoraX configuration is ready.
- Reuse the foreground setup/reconcile path to commit the versioned completion record while preserving the existing configuration; incomplete installations continue to receive explicit setup guidance.
- Cover both CLI routing and the packaged no-argument migration path, including byte-for-byte configuration preservation.

## Validation

- `node --test packages/npm/memorax-code/test/memorax-code-entrypoint.test.mjs`: 20 passed.
- `make npm-package-check`: 221 passed, 2 skipped.
- Isolated Docker/Verdaccio upgrade E2E from published `0.1.3` to local `0.1.6-legacy-e2e.0`: passed.

## Full End-to-End Validation Results

- Environment: Linux aarch64, `node:24-bookworm` (Node.js 24.19.0, npm 11.17.0), Verdaccio 6, isolated home/config/npm-prefix directories; the production MemoraX hostname was redirected to loopback to prevent external provisioning.
- Scenario or matrix: one representative legacy release (`0.1.3`) with a complete existing configuration, a running Backend, and no setup-completion record, upgraded to the package built from this branch.
- Command or workflow: publish both tarballs to the isolated registry, install exact `0.1.3`, invoke `memorax-code update` through the old CLI, then invoke the upgraded `memorax-code` with no command.
- Result: the old CLI installed the new package; package transition replaced the Backend PID and restored a healthy service; configuration bytes remained unchanged; the completion record remained absent until the upgraded CLI ran, then was committed with `completedByVersion = 0.1.6-legacy-e2e.0`; no trial credential or provisioning state was created.
- Evidence or artifacts: redacted terminal assertions reported `legacy update E2E: PASS` for the old CLI update path, configured migration, configuration preservation, Backend replacement/health, and avoided trial provisioning.
- Reason not run / remaining risk: a native Windows upgrade E2E was not repeated for this focused change. The same platform-independent Node.js CLI path is covered by the entrypoint suite, macOS package check, and isolated Linux registry E2E.
