### PR TITLE
fix: restore standard install command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,17 +64,8 @@ beforehand through its official `npx` workflow.
 #### 1. Install the Package
 
 ```bash
-npm install -g @memorax/memorax-code --foreground-scripts
+npm install -g @memorax/memorax-code
 ```
-
-Keep `--foreground-scripts` so the complete setup remains visible. The
-installer automatically detects available Codex, Claude Code, CodeBuddy/WorkBuddy, DeepSeek
-Harness, and OpenCode installations and connects those it finds. Follow the
-prompts to enter your MemoraX user ID, preferred language, and API key. On an
-interactive first install, a non-empty user ID and API key are required unless
-the effective configuration already supplies both. Codex users must also
-approve Hook activation and trust when prompted. Restart or refresh every
-detected coding agent after installation before starting a new session.
 
 #### 2. Connect a MemoraX Account (Recommended)
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -57,14 +57,8 @@ CodeBuddy/WorkBuddy、DeepSeek Harness 或 OpenCode 中的至少一个。Repo Me
 #### 1. 安装 npm 包
 
 ```bash
-npm install -g @memorax/memorax-code --foreground-scripts
+npm install -g @memorax/memorax-code
 ```
-
-请保留 `--foreground-scripts`，以便查看完整的安装过程。安装器会自动检测本机可用的 Codex、
-Claude Code、CodeBuddy/WorkBuddy、DeepSeek Harness 和 OpenCode，并为检测到的 Coding Agent 启用集成。按照终端提示输入
-MemoraX User ID、偏好语言和 API Key；首次交互安装时，除非有效配置已经提供 User ID 和 API Key，
-否则两者均不能为空。Codex 用户还需按提示完成 Hook 的激活和信任确认。安装完成后，请重启或刷新
-所有检测到的 Coding Agent，再开始新会话。
 
 #### 2. 注册或接入 MemoraX 账号（推荐）
 


### PR DESCRIPTION
## Change Summary
Restore the documented two-stage installation flow by removing the accidentally reintroduced `--foreground-scripts` option and legacy interactive-installer description.

## Implementation Highlights
- Use the standard `npm install -g @memorax/memorax-code` command in both root READMEs.
- Remove stale wording that incorrectly says npm installation performs interactive client setup; explicit `memorax-code setup` remains the integration entrypoint.

## Validation
- `make docs-check`
- `make npm-package-check` — completed successfully; 244 tests passed and 2 platform-dependent tests were skipped
- `git diff --check`

## Full End-to-End Validation Results
- Environment: macOS local package-check harness with isolated temporary homes
- Scenario or matrix: synchronized English/Chinese installation guidance and staged npm package documentation contract
- Command or workflow: `make docs-check` and `make npm-package-check`
- Result: both checks passed; the packaged README contract confirms `--foreground-scripts` is absent
- Evidence or artifacts: redacted command output only; temporary package-check artifacts were cleaned by the harness
- Reason not run / remaining risk: real-client E2E was not repeated because this PR changes documentation only and does not modify runtime behavior