### PR TITLE
fix: support npx-initialized DSH profiles

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -224,8 +224,13 @@ process's in-memory serialization.
 DSH lifecycle discovery reads valid Profiles under `DSH_HOME`. The globally
 staged adapter source is immutable; the adapter materializes a content-addressed
 runtime generation under the selected `MEMORAX_CODE_HOME` and asks DSH's native
-plugin command to install that generation into each managed Profile. When DSH
-has an existing Profile but none can run headless work, the same native command
+plugin command to install that generation into each managed Profile. It uses an
+explicit, persisted, or directly available DSH command, or validates the DSH
+package already linked into the existing Profile dependency tree. It never
+installs or updates DSH. The resolved entrypoint and package version become the
+durable runtime authority; a later lifecycle reconciliation reads the existing
+runtime again so user-managed DSH updates can advance it. When DSH has an
+existing Profile but none can run headless work, the same native command
 initializes the standard `headless` Profile and brings it under adapter
 ownership so supervised Repo Memory always has a worker. Removal uninstalls the
 adapter without deleting DSH Profiles. The Backend lifecycle lock is acquired
@@ -233,7 +238,10 @@ before the DSH state lock. Start quiesces the old authority, prepares Profile
 artifacts with authority disabled, and activates them only after Backend
 readiness. Stop, update, and uninstall publish disabled authority before
 Profile mutation. A disabled or invalid runtime stays inert inside DSH rather
-than registering listeners or recovering the Backend.
+than registering listeners or recovering the Backend. A DSH failure found by
+automatic client discovery makes setup or an unqualified `start` or `status`
+command degraded without blocking the Backend or another client. Explicit
+`--clients dsh` and `--clients all` selections remain strict.
 
 OpenCode lifecycle discovery accepts either its configuration directory or an
 `opencode` executable on `PATH`, so Desktop-only, CLI-only, and combined

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -9,11 +9,13 @@ installation. For a source checkout and contributor setup, see
 
 - Node.js 20 or newer (Node.js 24 LTS recommended) and npm.
 - At least one of Codex, Claude Code, DeepSeek Harness (DSH), OpenCode Desktop,
-  or the OpenCode CLI installed in the environment where MemoraX Code will
-  run. DSH integration requires at least one existing Profile and `pnpm` on
-  `PATH` because DSH's native Profile plugin manager delegates package changes
-  to it. The tested DSH baseline is `0.1.0-rc.6`; other valid semantic versions
-  are reported as untested rather than rejected automatically.
+  or the OpenCode CLI available in the environment where MemoraX Code will
+  run. DSH must already be installed globally or initialized through its
+  official `npx` workflow; MemoraX Code does not install or update it. DSH
+  integration requires at least one existing Profile and `pnpm` on `PATH`
+  because DSH's native Profile plugin manager delegates package changes to it.
+  The tested DSH baseline is `0.1.0-rc.6`; other valid semantic versions are
+  reported as untested rather than rejected automatically.
 - Python 3 only when using Repo Memory operations.
 - On Linux, `/usr/bin/secret-tool` from libsecret and an available Secret
   Service in the current user session for setup-managed credentials.
@@ -100,7 +102,13 @@ refresh OpenCode after installation so the managed integration is loaded.
 DSH registration is applied to the existing Profiles found under `DSH_HOME`
 (`~/.dsh` by default). Restart or refresh DSH after installation so those
 Profiles load the managed integration. MemoraX Code does not replace the
-Profiles or their session data.
+Profiles or their session data. If no global `dsh` command is available,
+MemoraX Code can use the DSH runtime already linked into the existing Profile
+dependency tree. It never invokes `npx` or installs or updates DSH.
+If automatically discovered DSH is unavailable, setup keeps the Backend and
+other detected clients running and reports the DSH integration as degraded.
+After repairing DSH, run `memorax-code start --clients dsh` to reconcile it;
+explicit DSH selection reports failure until the integration is ready.
 
 Open the client in a real project directory and submit at least one prompt
 before using the client doctor as the final verification. Until the Hooks have

--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ Prepare Node.js 20+ (Node.js 24 LTS recommended) and at least one of Codex,
 Claude Code, DeepSeek Harness, or OpenCode. Python 3 is required for Repo
 Memory operations. Each coding-agent harness retains its own runtime
 requirements; current DeepSeek Harness releases require Node.js
-`^22.19.0 || >=24.0.0`.
+`^22.19.0 || >=24.0.0`. DSH may be installed globally or initialized
+beforehand through its official `npx` workflow.
 
 ### Install and Connect
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -50,7 +50,7 @@ MemoraX Code 让 Codex、Claude Code、DeepSeek Harness 和 OpenCode 共享一�
 开始前，请确保已安装 Node.js 20 或更高版本（推荐 Node.js 24 LTS），以及 Codex、Claude Code、
 DeepSeek Harness 或 OpenCode 中的至少一个。Repo Memory 操作还需要 Python 3。各 Coding Agent
 Harness 仍需满足自身的运行时要求；当前 DeepSeek Harness 版本要求 Node.js
