### PR TITLE
chore: release 0.1.6

### DIFF
--- a/packages/npm/memorax-code/package.json
+++ b/packages/npm/memorax-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax/memorax-code",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Persistent coding memory for Codex, Claude Code, DeepSeek Harness, and OpenCode.",
   "license": "MIT",
   "type": "module",

--- a/packages/npm/memorax-code/test/memorax-code-update.test.mjs
+++ b/packages/npm/memorax-code/test/memorax-code-update.test.mjs
@@ -19,6 +19,7 @@ async function createPackageFixture(version) {
   await cp(join(packageRoot, "lib", "run-entrypoint.mjs"), join(root, "lib", "run-entrypoint.mjs"));
   await cp(join(packageRoot, "lib", "resolve-claude-command.mjs"), join(root, "lib", "resolve-claude-command.mjs"));
   await cp(join(packageRoot, "lib", "resolve-codex-command.mjs"), join(root, "lib", "resolve-codex-command.mjs"));
+  await cp(join(packageRoot, "lib", "windows-cli-invocation.mjs"), join(root, "lib", "windows-cli-invocation.mjs"));
   await cp(join(packageRoot, "lib", "vscode-extension-command.mjs"), join(root, "lib", "vscode-extension-command.mjs"));
   const manifest = JSON.parse(await readFile(join(packageRoot, "package.json"), "utf8"));
   manifest.version = version;

--- a/packages/ts/memorax-code-backend/package-lock.json
+++ b/packages/ts/memorax-code-backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@memorax-code/backend",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@memorax-code/backend",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "dependencies": {
         "smol-toml": "^1.7.0"
       },

--- a/packages/ts/memorax-code-backend/package.json
+++ b/packages/ts/memorax-code-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/backend",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "type": "module",
   "description": "Local memory integration, lifecycle, trace, and diagnostics for MemoraX Code.",

--- a/packages/ts/memorax-code-backend/test/entrypoints/npm-run-entrypoint.test.mjs
+++ b/packages/ts/memorax-code-backend/test/entrypoints/npm-run-entrypoint.test.mjs
@@ -24,6 +24,10 @@ async function copyNpmEntrypointFixture() {
     join(packageRoot, "lib", "resolve-codex-command.mjs"),
   );
   await copyFile(
+    join(repoRoot, "packages", "npm", "memorax-code", "lib", "windows-cli-invocation.mjs"),
+    join(packageRoot, "lib", "windows-cli-invocation.mjs"),
+  );
+  await copyFile(
     join(repoRoot, "packages", "npm", "memorax-code", "lib", "resolve-claude-command.mjs"),
     join(packageRoot, "lib", "resolve-claude-command.mjs"),
   );

--- a/packages/ts/memorax-code-claude-adapter/.claude-plugin/plugin.json
+++ b/packages/ts/memorax-code-claude-adapter/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorax-code-claude-adapter",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Memory skill and local hooks for MemoraX Code in Claude Code.",
   "author": {
     "name": "MemoraX Code Maintainers"

--- a/packages/ts/memorax-code-claude-adapter/hooks/runtime-shell.json
+++ b/packages/ts/memorax-code-claude-adapter/hooks/runtime-shell.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
-  "shellVersion": "0.1.5",
+  "shellVersion": "0.1.6",
   "runtimeAbi": 1
 }

--- a/packages/ts/memorax-code-claude-adapter/package.json
+++ b/packages/ts/memorax-code-claude-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/claude-adapter",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "type": "module",
   "description": "Claude Code Hook adapter for MemoraX Code memory services.",

--- a/packages/ts/memorax-code-codex-adapter/.codex-plugin/plugin.json
+++ b/packages/ts/memorax-code-codex-adapter/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorax-code-codex-adapter",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Codex adapter, memory skill, and local hooks for MemoraX Code.",
   "author": {
     "name": "MemoraX AI"

--- a/packages/ts/memorax-code-codex-adapter/hooks/runtime-shell.json
+++ b/packages/ts/memorax-code-codex-adapter/hooks/runtime-shell.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
-  "shellVersion": "0.1.5",
+  "shellVersion": "0.1.6",
   "runtimeAbi": 1
 }

--- a/packages/ts/memorax-code-codex-adapter/package.json
+++ b/packages/ts/memorax-code-codex-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/codex-adapter",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "type": "module",
   "description": "Codex Hook and memory integration for MemoraX Code.",

--- a/packages/ts/memorax-code-dsh-adapter/package.json
+++ b/packages/ts/memorax-code-dsh-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/dsh-memorax-code",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "type": "module",
   "description": "DeepSeek Harness native memory adapter for MemoraX Code.",

--- a/packages/ts/memorax-code-opencode-adapter/package.json
+++ b/packages/ts/memorax-code-opencode-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/opencode-adapter",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "type": "module",
   "description": "OpenCode plugin adapter for MemoraX Code memory services.",


### PR DESCRIPTION
## Change Summary

Prepare the current main branch for the stable @memorax/memorax-code 0.1.6 release and repair the isolated npm wrapper fixtures affected by the newly shared Windows command helper.

## Implementation Highlights

- Bump the authoritative package version to 0.1.6 and synchronize Backend, adapter, plugin, Hook shell, and lockfile versions through the repository release script.
- Include windows-cli-invocation.mjs in the two isolated npm test fixtures that import resolve-codex-command.mjs; production package staging already included the dependency and runtime behavior is unchanged.

## Validation

- `make test`: Backend 558 passed / 2 skipped; Codex 227 passed; Claude 65 passed; DSH 28 passed; OpenCode 31 passed; npm package tests 223 passed / 2 skipped.
- `make docs-check`: passed.
- `make npm-package-check`: passed, including package allowlist, staged install/update lifecycle checks, and local-only trace contract.
- `make npm-publish-dry-run`: passed for @memorax/memorax-code@0.1.6 with the `latest` dist-tag.

## Full End-to-End Validation Results

- Environment: isolated package lifecycle fixtures on macOS arm64 with Node.js 24.15.0 and npm 11.12.1.
- Scenario or matrix: stable package build, fresh install, configured/stopped install, live Backend replacement, update channel preservation, DSH managed-state replacement, Windows command-resolution contracts, and publish staging.
- Command or workflow: `make test`; `make docs-check`; `make npm-package-check`; `make npm-publish-dry-run`.
- Result: all release gates passed. The dry-run produced a public `latest`-tag candidate with 394 files, 489.9 kB packed size, and 3.1 MB unpacked size.
- Evidence or artifacts: npm pack allowlist validation passed; package staging produced `memorax-memorax-code-0.1.6.tgz`; dry-run reported `+ @memorax/memorax-code@0.1.6` without uploading.
- Reason not run / remaining risk: a real registry publish and post-publish installation smoke test are intentionally deferred until this PR is merged and explicit release approval is given.
