### PR TITLE
fix: fall back from inaccessible Windows Codex aliases

### DIFF
--- a/packages/npm/memorax-code/lib/resolve-codex-command.mjs
+++ b/packages/npm/memorax-code/lib/resolve-codex-command.mjs
@@ -8,9 +8,10 @@ import {
   findVsCodeExtensionCommand,
   isExecutableCommand,
 } from "./vscode-extension-command.mjs";
+import { resolveWindowsCliInvocation } from "./windows-cli-invocation.mjs";
 
 const APP_BUNDLE_NAMES = ["ChatGPT.app", "Codex.app"];
-const WINDOWS_CODEX_APP_PROBE_TIMEOUT_MS = 10_000;
+const WINDOWS_CODEX_DISCOVERY_PROBE_TIMEOUT_MS = 2_000;
 const WINDOWS_CODEX_APP_RUNTIME_SEGMENTS = ["plugins", ".plugin-appserver", "codex.exe"];
 
 export function resolveCodexCommand({
@@ -19,10 +20,12 @@ export function resolveCodexCommand({
   platform = process.platform,
   arch = process.arch,
   applicationRoots = [join(homeDir, "Applications"), "/Applications"],
+  pathCommandAvailable = commandOnPath,
   vscodeExtensionRoots = defaultVsCodeExtensionRoots(homeDir),
   windowsAppProbe = spawnSync,
   windowsAppRuntimePaths,
   windowsPathExists = isExecutableCommand,
+  windowsPathProbe = spawnSync,
 } = {}) {
   const npmOverride = nonEmpty(env.MEMORAX_CODE_CODEX_COMMAND);
   if (npmOverride) return { command: npmOverride, source: "npm-override" };
@@ -30,7 +33,13 @@ export function resolveCodexCommand({
   const configured = nonEmpty(env.CODEX_CLI_PATH);
   if (configured) return { command: configured, source: "configured" };
 
-  if (commandOnPath("codex", env.PATH, platform, env.PATHEXT)) {
+  if (
+    pathCommandAvailable("codex", env.PATH, platform, env.PATHEXT)
+    && (
+      platform !== "win32"
+      || windowsCodexPathCommandIsRunnable("codex", env, windowsPathProbe)
+    )
+  ) {
     return { command: "codex", source: "path" };
   }
 
@@ -77,7 +86,10 @@ export function resolveWindowsCodexAppCommand({
   const codexHome = nonEmpty(env.CODEX_HOME) ?? win32.join(homeDir, ".codex");
   const candidates = runtimePaths ?? [win32.join(codexHome, ...WINDOWS_CODEX_APP_RUNTIME_SEGMENTS)];
   for (const command of candidates) {
-    if (pathExists(command, platform) && windowsCodexCommandIsRunnable(command, env, spawnSyncImpl)) {
+    if (
+      pathExists(command, platform)
+      && windowsCodexCommandIsRunnable(command, ["--version"], env, spawnSyncImpl)
+    ) {
       return command;
     }
   }
@@ -123,17 +135,31 @@ function codexPlatformDirectories(platform, arch) {
   return [];
 }
 
-function windowsCodexCommandIsRunnable(command, env, spawnSyncImpl) {
+function windowsCodexPathCommandIsRunnable(command, env, spawnSyncImpl) {
+  let invocation;
+  try {
+    invocation = resolveWindowsCliInvocation(command, ["--version"], {
+      env,
+      platform: "win32",
+      spawnSync: spawnSyncImpl,
+    });
+  } catch {
+    return false;
+  }
+  return windowsCodexCommandIsRunnable(invocation.command, invocation.args, env, spawnSyncImpl);
+}
+
+function windowsCodexCommandIsRunnable(command, args, env, spawnSyncImpl) {
   let result;
   try {
     result = spawnSyncImpl(
       command,
-      ["--version"],
+      args,
       {
         encoding: "utf8",
         env,
         stdio: ["ignore", "pipe", "pipe"],
-        timeout: WINDOWS_CODEX_APP_PROBE_TIMEOUT_MS,
+        timeout: WINDOWS_CODEX_DISCOVERY_PROBE_TIMEOUT_MS,
         windowsHide: true,
       },
     );

--- a/packages/npm/memorax-code/test/memorax-code-entrypoint.test.mjs
+++ b/packages/npm/memorax-code/test/memorax-code-entrypoint.test.mjs
@@ -330,6 +330,7 @@ async function createPackageFixture() {
     "lib/resolve-codex-command.mjs",
     "lib/run-entrypoint.mjs",
     "lib/vscode-extension-command.mjs",
+    "lib/windows-cli-invocation.mjs",
   ];
   for (const relativePath of copiedFiles) {
     const target = join(root, relativePath);

--- a/packages/npm/memorax-code/test/resolve-codex-command.test.mjs
+++ b/packages/npm/memorax-code/test/resolve-codex-command.test.mjs
@@ -42,7 +42,7 @@ test("Codex command resolution preserves explicit overrides and PATH CLI precede
       platform: "darwin",
       applicationRoots: [join(root, "Applications")],
     }), { command: "codex", source: "path" });
-    assert.ok(appCommand.endsWith("ChatGPT.app/Contents/Resources/codex"));
+    assert.ok(appCommand.replaceAll("\\", "/").endsWith("ChatGPT.app/Contents/Resources/codex"));
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -106,7 +106,90 @@ test("Codex command resolution uses the runnable Windows App plugin runtime", ()
   assert.equal(calls.length, 1);
   assert.equal(calls[0].command, appCommand);
   assert.deepEqual(calls[0].args, ["--version"]);
-  assert.equal(calls[0].options.timeout, 10_000);
+  assert.equal(calls[0].options.timeout, 2_000);
+});
+
+test("Codex command resolution falls back from an inaccessible Windows PATH alias", () => {
+  const pathCommand = "C:\\Users\\tester\\AppData\\Local\\Microsoft\\WindowsApps\\codex.exe";
+  const appCommand = "C:\\Users\\tester\\.codex\\plugins\\.plugin-appserver\\codex.exe";
+  const pathCalls = [];
+  const appCalls = [];
+  const env = {
+    PATH: "C:\\Users\\tester\\AppData\\Local\\Microsoft\\WindowsApps",
+    PATHEXT: ".EXE;.CMD;.BAT;.COM",
+  };
+  const resolved = resolveCodexCommand({
+    env,
+    homeDir: "C:\\Users\\tester",
+    platform: "win32",
+    arch: "x64",
+    pathCommandAvailable: () => true,
+    vscodeExtensionRoots: [],
+    windowsAppProbe(command, args, options) {
+      appCalls.push({ command, args, options });
+      return { status: 0, stdout: "codex-cli 0.146.0-test\r\n", stderr: "" };
+    },
+    windowsAppRuntimePaths: [appCommand],
+    windowsPathExists: (candidate) => candidate === appCommand,
+    windowsPathProbe(command, args, options) {
+      pathCalls.push({ command, args, options });
+      if (command === "where.exe") {
+        return { status: 0, stdout: `${pathCommand}\r\n`, stderr: "" };
+      }
+      return {
+        status: null,
+        stdout: "",
+        stderr: "",
+        error: Object.assign(new Error("spawn EPERM"), { code: "EPERM" }),
+      };
+    },
+  });
+
+  assert.deepEqual(resolved, { command: appCommand, source: "app-bundled" });
+  assert.equal(pathCalls.length, 2);
+  assert.equal(pathCalls[0].command, "where.exe");
+  assert.deepEqual(pathCalls[0].args, ["codex"]);
+  assert.equal(pathCalls[1].command, pathCommand);
+  assert.deepEqual(pathCalls[1].args, ["--version"]);
+  assert.equal(pathCalls[1].options.timeout, 2_000);
+  assert.equal(appCalls.length, 1);
+  assert.equal(appCalls[0].command, appCommand);
+});
+
+test("Codex command resolution keeps a runnable Windows PATH command ahead of the App runtime", () => {
+  const pathCommand = "C:\\tools\\codex.exe";
+  const pathCalls = [];
+  let appProbeCount = 0;
+  const resolved = resolveCodexCommand({
+    env: {
+      PATH: "C:\\tools",
+      PATHEXT: ".EXE;.CMD;.BAT;.COM",
+    },
+    homeDir: "C:\\Users\\tester",
+    platform: "win32",
+    arch: "x64",
+    pathCommandAvailable: () => true,
+    vscodeExtensionRoots: [],
+    windowsAppProbe() {
+      appProbeCount += 1;
+      return { status: 0, stdout: "codex-cli app-test\r\n", stderr: "" };
+    },
+    windowsAppRuntimePaths: ["C:\\Users\\tester\\.codex\\plugins\\.plugin-appserver\\codex.exe"],
+    windowsPathExists: () => true,
+    windowsPathProbe(command, args, options) {
+      pathCalls.push({ command, args, options });
+      if (command === "where.exe") {
+        return { status: 0, stdout: `${pathCommand}\r\n`, stderr: "" };
+      }
+      return { status: 0, stdout: "codex-cli path-test\r\n", stderr: "" };
+    },
+  });
+
+  assert.deepEqual(resolved, { command: "codex", source: "path" });
+  assert.equal(pathCalls.length, 2);
+  assert.equal(pathCalls[1].command, pathCommand);
+  assert.equal(pathCalls[1].options.timeout, 2_000);
+  assert.equal(appProbeCount, 0);
 });
 
 test("Windows Codex App resolution rejects inaccessible and failing plugin runtimes", () => {


### PR DESCRIPTION
## Change Summary
Make Windows Codex auto-detection reject inaccessible PATH aliases and fall back to a runnable Codex Desktop runtime.

## Implementation Highlights
- Probe auto-discovered Windows PATH candidates through the existing safe CLI invocation layer and accept them only when `codex --version` succeeds.
- Bound Windows discovery probes to two seconds while preserving explicit command overrides, normal PATH precedence, and the ten-second final setup preflight.
- Add regression coverage for an `EPERM` WindowsApps alias, a runnable PATH CLI, package fixture dependencies, and Windows path separators.

## Validation
- `node --test packages/npm/memorax-code/test/resolve-codex-command.test.mjs packages/npm/memorax-code/test/windows-cli-invocation.test.mjs packages/npm/memorax-code/test/memorax-code-entrypoint.test.mjs packages/npm/memorax-code/test/npm-source-files.test.mjs` — 40 passed, 1 existing Windows skip.
- `node scripts/sync-release-version.mjs --check` — passed.
- `node scripts/check-docs.mjs` — passed.
- `git diff --check` — passed.
- Native Windows probe confirmed the WindowsApps candidate fails with `EPERM` and resolution continues to the runnable `app-bundled` runtime.

## Full End-to-End Validation Results
- Environment: Native Windows, Node.js 24.19.0, branch based on `origin/main` at `071e4d2`.
- Scenario or matrix: A WindowsApps `codex.exe` alias is present on PATH but cannot be spawned, while the Codex Desktop plugin runtime is runnable.
- Command or workflow: Run the source command resolver against the native environment, then execute the focused npm command-resolution, Windows invocation, entrypoint, and package-source tests.
- Result: PASS — the PATH alias returned `EPERM`, the resolver selected `source=app-bundled`, and all 40 applicable focused tests passed.
- Evidence or artifacts: Redacted source labels, process result codes, command basenames, and test output only; no credentials, private paths, or session content included.
- Reason not run / remaining risk: The full POSIX-oriented `make npm-package-check` was not run because this native Windows host has no `make` or `bash`. The broader setup fixture also requires symlink privileges unavailable on this host and returns `EPERM`; CI should provide the remaining package and POSIX fixture coverage.