### PR TITLE
fix: let memorax-cli exit naturally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ behavior.
   managed Backend, so a continuously running installation keeps checking on
   its persisted cadence without requiring a new coding-agent session.
 
+### Fixed
+
+- Stopped `memorax-cli` from exiting with a nonzero status on Windows after
+  printing complete results by letting the Node process drain naturally
+  instead of calling `process.exit()`.
+
 ## [0.1.9] - 2026-08-28
 
 ### Fixed

--- a/packages/ts/memorax-code-backend/src/memorax-cli.ts
+++ b/packages/ts/memorax-code-backend/src/memorax-cli.ts
@@ -11,8 +11,8 @@ runMemoryCli(process.argv.slice(2)).then((result) => {
   } else {
     console.log(JSON.stringify(result, null, 2));
   }
-  process.exit(result.ok ? 0 : 1);
+  process.exitCode = result.ok ? 0 : 1;
 }).catch((error) => {
   console.error(error instanceof Error ? error.message : String(error));
-  process.exit(1);
+  process.exitCode = 1;
 });

--- a/packages/ts/memorax-code-backend/test/architecture/source-boundaries.test.mjs
+++ b/packages/ts/memorax-code-backend/test/architecture/source-boundaries.test.mjs
@@ -198,6 +198,13 @@ test("memorax-code lifecycle delegates client implementation details to adapter 
   assert.doesNotMatch(source, /memorax-code-(?:codex|claude)-adapter\/src/);
 });
 
+test("memorax-cli entrypoint exits naturally instead of forcing process exit", async () => {
+  const source = await readFile(join(backendSrc, "memorax-cli.ts"), "utf8");
+
+  assert.equal((source.match(/process\.exitCode\s*=/g) ?? []).length, 2);
+  assert.doesNotMatch(source, /process\.exit\s*\(/);
+});
+
 test("managed Backend owns automatic-update wakeups instead of client Hooks", async () => {
   const backendCli = await readFile(join(backendSrc, "entrypoints", "backend-cli.ts"), "utf8");
   const scheduler = await readFile(join(


### PR DESCRIPTION
## Change Summary

Replace `process.exit()` with `process.exitCode` in the `memorax-cli` entrypoint so the Node process drains naturally instead of tearing down in-flight async handles on Windows.

Fixes the following assertion failure crash on CLI exit under Windows:
```text
Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), file src\win\async.c, line 94
```

## Implementation Highlights

- `memorax-cli.ts`: success and error paths now set `process.exitCode` instead of calling `process.exit()`.
- Added a source-boundary regression test requiring two `process.exitCode` assignments and no `process.exit(` in the entrypoint.
- Added an Unreleased `Fixed` changelog entry.

## Reproduction

1. Start a chunked-response mock server so the fetch body is still draining when `memorax-cli` exits:

   ```bash
   node -e "const http=require('node:http'); const body=JSON.stringify({success:true,data:{answer:'mock'}}); http.createServer((req,res)=>{res.writeHead(200,{'content-type':'application/json'}); let i=0; const t=setInterval(()=>{res.write(body.slice(i,i+2)); i+=2; if(i>=body.length){clearInterval(t); res.end();}},10);}).listen(18803,'127.0.0.1');"
   ```

2. From a git repository, with the PR branch package installed or staged, configure the memory endpoint and run a search:

   ```powershell
   $env:MEMORAX_CODE_MEMORAX_ENDPOINT = 'http://127.0.0.1:18803'
   $env:MEMORAX_CODE_MEMORAX_API_KEY = 'test'
   $env:MEMORAX_CODE_MEMORAX_USER_ID = 'user'
   $env:MEMORAX_CODE_MEMORAX_TIMEOUT_MS = '5000'
   memorax-cli search --query test
   ```

3. Expected on `main`:

   ```text
   Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), file src\win\async.c, line 94
   ```

   Expected with this PR: complete JSON output and exit code `0`.

## Validation

- `npm run typecheck --prefix packages/ts/memorax-code-backend` passed.
- source-boundary + memory CLI tests: 33/33 passed.

## Full End-to-End Validation Results

- **Environment**: Windows 11, Node v24.19.0, libuv 1.52.1, undici 7.29.0
- **Scenario or matrix**: repeated `memorax-cli status/search` runs comparing `process.exit` against `process.exitCode`
- **Command or workflow**: run the CLI, capture stdout/stderr and exit code
- **Result**: the `process.exit` path aborted with `Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), file src\win\async.c, line 94` after complete output; the `process.exitCode` path exited cleanly
- **Evidence or artifacts**: local redacted comparison output
- **Reason not run / remaining risk**: full backend suite on Windows still hits the same libuv assertion from `--test-force-exit` in the Node test runner, which is a separate test-runner issue; no real MemoraX writes were performed

