### PR TITLE
fix: preserve OpenCode turn lineage across compaction

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -403,11 +403,14 @@ sequenceDiagram
   client-qualified trace paths. Its normalized Search and Add operations enter
   DSH trace without copying the native Session Event Log.
 - OpenCode terminal handling accepts only matching SDK user and completed
-  assistant records for the correlated session and parent message. An exact
-  `MessageAbortedError` closes the Turn as interrupted without writeback; other
-  errors, summary, compaction, incomplete, or identity-mismatched messages are
-  rejected. It does not fall back to plugin prompt text or local database
-  guesses.
+  assistant records for the correlated session and native parent lineage. When
+  OpenCode compacts an active Turn, the lineage must prove the compaction
+  `tail_start_id`, its marked synthetic continuation, and the final assistant;
+  only the original user text and visible final reply are materialized. A
+  completed native assistant error closes the Turn as interrupted without
+  writeback; malformed errors, summary, compaction, incomplete, or
+  identity-mismatched messages are rejected. It does not fall back to plugin
+  prompt text or local database guesses.
 - Because OpenCode terminal notifications are event callbacks, the plugin
   serializes idle- and interruption-triggered SDK reads per session, tracks
   the resulting work, and drains already-started tasks during plugin disposal.

--- a/packages/ts/memorax-code-backend/src/clients/opencode/message-turn.ts
+++ b/packages/ts/memorax-code-backend/src/clients/opencode/message-turn.ts
@@ -43,7 +43,7 @@ export function openCodeMessageTurn(
   if (
     stringField(user.info, "sessionID") !== input.sessionId
     || stringField(assistant.info, "sessionID") !== input.sessionId
-    || stringField(assistant.info, "parentID") !== input.userMessageId
+    || !assistantBelongsToTurn(messages, input, assistant)
   ) {
     return { ok: false, reason: "message_identity_mismatch" };
   }
@@ -52,7 +52,7 @@ export function openCodeMessageTurn(
     return { ok: false, reason: "assistant_not_completed" };
   }
   const assistantError = assistant.info.error;
-  const interrupted = isRecord(assistantError) && assistantError.name === "MessageAbortedError";
+  const interrupted = isRecord(assistantError) && stringField(assistantError, "name") !== undefined;
   if (assistantError !== undefined && assistantError !== null && !interrupted) {
     return { ok: false, reason: "assistant_error" };
   }
@@ -77,6 +77,61 @@ export function openCodeMessageTurn(
       outcome: interrupted ? "interrupted" : "completed",
     },
   };
