### PR TITLE
fix:(npm) reconcile manual updates from stopped backend

### DIFF
--- a/packages/npm/memorax-code/bin/memorax-code.mjs
+++ b/packages/npm/memorax-code/bin/memorax-code.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { spawn, spawnSync } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -210,10 +210,6 @@ async function runUpdateCommand(args) {
   if (npmResult.exitCode !== 0) return npmResult.exitCode;
 
   const memoraxCodeHome = requestedHome ?? requestedMemoraxCodeHome([]);
-  if (!existsSync(join(memoraxCodeHome, "runtime", "backend", "backend.pid.json"))) {
-    console.error("memorax-code update: package updated; the managed Backend remains stopped; run `memorax-code setup` from a terminal to reconcile clients and verify Hook changes");
-    return 0;
-  }
   if (!setupCanPrompt()) {
     console.error("memorax-code update: package updated; run `memorax-code setup` from a terminal to reconcile clients and verify Hook changes");
     return 0;

--- a/packages/npm/memorax-code/test/memorax-code-entrypoint.test.mjs
+++ b/packages/npm/memorax-code/test/memorax-code-entrypoint.test.mjs
@@ -142,10 +142,11 @@ test("setup propagates the setup process exit code", async () => {
 test("update reconciles clients and verified Hooks or migrates a configured legacy install", {
   skip: process.platform === "win32",
 }, async (t) => {
-  for (const [name, completed, configured = false] of [
+  for (const [name, completed, configured = false, writeBackendPid = true] of [
     ["setup incomplete", false],
     ["configured legacy install", false, true],
-    ["setup complete", true],
+    ["setup complete with restored Backend PID", true],
+    ["setup complete with stopped Backend", true, false, false],
   ]) {
     await t.test(name, async () => {
       const fixture = await createPackageFixture();
@@ -157,9 +158,11 @@ test("update reconciles clients and verified Hooks or migrates a configured lega
           "#!/usr/bin/env node",
           "import { mkdirSync, writeFileSync } from 'node:fs';",
           "import { dirname, join } from 'node:path';",
-          "const path = join(process.env.MEMORAX_CODE_HOME, 'runtime', 'backend', 'backend.pid.json');",
-          "mkdirSync(dirname(path), { recursive: true });",
-          "writeFileSync(path, JSON.stringify({ pid: process.pid }) + '\\n');",
+          "if (process.env.MEMORAX_CODE_TEST_WRITE_BACKEND_PID === '1') {",
+          "  const path = join(process.env.MEMORAX_CODE_HOME, 'runtime', 'backend', 'backend.pid.json');",
+          "  mkdirSync(dirname(path), { recursive: true });",
+          "  writeFileSync(path, JSON.stringify({ pid: process.pid }) + '\\n');",
+          "}",
           "",
         ].join("\n"));
         await chmod(npmModule, 0o755);
@@ -172,6 +175,7 @@ test("update reconciles clients and verified Hooks or migrates a configured lega
           assumeInteractive: true,
           extraEnv: {
             PATH: `${fakeBin}${delimiter}${process.env.PATH ?? ""}`,
+            MEMORAX_CODE_TEST_WRITE_BACKEND_PID: writeBackendPid ? "1" : "0",
             ...(configured ? { MEMORAX_CODE_TEST_CONFIGURED: "1" } : {}),
           },
         });


### PR DESCRIPTION
## Summary

- continue foreground update reconciliation after npm succeeds even when the managed Backend was already stopped
- refresh the enabled client integrations, verified Codex Hook trust, setup-completion state, and managed Backend lifecycle
- preserve the existing non-interactive and setup-incomplete guidance

## Verification

- focused npm entrypoint suite: 21/21 passed
- npm package check: 245 passed, 2 platform E2E checks skipped as expected
- Windows 11 real Codex E2E: A to B manual update passed with the Backend initially stopped
- verified CLI/package, active Codex plugin/cache, Skill, Hook trust, setup completion, Backend replacement/health, and transition consumption
- npm 11.17 allow-scripts advisory was observed but did not block any required downstream behavior

## Out of scope

The existing interactive setup question for newly detected but disabled clients remains unchanged. Preserving client selection without that prompt during manual update will be handled separately.