### PR TITLE
fix: isolate OpenCode Repo Memory worker database

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -442,8 +442,9 @@ headless-capable Profile. For OpenCode, both on-demand maintenance and
 first-eligible-prompt initialization run through a short-lived subagent session.
 The detached worker reuses the active OpenCode server when it is reachable.
 Because standalone `opencode run` exposes only process-local server authority,
-the worker owns an authenticated, loopback-only `opencode serve` process when
-session creation cannot reach that authority, and closes it afterward.
+the worker owns an authenticated, loopback-only `opencode serve` process with
+a process-local database when session creation cannot reach that authority,
+and closes it afterward.
 Desktop-only installations with a reachable server do not require a standalone
 OpenCode CLI.
 

--- a/packages/ts/memorax-code-opencode-adapter/src/repo-memory-server-runner.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/src/repo-memory-server-runner.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 export const OPENCODE_REPO_MEMORY_AGENT = "memorax-code-repo-memory";
 
 const OWNED_SERVER_USERNAME = "memorax-code";
+const OWNED_SERVER_DATABASE = ":memory:";
 const DEFAULT_SERVER_START_TIMEOUT_MS = 20_000;
 const DEFAULT_SERVER_STOP_TIMEOUT_MS = 5_000;
 const MAX_SERVER_START_OUTPUT = 8_192;
@@ -155,6 +156,7 @@ async function startOwnedOpenCodeServer(input) {
     cwd: input.directory,
     env: {
       ...input.env,
+      OPENCODE_DB: OWNED_SERVER_DATABASE,
       OPENCODE_SERVER_USERNAME: username,
       OPENCODE_SERVER_PASSWORD: password,
     },

--- a/packages/ts/memorax-code-opencode-adapter/test/repo-memory-server-runner.test.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/test/repo-memory-server-runner.test.mjs
@@ -154,6 +154,7 @@ test("OpenCode repo memory runner owns a temporary server when the inherited ser
       env: {
         MEMORAX_CODE_MEMORY_CLI_SESSION_ID: "parent-fallback",
         MEMORAX_CODE_OPENCODE_COMMAND: "/opt/opencode",
+        OPENCODE_DB: "/shared/opencode.db",
       },
       fetchImpl: async (url, init) => {
         if (url.origin === "http://127.0.0.1:9") throw new TypeError("fetch failed");
@@ -177,6 +178,7 @@ test("OpenCode repo memory runner owns a temporary server when the inherited ser
     assert.deepEqual(spawnCall.args, ["serve", "--hostname=127.0.0.1", "--port=0"]);
     assert.equal(spawnCall.command, "/opt/opencode");
     assert.equal(spawnCall.options.cwd, root);
+    assert.equal(spawnCall.options.env.OPENCODE_DB, ":memory:");
     assert.equal(spawnCall.options.env.OPENCODE_SERVER_USERNAME, "memorax-code");
     assert.match(spawnCall.options.env.OPENCODE_SERVER_PASSWORD, /^[A-Za-z0-9_-]{32}$/);
     assert.deepEqual(requests.map((request) => request.method), ["POST", "POST", "DELETE"]);


### PR DESCRIPTION
## Change Summary
Prevent standalone OpenCode Repo Memory initialization from racing the active coding session on the same SQLite database by giving the short-lived fallback server a process-local database.

## Implementation Highlights
- Override any inherited `OPENCODE_DB` with `:memory:` only for the owned fallback `opencode serve` process; reachable active OpenCode servers keep their existing behavior.
- Extend the existing fallback-server contract test and architecture description without copying or relocating OpenCode credentials.

## Validation
- `node --test test/repo-memory-server-runner.test.mjs` — 3/3 passed.
- `npm test --prefix packages/ts/memorax-code-opencode-adapter` — 31/31 passed.
- `make docs-check` — 10/10 tests passed; documentation and README synchronization checks passed.
- `make npm-package-check` — completed; 224 passed and 2 platform-specific tests skipped.

## Full End-to-End Validation Results
- Environment: macOS arm64; isolated HOME, MemoraX Code home, OpenCode config, and XDG roots; npm-packed MemoraX Code; OpenCode 1.18.18; deterministic local model and MemoraX service substitutes.
- Scenario or matrix: standalone `opencode run` with automatic Search and Add, a resumed second turn, and first-prompt cold Repo Memory initialization through the owned fallback `opencode serve` process.
- Command or workflow: `node scripts/opencode-e2e.mjs`.
- Result: passed; 2 Search requests, 2 Add requests, and Repo Memory job status `succeeded`.
- Evidence or artifacts: redacted structured command output reported `ok: true`; the isolated E2E removed its temporary artifacts after completion.
- Reason not run / remaining risk: no live-provider or real Windows client E2E was rerun for this focused process-local database change; the deterministic packaged-client E2E and explicit spawn-environment contract cover the affected boundary.