+}
+
+function assistantBelongsToTurn(
+  messages: readonly unknown[],
+  input: { sessionId: string; userMessageId: string },
+  assistant: OpenCodeMessageRecord,
+): boolean {
+  return stringField(assistant.info, "parentID") === terminalUserMessageFor(messages, input);
+}
+
+function terminalUserMessageFor(
+  messages: readonly unknown[],
+  input: { sessionId: string; userMessageId: string },
+): string | undefined {
+  const sessionMessages = messages.filter((message): message is OpenCodeMessageRecord => (
+    isMessageRecord(message)
+    && stringField(message.info, "sessionID") === input.sessionId
+    && messageId(message) !== undefined
+  ));
+  const startIndex = sessionMessages.findIndex((message) => (
+    message.info.role === "user" && messageId(message) === input.userMessageId
+  ));
+  if (startIndex < 0) return undefined;
+  const lineageAssistantIds = new Set<string>();
+  let terminalUserMessageId = input.userMessageId;
+  let awaitingContinuation = false;
+
+  for (const message of sessionMessages.slice(startIndex + 1)) {
+    if (message.info.role === "assistant") {
+      if (stringField(message.info, "parentID") === terminalUserMessageId) {
+        const id = messageId(message);
+        if (id) lineageAssistantIds.add(id);
+      }
+      continue;
+    }
+    if (message.info.role !== "user") continue;
+    if (hasCompactionPart(message.parts)) {
+      const compactionTailId = compactionTailStartId(message, input.sessionId);
+      if (!compactionTailId || !lineageAssistantIds.has(compactionTailId) || awaitingContinuation) {
+        return undefined;
+      }
+      awaitingContinuation = true;
+      continue;
+    }
+    if (isCompactionContinuation(message, input.sessionId)) {
+      if (!awaitingContinuation) return undefined;
+      const id = messageId(message);
+      if (!id) return undefined;
+      terminalUserMessageId = id;
+      awaitingContinuation = false;
+      continue;
+    }
+    break;
+  }
+  return !awaitingContinuation ? terminalUserMessageId : undefined;
 }
 
 type OpenCodeMessageRecord = Readonly<{
@@ -116,6 +171,37 @@ function messageText(
 
 function hasCompactionPart(parts: readonly unknown[]): boolean {
   return parts.some((part) => isRecord(part) && part.type === "compaction");
+}
+
+function compactionTailStartId(
+  message: OpenCodeMessageRecord,
+  sessionId: string,
+): string | undefined {
+  const id = messageId(message);
+  const parts = message.parts.filter((part) => (
+    isRecord(part)
+    && part.type === "compaction"
+    && stringField(part, "sessionID") === sessionId
+    && stringField(part, "messageID") === id
+  ));
+  if (parts.length !== 1 || !isRecord(parts[0])) return undefined;
+  return stringField(parts[0], "tail_start_id");
+}
+
+function isCompactionContinuation(
+  message: OpenCodeMessageRecord,
+  sessionId: string,
+): boolean {
+  const id = messageId(message);
+  return message.parts.some((part) => (
+    isRecord(part)
+    && part.type === "text"
+    && part.synthetic === true
+    && isRecord(part.metadata)
+    && part.metadata.compaction_continue === true
+    && stringField(part, "sessionID") === sessionId
+    && stringField(part, "messageID") === id
+  ));
 }
 
 function stringField(value: Record<string, unknown>, key: string): string | undefined {

--- a/packages/ts/memorax-code-backend/test/clients/opencode/opencode-memory-hook.test.mjs
+++ b/packages/ts/memorax-code-backend/test/clients/opencode/opencode-memory-hook.test.mjs
@@ -103,7 +103,6 @@ test("OpenCode SDK messages materialize only an exact completed normal turn", ()
     ["parent mismatch", (messages) => { messages[1].info.parentID = "other-user"; }, "message_identity_mismatch"],
     ["session mismatch", (messages) => { messages[1].info.sessionID = "other-session"; }, "message_identity_mismatch"],
     ["incomplete assistant", (messages) => { delete messages[1].info.time.completed; }, "assistant_not_completed"],
-    ["other assistant error", (messages) => { messages[1].info.error = { name: "UnknownError" }; }, "assistant_error"],
     ["summary assistant", (messages) => { messages[1].info.summary = true; }, "summary_message"],
     ["compaction turn", (messages) => { messages[0].parts.push(part("compaction", "user-1")); }, "compaction_message"],
   ]) {
@@ -115,6 +114,83 @@ test("OpenCode SDK messages materialize only an exact completed normal turn", ()
       assistantMessageId: "assistant-1",
     }), { ok: false, reason }, name);
   }
