### PR TITLE
fix:(opencode) retry incomplete writeback snapshots

### DIFF
--- a/packages/ts/memorax-code-opencode-adapter/src/plugin.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/src/plugin.mjs
@@ -139,7 +139,7 @@ export function createMemoraxOpenCodePlugin(options = {}) {
         }
       }
       if (incomplete && retryBudget > 0 && pluginEnabled(options)) {
-        await delay(INCOMPLETE_WRITEBACK_RETRY_DELAY_MS, undefined, { ref: false });
+        await delay(INCOMPLETE_WRITEBACK_RETRY_DELAY_MS);
         await flushSession(sessionId, target, retryBudget - 1);
       }
     }

--- a/packages/ts/memorax-code-opencode-adapter/src/plugin.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/src/plugin.mjs
@@ -18,6 +18,7 @@ const DEFAULT_BACKEND_PROMPT_WAIT_TIMEOUT_MS = 5_000;
 const TURN_START_TIMEOUT_MS = 12_000;
 const REMINDER_TRACE_TIMEOUT_MS = 1_000;
 const WRITEBACK_TIMEOUT_MS = 5_000;
+const INCOMPLETE_WRITEBACK_RETRY_DELAY_MS = 50;
 const MAX_PENDING_TURNS = 256;
 const MEMORY_SKILL_INVOCATION = "the `memorax-code` skill";
 
@@ -82,7 +83,7 @@ export function createMemoraxOpenCodePlugin(options = {}) {
       void observed.finally(() => inFlight.delete(observed));
     }
 
-    async function flushSession(sessionId, target) {
+    async function flushSession(sessionId, target, retryBudget = 1) {
       if (!pluginEnabled(options)) return;
       await ensureBackendReady();
       if (!pluginEnabled(options)) return;
@@ -97,6 +98,7 @@ export function createMemoraxOpenCodePlugin(options = {}) {
       });
       if (!pluginEnabled(options)) return;
       const messages = Array.isArray(response?.data) ? response.data : [];
+      let incomplete = false;
       for (const turn of turns) {
         const user = messages.find((message) => (
           message?.info?.role === "user"
@@ -109,7 +111,10 @@ export function createMemoraxOpenCodePlugin(options = {}) {
           turn.userMessageId,
           target?.assistantMessageId,
         );
-        if (!user || !terminal) continue;
+        if (!user || !terminal) {
+          incomplete = true;
+          continue;
+        }
         const { assistant, evidence } = terminal;
         let result;
         try {
@@ -133,13 +138,17 @@ export function createMemoraxOpenCodePlugin(options = {}) {
           pendingTurns.delete(turnKey(turn));
         }
       }
+      if (incomplete && retryBudget > 0 && pluginEnabled(options)) {
+        await delay(INCOMPLETE_WRITEBACK_RETRY_DELAY_MS, undefined, { ref: false });
+        await flushSession(sessionId, target, retryBudget - 1);
+      }
     }
 
-    function queueSessionFlush(sessionId, target) {
+    function queueSessionFlush(sessionId, target, retryBudget) {
       const previous = sessionFlushes.get(sessionId) ?? Promise.resolve();
       const queued = previous
         .catch(() => undefined)
-        .then(() => flushSession(sessionId, target));
+        .then(() => flushSession(sessionId, target, retryBudget));
       sessionFlushes.set(sessionId, queued);
       const clear = () => {
         if (sessionFlushes.get(sessionId) === queued) sessionFlushes.delete(sessionId);

--- a/packages/ts/memorax-code-opencode-adapter/test/plugin.test.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/test/plugin.test.mjs
@@ -609,6 +609,56 @@ test("idle reads authoritative SDK messages and dispose drains the pending write
   });
 });
 
+test("idle retries a pending writeback when its first SDK snapshot is incomplete", async () => {
+  const requests = [];
+  let messageReads = 0;
+  const plugin = createPluginWithoutReminders({
+    backendConnection: { url: "http://127.0.0.1:8787" },
+    fetchImpl: responseSequence(requests, [{ ok: true }, { ok: true }]),
+  });
+  const hooks = await plugin(pluginInput({
+    client: {
+      session: {
+        async messages() {
+          messageReads += 1;
+          const user = {
+            info: { id: "user-incomplete", role: "user", sessionID: "session-incomplete" },
+            parts: [{ type: "text", text: "Remember this completed turn." }],
+          };
+          if (messageReads === 1) return { data: [user] };
+          return {
+            data: [
+              user,
+              {
+                info: {
+                  id: "assistant-incomplete",
+                  role: "assistant",
+                  sessionID: "session-incomplete",
+                  parentID: "user-incomplete",
+                  time: { completed: 123 },
+                },
+                parts: [{ type: "text", text: "The turn is complete." }],
+              },
+            ],
+          };
+        },
+      },
+    },
+  }));
+
+  await hooks["chat.message"](
+    { sessionID: "session-incomplete" },
+    promptOutput("user-incomplete", "Remember this completed turn."),
+  );
+  hooks.event(sessionIdleEvent("session-incomplete"));
+  await hooks.dispose();
+
+  assert.deepEqual(
+    requests.map((request) => new URL(request.url).pathname),
+    ["/memory/turn-start", "/memory/writeback"],
+  );
+});
+
 test("idle follows an OpenCode compaction continuation back to the original pending turn", async () => {
   const requests = [];
   const messages = compactedMessages();


### PR DESCRIPTION
## Change Summary

  Retry one OpenCode SDK session-message read when an idle-triggered snapshot is incomplete, preventing a pending automatic writeback from being missed when no later event arrives.

  ## Implementation Highlights

  - Track incomplete SDK snapshots during a serialized session flush.
  - Wait 50 ms and retry the same flush once; do not poll indefinitely.
  - Continue to write back only validated OpenCode SDK user/assistant records.
  - Keep the retry inside the existing flush promise so plugin disposal waits for it.

  ## Validation

  - `npm test --prefix packages/ts/memorax-code-opencode-adapter`
  - Result: 36 tests passed.
  - Added a regression test covering an incomplete first SDK snapshot followed by a complete retry snapshot.

  ## Full End-to-End Validation Results

  - Environment: local Node.js adapter test environment.
  - Scenario or matrix: idle-triggered writeback with an incomplete first SDK message snapshot.
  - Command or workflow: `npm test --prefix packages/ts/memorax-code-opencode-adapter`
  - Result: 36/36 tests passed.
  - Evidence or artifacts: new regression test in `test/plugin.test.mjs`.
  - Reason not run / remaining risk: no real OpenCode client end-to-end run was performed; the retry is bounded to one delayed SDK reread and relies on the existing SDK message endpoint.