### PR TITLE
docs: clarify account onboarding paths

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -21,9 +21,8 @@ installation. For a source checkout and contributor setup, see
   Service in the current user session for setup-managed credentials.
 
 MemoraX-backed search, retrieval, and writeback require network access.
-First-time setup can create an account-free connection, so no account or API
-key is required beforehand. Existing MemoraX accounts remain supported through
-an explicit setup option.
+Connecting a MemoraX account is recommended. A 90-day account-free guest mode
+is also available if you want to try MemoraX Code before creating an account.
 
 For Remote SSH, WSL, or Dev Container use, install MemoraX Code inside the same
 remote environment as the client runtime.
@@ -43,9 +42,22 @@ An installation that was already stopped remains stopped.
 Do not use `--ignore-scripts` for a normal install or update. It skips the
 safe retirement and restoration of a running managed Backend.
 
-## 2. Run Setup
+## 2. Connect a MemoraX Account (Recommended)
 
-Run the installed command from a normal interactive terminal:
+[Create a MemoraX account](https://platform.memorax.net/) or use an existing
+one, then run this command from a normal interactive terminal:
+
+```bash
+memorax-code setup --existing-account
+```
+
+This mode asks for the username used by the existing MemoraX Code connection
+and accepts the API key through masked local terminal input. Never paste an API
+key into a chat, repository, screenshot, or public issue.
+
+### Or Try Without an Account (90-Day Guest Mode)
+
+To start immediately and connect an account later, run:
 
 ```bash
 memorax-code setup
@@ -57,15 +69,16 @@ asks only when either value cannot be detected safely, and creates or restores
 an account-free credential. The resulting API key is written to the private
 configuration together with the selected memory preferences.
 
-If you already have a MemoraX account, run:
+To activate your guest account, first run this command directly in your local
+terminal:
 
 ```bash
-memorax-code setup --existing-account
+memorax-code account --show-mark-id
 ```
 
-This mode asks for the username used by the existing MemoraX Code connection
-and accepts the API key through masked local terminal input. Never paste an API
-key into a chat, repository, screenshot, or public issue.
+After obtaining the Mark ID, create your MemoraX account. The platform does
+not currently support attaching a Mark ID to an account that has already been
+registered.
 
 Use `memorax-code setup --reconfigure` to replace an automatically reusable
 connection and re-detect its preferences. Setup detects supported clients,

--- a/README.md
+++ b/README.md
@@ -67,16 +67,42 @@ beforehand through its official `npx` workflow.
 npm install -g @memorax/memorax-code
 ```
 
-#### 2. Run Setup
+#### 2. Connect a MemoraX Account (Recommended)
+
+[Create a MemoraX account](https://platform.memorax.net/) or use an existing
+one, then run:
+
+```bash
+memorax-code setup --existing-account
+```
+
+> [!TIP]
+> Using MemoraX Code across devices? Find the MemoraX username and API key
+> needed by setup in `~/.memorax-code/config.toml` on a configured device, then
+> enter them locally during setup on another device. This file contains your
+> API key—keep it private and never paste it into chats or public issues.
+
+#### Or Try Without an Account (90-Day Guest Mode)
+
+To start immediately and connect an account later, run:
 
 ```bash
 memorax-code setup
 ```
 
-Setup automatically detects supported coding agents and completes an
-account-free connection. If you already have a MemoraX account, run
-`memorax-code setup --existing-account` instead. Restart or refresh every
-detected coding agent after setup.
+To activate your guest account, first run this command directly in your local
+terminal:
+
+```bash
+memorax-code account --show-mark-id
+```
+
+After obtaining the Mark ID, create your MemoraX account. The platform does
+not currently support attaching a Mark ID to an account that has already been
+registered.
+
+Both setup paths automatically detect supported coding agents. Restart or
+refresh every detected coding agent after setup.
 
 ### Installation Troubleshooting
 
@@ -85,8 +111,7 @@ If the initial setup does not work as expected, check these common cases:
 | Symptom | Recommended fix |
 | --- | --- |
 | Installation fails with an unsupported Node.js version | Run `node --version` and upgrade to Node.js 20 or later before reinstalling MemoraX Code. |
-| The package installed but setup did not start | This is expected. Run `memorax-code setup` from a normal interactive terminal. |
-| You want to use an existing MemoraX account | Run `memorax-code setup --existing-account` and enter the requested values locally. Never paste the API key into chats or public issues. |
+| The package installed but setup did not start | This is expected. Run the appropriate setup command above from a normal interactive terminal. |
 | Search, retrieval, or writeback is unavailable after setup | Run `memorax-code status` and `memorax-cli status`, then follow the detailed troubleshooting guide. |
 
 See [Configuration](docs/configuration.md) for supported settings and

--- a/README.md
+++ b/README.md
@@ -78,9 +78,10 @@ memorax-code setup --existing-account
 
 > [!TIP]
 > Using MemoraX Code across devices? Find the MemoraX username and API key
-> needed by setup in `~/.memorax-code/config.toml` on a configured device, then
-> enter them locally during setup on another device. This file contains your
-> API key—keep it private and never paste it into chats or public issues.
+> needed by setup in the MemoraX Code configuration file on a configured device
+> (normally `~/.memorax-code/config.toml`), then enter them locally during setup
+> on another device. This file contains your API key—keep it private and never
+> paste it into chats or public issues.
 
 #### Or Try Without an Account (90-Day Guest Mode)
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -69,9 +69,10 @@ memorax-code setup --existing-account
 ```
 
 > [!TIP]
-> 跨设备使用时，可在一台已配置设备的 `~/.memorax-code/config.toml` 中找到安装引导所需的
-> MemoraX 用户名和 API Key，再在其他设备的安装引导中本地输入。该文件包含您的 API Key，
-> 请妥善保管，不要粘贴到聊天记录或公开 Issue 中。
+> 跨设备使用时，可在一台已配置设备的 MemoraX Code 配置文件（默认位于
+> `~/.memorax-code/config.toml`）中找到安装引导所需的 MemoraX 用户名和 API Key，
+> 再在其他设备的安装引导中本地输入。该文件包含您的 API Key，请妥善保管，
+> 不要粘贴到聊天记录或公开 Issue 中。
 
 #### 或免账号体验（90 天游客模式）
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -60,14 +60,36 @@ Harness 仍需满足自身的运行时要求；当前 DeepSeek Harness 版本要
 npm install -g @memorax/memorax-code
 ```
 
-#### 2. 运行安装引导
+#### 2. 注册或接入 MemoraX 账号（推荐）
+
+前往 [MemoraX](https://platform.memorax.net/) 注册账号；已有账号可直接使用，然后运行：
+
+```bash
+memorax-code setup --existing-account
+```
+
+> [!TIP]
+> 跨设备使用时，可在一台已配置设备的 `~/.memorax-code/config.toml` 中找到安装引导所需的
+> MemoraX 用户名和 API Key，再在其他设备的安装引导中本地输入。该文件包含您的 API Key，
+> 请妥善保管，不要粘贴到聊天记录或公开 Issue 中。
+
+#### 或免账号体验（90 天游客模式）
+
+如果您希望先体验并稍后再接入账号，请运行：
 
 ```bash
 memorax-code setup
 ```
 
-安装引导会自动检测受支持的 Coding Agent，并完成免账号接入。如果您已有 MemoraX 账号，请改为运行
-`memorax-code setup --existing-account`。完成后，请重启或刷新检测到的 Coding Agent。
+如果您希望将游客账号激活为正式账号，请先直接在本机终端运行：
+
+```bash
+memorax-code account --show-mark-id
+```
+
+获取 Mark ID 后，再前往 MemoraX 注册。当前暂不支持为已经注册的账号补绑 Mark ID。
+
+两种安装引导都会自动检测受支持的 Coding Agent。完成后，请重启或刷新检测到的 Coding Agent。
 
 ### 安装故障排查
 
@@ -76,8 +98,7 @@ memorax-code setup
 | 现象 | 建议处理方式 |
 | --- | --- |
 | 因 Node.js 版本不受支持导致安装失败 | 运行 `node --version` 检查版本，并升级到 Node.js 20 或更高版本后重新安装 MemoraX Code。 |
-| npm 包已安装，但没有进入安装引导 | 这是正常行为。请在正常的交互式终端中运行 `memorax-code setup`。 |
-| 希望使用已有的 MemoraX 账号 | 运行 `memorax-code setup --existing-account`，并只在本机输入所需信息。不要将 API Key 粘贴到聊天记录或公开 Issue 中。 |
+| npm 包已安装，但没有进入安装引导 | 这是正常行为。请在正常的交互式终端中选择并运行上方适合您的安装引导命令。 |
 | 完成安装引导后，搜索、召回或写回仍不可用 | 运行 `memorax-code status` 和 `memorax-cli status`，然后按照详细的故障排查指南处理。 |
 
 有关支持的配置项，请参阅[配置](docs/configuration.md)；

--- a/packages/npm/memorax-code/README.md
+++ b/packages/npm/memorax-code/README.md
@@ -14,14 +14,44 @@ Harness, and OpenCode.
 
 ```bash
 npm install -g @memorax/memorax-code
+```
+
+### Connect a MemoraX Account (Recommended)
+
+[Create a MemoraX account](https://platform.memorax.net/) or use an existing
+one, then run:
+
+```bash
+memorax-code setup --existing-account
+```
+
+> Using MemoraX Code across devices? Find the MemoraX username and API key
+> needed by setup in `~/.memorax-code/config.toml` on a configured device, then
+> enter them locally during setup on another device. This file contains your
+> API key—keep it private and never paste it into chats or public issues.
+
+### Or Try Without an Account (90-Day Guest Mode)
+
+To start immediately and connect an account later, run:
+
+```bash
 memorax-code setup
 ```
 
-Setup automatically detects supported coding agents and completes an
-account-free connection. If you already have a MemoraX account, run
-`memorax-code setup --existing-account` instead. Later setup runs reuse a
-complete saved configuration; use `memorax-code setup --reconfigure` to
-replace it.
+To activate your guest account, first run this command directly in your local
+terminal:
+
+```bash
+memorax-code account --show-mark-id
+```
+
+After obtaining the Mark ID, create your MemoraX account. The platform does
+not currently support attaching a Mark ID to an account that has already been
+registered.
+
+Both setup paths automatically detect supported coding agents. Later setup
+runs reuse a complete saved configuration; use
+`memorax-code setup --reconfigure` to replace it.
 
 After the first installation, restart or refresh the detected coding agents
 before opening a new session. In Codex, enable **MemoraX Code Codex Adapter**

--- a/packages/npm/memorax-code/README.md
+++ b/packages/npm/memorax-code/README.md
@@ -26,9 +26,10 @@ memorax-code setup --existing-account
 ```
 
 > Using MemoraX Code across devices? Find the MemoraX username and API key
-> needed by setup in `~/.memorax-code/config.toml` on a configured device, then
-> enter them locally during setup on another device. This file contains your
-> API key—keep it private and never paste it into chats or public issues.
+> needed by setup in the MemoraX Code configuration file on a configured device
+> (normally `~/.memorax-code/config.toml`), then enter them locally during setup
+> on another device. This file contains your API key—keep it private and never
+> paste it into chats or public issues.
 
 ### Or Try Without an Account (90-Day Guest Mode)
 


### PR DESCRIPTION
## Change Summary
Clarify the recommended account onboarding path while keeping the 90-day guest mode available as an alternative, and document guest activation and cross-device setup guidance.

## Implementation Highlights
- Put registered-account setup first and keep guest setup as the secondary 90-day trial path.
- Document cross-device credential reuse without assuming the default MemoraX Code home.
- Document the Mark ID ordering required to activate a guest account.
- Keep the root English, Chinese, npm package, and detailed installation guides consistent.

## Validation
- make docs-check
- git diff --check

## Full End-to-End Validation Results
- Environment: Local macOS documentation worktree.
- Scenario or matrix: Root English README, root Chinese README, npm package README, and detailed installation guide synchronization and link contracts.
- Command or workflow: make docs-check and git diff --check.
- Result: All 10 documentation contract tests passed; documentation and README synchronization checks passed; no whitespace errors were found.
- Evidence or artifacts: Redacted local command output reported in this PR validation section.
- Reason not run / remaining risk: Runtime E2E was not run because this PR changes documentation only and does not modify installation behavior. Remaining risk is limited to wording clarity.