-`^22.19.0 || >=24.0.0`。
+`^22.19.0 || >=24.0.0`。DSH 可全局安装，也可事先通过其官方 `npx` 流程完成初始化。
 
 ### 安装与接入
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -206,10 +206,18 @@ memorax-code start --clients dsh
 memorax-code status --clients dsh
 ```
 
+Automatic DSH discovery is optional: an unavailable DSH integration is
+reported as degraded without blocking the Backend or another detected client.
+The explicit commands above are strict and return a failure until DSH is ready.
+
 MemoraX Code discovers existing Profiles under `$DSH_HOME/profiles`;
 `DSH_HOME` defaults to `~/.dsh`. A `no_existing_profiles` result means DSH has
 not created a valid Profile in that home. A `dsh_version_unavailable` result
-means the selected `dsh` command did not return a valid semantic version. The
+means neither the selected DSH command nor an existing Profile-linked DSH
+runtime supplied a valid semantic version. A `dsh_profile_runtime_stale` result
+means that Profile-linked package is invalid or its original package cache is
+no longer available. Repair or relaunch DSH itself, then rerun the MemoraX Code
+start command. MemoraX Code never invokes `npx` or installs or updates DSH. The
 tested baseline is `0.1.0-rc.6`; another valid version is allowed but marked
 untested. A `pnpm_not_found` result means DSH's native Profile plugin manager
 could not find `pnpm` on `PATH`; install `pnpm`, then rerun the start command.

--- a/packages/npm/memorax-code/bin/memorax-code-setup.mjs
+++ b/packages/npm/memorax-code/bin/memorax-code-setup.mjs
@@ -39,6 +39,7 @@ const BLUE = "\x1b[34m";
 const RED = "\x1b[31m";
 const BOLD = "\x1b[1m";
 const RESET = "\x1b[0m";
+const DSH_OPTIONAL_ENV = "MEMORAX_CODE_DSH_ADAPTER_OPTIONAL";
 
 const skipCodexPluginInstall = truthyEnv(process.env.MEMORAX_CODE_SKIP_CODEX_PLUGIN_INSTALL);
 const skipClaudeAdapterInstall = truthyEnv(process.env.MEMORAX_CODE_SKIP_CLAUDE_ADAPTER_INSTALL);
@@ -255,7 +256,10 @@ if (backendAndAdaptersStatus === "enabled") {
     opencodeAdapterEnabled: !skipOpenCodeAdapter,
   });
 }
-printPostinstallSummary(backendAndAdaptersStatus);
+printPostinstallSummary(
+  backendAndAdaptersStatus,
+  backendAndAdapters.dshAdapterUnavailable,
+);
 if (backendAndAdaptersStatus === "enabled") {
   log("View local memory activity: http://127.0.0.1:8787/memory-viewer");
 }
@@ -1035,12 +1039,16 @@ async function startBackendAndCheck({
   const adapterFlags = clientLifecycleFlags({ clientMode });
   const startArgs = ["start", ...adapterFlags];
   const statusArgs = ["status", ...adapterFlags];
+  const optionalDshEnv = { [DSH_OPTIONAL_ENV]: "1" };
   let statusResult;
   const result = await reconcileSetup({
-    start: () => runMemoraxCodeCommand(startArgs, pendingClientHookRuntimeEnv()),
+    start: () => runMemoraxCodeCommand(startArgs, {
+      ...pendingClientHookRuntimeEnv(),
+      ...optionalDshEnv,
+    }),
     stop: () => runMemoraxCodeCommand(["stop", ...adapterFlags]),
     status: () => {
-      statusResult = runMemoraxCodeCommand(statusArgs);
+      statusResult = runMemoraxCodeCommand(statusArgs, optionalDshEnv);
       return statusResult;
     },
     isReady: (checked) => memoraxCodeEnabled(checked, {
@@ -1086,6 +1094,9 @@ async function startBackendAndCheck({
     dshAdapterEnabled: result.status === "enabled" && statusResult
       ? dshAdapterReady(statusResult)
       : false,
+    dshAdapterUnavailable: result.status === "enabled" && statusResult
+      ? dshAdapterUnavailable(statusResult)
+      : false,
   };
 }
 
@@ -1120,6 +1131,11 @@ function printReconcileFailure(result, {
 function dshAdapterReady(statusResult) {
   const output = `${statusResult.stdout ?? ""}\n${statusResult.stderr ?? ""}`;
   return /\bDSH adapter:\s*ok\b[^\r\n]*\bintegration=plugin\b/im.test(stripAnsi(output));
+}
+
+function dshAdapterUnavailable(statusResult) {
+  const output = `${statusResult.stdout ?? ""}\n${statusResult.stderr ?? ""}`;
+  return /\bDSH adapter:\s*unavailable\b/im.test(stripAnsi(output));
 }
 
 function pendingClientHookRuntimeEnv() {
@@ -1403,10 +1419,10 @@ function statusCommandText({
   return `${commands.slice(0, -1).join(", ")}, and ${commands.at(-1)}`;
 }
 
-function printPostinstallSummary(backendAndAdaptersStatus) {
+function printPostinstallSummary(backendAndAdaptersStatus, degraded = false) {
   log("Package: Installed");
   const backendStatusLabel = backendAndAdaptersStatus === "enabled"
-    ? blueBold("Enabled")
+    ? blueBold(degraded ? "Enabled (degraded)" : "Enabled")
     : backendAndAdaptersStatus === "unavailable"
       ? redBold("Unavailable")
       : "Not verified";

--- a/packages/npm/memorax-code/test/setup.test.mjs
+++ b/packages/npm/memorax-code/test/setup.test.mjs
@@ -280,6 +280,7 @@ async function runSetup({ existingCache = false, explicitCache = false, hookRunt
     "import { appendFileSync, existsSync, readdirSync, rmSync, writeFileSync } from 'node:fs';",
     "import { join } from 'node:path';",
     `appendFileSync(${JSON.stringify(logPath)}, 'memorax-code ' + process.argv.slice(2).join(' ') + '\\n');`,
+    `if (process.env.MEMORAX_CODE_DSH_ADAPTER_OPTIONAL === '1') appendFileSync(${JSON.stringify(logPath)}, 'dsh-adapter-optional ' + process.argv[2] + '\\n');`,
     `if (process.argv[2] === 'codex-plugin') appendFileSync(${JSON.stringify(logPath)}, 'codex-runtime ' + (process.env.CODEX_CLI_PATH ?? '') + '\\n');`,
     "if (process.argv[2] === '--version') { console.log('memorax-code 0.1.1-test'); process.exit(0); }",
     `const hookSnapshot = ${JSON.stringify(hookSnapshot)};`,
@@ -727,6 +728,8 @@ test("setup fresh install auto-detects Codex and skips an unavailable Claude run
     assert.match(run.log, /^memorax-code codex-plugin install --json$/m);
     assert.match(run.log, /^memorax-code start --clients codex,dsh$/m);
     assert.match(run.log, /^memorax-code status --clients codex,dsh$/m);
+    assert.match(run.log, /^dsh-adapter-optional start$/m);
+    assert.match(run.log, /^dsh-adapter-optional status$/m);
     assert.match(run.result.stderr, /Backend and selected adapters: .*Enabled/);
     const config = await readFile(join(run.memoraxCodeHome, "config.toml"), "utf8");
     assert.match(config, /\[clients\][^\r\n]*\r?\ncodex = true[^\r\n]*\r?\nclaude = false[^\r\n]*\r?\ndsh = true[^\r\n]*\r?\nopencode = false/m);

--- a/packages/ts/memorax-code-backend/src/entrypoints/backend-cli.ts
+++ b/packages/ts/memorax-code-backend/src/entrypoints/backend-cli.ts
@@ -516,7 +516,8 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function printMemoraxCodeStatus(report: MemoraxCodeStatusReport): void {
   const backend = report.backend;
-  backendLog(`MemoraX Code Backend status: ${report.ok ? blueBold("Enabled") : redBold("Unavailable")}`);
+  const degraded = report.degraded === true;
+  backendLog(`MemoraX Code Backend status: ${report.ok ? blueBold(degraded ? "Enabled (degraded)" : "Enabled") : redBold("Unavailable")}`);
   backendLog(report.ok
     ? green("MemoraX Code is ready for new client sessions.")
     : red("MemoraX Code is not ready for new client sessions."));
@@ -619,7 +620,7 @@ export async function runBackendTokenCommand(
 }
 
 function printLifecycleResult(report: MemoraxCodeLifecycleReport): void {
-  const degraded = report.backend?.degraded === true;
+  const degraded = report.degraded === true || report.backend?.degraded === true;
   backendLog(`${lifecycleActionLabel(report.action)}: ${report.ok ? green(degraded ? "ok (degraded)" : "ok") : red("needs attention")}`);
   if (report.message) backendLog(report.message);
   if (report.backend) {
@@ -701,29 +702,29 @@ function lifecycleGuidance(report: MemoraxCodeLifecycleReport): string[] {
         "Adapters were not changed for this command.",
       ];
     }
-    const optionalDshSkipped = isOptionalUnavailableDshAdapter(report.dshAdapter);
+    const optionalDshUnavailable = isOptionalUnavailableDshAdapter(report.dshAdapter);
     if ((!report.codexAdapter || isAdapterReady(report.codexAdapter))
       && (!report.claudeAdapter || isAdapterReady(report.claudeAdapter))
       && (!report.dshAdapter
         || isAdapterReady(report.dshAdapter)
-        || optionalDshSkipped)
+        || optionalDshUnavailable)
       && (!report.opencodeAdapter || isAdapterReady(report.opencodeAdapter))) {
       return [
-        green(optionalDshSkipped
+        green(optionalDshUnavailable
           && !report.codexAdapter
           && !report.claudeAdapter
           && !report.opencodeAdapter
-          ? "Backend is running; the optional DSH integration was skipped."
+          ? "Backend is running; the optional DSH integration is unavailable."
           : "Backend is running and available client integrations are enabled."),
-        ...(optionalDshSkipped
-          ? [`DSH integration was skipped: ${report.dshAdapter?.reason ?? "not available"}.`]
+        ...(optionalDshUnavailable
+          ? [`DSH integration is unavailable: ${report.dshAdapter?.reason ?? "not available"}.`]
           : []),
         ...(report.codexAdapter || report.claudeAdapter || report.opencodeAdapter
           ? [
               green("Existing sessions with the stable plugin shell select the active runtime on their next user prompt."),
               "Restart or refresh a client only if its plugin shell changed or MemoraX Code is not active on the next prompt.",
             ]
-          : optionalDshSkipped
+          : optionalDshUnavailable
             ? []
             : [green("New DSH sessions can use MemoraX Code through the active Profile integration.")]),
       ];
@@ -792,15 +793,15 @@ function lifecycleGuidance(report: MemoraxCodeLifecycleReport): string[] {
 
 function statusGuidance(report: MemoraxCodeStatusReport): string[] {
   if (report.ok) {
-    const optionalDshSkipped = isOptionalUnavailableDshAdapter(report.dshAdapter);
+    const optionalDshUnavailable = isOptionalUnavailableDshAdapter(report.dshAdapter);
     if (report.dshAdapter
       && !report.codexAdapter
       && !report.claudeAdapter
       && !report.opencodeAdapter) {
-      if (optionalDshSkipped) {
+      if (optionalDshUnavailable) {
         return [
-          green("Backend is running; the optional DSH integration was skipped."),
-          `DSH integration was skipped: ${report.dshAdapter.reason ?? "not available"}.`,
+          green("Backend is running; the optional DSH integration is unavailable."),
+          `DSH integration is unavailable: ${report.dshAdapter.reason ?? "not available"}.`,
         ];
       }
       return [
@@ -810,8 +811,8 @@ function statusGuidance(report: MemoraxCodeStatusReport): string[] {
     }
     return [
       green("MemoraX Code is ready; sessions with the stable plugin shell use the active Hook runtime on their next user prompt."),
-      ...(optionalDshSkipped
-        ? [`DSH integration was skipped: ${report.dshAdapter?.reason ?? "not available"}.`]
+      ...(optionalDshUnavailable
+        ? [`DSH integration is unavailable: ${report.dshAdapter?.reason ?? "not available"}.`]
         : []),
       "Restart or refresh a client only if its plugin shell was installed, changed, or newly enabled, or MemoraX Code is not active on the next prompt.",
     ];
@@ -928,7 +929,7 @@ function claudeAdapterStatusLine(report: AdapterReport, codexAdapter?: AdapterRe
 
 function dshAdapterStatusLine(report: AdapterReport): string {
   if (isOptionalUnavailableDshAdapter(report)) {
-    return `skipped ${report.reason ?? "not-detected"}`;
+    return `unavailable ${report.reason ?? "not-detected"}`;
   }
   const version = report.version ?? report.dshVersion;
   const tested = version && report.dshVersionTested !== undefined

--- a/packages/ts/memorax-code-backend/src/lifecycle/orchestrator.ts
+++ b/packages/ts/memorax-code-backend/src/lifecycle/orchestrator.ts
@@ -278,7 +278,7 @@ async function executeMemoraxCodeStart(
   const quiescedDsh = dshLifecycle && (clients.dsh || previousClients?.dsh)
     ? await dshLifecycle.quiesce?.(lifecycleContext)
     : undefined;
-  if (quiescedDsh?.ok === false) {
+  if (quiescedDsh?.ok === false && !optionalDsh) {
     return {
       ok: false,
       action: "start",
@@ -388,9 +388,14 @@ async function executeMemoraxCodeStart(
       opencodeAdapter,
     };
   }
-  const preparedDshAdapter = markOptionalDshAdapter(clients.dsh && dshLifecycle
-    ? await dshLifecycle.prepareEnable(lifecycleBackendContext)
-    : undefined, optionalDsh);
+  const preparedDshAdapter = markOptionalDshAdapter(
+    quiescedDsh?.ok === false
+      ? quiescedDsh
+      : clients.dsh && dshLifecycle
+        ? await dshLifecycle.prepareEnable(lifecycleBackendContext)
+        : undefined,
+    optionalDsh,
+  );
   if (preparedDshAdapter?.ok === false && !optionalDsh) {
     const recovery = await recoverPreparationFailure("dsh_adapter_enable_failed");
     return {

--- a/packages/ts/memorax-code-backend/src/lifecycle/orchestrator.ts
+++ b/packages/ts/memorax-code-backend/src/lifecycle/orchestrator.ts
@@ -42,6 +42,7 @@ export type {
 export type MemoraxCodeStatusReport = {
   ok: boolean;
   action: "status";
+  degraded?: true;
   backend: Awaited<ReturnType<typeof runBackendStatus>>;
   codexAdapter?: AdapterReport;
   claudeAdapter?: AdapterReport;
@@ -52,6 +53,7 @@ export type MemoraxCodeStatusReport = {
 export type MemoraxCodeLifecycleReport = {
   ok: boolean;
   action: "start" | "stop" | "restart" | "uninstall";
+  degraded?: true;
   reason?: string;
   message?: string;
   backend?: Awaited<ReturnType<typeof startBackendService | typeof stopBackendService>>;
@@ -89,6 +91,7 @@ type MemoraxCodeStopExecution = Readonly<{
 }>;
 
 const PACKAGE_REPLACEMENT_ENV = "MEMORAX_CODE_PACKAGE_REPLACEMENT";
+const DSH_OPTIONAL_ENV = "MEMORAX_CODE_DSH_ADAPTER_OPTIONAL";
 const DSH_RECOVERY_ENV = "MEMORAX_CODE_DSH_ADAPTER_RECOVERY";
 const DSH_RECOVERY_REVISION_ENV = "MEMORAX_CODE_DSH_ADAPTER_EXPECTED_REVISION";
 
@@ -133,9 +136,12 @@ export async function collectMemoraxCodeStatus(
   const claudeAdapter = clients.claude
     ? await claudeAdapterLifecycle.status({ argv, serviceOptions, backendUrl })
     : undefined;
-  const dshAdapter = clients.dsh
-    ? await collectDshAdapterLifecycleStatus({ argv, serviceOptions, backendUrl })
-    : undefined;
+  const dshAdapter = markOptionalDshAdapter(
+    clients.dsh
+      ? await collectDshAdapterLifecycleStatus({ argv, serviceOptions, backendUrl })
+      : undefined,
+    clients.dsh && isOptionalDshSelection(argv),
+  );
   const opencodeAdapter = clients.opencode
     ? await openCodeAdapterLifecycle.status({ argv, serviceOptions, backendUrl })
     : undefined;
@@ -143,13 +149,15 @@ export async function collectMemoraxCodeStatus(
   const claudeReady = claudeAdapter ? isAdapterReady(claudeAdapter) : true;
   const dshReady = dshAdapter ? isAdapterReady(dshAdapter) : true;
   const opencodeReady = opencodeAdapter ? isAdapterReady(opencodeAdapter) : true;
+  const optionalDshUnavailable = isOptionalUnavailableDshAdapter(dshAdapter);
   return {
     ok: backend.ok
       && codexReady
       && opencodeReady
       && (isOptionalUnconfiguredClaudeAdapter(claudeAdapter, codexAdapter) || claudeReady)
-      && (isOptionalUnavailableDshAdapter(dshAdapter) || dshReady),
+      && (optionalDshUnavailable || dshReady),
     action: "status",
+    ...(optionalDshUnavailable ? { degraded: true } : {}),
     backend,
     ...(codexAdapter ? { codexAdapter } : {}),
     ...(claudeAdapter ? { claudeAdapter } : {}),
@@ -204,6 +212,7 @@ async function startMemoraxCodeServiceLocked(
     ? { ...requestedClients, dsh: true }
     : requestedClients;
   const previousClients = readActiveManagedClients(memoraxCodeHome);
+  const optionalDsh = clients.dsh && isOptionalDshSelection(argv);
   const context = { argv, serviceOptions };
   if (clients.dsh || previousClients?.dsh || isDshAdapterRecovery()) {
     try {
@@ -216,6 +225,7 @@ async function startMemoraxCodeServiceLocked(
           clients,
           previousClients,
           dshLifecycle,
+          optionalDsh,
         )
       ));
     } catch (error) {
@@ -240,6 +250,7 @@ async function executeMemoraxCodeStart(
   clients: ManagedClients,
   previousClients: ManagedClients | undefined,
   dshLifecycle?: DshAdapterLifecycleParticipant,
+  optionalDsh = false,
 ): Promise<MemoraxCodeLifecycleReport> {
   const lifecycleContext = { argv, serviceOptions };
   const lifecycleBackendContext = { ...lifecycleContext, backendUrl };
@@ -377,10 +388,10 @@ async function executeMemoraxCodeStart(
       opencodeAdapter,
     };
   }
-  const preparedDshAdapter = clients.dsh && dshLifecycle
+  const preparedDshAdapter = markOptionalDshAdapter(clients.dsh && dshLifecycle
     ? await dshLifecycle.prepareEnable(lifecycleBackendContext)
-    : undefined;
-  if (preparedDshAdapter?.ok === false) {
+    : undefined, optionalDsh);
+  if (preparedDshAdapter?.ok === false && !optionalDsh) {
     const recovery = await recoverPreparationFailure("dsh_adapter_enable_failed");
     return {
       ok: false,
@@ -414,12 +425,15 @@ async function executeMemoraxCodeStart(
       ...(disabledOpenCode ? { opencodeAdapter: disabledOpenCode } : {}),
     };
   }
-  const dshAdapter = preparedDshAdapter?.installed === true
+  const dshAdapter = markOptionalDshAdapter(preparedDshAdapter?.installed === true
     ? await dshLifecycle?.activate?.(lifecycleBackendContext)
-    : preparedDshAdapter;
+    : preparedDshAdapter, optionalDsh);
+  const optionalDshUnavailable = isOptionalUnavailableDshAdapter(dshAdapter);
   return {
-    ok: claudeAdapter?.ok !== false && dshAdapter?.ok !== false,
+    ok: claudeAdapter?.ok !== false
+      && (!dshAdapter || isAdapterReady(dshAdapter) || optionalDshUnavailable),
     action: "start",
+    ...(optionalDshUnavailable ? { degraded: true } : {}),
     backend,
     ...(codexAdapter ? { codexAdapter } : {}),
     ...(claudeAdapter ? { claudeAdapter } : {}),
@@ -870,6 +884,11 @@ function hasExplicitClientSelection(argv: string[]): boolean {
   return argv.includes("--clients");
 }
 
+function isOptionalDshSelection(argv: string[]): boolean {
+  return !isDshAdapterRecovery()
+    && (!hasExplicitClientSelection(argv) || truthyEnv(process.env[DSH_OPTIONAL_ENV]));
+}
+
 function argValue(argv: string[], name: string): string | undefined {
   const index = argv.indexOf(name);
   return index >= 0 ? argv[index + 1] : undefined;
@@ -1051,13 +1070,16 @@ export function isAdapterReady(report: AdapterReport): boolean {
 }
 
 export function isOptionalUnavailableDshAdapter(report: AdapterReport | undefined): boolean {
-  return Boolean(
-    report
-      && report.ok !== false
-      && report.skipped === true
-      && report.managed !== true
-      && report.reason === "no_existing_profiles",
-  );
+  return Boolean(report?.optional === true && !isAdapterReady(report));
+}
+
+function markOptionalDshAdapter(
+  report: AdapterReport | undefined,
+  optional: boolean,
+): AdapterReport | undefined {
+  return report && optional && !isAdapterReady(report)
+    ? { ...report, optional: true }
+    : report;
 }
 
 

--- a/packages/ts/memorax-code-backend/src/lifecycle/participant.ts
+++ b/packages/ts/memorax-code-backend/src/lifecycle/participant.ts
@@ -25,6 +25,7 @@ export type AdapterReport = {
   statePath?: string;
   changed?: boolean;
   skipped?: boolean;
+  optional?: true;
   reason?: string;
   message?: string;
   error?: string;

--- a/packages/ts/memorax-code-backend/test/lifecycle/dsh-participant.test.mjs
+++ b/packages/ts/memorax-code-backend/test/lifecycle/dsh-participant.test.mjs
@@ -291,6 +291,34 @@ test("setup-marked DSH preparation failures keep the Backend available", async (
   }
 });
 
+test("setup-marked DSH quiesce failures degrade without blocking the Backend", async () => {
+  const fixture = await createFixture();
+  try {
+    mkdirSync(dirname(fixture.statePath), { recursive: true });
+    writeJson(fixture.statePath, { version: 999 });
+
+    const strict = runCli(fixture, "start", ["--clients", "dsh"]);
+    assert.equal(strict.status, 1, `${strict.stdout}\n${strict.stderr}`);
+    assert.equal(JSON.parse(strict.stdout).dshAdapter.reason, "state_invalid");
+
+    const started = runCli(fixture, "start", ["--clients", "dsh"], {
+      MEMORAX_CODE_DSH_ADAPTER_OPTIONAL: "1",
+    });
+    assert.equal(started.status, 0, `${started.stdout}\n${started.stderr}`);
+    const report = JSON.parse(started.stdout);
+    assert.equal(report.ok, true);
+    assert.equal(report.degraded, true);
+    assert.equal(report.backend.ok, true);
+    assert.equal(report.dshAdapter.action, "dsh-plugin-quiesce");
+    assert.equal(report.dshAdapter.reason, "state_invalid");
+    assert.equal(report.dshAdapter.optional, true);
+    assert.equal(existsSync(fixture.pidPath), true);
+  } finally {
+    runCli(fixture, "stop", ["--clients", "none"]);
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
 test("an existing DSH Profile with an unavailable command needs attention", async () => {
   const fixture = await createFixture();
   try {

--- a/packages/ts/memorax-code-backend/test/lifecycle/dsh-participant.test.mjs
+++ b/packages/ts/memorax-code-backend/test/lifecycle/dsh-participant.test.mjs
@@ -238,18 +238,53 @@ test("failed DSH deselection restores every previously enabled Profile", async (
   }
 });
 
-test("DSH-only status reports an optional skip when no Profile exists", async () => {
+test("automatic DSH discovery degrades without a Profile while explicit selection stays strict", async () => {
   const fixture = await createFixture();
   try {
+    writeDshOnlyConfig(fixture);
     rmSync(join(fixture.dshHome, "profiles"), { recursive: true, force: true });
-    const started = runCli(fixture, "start", ["--clients", "none"]);
-    assert.equal(started.status, 0, `${started.stdout}\n${started.stderr}`);
 
-    const status = runHumanCli(fixture, "status", ["--clients", "dsh"]);
+    const started = runCli(fixture, "start");
+    assert.equal(started.status, 0, `${started.stdout}\n${started.stderr}`);
+    const startReport = JSON.parse(started.stdout);
+    assert.equal(startReport.ok, true);
+    assert.equal(startReport.degraded, true);
+    assert.equal(startReport.backend.ok, true);
+    assert.equal(startReport.dshAdapter.optional, true);
+    assert.equal(startReport.dshAdapter.reason, "no_existing_profiles");
+
+    const status = runHumanCli(fixture, "status");
     assert.equal(status.status, 0, `${status.stdout}\n${status.stderr}`);
-    assert.match(status.stdout, /optional DSH integration was skipped/);
-    assert.match(status.stdout, /DSH integration was skipped: no_existing_profiles/);
+    assert.match(status.stdout, /optional DSH integration is unavailable/);
+    assert.match(status.stdout, /DSH integration is unavailable: no_existing_profiles/);
     assert.doesNotMatch(status.stdout, /ready for new DSH sessions/);
+
+    const explicit = runHumanCli(fixture, "status", ["--clients", "dsh"]);
+    assert.equal(explicit.status, 1, `${explicit.stdout}\n${explicit.stderr}`);
+    assert.match(explicit.stdout, /DSH adapter: skipped no_existing_profiles/);
+    assert.doesNotMatch(explicit.stdout, /optional DSH integration is unavailable/);
+  } finally {
+    runCli(fixture, "stop", ["--clients", "none"]);
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("setup-marked DSH preparation failures keep the Backend available", async () => {
+  const fixture = await createFixture();
+  try {
+    const started = runCli(fixture, "start", ["--clients", "dsh"], {
+      FAKE_DSH_VERSION: "not-a-semver",
+      MEMORAX_CODE_DSH_ADAPTER_OPTIONAL: "1",
+    });
+    assert.equal(started.status, 0, `${started.stdout}\n${started.stderr}`);
+    const report = JSON.parse(started.stdout);
+    assert.equal(report.ok, true);
+    assert.equal(report.degraded, true);
+    assert.equal(report.backend.ok, true);
+    assert.equal(report.dshAdapter.ok, false);
+    assert.equal(report.dshAdapter.optional, true);
+    assert.equal(report.dshAdapter.reason, "dsh_version_unavailable");
+    assert.equal(existsSync(fixture.pidPath), true);
   } finally {
     runCli(fixture, "stop", ["--clients", "none"]);
     rmSync(fixture.root, { recursive: true, force: true });
@@ -414,6 +449,18 @@ function childEnv(fixture, overrides) {
     FAKE_DSH_LOG: fixture.dshLog,
     ...overrides,
   };
+}
+
+function writeDshOnlyConfig(fixture) {
+  mkdirSync(fixture.memoraxCodeHome, { recursive: true });
+  writeFileSync(join(fixture.memoraxCodeHome, "config.toml"), [
+    "[clients]",
+    "codex = false",
+    "claude = false",
+    "dsh = true",
+    "opencode = false",
+    "",
+  ].join("\n"));
 }
 
 async function waitFor(predicate, timeoutMs = 5_000) {

--- a/packages/ts/memorax-code-dsh-adapter/hooks/repo-memory-job.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/hooks/repo-memory-job.mjs
@@ -4,7 +4,10 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runRepoMemoryJob } from "../memorax-code-adapter-common/src/repo-memory/repo-memory-job-supervisor.mjs";
 import { evaluateRepository } from "../memorax-code-adapter-common/src/repo-memory/repo-memory-update-policy-evaluator.mjs";
-import { requireEnabledDshRuntime } from "../src/runtime-state.mjs";
+import {
+  buildDshCommand,
+  requireEnabledDshRuntime,
+} from "../src/runtime-state.mjs";
 
 const ADAPTER_PACKAGE_NAME = "@memorax-code/dsh-memorax-code";
 const HEADLESS_BUNDLE_NAME = "@deepseek-ai/dsh-headless";
@@ -23,7 +26,7 @@ try {
     validatorPath: resolve(pluginRoot, "skills/memorax-code/scripts/validate_memory.py"),
     evaluateRepository,
     createCommand({ prompt }) {
-      return [runtime.dshCommand, "--profile", profile, prompt];
+      return buildDshCommand(runtime.dshCommand, ["--profile", profile, prompt]);
     },
   });
   process.stdout.write(`${JSON.stringify(payload)}\n`);

--- a/packages/ts/memorax-code-dsh-adapter/src/profile-lifecycle.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/src/profile-lifecycle.mjs
@@ -6,6 +6,7 @@ import {
   lstatSync,
   mkdirSync,
   readFileSync,
+  realpathSync,
   readdirSync,
   renameSync,
   rmSync,
@@ -22,6 +23,7 @@ import {
   parseDshVersion,
 } from "./dsh-version.mjs";
 import {
+  buildDshCommand,
   requireDshRuntimeAuthority,
   requireEnabledDshRuntime,
 } from "./runtime-state.mjs";
@@ -49,6 +51,7 @@ const { resolveWindowsCliInvocation } = await import(
 
 const STATE_VERSION = 1;
 const RUNTIME = "dsh";
+const DSH_PACKAGE_NAME = "@deepseek-ai/dsh";
 const ADAPTER_PACKAGE_NAME = "@memorax-code/dsh-memorax-code";
 const HEADLESS_PROFILE_NAME = "headless";
 const HEADLESS_BUNDLE_NAME = "@deepseek-ai/dsh-headless";
@@ -160,14 +163,14 @@ export function collectDshAdapterStatus(options = {}) {
       return { ok: true, ...base, skipped: true, reason: "no_existing_profiles" };
     }
 
-    const dshCommand = resolveDshCommand(options, paths, state);
-    const compatibility = inspectDshCompatibility(options, paths, dshCommand);
+    const { dshCommand, compatibility } = resolveDshCompatibility(options, paths, state);
     const version = compatibility.dshVersion;
     const versionStatus = {
       dshVersionTested: compatibility.dshVersionTested,
       testedDshVersions: [...DSH_TESTED_VERSIONS],
     };
-    if (compatibility.reason === "dsh_version_unavailable") {
+    if (compatibility.reason === "dsh_version_unavailable"
+      || compatibility.reason === "dsh_profile_runtime_stale") {
       return {
         ok: false,
         ...base,
@@ -327,8 +330,7 @@ function ensureDshPluginInstalledUnlocked(paths, options) {
     };
   }
 
-  const dshCommand = resolveDshCommand(options, paths, state);
-  const compatibility = inspectDshCompatibility(options, paths, dshCommand);
+  const { dshCommand, compatibility } = resolveDshCompatibility(options, paths, state);
   if (compatibility.compatible !== true) {
     const nextState = state?.enabled === true
       ? disabledState(state, state.profiles)
@@ -805,7 +807,13 @@ function disableDshPluginInstallationUnlocked(paths, options, removeState) {
   };
 }
 
-function removeProfileAdapterPackages(paths, options, name, packageNames, dshCommand) {
+function removeProfileAdapterPackages(
+  paths,
+  options,
+  name,
+  packageNames,
+  dshCommand,
+) {
   const profilePath = join(paths.profilesRoot, name);
   let profile = inspectProfile(name, profilePath);
   let failure;
@@ -1049,14 +1057,138 @@ function resolveDshCommand(options, paths, state) {
     ?? nonEmpty(paths.env.MEMORAX_CODE_DSH_COMMAND)
     ?? nonEmpty(state?.dshCommand)
     ?? "dsh";
+  const normalized = normalizeDshCommand(command);
+  if (normalized) return normalized;
+  const profileRuntime = inspectProfileDshRuntime(paths, state);
+  return profileRuntime?.compatibility.compatible === true
+    ? profileRuntime.dshCommand
+    : "dsh";
+}
+
+function resolveDshCompatibility(options, paths, state) {
+  const configured = nonEmpty(options.dshCommand)
+    ?? nonEmpty(paths.env.MEMORAX_CODE_DSH_COMMAND);
+  if (configured) {
+    const dshCommand = normalizeDshCommand(configured);
+    return dshCommand
+      ? { dshCommand, compatibility: inspectDshCompatibility(options, paths, dshCommand) }
+      : {
+          dshCommand: configured,
+          compatibility: unavailableDshCompatibility("dsh_version_unavailable"),
+        };
+  }
+
+  const profileRuntime = inspectProfileDshRuntime(paths, state);
+  const attemptedCommands = new Set();
+  let unavailable;
+  for (const value of [state?.dshCommand, "dsh"]) {
+    const dshCommand = normalizeDshCommand(value);
+    if (!dshCommand || attemptedCommands.has(dshCommand)) continue;
+    attemptedCommands.add(dshCommand);
+    if (dshCommand === profileRuntime?.dshCommand) {
+      if (profileRuntime.compatibility.compatible === true) return profileRuntime;
+      continue;
+    }
+    const compatibility = inspectDshCompatibility(options, paths, dshCommand);
+    if (compatibility.compatible === true) return { dshCommand, compatibility };
+    unavailable ??= { dshCommand, compatibility };
+  }
+  if (profileRuntime?.compatibility.compatible === true) return profileRuntime;
+  if (profileRuntime?.compatibility.reason === "dsh_profile_runtime_stale") {
+    return {
+      dshCommand: profileRuntime.dshCommand ?? unavailable?.dshCommand ?? "dsh",
+      compatibility: profileRuntime.compatibility,
+    };
+  }
+  return unavailable ?? {
+    dshCommand: "dsh",
+    compatibility: unavailableDshCompatibility("dsh_version_unavailable"),
+  };
+}
+
+function normalizeDshCommand(value) {
+  const command = nonEmpty(value);
+  if (!command) return undefined;
+  const name = command
+    .split(/[\\/]/)
+    .at(-1)
+    .replace(/\.(?:cmd|bat|exe|com)$/i, "")
+    .toLowerCase();
+  if (name === "npx") return undefined;
   return command.includes("/") || command.includes("\\") ? resolve(command) : command;
+}
+
+function inspectProfileDshRuntime(paths, state) {
+  const packageRoot = join(paths.profilesRoot, "node_modules", ...DSH_PACKAGE_NAME.split("/"));
+  const persistedCommand = normalizeDshCommand(state?.dshCommand);
+  const profileCommand = persistedCommand && isPathInside(persistedCommand, packageRoot)
+    ? persistedCommand
+    : undefined;
+  try {
+    lstatSync(packageRoot);
+  } catch (error) {
+    return error?.code === "ENOENT" && !profileCommand
+      ? undefined
+      : {
+          dshCommand: profileCommand,
+          compatibility: unavailableDshCompatibility("dsh_profile_runtime_stale"),
+        };
+  }
+
+  try {
+    const realPackageRoot = realpathSync(packageRoot);
+    if (!lstatSync(realPackageRoot).isDirectory()) throw new Error("DSH package root is not a directory");
+    const manifest = readJsonObject(join(realPackageRoot, "package.json"));
+    const version = manifest?.name === DSH_PACKAGE_NAME
+      ? parseDshVersion(manifest.version)
+      : undefined;
+    const bin = manifest?.bin !== null
+      && typeof manifest?.bin === "object"
+      && !Array.isArray(manifest.bin)
+      ? nonEmpty(manifest.bin.dsh)
+      : undefined;
+    if (!version || !bin || isAbsolute(bin)) throw new Error("DSH package metadata is invalid");
+
+    const dshCommand = resolve(packageRoot, bin);
+    const realCommand = realpathSync(dshCommand);
+    if (!isPathInside(dshCommand, packageRoot)
+      || !isPathInside(realCommand, realPackageRoot)
+      || !lstatSync(realCommand).isFile()) {
+      throw new Error("DSH package entrypoint is invalid");
+    }
+    return {
+      dshCommand,
+      compatibility: {
+        compatible: true,
+        dshVersion: version,
+        dshVersionTested: isTestedDshVersion(version),
+        testedDshVersions: [...DSH_TESTED_VERSIONS],
+      },
+    };
+  } catch {
+    return {
+      dshCommand: profileCommand,
+      compatibility: unavailableDshCompatibility("dsh_profile_runtime_stale"),
+    };
+  }
+}
+
+function unavailableDshCompatibility(reason) {
+  return {
+    compatible: false,
+    reason,
+    testedDshVersions: [...DSH_TESTED_VERSIONS],
+  };
 }
 
 function runDsh(options, paths, args, command) {
   const env = { ...paths.env, DSH_HOME: paths.dshHome };
   let executable;
   try {
-    executable = resolveWindowsCliInvocation(command, args, {
+    const [launcher, ...launcherArgs] = buildDshCommand(command, args, {
+      nodePath: options.windowsCliResolution?.nodePath,
+    });
+    executable = resolveWindowsCliInvocation(launcher, launcherArgs, {
       ...options.windowsCliResolution,
       env,
     });

--- a/packages/ts/memorax-code-dsh-adapter/src/profile-lifecycle.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/src/profile-lifecycle.mjs
@@ -163,7 +163,11 @@ export function collectDshAdapterStatus(options = {}) {
       return { ok: true, ...base, skipped: true, reason: "no_existing_profiles" };
     }
 
-    const { dshCommand, compatibility } = resolveDshCompatibility(options, paths, state);
+    const { dshCommand, compatibility } = resolveDshStatusCompatibility(
+      options,
+      paths,
+      state,
+    );
     const version = compatibility.dshVersion;
     const versionStatus = {
       dshVersionTested: compatibility.dshVersionTested,
@@ -1063,6 +1067,21 @@ function resolveDshCommand(options, paths, state) {
   return profileRuntime?.compatibility.compatible === true
     ? profileRuntime.dshCommand
     : "dsh";
+}
+
+function resolveDshStatusCompatibility(options, paths, state) {
+  if (state?.enabled !== true) return resolveDshCompatibility(options, paths, state);
+  const dshCommand = normalizeDshCommand(state.dshCommand);
+  if (!dshCommand) {
+    return {
+      dshCommand: state.dshCommand,
+      compatibility: unavailableDshCompatibility("dsh_version_unavailable"),
+    };
+  }
+  const profileRuntime = inspectProfileDshRuntime(paths, state);
+  return profileRuntime?.dshCommand === dshCommand
+    ? profileRuntime
+    : { dshCommand, compatibility: inspectDshCompatibility(options, paths, dshCommand) };
 }
 
 function resolveDshCompatibility(options, paths, state) {

--- a/packages/ts/memorax-code-dsh-adapter/src/runtime-state.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/src/runtime-state.mjs
@@ -5,6 +5,17 @@ import { parseDshVersion } from "./dsh-version.mjs";
 
 const PACKAGE_METADATA_VERSION = 1;
 const STATE_VERSION = 1;
+
+export function buildDshCommand(command, args, options = {}) {
+  const executable = nonEmptyString(command);
+  if (!executable) throw new TypeError("DSH command must be a non-empty string");
+  if (!Array.isArray(args)) throw new TypeError("DSH arguments must be an array");
+  if (isNpxCommand(executable)) throw disabledError();
+  return isAbsolute(executable) && /\.(?:cjs|js|mjs)$/i.test(executable)
+    ? [nonEmptyString(options.nodePath) ?? process.execPath, executable, ...args]
+    : [executable, ...args];
+}
+
 /** Read the current durable enablement authority for this installed DSH bundle. */
 export function requireEnabledDshRuntime(pluginRoot) {
   const authority = requireDshRuntimeAuthority(pluginRoot);
@@ -28,6 +39,7 @@ export function requireDshRuntimeAuthority(pluginRoot) {
     || !nonEmptyString(metadata.memoraxCodeCommand)
     || !nonEmptyString(metadata.memoraxCodeHome)
     || !nonEmptyString(metadata.dshCommand)
+    || isNpxCommand(metadata.dshCommand)
     || !nonEmptyString(metadata.dshHome)
     || !parseDshVersion(metadata.dshVersion)
     || !nonEmptyString(metadata.sourceAdapterRoot)
@@ -100,6 +112,15 @@ function resolveString(value) {
 
 function nonEmptyString(value) {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function isNpxCommand(value) {
+  const command = nonEmptyString(value);
+  return Boolean(command && command
+    .split(/[\\/]/)
+    .at(-1)
+    .replace(/\.(?:cmd|bat|exe|com)$/i, "")
+    .toLowerCase() === "npx");
 }
 
 function timestampString(value) {

--- a/packages/ts/memorax-code-dsh-adapter/test/profile-lifecycle.test.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/test/profile-lifecycle.test.mjs
@@ -612,7 +612,7 @@ test("reports pnpm missing from DSH's native Profile plugin manager", async (t) 
   ]);
 });
 
-test("materializes one runtime generation and provisions a web-only headless worker", async (t) => {
+test("uses the DSH runtime already linked by Profiles and refreshes it on reconciliation", async (t) => {
   const root = mkdtempSync(join(tmpdir(), "memorax-code-dsh-runtime-bundle-"));
   t.after(() => rmSync(root, { recursive: true, force: true }));
   const adapterRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
@@ -635,7 +635,22 @@ test("materializes one runtime generation and provisions a web-only headless wor
       "@deepseek-ai/dsh-web-app",
     ] } },
   });
+  const dshPackageRoot = join(
+    profilesRoot,
+    "node_modules",
+    "@deepseek-ai",
+    "dsh",
+  );
+  const dshEntrypoint = join(dshPackageRoot, "lib", "bin.js");
+  mkdirSync(dirname(dshEntrypoint), { recursive: true });
+  writeJson(join(dshPackageRoot, "package.json"), {
+    name: "@deepseek-ai/dsh",
+    version: "0.1.0-rc.6",
+    bin: { dsh: "lib/bin.js" },
+  });
+  writeFileSync(dshEntrypoint, "#!/usr/bin/env node\n");
 
+  let directProbeCalls = 0;
   let addCalls = 0;
   let packedFiles;
   const options = {
@@ -644,14 +659,22 @@ test("materializes one runtime generation and provisions a web-only headless wor
     memoraxCodeHome,
     memoraxCodeCommand: join(root, "memorax-code.mjs"),
     runDsh(invocation) {
-      if (invocation.args.length === 1 && invocation.args[0] === "--version") {
-        return { status: 0, stdout: "0.1.0-rc.6\n" };
+      if (invocation.command === "dsh") {
+        directProbeCalls += 1;
+        assert.deepEqual(invocation.args, ["--version"]);
+        return {
+          status: 1,
+          error: Object.assign(new Error("missing dsh"), { code: "ENOENT" }),
+        };
       }
+      assert.equal(invocation.command, process.execPath);
+      assert.equal(invocation.args[0], dshEntrypoint);
+      const dshArgs = invocation.args.slice(1);
       assert.deepEqual(
-        [invocation.args[0], invocation.args[1], invocation.args[3]],
+        [dshArgs[0], dshArgs[1], dshArgs[3]],
         ["plugin", "--profile", "add"],
       );
-      const profileName = invocation.args[2];
+      const profileName = dshArgs[2];
       if (profileName === "headless") {
         writeProfile(profilesRoot, profileName, [
           "@deepseek-ai/dsh-base",
@@ -661,7 +684,7 @@ test("materializes one runtime generation and provisions a web-only headless wor
       const profileRoot = join(profilesRoot, profileName);
       const profileManifestPath = join(profileRoot, "package.json");
       addCalls += 1;
-      const runtimeBundleRoot = invocation.args[4].slice("file:".length);
+      const runtimeBundleRoot = dshArgs[4].slice("file:".length);
       if (packedFiles === undefined) {
         const pack = spawnSync("npm", [
           "pack",
@@ -678,11 +701,13 @@ test("materializes one runtime generation and provisions a web-only headless wor
         "--no-audit",
         "--no-fund",
         "--package-lock=false",
-        invocation.args[4],
+        dshArgs[4],
       ], { cwd: profileRoot, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
       assert.equal(install.status, 0, install.stderr);
       const manifest = JSON.parse(readFileSync(profileManifestPath, "utf8"));
-      manifest.dsh.profile.bundles.push("@memorax-code/dsh-memorax-code");
+      if (!manifest.dsh.profile.bundles.includes("@memorax-code/dsh-memorax-code")) {
+        manifest.dsh.profile.bundles.push("@memorax-code/dsh-memorax-code");
+      }
       writeJson(profileManifestPath, manifest);
       return { status: 0 };
     },
@@ -702,6 +727,9 @@ test("materializes one runtime generation and provisions a web-only headless wor
   const statePath = join(memoraxCodeHome, "adapters", "dsh", "state.json");
   const firstState = JSON.parse(readFileSync(statePath, "utf8"));
   assert.deepEqual(firstState.profiles, ["headless", "web"]);
+  assert.equal(firstState.dshCommand, dshEntrypoint);
+  assert.equal(firstState.dshVersion, "0.1.0-rc.6");
+  assert.equal(directProbeCalls, 1);
   assert.match(firstState.runtimeBundleRoot, /[/\\]runtime[/\\]generations[/\\][0-9a-f]{64}$/);
   assert.equal(existsSync(join(firstState.runtimeBundleRoot, "src", "profile-lifecycle.mjs")), false);
   assert.equal(existsSync(join(
@@ -744,10 +772,37 @@ test("materializes one runtime generation and provisions a web-only headless wor
   assert.equal(second.ok, true);
   assert.equal(addCalls, 2);
   assert.equal(secondState.runtimeBundleRoot, firstState.runtimeBundleRoot);
+  assert.equal(directProbeCalls, 1);
   assert.deepEqual(
     readdirSync(join(memoraxCodeHome, "adapters", "dsh", "runtime", "generations")),
     [firstState.runtimeBundleRoot.split(/[/\\]/).at(-1)],
   );
+
+  writeJson(join(dshPackageRoot, "package.json"), {
+    name: "@deepseek-ai/dsh",
+    version: "0.1.1-rc.1",
+    bin: { dsh: "lib/bin.js" },
+  });
+  const updated = await withDshPluginLifecycleLock(options, (lifecycle) => (
+    lifecycle.ensureInstalled({ enabled: false })
+  ));
+  const updatedState = JSON.parse(readFileSync(statePath, "utf8"));
+  assert.equal(updated.ok, true);
+  assert.equal(addCalls, 4);
+  assert.equal(directProbeCalls, 1);
+  assert.equal(updatedState.dshCommand, dshEntrypoint);
+  assert.equal(updatedState.dshVersion, "0.1.1-rc.1");
+  assert.notEqual(updatedState.runtimeBundleRoot, firstState.runtimeBundleRoot);
+  assert.deepEqual(
+    readdirSync(join(memoraxCodeHome, "adapters", "dsh", "runtime", "generations")),
+    [updatedState.runtimeBundleRoot.split(/[/\\]/).at(-1)],
+  );
+
+  rmSync(dshPackageRoot, { recursive: true, force: true });
+  const stale = collectDshAdapterStatus(options);
+  assert.equal(stale.ok, false);
+  assert.equal(stale.reason, "dsh_profile_runtime_stale");
+  assert.equal(directProbeCalls, 2);
 });
 
 async function createReconciliationFixture(t) {

--- a/packages/ts/memorax-code-dsh-adapter/test/profile-lifecycle.test.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/test/profile-lifecycle.test.mjs
@@ -650,6 +650,7 @@ test("uses the DSH runtime already linked by Profiles and refreshes it on reconc
   });
   writeFileSync(dshEntrypoint, "#!/usr/bin/env node\n");
 
+  let directDshVersion;
   let directProbeCalls = 0;
   let addCalls = 0;
   let packedFiles;
@@ -662,6 +663,9 @@ test("uses the DSH runtime already linked by Profiles and refreshes it on reconc
       if (invocation.command === "dsh") {
         directProbeCalls += 1;
         assert.deepEqual(invocation.args, ["--version"]);
+        if (directDshVersion) {
+          return { status: 0, stdout: `${directDshVersion}\n` };
+        }
         return {
           status: 1,
           error: Object.assign(new Error("missing dsh"), { code: "ENOENT" }),
@@ -778,11 +782,25 @@ test("uses the DSH runtime already linked by Profiles and refreshes it on reconc
     [firstState.runtimeBundleRoot.split(/[/\\]/).at(-1)],
   );
 
+  const activated = await withDshPluginLifecycleLock(options, (lifecycle) => (
+    lifecycle.activate()
+  ));
+  assert.equal(activated.ok, true, JSON.stringify(activated));
+  assert.equal(activated.enabled, true);
+  directDshVersion = "0.1.1-rc.2";
+  rmSync(dshPackageRoot, { recursive: true, force: true });
+  const stale = collectDshAdapterStatus(options);
+  assert.equal(stale.ok, false);
+  assert.equal(stale.reason, "dsh_profile_runtime_stale");
+  assert.equal(directProbeCalls, 1);
+
+  mkdirSync(dirname(dshEntrypoint), { recursive: true });
   writeJson(join(dshPackageRoot, "package.json"), {
     name: "@deepseek-ai/dsh",
     version: "0.1.1-rc.1",
     bin: { dsh: "lib/bin.js" },
   });
+  writeFileSync(dshEntrypoint, "#!/usr/bin/env node\n");
   const updated = await withDshPluginLifecycleLock(options, (lifecycle) => (
     lifecycle.ensureInstalled({ enabled: false })
   ));
@@ -797,12 +815,6 @@ test("uses the DSH runtime already linked by Profiles and refreshes it on reconc
     readdirSync(join(memoraxCodeHome, "adapters", "dsh", "runtime", "generations")),
     [updatedState.runtimeBundleRoot.split(/[/\\]/).at(-1)],
   );
-
-  rmSync(dshPackageRoot, { recursive: true, force: true });
-  const stale = collectDshAdapterStatus(options);
-  assert.equal(stale.ok, false);
-  assert.equal(stale.reason, "dsh_profile_runtime_stale");
-  assert.equal(directProbeCalls, 2);
 });
 
 async function createReconciliationFixture(t) {

--- a/packages/ts/memorax-code-dsh-adapter/test/runtime-state.test.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/test/runtime-state.test.mjs
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import test from "node:test";
 
 import {
+  buildDshCommand,
   requireDshRuntimeAuthority,
   requireEnabledDshRuntime,
 } from "../src/runtime-state.mjs";
@@ -84,6 +85,10 @@ test("re-reads durable DSH authority without pinning the host version", (t) => {
   writeJson(join(pluginRoot, ".memorax-code-package.json"), updatedMetadata);
   writeJson(statePath, updatedState);
   assert.equal(requireEnabledDshRuntime(pluginRoot).dshVersion, "0.1.0-rc.7");
+  assert.throws(
+    () => buildDshCommand("npx", ["@deepseek-ai/dsh", "--version"]),
+    (error) => error?.code === "MEMORAX_CODE_DSH_DISABLED",
+  );
 });
 
 function writeJson(path, value) {


### PR DESCRIPTION
## Change Summary

Support DeepSeek Harness Profiles initialized through the official `npx` workflow without requiring a globally installed `dsh`, while preventing an automatically discovered DSH failure from blocking a healthy Backend or other client integrations. Closes #97.

## Implementation Highlights

- Resolve `@deepseek-ai/dsh` from the existing Profile dependency tree, validate its package identity, semantic version, `bin.dsh` entrypoint, and logical/real-path containment, then persist and reuse that runtime authority without invoking or installing through `npx`.
- Treat automatically discovered DSH failures as a visible degraded result while keeping explicit `--clients dsh` and `--clients all` lifecycle commands strict; setup no longer performs stop/start recovery for an adapter-local DSH failure.
- Re-read the Profile-linked runtime during reconciliation so user-managed DSH updates are adopted, and report `dsh_profile_runtime_stale` when the linked package or cache disappears.

## Validation

- `npm test --prefix packages/ts/memorax-code-dsh-adapter`: 28 passed.
- `npm test --prefix packages/ts/memorax-code-backend`: 557 passed, 2 skipped.
- `node --test packages/npm/memorax-code/test/setup.test.mjs`: 15 passed.
- `make npm-package-check`: 221 passed, 2 skipped; package allowlist and local-only trace checks passed.
- `make docs-check` and `git diff --check`: passed.

## Full End-to-End Validation Results

- Environment: isolated macOS arm64 directories for `HOME`, `DSH_HOME`, `MEMORAX_CODE_HOME`, client homes, npm prefix, npm cache, and PATH; Node.js 24.15.0; official `@deepseek-ai/dsh@0.1.1-rc.2`; locally packed `@memorax/memorax-code@0.1.5` from this branch. The isolated PATH contained Node and pnpm but no global `dsh` executable.
- Scenario or matrix: healthy Profile-linked DSH runtime; removed npx cache; automatic lifecycle selection; explicit DSH lifecycle selection.
- Command or workflow: initialized the official headless Profile with `npx --yes @deepseek-ai/dsh@0.1.1-rc.2 --profile headless --dump-default-config`; installed the local MemoraX Code tarball; ran DSH-only start/status; temporarily moved the isolated npx package to simulate a stale cache; repeated automatic and explicit start/status commands; restored the package and stopped the Backend.
- Result: the healthy Profile-linked runtime activated successfully with DSH version `0.1.1-rc.2`; automatic start/status returned exit 0 with top-level `degraded: true`, `optional: true`, and `dsh_profile_runtime_stale` while the Backend remained healthy; explicit `--clients dsh` start/status returned exit 1, and explicit start recovered the Backend with `dsh_adapter_enable_failed_backend_recovered`.
- Evidence or artifacts: redacted structured CLI reports showed the persisted launcher under `$DSH_HOME/profiles/node_modules/@deepseek-ai/dsh/lib/bin.js`, the enabled headless Profile, the degraded automatic reports, and strict explicit reports. The Backend was stopped, its port was verified closed, and all 493 MB of isolated test data plus package staging were deleted after validation.
- Reason not run / remaining risk: the real npx workflow was exercised on macOS. Windows and Linux behavior is covered by automated lifecycle, packaging, path-containment, and Windows command-resolution tests, but a real npx-created Profile was not exercised on those two platforms in this PR validation.