+
+  const providerFailure = openCodeMessages();
+  providerFailure[1].info.error = { name: "UnknownError" };
+  providerFailure[1].parts = [];
+  assert.deepEqual(openCodeMessageTurn(providerFailure, {
+    sessionId: "session-1",
+    userMessageId: "user-1",
+    assistantMessageId: "assistant-1",
+  }), {
+    ok: true,
+    turn: {
+      sessionId: "session-1",
+      userMessageId: "user-1",
+      assistantMessageId: "assistant-1",
+      userPrompt: "OpenCode user prompt.",
+      assistantReply: "",
+      outcome: "interrupted",
+    },
+  });
+});
+
+test("OpenCode SDK messages materialize a completed compaction continuation as the original turn", () => {
+  const messages = compactedOpenCodeMessages();
+  assert.deepEqual(openCodeMessageTurn(messages, {
+    sessionId: "session-1",
+    userMessageId: "user-1",
+    assistantMessageId: "assistant-final",
+  }), {
+    ok: true,
+    turn: {
+      sessionId: "session-1",
+      userMessageId: "user-1",
+      assistantMessageId: "assistant-final",
+      userPrompt: "OpenCode user prompt.",
+      assistantReply: "OpenCode final reply.",
+      outcome: "completed",
+    },
+  });
+
+  assert.deepEqual(openCodeMessageTurn(messages, {
+    sessionId: "session-1",
+    userMessageId: "user-1",
+    assistantMessageId: "assistant-tail",
+  }), { ok: false, reason: "message_identity_mismatch" });
+
+  for (const [name, mutate] of [
+    ["unknown compaction tail", (input) => { input[2].parts[0].tail_start_id = "assistant-other"; }],
+    ["unmarked synthetic continuation", (input) => { delete input[3].parts[0].metadata; }],
+    ["unrelated final parent", (input) => { input[4].info.parentID = "user-other"; }],
+  ]) {
+    const invalid = compactedOpenCodeMessages();
+    mutate(invalid);
+    assert.deepEqual(openCodeMessageTurn(invalid, {
+      sessionId: "session-1",
+      userMessageId: "user-1",
+      assistantMessageId: "assistant-final",
+    }), { ok: false, reason: "message_identity_mismatch" }, name);
+  }
+
+  const interrupted = compactedOpenCodeMessages();
+  interrupted[4].info.error = { name: "MessageAbortedError" };
+  interrupted[4].parts = [];
+  assert.deepEqual(openCodeMessageTurn(interrupted, {
+    sessionId: "session-1",
+    userMessageId: "user-1",
+    assistantMessageId: "assistant-final",
+  }), {
+    ok: true,
+    turn: {
+      sessionId: "session-1",
+      userMessageId: "user-1",
+      assistantMessageId: "assistant-final",
+      userPrompt: "OpenCode user prompt.",
+      assistantReply: "",
+      outcome: "interrupted",
+    },
+  });
 });
 
 test("OpenCode finalizes an explicit MessageAbortedError without writeback", async () => {
@@ -294,6 +370,58 @@ function openCodeMessages() {
         time: { created: 2, completed: 3 },
       },
       parts: [textPart("assistant-1", "OpenCode assistant reply.")],
+    },
+  ];
+}
+
+function compactedOpenCodeMessages() {
+  return [
+    openCodeMessages()[0],
+    {
+      info: {
+        id: "assistant-tail",
+        sessionID: "session-1",
+        role: "assistant",
+        parentID: "user-1",
+        time: { created: 2, completed: 3 },
+      },
+      parts: [part("tool", "assistant-tail")],
+    },
+    {
+      info: {
+        id: "user-compaction",
+        sessionID: "session-1",
+        role: "user",
+        time: { created: 4 },
+      },
+      parts: [{
+        ...part("compaction", "user-compaction"),
+        auto: true,
+        tail_start_id: "assistant-tail",
+      }],
+    },
+    {
+      info: {
+        id: "user-continuation",
+        sessionID: "session-1",
+        role: "user",
+        time: { created: 5 },
+      },
+      parts: [{
+        ...textPart("user-continuation", "Continue."),
+        synthetic: true,
+        metadata: { compaction_continue: true },
+      }],
+    },
+    {
+      info: {
+        id: "assistant-final",
+        sessionID: "session-1",
+        role: "assistant",
+        parentID: "user-continuation",
+        time: { created: 6, completed: 7 },
+      },
+      parts: [textPart("assistant-final", "OpenCode final reply.")],
     },
   ];
 }

--- a/packages/ts/memorax-code-backend/test/clients/opencode/opencode-memory-hook.test.mjs
+++ b/packages/ts/memorax-code-backend/test/clients/opencode/opencode-memory-hook.test.mjs
@@ -385,7 +385,7 @@ function compactedOpenCodeMessages() {
         parentID: "user-1",
         time: { created: 2, completed: 3 },
       },
