### PR TITLE
docs: document 0.1.9 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ behavior.
 
 ## Unreleased
 
+## [0.1.9] - 2026-08-28
+
+### Fixed
+
+- Restored Codex automatic writeback for current rollout transcripts by reading
+  authoritative response-item user and final-assistant messages before falling
+  back to legacy event messages.
+- Rejected response-item messages whose embedded Turn ID conflicts with the
+  active Turn, preventing mismatched content from being written to memory.
+
 ## [0.1.8] - 2026-08-24
 
 ### Added
@@ -121,6 +131,7 @@ Later upgrades do not require this workaround.
 - Required a non-empty MemoraX user ID and API key during interactive setup,
   with clearer registration guidance.
 
+[0.1.9]: https://www.npmjs.com/package/@memorax/memorax-code/v/0.1.9
 [0.1.8]: https://www.npmjs.com/package/@memorax/memorax-code/v/0.1.8
 [0.1.7]: https://www.npmjs.com/package/@memorax/memorax-code/v/0.1.7
 [0.1.6]: https://www.npmjs.com/package/@memorax/memorax-code/v/0.1.6


### PR DESCRIPTION
## Change Summary
Document the user-facing Codex automatic-writeback fix planned for MemoraX Code 0.1.9 before the version-only release PR and npm publication.

## Implementation Highlights
- Add a dated 0.1.9 changelog section for current Codex response-item rollout support.
- Document fail-closed handling when response-item Turn metadata conflicts with the active Turn.
- Add the future npm version link while preserving the empty Unreleased section.

## Validation
- `make docs-check`
- `git diff --check`
- Compared `v0.1.8..origin/main`; PR #119 is the only merged change in this release window.

## Full End-to-End Validation Results
- Environment: isolated documentation worktree based on `origin/main` at `d01eadd`.
- Result: all 10 documentation contract tests and README language synchronization passed.
- Evidence or artifacts: commit `a5790da`; no generated artifacts.
- Reason not run / remaining risk: runtime E2E was not repeated because this PR changes only `CHANGELOG.md`; PR #119 already passed Backend and package validation.