### PR TITLE
chore: release 0.1.7

### DIFF
--- a/packages/npm/memorax-code/package.json
+++ b/packages/npm/memorax-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax/memorax-code",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Persistent coding memory for Codex, Claude Code, DeepSeek Harness, and OpenCode.",
   "license": "MIT",
   "type": "module",

--- a/packages/ts/memorax-code-backend/package-lock.json
+++ b/packages/ts/memorax-code-backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@memorax-code/backend",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@memorax-code/backend",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "smol-toml": "^1.7.0"
       },

--- a/packages/ts/memorax-code-backend/package.json
+++ b/packages/ts/memorax-code-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/backend",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": true,
   "type": "module",
   "description": "Local memory integration, lifecycle, trace, and diagnostics for MemoraX Code.",

--- a/packages/ts/memorax-code-claude-adapter/.claude-plugin/plugin.json
+++ b/packages/ts/memorax-code-claude-adapter/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorax-code-claude-adapter",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Memory skill and local hooks for MemoraX Code in Claude Code.",
   "author": {
     "name": "MemoraX Code Maintainers"

--- a/packages/ts/memorax-code-claude-adapter/hooks/runtime-shell.json
+++ b/packages/ts/memorax-code-claude-adapter/hooks/runtime-shell.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
-  "shellVersion": "0.1.6",
+  "shellVersion": "0.1.7",
   "runtimeAbi": 1
 }

--- a/packages/ts/memorax-code-claude-adapter/package.json
+++ b/packages/ts/memorax-code-claude-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/claude-adapter",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": true,
   "type": "module",
   "description": "Claude Code Hook adapter for MemoraX Code memory services.",

--- a/packages/ts/memorax-code-codex-adapter/.codex-plugin/plugin.json
+++ b/packages/ts/memorax-code-codex-adapter/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorax-code-codex-adapter",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Codex adapter, memory skill, and local hooks for MemoraX Code.",
   "author": {
     "name": "MemoraX AI"

--- a/packages/ts/memorax-code-codex-adapter/hooks/runtime-shell.json
+++ b/packages/ts/memorax-code-codex-adapter/hooks/runtime-shell.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
-  "shellVersion": "0.1.6",
+  "shellVersion": "0.1.7",
   "runtimeAbi": 1
 }

--- a/packages/ts/memorax-code-codex-adapter/package.json
+++ b/packages/ts/memorax-code-codex-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/codex-adapter",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": true,
   "type": "module",
   "description": "Codex Hook and memory integration for MemoraX Code.",

--- a/packages/ts/memorax-code-dsh-adapter/package.json
+++ b/packages/ts/memorax-code-dsh-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/dsh-memorax-code",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": true,
   "type": "module",
   "description": "DeepSeek Harness native memory adapter for MemoraX Code.",

--- a/packages/ts/memorax-code-opencode-adapter/package.json
+++ b/packages/ts/memorax-code-opencode-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/opencode-adapter",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": true,
   "type": "module",
   "description": "OpenCode plugin adapter for MemoraX Code memory services.",


### PR DESCRIPTION
## Change Summary

Prepare the latest main branch for the stable @memorax/memorax-code 0.1.7 release by synchronizing every version authority.

## Implementation Highlights

- Bump the authoritative npm package version to 0.1.7 and synchronize Backend, adapter, plugin, Hook shell, and lockfile versions through the repository release script.
- Keep this release change version-only; it does not alter runtime behavior.

## Validation

- `make test`: Backend 558 passed / 2 skipped; Codex 227 passed; Claude 65 passed; DSH 28 passed; OpenCode 31 passed; npm package tests 224 passed / 2 skipped.
- `make docs-check`: passed.
- `make npm-package-check`: passed, including the package allowlist, staged install/update lifecycle checks, and local-only trace contract.
- `make npm-publish-dry-run`: passed for @memorax/memorax-code@0.1.7 with the `latest` dist-tag.

## Full End-to-End Validation Results

- Environment: macOS 26.5.1 arm64 with Node.js 24.15.0 and npm 11.12.1.
- Scenario or matrix: stable package build, fresh and configured/stopped installation, live Backend package replacement, update channel preservation, managed DSH replacement, Windows command-resolution contracts, and publish staging.
- Command or workflow: `make test`; `make docs-check`; `make npm-package-check`; `make npm-publish-dry-run`.
- Result: all release gates passed. The dry-run produced a public `latest` candidate with 394 files, 490.1 kB packed size, and 3.1 MB unpacked size.
- Evidence or artifacts: npm pack allowlist validation passed; staging produced `memorax-memorax-code-0.1.7.tgz`; dry-run reported `+ @memorax/memorax-code@0.1.7` without uploading.
- Reason not run / remaining risk: real registry publication and the post-publish installation smoke test are deferred until this version-only PR is merged. Native Windows upgrade validation for the package-lock fix is recorded in PR #101 and was not repeated for this metadata-only bump.