-      parts: [part("tool", "assistant-tail")],
+      parts: [],
     },
     {
       info: {

--- a/packages/ts/memorax-code-opencode-adapter/src/plugin.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/src/plugin.mjs
@@ -103,13 +103,14 @@ export function createMemoraxOpenCodePlugin(options = {}) {
           && message.info.id === turn.userMessageId
           && message.info.sessionID === sessionId
         ));
-        const assistant = terminalAssistantFor(
+        const terminal = terminalTurnFor(
           messages,
           sessionId,
           turn.userMessageId,
           target?.assistantMessageId,
         );
-        if (!user || !assistant) continue;
+        if (!user || !terminal) continue;
+        const { assistant, evidence } = terminal;
         let result;
         try {
           result = await postBackend(options, "/memory/writeback", {
@@ -118,7 +119,7 @@ export function createMemoraxOpenCodePlugin(options = {}) {
             sessionId,
             userMessageId: turn.userMessageId,
             assistantMessageId: assistant.info.id,
-            messages: [user, assistant],
+            messages: evidence,
             cwd: workspaceRoot,
             workspaceKind,
           }, WRITEBACK_TIMEOUT_MS);
@@ -281,10 +282,13 @@ export function createMemoraxOpenCodePlugin(options = {}) {
           return;
         }
         if (event?.type === "message.updated") {
-          const interrupted = interruptedAssistantFromEvent(event, pendingTurns);
+          const interrupted = terminalErrorAssistantFromEvent(event, pendingTurns);
           if (interrupted) {
             track(
-              queueSessionFlush(interrupted.sessionId, interrupted),
+              queueSessionFlush(
+                interrupted.sessionId,
+                interrupted.userMessageId ? interrupted : undefined,
+              ),
               "opencode interrupted turn finalization failed",
             );
           }
@@ -310,18 +314,16 @@ export function createMemoraxOpenCodePlugin(options = {}) {
 export const MemoraxOpenCodePlugin = createMemoraxOpenCodePlugin();
 export default MemoraxOpenCodePlugin;
 
-function terminalAssistantFor(messages, sessionId, userMessageId, assistantMessageId) {
-  return messages
+function terminalTurnFor(messages, sessionId, userMessageId, assistantMessageId) {
+  const lineage = turnLineage(messages, sessionId, userMessageId);
+  if (!lineage || lineage.awaitingContinuation) return undefined;
+  const assistant = lineage.messages
     .filter((message) => (
       message?.info?.role === "assistant"
       && message.info.sessionID === sessionId
-      && message.info.parentID === userMessageId
+      && message.info.parentID === lineage.terminalUserMessageId
       && (!assistantMessageId || message.info.id === assistantMessageId)
       && Number.isFinite(message.info.time?.completed)
-      && (
-        message.info.error === undefined
-        || message.info.error?.name === "MessageAbortedError"
-      )
       && message.info.summary !== true
       && !message.parts?.some((part) => part?.type === "compaction")
     ))
@@ -330,24 +332,110 @@ function terminalAssistantFor(messages, sessionId, userMessageId, assistantMessa
       || String(left.info.id).localeCompare(String(right.info.id))
     ))
     .at(-1);
+  if (!assistant) return undefined;
+  return {
+    assistant,
+    evidence: uniqueMessages([...lineage.evidence, assistant]),
+  };
 }
 
-function interruptedAssistantFromEvent(event, pendingTurns) {
+function turnLineage(messages, sessionId, userMessageId) {
+  const sessionMessages = messages.filter((message) => (
+    message?.info?.sessionID === sessionId
+    && stringValue(message.info.id)
+    && Array.isArray(message.parts)
+  ));
+  const startIndex = sessionMessages.findIndex((message) => (
+    message.info.role === "user" && message.info.id === userMessageId
+  ));
+  if (startIndex < 0) return undefined;
+  const original = sessionMessages[startIndex];
+  const lineageAssistants = new Map();
+  const evidence = [original];
+  let terminalUserMessageId = userMessageId;
+  let awaitingContinuation = false;
+
+  for (const message of sessionMessages.slice(startIndex + 1)) {
+    if (message.info.role === "assistant") {
+      if (message.info.parentID === terminalUserMessageId) {
+        lineageAssistants.set(message.info.id, message);
+      }
+      continue;
+    }
+    if (message.info.role !== "user") continue;
+    const compactionTailId = compactionTailStartId(message, sessionId);
+    if (compactionTailId) {
+      const tail = lineageAssistants.get(compactionTailId);
+      if (!tail || awaitingContinuation) return undefined;
+      evidence.push(tail, message);
+      awaitingContinuation = true;
+      continue;
+    }
+    if (isCompactionContinuation(message, sessionId)) {
+      if (!awaitingContinuation) return undefined;
+      terminalUserMessageId = message.info.id;
+      evidence.push(message);
+      awaitingContinuation = false;
+      continue;
+    }
+    break;
+  }
+  return {
+    messages: sessionMessages.slice(startIndex + 1),
+    terminalUserMessageId,
+    awaitingContinuation,
+    evidence,
+  };
+}
+
+function compactionTailStartId(message, sessionId) {
+  const messageId = stringValue(message?.info?.id);
+  const parts = message?.parts?.filter((part) => (
+    part?.type === "compaction"
+    && part.sessionID === sessionId
+    && part.messageID === messageId
+  )) ?? [];
+  if (parts.length !== 1) return undefined;
+  return stringValue(parts[0].tail_start_id);
+}
+
+function isCompactionContinuation(message, sessionId) {
+  const messageId = stringValue(message?.info?.id);
+  return message?.parts?.some((part) => (
+    part?.type === "text"
+    && part.synthetic === true
+    && part.metadata?.compaction_continue === true
+    && part.sessionID === sessionId
+    && part.messageID === messageId
+  )) === true;
+}
+
+function uniqueMessages(messages) {
+  const unique = new Map();
+  for (const message of messages) unique.set(message.info.id, message);
+  return [...unique.values()];
+}
+
+function terminalErrorAssistantFromEvent(event, pendingTurns) {
   const info = event?.properties?.info;
   const sessionId = stringValue(info?.sessionID);
   const userMessageId = stringValue(info?.parentID);
   const assistantMessageId = stringValue(info?.id);
   if (
     info?.role !== "assistant"
-    || info?.error?.name !== "MessageAbortedError"
+    || !stringValue(info?.error?.name)
     || !Number.isFinite(info?.time?.completed)
     || info?.summary === true
     || !sessionId
     || !userMessageId
     || !assistantMessageId
-    || !pendingTurns.has(turnKey({ sessionId, userMessageId }))
   ) return undefined;
-  return { sessionId, userMessageId, assistantMessageId };
+  if (pendingTurns.has(turnKey({ sessionId, userMessageId }))) {
+    return { sessionId, userMessageId, assistantMessageId };
+  }
+  return [...pendingTurns.values()].some((turn) => turn.sessionId === sessionId)
+    ? { sessionId }
+    : undefined;
 }
 
 function textParts(parts) {

--- a/packages/ts/memorax-code-opencode-adapter/src/plugin.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/src/plugin.mjs
@@ -363,11 +363,12 @@ function turnLineage(messages, sessionId, userMessageId) {
       continue;
     }
     if (message.info.role !== "user") continue;
-    const compactionTailId = compactionTailStartId(message, sessionId);
-    if (compactionTailId) {
+    if (hasCompactionPart(message.parts)) {
+      const compactionTailId = compactionTailStartId(message, sessionId);
+      if (!compactionTailId || awaitingContinuation) return undefined;
       const tail = lineageAssistants.get(compactionTailId);
-      if (!tail || awaitingContinuation) return undefined;
-      evidence.push(tail, message);
+      if (!tail) return undefined;
+      evidence.push(minimalAssistantEvidence(tail), message);
       awaitingContinuation = true;
       continue;
     }
@@ -388,6 +389,10 @@ function turnLineage(messages, sessionId, userMessageId) {
   };
 }
 
+function hasCompactionPart(parts) {
+  return parts.some((part) => part?.type === "compaction");
+}
+
 function compactionTailStartId(message, sessionId) {
   const messageId = stringValue(message?.info?.id);
   const parts = message?.parts?.filter((part) => (
@@ -397,6 +402,18 @@ function compactionTailStartId(message, sessionId) {
   )) ?? [];
   if (parts.length !== 1) return undefined;
   return stringValue(parts[0].tail_start_id);
+}
+
+function minimalAssistantEvidence(message) {
+  return {
+    info: {
+      id: message.info.id,
+      sessionID: message.info.sessionID,
+      role: message.info.role,
+      parentID: message.info.parentID,
+    },
+    parts: [],
+  };
 }
 
 function isCompactionContinuation(message, sessionId) {

--- a/packages/ts/memorax-code-opencode-adapter/test/plugin.test.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/test/plugin.test.mjs
@@ -609,6 +609,62 @@ test("idle reads authoritative SDK messages and dispose drains the pending write
   });
 });
 
+test("idle follows an OpenCode compaction continuation back to the original pending turn", async () => {
+  const requests = [];
+  const messages = compactedMessages();
+  const plugin = createPluginWithoutReminders({
+    backendConnection: { url: "http://127.0.0.1:8787" },
+    fetchImpl: responseSequence(requests, [{ ok: true }, { ok: true }]),
+  });
+  const hooks = await plugin(pluginInput({
+    client: { session: { async messages() { return { data: messages }; } } },
+  }));
+
+  await hooks["chat.message"](
+    { sessionID: "session-compacted-turn" },
+    promptOutput("user-original", "Implement the requested change."),
+  );
+  hooks.event(sessionIdleEvent("session-compacted-turn"));
+  await hooks.dispose();
+
+  assert.equal(requests.length, 2);
+  assert.equal(requests[1].body.userMessageId, "user-original");
+  assert.equal(requests[1].body.assistantMessageId, "assistant-final");
+  assert.deepEqual(
+    requests[1].body.messages.map((message) => message.info.id),
+    ["user-original", "assistant-tail", "user-compaction", "user-continuation", "assistant-final"],
+  );
+});
+
+test("message.updated finalizes an interrupted compaction continuation", async () => {
+  const requests = [];
+  const messages = compactedMessages();
+  const assistant = messages.at(-1);
+  assistant.info.error = { name: "MessageAbortedError" };
+  assistant.parts = [];
+  const plugin = createPluginWithoutReminders({
+    backendConnection: { url: "http://127.0.0.1:8787" },
+    fetchImpl: responseSequence(requests, [
+      { ok: true },
+      { ok: true, scheduled: false, reason: "interrupted" },
+    ]),
+  });
+  const hooks = await plugin(pluginInput({
+    client: { session: { async messages() { return { data: messages }; } } },
+  }));
+
+  await hooks["chat.message"](
+    { sessionID: "session-compacted-turn" },
+    promptOutput("user-original", "Implement the requested change."),
+  );
+  hooks.event(messageUpdatedEvent(assistant.info));
+  await hooks.dispose();
+
+  assert.equal(requests.length, 2);
+  assert.equal(requests[1].body.userMessageId, "user-original");
+  assert.equal(requests[1].body.assistantMessageId, "assistant-final");
+});
+
 test("idle discards HTTP 413 without starving a runtime-closed retry", async () => {
   const requests = [];
   const names = ["oversized", "retry"];
@@ -669,7 +725,7 @@ test("idle discards HTTP 413 without starving a runtime-closed retry", async () 
   );
 });
 
-test("message.updated finalizes only MessageAbortedError and serializes with idle", async () => {
+test("message.updated finalizes MessageAbortedError and serializes with idle", async () => {
   const requests = [];
   let clientCalls = 0;
   let markIdleStarted;
@@ -717,14 +773,6 @@ test("message.updated finalizes only MessageAbortedError and serializes with idl
     { sessionID: "session-interrupted" },
     promptOutput("user-interrupted", "Stop this Turn."),
   );
-  hooks.event(messageUpdatedEvent({
-    ...assistantInfo,
-    id: "assistant-other-error",
-    error: { name: "UnknownError" },
-  }));
-  await delay(0);
-  assert.equal(clientCalls, 0);
-
   hooks.event(sessionIdleEvent("session-interrupted"));
   await idleStarted;
   const abortEvent = messageUpdatedEvent(assistantInfo);
@@ -743,6 +791,44 @@ test("message.updated finalizes only MessageAbortedError and serializes with idl
     "/memory/writeback",
   ]);
   assert.deepEqual(requests[1].body.messages, interruptedMessages);
+});
+
+test("message.updated closes an explicit provider error without writeback", async () => {
+  const requests = [];
+  const assistantInfo = {
+    id: "assistant-provider-error",
+    role: "assistant",
+    sessionID: "session-provider-error",
+    parentID: "user-provider-error",
+    time: { completed: 123 },
+    error: { name: "UnknownError" },
+  };
+  const messages = [
+    {
+      info: { id: "user-provider-error", role: "user", sessionID: "session-provider-error" },
+      parts: [{ type: "text", text: "Run the request." }],
+    },
+    { info: assistantInfo, parts: [] },
+  ];
+  const hooks = await createPluginWithoutReminders({
+    backendConnection: { url: "http://127.0.0.1:8787" },
+    fetchImpl: responseSequence(requests, [
+      { ok: true },
+      { ok: true, scheduled: false, reason: "interrupted" },
+    ]),
+  })(pluginInput({
+    client: { session: { async messages() { return { data: messages }; } } },
+  }));
+
+  await hooks["chat.message"](
+    { sessionID: "session-provider-error" },
+    promptOutput("user-provider-error", "Run the request."),
+  );
+  hooks.event(messageUpdatedEvent(assistantInfo));
+  await hooks.dispose();
+
+  assert.equal(requests.length, 2);
+  assert.equal(requests[1].body.assistantMessageId, "assistant-provider-error");
 });
 
 function pluginInput(overrides = {}) {
@@ -776,6 +862,73 @@ function promptOutput(id, text, system) {
     message: { id, ...(system ? { system } : {}) },
     parts: [{ type: "text", text }],
   };
+}
+
+function compactedMessages() {
+  const sessionID = "session-compacted-turn";
+  const text = (messageID, value, extra = {}) => ({
+    id: `${messageID}-text`,
+    sessionID,
+    messageID,
+    type: "text",
+    text: value,
+    ...extra,
+  });
+  return [
+    {
+      info: { id: "user-original", sessionID, role: "user", time: { created: 1 } },
+      parts: [text("user-original", "Implement the requested change.")],
+    },
+    {
+      info: {
+        id: "assistant-tail",
+        sessionID,
+        role: "assistant",
+        parentID: "user-original",
+        time: { created: 2, completed: 3 },
+      },
+      parts: [{ id: "assistant-tail-tool", sessionID, messageID: "assistant-tail", type: "tool" }],
+    },
+    {
+      info: { id: "user-compaction", sessionID, role: "user", time: { created: 4 } },
+      parts: [{
+        id: "user-compaction-part",
+        sessionID,
+        messageID: "user-compaction",
+        type: "compaction",
+        auto: true,
+        tail_start_id: "assistant-tail",
+      }],
+    },
+    {
+      info: {
+        id: "assistant-summary",
+        sessionID,
+        role: "assistant",
+        parentID: "user-compaction",
+        summary: true,
+        time: { created: 5, completed: 6 },
+      },
+      parts: [text("assistant-summary", "Internal summary.")],
+    },
+    {
+      info: { id: "user-continuation", sessionID, role: "user", time: { created: 7 } },
+      parts: [text("user-continuation", "Continue.", {
+        synthetic: true,
+        metadata: { compaction_continue: true },
+      })],
+    },
+    {
+      info: {
+        id: "assistant-final",
+        sessionID,
+        role: "assistant",
+        parentID: "user-continuation",
+        time: { created: 8, completed: 9 },
+      },
+      parts: [text("assistant-final", "Implemented and verified.")],
+    },
+  ];
 }
 
 function memoryResponse(requests) {

--- a/packages/ts/memorax-code-opencode-adapter/test/plugin.test.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/test/plugin.test.mjs
@@ -634,6 +634,55 @@ test("idle follows an OpenCode compaction continuation back to the original pend
     requests[1].body.messages.map((message) => message.info.id),
     ["user-original", "assistant-tail", "user-compaction", "user-continuation", "assistant-final"],
   );
+  assert.deepEqual(requests[1].body.messages[1], {
+    info: {
+      id: "assistant-tail",
+      sessionID: "session-compacted-turn",
+      role: "assistant",
+      parentID: "user-original",
+    },
+    parts: [],
+  });
+  assert.equal(messages[1].parts[0].type, "tool", "native SDK messages remain unchanged");
+});
+
+test("malformed compaction records remain pending until the SDK lineage is complete", async () => {
+  for (const [name, mutate] of [
+    ["missing tail id", (message) => { delete message.parts[0].tail_start_id; }],
+    ["blank tail id", (message) => { message.parts[0].tail_start_id = " "; }],
+    ["duplicate compaction part", (message) => { message.parts.push({ ...message.parts[0] }); }],
+  ]) {
+    const requests = [];
+    const messages = compactedMessages();
+    mutate(messages[2]);
+    const plugin = createPluginWithoutReminders({
+      backendConnection: { url: "http://127.0.0.1:8787" },
+      fetchImpl: responseSequence(requests, [{ ok: true }, { ok: true }]),
+    });
+    const hooks = await plugin(pluginInput({
+      client: { session: { async messages() { return { data: messages }; } } },
+    }));
+
+    await hooks["chat.message"](
+      { sessionID: "session-compacted-turn" },
+      promptOutput("user-original", "Implement the requested change."),
+    );
+    hooks.event(sessionIdleEvent("session-compacted-turn"));
+    await hooks.dispose();
+
+    assert.deepEqual(
+      requests.map((request) => new URL(request.url).pathname),
+      ["/memory/turn-start"],
+      name,
+    );
+
+    messages[2] = compactedMessages()[2];
+    hooks.event(sessionIdleEvent("session-compacted-turn"));
+    await hooks.dispose();
+
+    assert.equal(requests.length, 2, name);
+    assert.equal(requests[1].body.assistantMessageId, "assistant-final", name);
+  }
 });
 
 test("message.updated finalizes an interrupted compaction continuation", async () => {


### PR DESCRIPTION
## Change Summary
Preserve one OpenCode Turn across native context compaction so MemoraX Code records the original user request and final visible assistant reply, while closing terminal provider errors as interrupted without automatic Add.

## Implementation Highlights
- Follow and validate OpenCode's native `tail_start_id` and synthetic `compaction_continue` lineage from the original user message to the final assistant message.
- Send only the native evidence required for Backend validation, excluding compaction summaries, synthetic continuation text, and pre-compaction assistant output from materialized Memory content.
- Finalize any completed, explicitly named assistant error as an interrupted Turn, and add fail-closed coverage for malformed lineage and pre-compaction terminal selection.
- Document the OpenCode compaction authority boundary in `ARCHITECTURE.md`.

## Validation
- `npm run typecheck && npm test` in Backend: 468 passed, 2 skipped.
- `npm test` in OpenCode Adapter: 34 passed.
- `make docs-check`: passed.
- `make test-npm-package`: 224 passed, 2 skipped; local-only trace contract passed.
- `make npm-package-check`: all staged-package runtime tests passed (224 passed, 2 skipped), then the final static README assertion failed because current `origin/main` now separates install and setup commands while the baseline script still requires them to be adjacent. This mismatch exists on `origin/main` and is not changed in this PR.
- `git diff --check`: passed.

## Full End-to-End Validation Results
- Environment: isolated container; OpenCode 1.18.21; real GPT-5.5 high request; isolated MemoraX Code configuration.
- Scenario or matrix: one native OpenCode Turn that triggered compaction and continued to a final visible assistant reply; separate terminal provider-error scenario.
- Command or workflow: installed the locally staged package, ran a real OpenCode request through the managed plugin and Backend, inspected native OpenCode message lineage plus redacted Trace/Add results, then repeated against a local provider returning HTTP 401.
- Result: native data contained one compaction and one synthetic continuation; Trace contained one start and one completed end; all six Add chunks succeeded after bounded retry; Add content excluded the summary, synthetic continuation, and pre-compaction assistant output. The provider-error case produced an OpenCode API error, closed the Turn as interrupted, and scheduled zero Memory writebacks.
- Evidence or artifacts: verified from redacted local runtime logs and native message metadata; temporary containers, images, processes, and test directories were removed after validation.
- Reason not run / remaining risk: Windows real-client E2E was not repeated because this change follows OpenCode SDK message semantics and does not alter platform-specific installation or process handling.
