### PR TITLE
docs: document 0.1.8 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ behavior.
 
 ## Unreleased
 
+## [0.1.8] - 2026-08-24
+
+### Added
+
+- Guest quota reminders can now display the matching anonymous identity's
+  Mark ID and 90-day guest term, while registered-account reminders remain
+  unchanged.
+
+### Changed
+
+- Clarified existing-account setup, 90-day guest mode, guest activation, and
+  cross-device configuration reuse in the installation guidance.
+
+### Fixed
+
+- Preserved OpenCode turns across native context compaction so automatic
+  writeback uses the original request and final visible reply instead of
+  synthetic compaction content.
+- Prevented standalone OpenCode Repo Memory initialization from contending
+  with the active client's database.
+
 ### Removed
 
 - Removed the local Memory Viewer. Memory search, automatic writeback, quota
@@ -100,6 +121,7 @@ Later upgrades do not require this workaround.
 - Required a non-empty MemoraX user ID and API key during interactive setup,
   with clearer registration guidance.
 
+[0.1.8]: https://www.npmjs.com/package/@memorax/memorax-code/v/0.1.8
 [0.1.7]: https://www.npmjs.com/package/@memorax/memorax-code/v/0.1.7
 [0.1.6]: https://www.npmjs.com/package/@memorax/memorax-code/v/0.1.6
 [0.1.5]: https://www.npmjs.com/package/@memorax/memorax-code/v/0.1.5


### PR DESCRIPTION
## Change Summary
Document the user-facing changes planned for MemoraX Code 0.1.8 before the version-only release PR and npm publication.

## Implementation Highlights
- Add a versioned 0.1.8 section covering the guest Mark ID reminder, OpenCode reliability fixes, onboarding guidance, and Memory Viewer removal.
- Keep internal refactors, test-only work, issue-form maintenance, and changelog maintenance out of the release notes.
- Add the future npm version link while retaining an empty Unreleased section for subsequent work.

## Validation
- `make docs-check` — passed all 10 documentation contract tests and README language synchronization.
- `git diff --check` — passed.
- Compared `v0.1.7..origin/main` against merged PRs #103, #105, #106, #107, and #108.

## Full End-to-End Validation Results
- Environment: isolated documentation worktree based on the latest `origin/main` merge commit for PR #108.
- Scenario or matrix: every merged user-facing runtime or onboarding change after tag `v0.1.7`; internal-only PRs excluded.
- Command or workflow: first-parent Git history, live merged-PR inspection, `make docs-check`, and `git diff --check`.
- Result: documentation checks passed; the final diff changes only `CHANGELOG.md` with 22 added lines.
- Evidence or artifacts: commit `f0041bb`; no generated artifacts.
- Reason not run / remaining risk: runtime E2E was not repeated because this is documentation-only. The dated entry assumes publication on 2026-08-24 and must be adjusted before release if the schedule changes.
