### PR TITLE
fix: prevent Windows npm package update directory locks

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,18 @@ The command follows the installed release channel and preserves configuration.
 Restart or refresh Codex, Claude Code, DeepSeek Harness, and OpenCode when a
 release changes installed integration assets.
 
+### Windows Upgrade Note
+
+If you are upgrading MemoraX Code v0.1.3-v0.1.6 to v0.1.7 on Windows, run:
+
+```powershell
+memorax-code stop
+memorax-code update --latest
+memorax-code
+```
+
+This one-time step is not required for later upgrades.
+
 ## Uninstall
 
 Run the product lifecycle before removing the npm package:

--- a/README.zh.md
+++ b/README.zh.md
@@ -172,6 +172,18 @@ memorax-code update
 该命令会沿用当前发布通道并保留配置。如果新版本修改了已安装的集成资产，请重启或刷新 Codex、
 Claude Code、DeepSeek Harness 和 OpenCode。
 
+### Windows 升级提示
+
+如果您在 Windows 上从 MemoraX Code v0.1.3-v0.1.6 升级到 v0.1.7，请执行：
+
+```powershell
+memorax-code stop
+memorax-code update --latest
+memorax-code
+```
+
+该操作仅需执行一次，后续升级无需重复。
+
 ## 卸载
 
 请先运行产品自身的卸载流程：

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -81,6 +81,24 @@ npm install -g @memorax/memorax-code
 Fresh and already-stopped installations do not create a transition and remain
 stopped.
 
+On Windows, a Backend started by MemoraX Code 0.1.6 or earlier from an npm
+lifecycle may keep the old global package directory as its working directory.
+Windows then prevents npm from renaming that directory, and update fails with
+an `EBUSY` rename error before the newer package's preinstall can stop the old
+Backend. Upgrade an affected installation with:
+
+```sh
+memorax-code stop
+memorax-code update --latest
+memorax-code
+```
+
+The final command reuses existing configuration and credentials, reconciles
+the client integrations, starts the Backend, and completes the one-time setup
+migration. `memorax-code start` alone does not commit that migration. Once a
+fixed release has started the Backend from its private runtime directory,
+later updates do not require this workaround.
+
 ## Installed, but memory is unavailable
 
 The package and Backend can be healthy while MemoraX remains unconfigured. Run:

--- a/packages/npm/memorax-code/lib/package-transition.mjs
+++ b/packages/npm/memorax-code/lib/package-transition.mjs
@@ -239,6 +239,7 @@ function readBackendPidState(path) {
 function runLifecycleCommand(options) {
   const spawn = options.spawnSyncImpl ?? spawnSync;
   const result = spawn(process.execPath, [options.memoraxCodeBin, ...options.args], {
+    cwd: join(options.memoraxCodeHome, "runtime", "install"),
     encoding: "utf8",
     env: { ...process.env, ...options.env, MEMORAX_CODE_HOME: options.memoraxCodeHome },
     stdio: ["ignore", "pipe", "pipe"],

--- a/packages/npm/memorax-code/lib/package-transition.mjs
+++ b/packages/npm/memorax-code/lib/package-transition.mjs
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import { spawnSync } from "node:child_process";
 import { existsSync, unlinkSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { withJsonFileLock, withJsonFileLockAsync } from "./memorax-code-adapter-common/src/config-utils.mjs";
 import {
   readJsonRuntimeRecord,
@@ -88,7 +88,7 @@ export function readPackageTransitionRecord(memoraxCodeHome = defaultMemoraxCode
 }
 
 export function runNpmPreinstallPackageTransition(options = {}) {
-  const memoraxCodeHome = nonEmptyString(options.memoraxCodeHome) ?? defaultMemoraxCodeHome();
+  const memoraxCodeHome = resolve(nonEmptyString(options.memoraxCodeHome) ?? defaultMemoraxCodeHome());
   const memoraxCodeBin = requiredString(options.memoraxCodeBin, "memoraxCodeBin");
   const packageVersion = requiredString(options.packageVersion, "packageVersion");
   const pidPath = backendPidPath(memoraxCodeHome);
@@ -158,7 +158,7 @@ export function runNpmPreinstallPackageTransition(options = {}) {
 }
 
 export async function runNpmPostinstallPackageTransition(options = {}) {
-  const memoraxCodeHome = nonEmptyString(options.memoraxCodeHome) ?? defaultMemoraxCodeHome();
+  const memoraxCodeHome = resolve(nonEmptyString(options.memoraxCodeHome) ?? defaultMemoraxCodeHome());
   const memoraxCodeBin = requiredString(options.memoraxCodeBin, "memoraxCodeBin");
   const transitionPath = packageTransitionPath(memoraxCodeHome);
   if (readJsonRuntimeRecord(transitionPath).status === "absent") {

--- a/packages/npm/memorax-code/test/package-transition.test.mjs
+++ b/packages/npm/memorax-code/test/package-transition.test.mjs
@@ -6,6 +6,7 @@ import {
   mkdir,
   mkdtemp,
   readFile,
+  realpath,
   rm,
   stat,
   writeFile,
@@ -80,6 +81,8 @@ test("a live Backend is retired before replacement and restored once afterward",
       ["start", "--home", fixture.home, "--json"],
       ["status", "--home", fixture.home, "--json"],
     ]);
+    const lifecycleCwd = await realpath(join(fixture.home, "runtime", "install"));
+    assert.ok(calls.every((call) => call.cwd === lifecycleCwd));
     assert.equal(calls[1].packageReplacement, true);
     assert.equal(calls[2].packageReplacement, false);
     assert.ok(calls.slice(1).every((call) => !call.args.includes("--clients")));
@@ -347,6 +350,7 @@ try { transitionState = JSON.parse(readFileSync(transitionPath, "utf8")).state; 
 appendFileSync(${JSON.stringify(logPath)}, JSON.stringify({
   command,
   args,
+  cwd: process.cwd(),
   transitionState,
   packageReplacement: process.env.MEMORAX_CODE_PACKAGE_REPLACEMENT === "1",
 }) + "\\n");

--- a/packages/npm/memorax-code/test/package-transition.test.mjs
+++ b/packages/npm/memorax-code/test/package-transition.test.mjs
@@ -96,6 +96,24 @@ test("a live Backend is retired before replacement and restored once afterward",
   }
 });
 
+test("relative MEMORAX_CODE_HOME is resolved before lifecycle commands change cwd", async () => {
+  const fixture = await createFixture({ pid: process.pid });
+  try {
+    const options = { cwd: fixture.root, memoraxCodeHome: "memorax-code-home" };
+    const preinstall = await runEntry(fixture, "preinstall", options);
+    assert.equal(preinstall.code, 0, preinstall.stderr);
+    const postinstall = await runEntry(fixture, "postinstall", options);
+    assert.equal(postinstall.code, 0, postinstall.stderr);
+
+    const calls = await readCalls(fixture);
+    const resolvedHome = await realpath(fixture.home);
+    assert.ok(calls.every((call) => call.args.includes(resolvedHome)));
+    assert.ok(calls.every((call) => call.cwd === join(resolvedHome, "runtime", "install")));
+  } finally {
+    await fixture.cleanup();
+  }
+});
+
 test("managed DSH state is quiesced and restored without Backend PID authority", async () => {
   const fixture = await createFixture({ withDshState: true });
   try {
@@ -364,14 +382,19 @@ console.log(JSON.stringify({ ok: true, command, pidExisted: existsSync(pidPath) 
 `;
 }
 
-async function runEntry(fixture, entry, { keepStdinOpen = false } = {}) {
+async function runEntry(fixture, entry, {
+  keepStdinOpen = false,
+  cwd,
+  memoraxCodeHome = fixture.home,
+} = {}) {
   const filename = entry === "preinstall"
     ? "memorax-code-npm-preinstall.mjs"
     : "memorax-code-plugin-postinstall.mjs";
   return await new Promise((resolve) => {
     const startedAt = Date.now();
     const child = spawn(process.execPath, [join(fixture.root, "bin", filename)], {
-      env: { ...process.env, ...fixture.env, MEMORAX_CODE_HOME: fixture.home },
+      cwd,
+      env: { ...process.env, ...fixture.env, MEMORAX_CODE_HOME: memoraxCodeHome },
       stdio: [keepStdinOpen ? "pipe" : "ignore", "pipe", "pipe"],
     });
     let stdout = "";

--- a/packages/ts/memorax-code-backend/src/lifecycle/backend/service.ts
+++ b/packages/ts/memorax-code-backend/src/lifecycle/backend/service.ts
@@ -205,6 +205,7 @@ export async function startBackendService(
       process.execPath,
       [serverPath, "--memorax-code-backend-instance", instanceId],
       {
+        cwd: serviceDir(options),
         detached: true,
         env: withLoopbackProxyBypass({
           ...process.env,

--- a/packages/ts/memorax-code-backend/test/lifecycle/backend/service-lifecycle.test.mjs
+++ b/packages/ts/memorax-code-backend/test/lifecycle/backend/service-lifecycle.test.mjs
@@ -254,14 +254,17 @@ test("service spawn error and missing PID fail before writing state", async (t) 
         const child = new EventEmitter();
         child.pid = undefined;
         child.unref = () => undefined;
+        let spawnOptions;
         const result = await startBackendService({ home, timeoutMs: 50 }, {
-          spawnProcess: () => {
+          spawnProcess: (_command, _args, options) => {
+            spawnOptions = options;
             process.nextTick(() => emit(child));
             return child;
           },
         });
         assert.equal(result.ok, false);
         assert.match(result.error, /failed to spawn Backend process/);
+        assert.equal(spawnOptions.cwd, join(home, "runtime", "backend"));
         assert.equal(readBackendServiceState({ home }), undefined);
         if (process.platform !== "win32") {
           assert.equal((await stat(join(home, "runtime", "backend"))).mode & 0o777, 0o700);


### PR DESCRIPTION
## Change Summary

Prevent a managed Backend from retaining the global npm package directory as its working directory, which otherwise blocks package replacement with `EBUSY` on Windows.

## Implementation Highlights

- Start the detached Backend from its private `$MEMORAX_CODE_HOME/runtime/backend` directory instead of inheriting the invoking npm lifecycle directory.
- Run package-transition lifecycle commands from `$MEMORAX_CODE_HOME/runtime/install`, keeping replacement work outside the package being renamed.
- Extend existing lifecycle tests with focused working-directory assertions and document the one-time Windows workaround for releases through 0.1.6.

## Validation

- `npm run typecheck --prefix packages/ts/memorax-code-backend` — passed.
- `npm test --prefix packages/ts/memorax-code-backend` — 558 passed, 2 platform skips.
- `node --test --test-timeout=5000 --test-force-exit packages/ts/memorax-code-backend/test/lifecycle/backend/service-lifecycle.test.mjs` — 26 passed.
- `node --test packages/npm/memorax-code/test/package-transition.test.mjs` — 33 passed.
- `make npm-package-check` — 223 passed, 2 platform skips; 394-file artifact validated.
- `make docs-check` — 10 documentation contract tests passed; README language sync passed.
- `git diff --check` — passed.

## Full End-to-End Validation Results

- Environment: native Windows 11 build 26200, Node.js v24.19.0, npm 11.17.0; commit `392ac573924c10c1ee83478548b4e0af02950ef3`.
- Scenario or matrix:
  - Published 0.1.3 with a healthy running Backend to local fixed build `0.1.7-windows-cwd.1`, using the documented one-time `stop` workaround.
  - Fixed build `0.1.7-windows-cwd.1` to `0.1.7-windows-cwd.2` while the Backend was running, without calling `memorax-code stop`.
- Command or workflow: install 0.1.3 with foreground lifecycle output; stop once before installing fixed build A; deliberately start A from the global npm package directory; leave that directory; install fixed build B directly with foreground lifecycle output and no manual stop.
- Result: both stages passed. The A-to-B replacement produced no `EBUSY` or locked-rename failure; package-transition automatically stopped and restored the Backend; the Backend PID changed and the previous process exited; `config.toml` remained byte-identical to the 0.1.3 baseline; setup completion was preserved; the transition record was consumed; final package and Backend status were healthy.
- Evidence or artifacts: redacted Windows terminal validation recorded the exact environment, commit, version transitions, PID replacement, configuration-hash equality, transition consumption, and final status without exposing credentials, Mark ID, configuration content, hashes, or user paths.
- Reason not run / remaining risk: the Windows fixture already had a setup-completion record, so native Windows validation covered preservation rather than creation of that record. The configured legacy-install migration without a completion record remains covered by the npm entrypoint suite. Reverse downgrade behavior from 0.1.6 to 0.1.3 is outside this forward-update fix; both forward upgrade stages preserved the 0.1.3 baseline.
