### PR TITLE
fix: repair Windows npm command path during setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,52 @@ If the initial setup does not work as expected, check these common cases:
 | --- | --- |
 | Installation fails with an unsupported Node.js version | Run `node --version` and upgrade to Node.js 20 or later before reinstalling MemoraX Code. |
 | The package installed but setup did not start | This is expected. Run the appropriate setup command above from a normal interactive terminal. |
+| Windows reports that `memorax-code` or `memorax-cli` is not recognized | Follow the Windows PATH steps below. Both commands are installed by the same package; do not install a separate `memorax-cli` package. |
 | Search, retrieval, or writeback is unavailable after setup | Run `memorax-code status` and `memorax-cli status`, then follow the detailed troubleshooting guide. |
+
+#### Windows: `memorax-code` or `memorax-cli` Is Not Found
+
+On Windows, a global npm installation places command shims in npm's global
+prefix (commonly `%APPDATA%\npm`). If that directory is missing from `PATH`,
+or a supported coding agent was started before Node.js or MemoraX Code was
+installed, it may report that `memorax-cli` is unavailable even though the
+package is installed. `memorax-code` and `memorax-cli` are both included in
+`@memorax/memorax-code`; no separate CLI installation is required.
+
+Use npm's actual global prefix to finish setup and verify the CLI in
+PowerShell:
+
+```powershell
+$NpmGlobalBin = (npm prefix -g).Trim()
+$env:Path = "$NpmGlobalBin;$env:Path"
+& (Join-Path $NpmGlobalBin "memorax-code.cmd") setup
+& (Join-Path $NpmGlobalBin "memorax-cli.cmd") status
+```
+
+The first two lines repair `PATH` for the current PowerShell process. If the
+global prefix is also missing from the user's persistent `PATH`, add it once:
+
+```powershell
+$NpmGlobalBin = (npm prefix -g).Trim()
+$UserPath = [Environment]::GetEnvironmentVariable("Path", "User")
+$UserEntries = @($UserPath -split ";" | Where-Object { $_ })
+$NormalizedNpmGlobalBin = $NpmGlobalBin.TrimEnd("\")
+
+if (-not ($UserEntries | Where-Object {
+    $_.Trim().TrimEnd("\") -ieq $NormalizedNpmGlobalBin
+})) {
+    [Environment]::SetEnvironmentVariable(
+        "Path",
+        (($UserEntries + $NpmGlobalBin) -join ";"),
+        "User"
+    )
+}
+```
+
+Open a new terminal after changing the persistent `PATH`. Fully exit and
+restart an affected coding agent only if it was already running during
+installation or still cannot find `memorax-cli`; reinstalling the package is
+not required.
 
 See [Configuration](docs/configuration.md) for supported settings and
 [Troubleshooting](docs/troubleshooting.md) for detailed diagnostics.

--- a/README.md
+++ b/README.md
@@ -125,8 +125,10 @@ installed, it may report that `memorax-cli` is unavailable even though the
 package is installed. `memorax-code` and `memorax-cli` are both included in
 `@memorax/memorax-code`; no separate CLI installation is required.
 
-Use npm's actual global prefix to finish setup and verify the CLI in
-PowerShell:
+Interactive setup automatically verifies npm's global command directory and,
+when needed, adds it to the current setup process and the Windows user `PATH`.
+If the current shell cannot start the bare `memorax-code` command, use npm's
+actual global prefix to bootstrap setup and verify the CLI in PowerShell:
 
 ```powershell
 $NpmGlobalBin = (npm prefix -g).Trim()
@@ -135,8 +137,9 @@ $env:Path = "$NpmGlobalBin;$env:Path"
 & (Join-Path $NpmGlobalBin "memorax-cli.cmd") status
 ```
 
-The first two lines repair `PATH` for the current PowerShell process. If the
-global prefix is also missing from the user's persistent `PATH`, add it once:
+The first two lines repair `PATH` for the current PowerShell process. If setup
+reports that it could not update the persistent Windows user `PATH`, add the
+global prefix once:
 
 ```powershell
 $NpmGlobalBin = (npm prefix -g).Trim()
@@ -155,10 +158,10 @@ if (-not ($UserEntries | Where-Object {
 }
 ```
 
-Open a new terminal after changing the persistent `PATH`. Fully exit and
-restart an affected coding agent only if it was already running during
-installation or still cannot find `memorax-cli`; reinstalling the package is
-not required.
+Open a new terminal after setup or the fallback changes the persistent `PATH`.
+Fully exit and restart an affected coding agent only if it was already running
+during installation or still cannot find `memorax-cli`; reinstalling the
+package is not required.
 
 See [Configuration](docs/configuration.md) for supported settings and
 [Troubleshooting](docs/troubleshooting.md) for detailed diagnostics.

--- a/README.zh.md
+++ b/README.zh.md
@@ -111,7 +111,9 @@ Node.js 或 MemoraX Code 之前就已启动，即使包已成功安装，它仍�
 `memorax-cli` 不可用。`memorax-code` 和 `memorax-cli` 都包含在
 `@memorax/memorax-code` 中，不需要单独安装 CLI。
 
-在 PowerShell 中使用 npm 的实际全局 prefix 完成 setup 并验证 CLI：
+交互式 setup 会自动校验 npm 全局命令目录，并在需要时将其加入当前 setup 进程和
+Windows 用户级 `PATH`。如果当前终端无法直接启动 `memorax-code`，可在 PowerShell
+中使用 npm 的实际全局 prefix 启动 setup 并验证 CLI：
 
 ```powershell
 $NpmGlobalBin = (npm prefix -g).Trim()
@@ -120,8 +122,8 @@ $env:Path = "$NpmGlobalBin;$env:Path"
 & (Join-Path $NpmGlobalBin "memorax-cli.cmd") status
 ```
 
-前两行只修复当前 PowerShell 进程的 `PATH`。如果用户级持久化 `PATH` 中也缺少
-该目录，可执行一次以下命令：
+前两行只修复当前 PowerShell 进程的 `PATH`。如果 setup 提示无法更新持久化的
+Windows 用户级 `PATH`，可执行一次以下命令：
 
 ```powershell
 $NpmGlobalBin = (npm prefix -g).Trim()
@@ -140,8 +142,9 @@ if (-not ($UserEntries | Where-Object {
 }
 ```
 
-修改持久化 `PATH` 后请打开一个新终端。仅当某个 Coding Agent 在安装期间已经运行，
-或者仍然找不到 `memorax-cli` 时，才需要彻底退出并重启受影响的客户端；无需重新安装 npm 包。
+setup 或上述兜底命令修改持久化 `PATH` 后，请打开一个新终端。仅当某个 Coding Agent
+在安装期间已经运行，或者仍然找不到 `memorax-cli` 时，才需要彻底退出并重启受影响的
+客户端；无需重新安装 npm 包。
 
 有关支持的配置项，请参阅[配置](docs/configuration.md)；
 更详细的诊断步骤请参阅[故障排查](docs/troubleshooting.md)。

--- a/README.zh.md
+++ b/README.zh.md
@@ -100,7 +100,48 @@ memorax-code account --show-mark-id
 | --- | --- |
 | 因 Node.js 版本不受支持导致安装失败 | 运行 `node --version` 检查版本，并升级到 Node.js 20 或更高版本后重新安装 MemoraX Code。 |
 | npm 包已安装，但没有进入安装引导 | 这是正常行为。请在正常的交互式终端中选择并运行上方适合您的安装引导命令。 |
+| Windows 提示无法识别 `memorax-code` 或 `memorax-cli` | 按照下方 Windows PATH 步骤处理。这两个命令由同一个包安装，不要单独安装 `memorax-cli` 包。 |
 | 完成安装引导后，搜索、召回或写回仍不可用 | 运行 `memorax-code status` 和 `memorax-cli status`，然后按照详细的故障排查指南处理。 |
+
+#### Windows：找不到 `memorax-code` 或 `memorax-cli`
+
+Windows 上，全局 npm 安装会将命令 shim 放在 npm 的全局 prefix 目录中（通常为
+`%APPDATA%\npm`）。如果该目录不在 `PATH` 中，或者受支持的 Coding Agent 在安装
+Node.js 或 MemoraX Code 之前就已启动，即使包已成功安装，它仍可能提示
+`memorax-cli` 不可用。`memorax-code` 和 `memorax-cli` 都包含在
+`@memorax/memorax-code` 中，不需要单独安装 CLI。
+
+在 PowerShell 中使用 npm 的实际全局 prefix 完成 setup 并验证 CLI：
+
+```powershell
+$NpmGlobalBin = (npm prefix -g).Trim()
+$env:Path = "$NpmGlobalBin;$env:Path"
+& (Join-Path $NpmGlobalBin "memorax-code.cmd") setup
+& (Join-Path $NpmGlobalBin "memorax-cli.cmd") status
+```
+
+前两行只修复当前 PowerShell 进程的 `PATH`。如果用户级持久化 `PATH` 中也缺少
+该目录，可执行一次以下命令：
+
+```powershell
+$NpmGlobalBin = (npm prefix -g).Trim()
+$UserPath = [Environment]::GetEnvironmentVariable("Path", "User")
+$UserEntries = @($UserPath -split ";" | Where-Object { $_ })
+$NormalizedNpmGlobalBin = $NpmGlobalBin.TrimEnd("\")
+
+if (-not ($UserEntries | Where-Object {
+    $_.Trim().TrimEnd("\") -ieq $NormalizedNpmGlobalBin
+})) {
+    [Environment]::SetEnvironmentVariable(
+        "Path",
+        (($UserEntries + $NpmGlobalBin) -join ";"),
+        "User"
+    )
+}
+```
+
+修改持久化 `PATH` 后请打开一个新终端。仅当某个 Coding Agent 在安装期间已经运行，
+或者仍然找不到 `memorax-cli` 时，才需要彻底退出并重启受影响的客户端；无需重新安装 npm 包。
 
 有关支持的配置项，请参阅[配置](docs/configuration.md)；
 更详细的诊断步骤请参阅[故障排查](docs/troubleshooting.md)。

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -42,6 +42,22 @@ Setup requires terminal input and terminal-visible stderr. A pipe, background
 process, or redirected stdin/stderr cannot complete setup; rerun it in a normal
 interactive terminal.
 
+On Windows, interactive setup verifies npm's global command directory and adds
+it to the current setup process and the Windows user `PATH` when needed. If the
+current shell cannot find `memorax-code`, use npm's actual global prefix to
+bootstrap setup:
+
+```powershell
+$NpmGlobalBin = (npm prefix -g).Trim()
+$env:Path = "$NpmGlobalBin;$env:Path"
+& (Join-Path $NpmGlobalBin "memorax-code.cmd") setup
+```
+
+The same npm package installs both `memorax-code` and `memorax-cli`; do not
+install a separate CLI package. Open a new terminal after setup changes the
+user `PATH`. Restart or refresh only coding agents that were already running
+or still cannot find `memorax-cli`.
+
 ## Setup does not complete
 
 Setup writes

--- a/packages/npm/memorax-code/README.md
+++ b/packages/npm/memorax-code/README.md
@@ -54,6 +54,16 @@ Both setup paths automatically detect supported coding agents. Later setup
 runs reuse a complete saved configuration; use
 `memorax-code setup --reconfigure` to replace it.
 
+On Windows, interactive setup also verifies npm's global command directory and
+adds it to the current setup process and the Windows user `PATH` when needed.
+If the current shell cannot find `memorax-code`, bootstrap setup with:
+
+```powershell
+$NpmGlobalBin = (npm prefix -g).Trim()
+$env:Path = "$NpmGlobalBin;$env:Path"
+& (Join-Path $NpmGlobalBin "memorax-code.cmd") setup
+```
+
 After the first installation, restart or refresh the detected coding agents
 before opening a new session. In Codex, enable **MemoraX Code Codex Adapter**
 from Plugins or `/plugins` if it is not already enabled.

--- a/packages/npm/memorax-code/bin/memorax-code.mjs
+++ b/packages/npm/memorax-code/bin/memorax-code.mjs
@@ -9,6 +9,7 @@ import { stagePackagedClientHookRuntime } from "../lib/client-hook-runtime.mjs";
 import { unsupportedNodeVersionMessage } from "../lib/node-version.mjs";
 import { runNpmCommand } from "../lib/npm-invocation.mjs";
 import { ensureNpmPackageRuntimeEnv, runBackendEntrypoint } from "../lib/run-entrypoint.mjs";
+import { ensureWindowsNpmGlobalPath } from "../lib/windows-user-path.mjs";
 
 const nodeVersionError = unsupportedNodeVersionMessage();
 if (nodeVersionError) {
@@ -251,6 +252,7 @@ async function runSetupCommand(args, { updateMode = false } = {}) {
     console.error("memorax-code setup: an interactive terminal is required");
     return 1;
   }
+  if (!updateMode) repairWindowsSetupPath();
   try {
     const { withSetupCompletionLock } = await loadSetupCompletionApi();
     return await withSetupCompletionLock(memoraxCodeHome, async (completion) => {
@@ -273,6 +275,28 @@ async function runSetupCommand(args, { updateMode = false } = {}) {
   } catch (error) {
     console.error(`memorax-code setup: ${error instanceof Error ? error.message : String(error)}`);
     return 1;
+  }
+}
+
+function repairWindowsSetupPath() {
+  if (readPackageJson().name !== "@memorax/memorax-code") return;
+  const repair = ensureWindowsNpmGlobalPath();
+  if (repair.userPathChanged) {
+    console.error("memorax-code setup: added npm's global command directory to the Windows user PATH");
+  }
+  if (repair.processPathChanged) {
+    console.error("memorax-code setup: npm global commands are available to the setup process");
+  }
+  if (repair.restartRecommended) {
+    console.error("memorax-code setup: restart or refresh coding agents that were already running so they inherit the updated PATH");
+  }
+  if (repair.status === "warning") {
+    const detail = repair.reason === "npm_prefix_unavailable"
+      ? "the npm global command directory could not be determined"
+      : repair.reason === "global_shims_missing"
+        ? "the installed MemoraX Code command shims could not be verified"
+        : "the Windows user PATH could not be updated";
+    console.error(`memorax-code setup: Windows PATH repair was not completed because ${detail}; setup will continue`);
   }
 }
 

--- a/packages/npm/memorax-code/lib/windows-user-path.mjs
+++ b/packages/npm/memorax-code/lib/windows-user-path.mjs
@@ -1,0 +1,192 @@
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { resolveNpmInvocation } from "./npm-invocation.mjs";
+
+const WINDOWS_USER_PATH_SCRIPT = String.raw`
+$ErrorActionPreference = "Stop"
+$globalBin = $env:MEMORAX_CODE_WINDOWS_NPM_GLOBAL_BIN
+
+function Normalize-PathEntry([string]$Value) {
+    if ([string]::IsNullOrWhiteSpace($Value)) { return "" }
+    return [Environment]::ExpandEnvironmentVariables(
+        $Value.Trim().Trim('"')
+    ).TrimEnd('\')
+}
+
+$userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+$entries = @($userPath -split ";" | Where-Object {
+    -not [string]::IsNullOrWhiteSpace($_)
+})
+$normalizedGlobalBin = Normalize-PathEntry $globalBin
+$present = @($entries | Where-Object {
+    (Normalize-PathEntry $_) -ieq $normalizedGlobalBin
+}).Count -gt 0
+
+if (-not $present) {
+    $separator = if ([string]::IsNullOrWhiteSpace($userPath) -or $userPath.TrimEnd().EndsWith(";")) { "" } else { ";" }
+    $updatedPath = "$userPath$separator$globalBin"
+    if ($updatedPath.Length -ge 32767) {
+        throw "The updated user PATH would exceed the Windows environment limit."
+    }
+    [Environment]::SetEnvironmentVariable("Path", $updatedPath, "User")
+}
+
+[Console]::Out.Write((@{ changed = -not $present } | ConvertTo-Json -Compress))
+`;
+
+export function ensureWindowsNpmGlobalPath(options = {}) {
+  const platform = options.platform ?? process.platform;
+  const env = options.env ?? process.env;
+  if (platform !== "win32") return result("skipped", "unsupported_platform");
+
+  let globalBin;
+  try {
+    globalBin = (options.resolveGlobalPrefix ?? resolveWindowsNpmGlobalPrefix)({
+      ...options,
+      env,
+      platform,
+    });
+  } catch {
+    return result("warning", "npm_prefix_unavailable");
+  }
+  if (typeof globalBin !== "string"
+    || globalBin.includes(";")
+    || !path.win32.isAbsolute(globalBin.trim())) {
+    return result("warning", "npm_prefix_unavailable");
+  }
+  globalBin = path.win32.normalize(globalBin.trim());
+
+  const fileExists = options.existsSync ?? existsSync;
+  const requiredShims = ["memorax-code.cmd", "memorax-cli.cmd"];
+  if (!requiredShims.every((name) => fileExists(path.win32.join(globalBin, name)))) {
+    return result("warning", "global_shims_missing");
+  }
+
+  const pathKey = windowsPathKey(env);
+  const currentPath = typeof env[pathKey] === "string" ? env[pathKey] : "";
+  const processPathChanged = !windowsPathContains(currentPath, globalBin, env);
+  if (processPathChanged) {
+    env[pathKey] = currentPath ? `${globalBin};${currentPath}` : globalBin;
+  }
+
+  let userPathChanged = false;
+  try {
+    const update = (options.updateUserPath ?? updateWindowsUserPath)(globalBin, {
+      ...options,
+      env,
+      platform,
+    });
+    if (typeof update?.changed !== "boolean") throw new Error("invalid user PATH update result");
+    userPathChanged = update.changed;
+  } catch {
+    return result("warning", "user_path_update_failed", {
+      processPathChanged,
+    });
+  }
+
+  const changed = processPathChanged || userPathChanged;
+  return result(changed ? "updated" : "unchanged", undefined, {
+    processPathChanged,
+    userPathChanged,
+    restartRecommended: changed,
+  });
+}
+
+export function resolveWindowsNpmGlobalPrefix(options = {}) {
+  const env = options.env ?? process.env;
+  const invocation = resolveNpmInvocation(["prefix", "-g"], options);
+  const run = options.spawnSync ?? spawnSync;
+  const resolved = run(invocation.command, invocation.args, {
+    encoding: "utf8",
+    env,
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: 10_000,
+    windowsHide: true,
+  });
+  if (resolved.error || resolved.signal || resolved.status !== 0) {
+    throw new Error("npm global prefix command failed");
+  }
+  const lines = String(resolved.stdout ?? "").split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+  const prefix = lines.at(-1);
+  if (!prefix || !path.win32.isAbsolute(prefix)) throw new Error("npm global prefix is invalid");
+  return prefix;
+}
+
+export function updateWindowsUserPath(globalBin, options = {}) {
+  const env = options.env ?? process.env;
+  const run = options.spawnSync ?? spawnSync;
+  const powerShell = windowsPowerShellCommand(env, options.existsSync ?? existsSync);
+  const encodedCommand = Buffer.from(WINDOWS_USER_PATH_SCRIPT, "utf16le").toString("base64");
+  const updated = run(powerShell, [
+    "-NoLogo",
+    "-NoProfile",
+    "-NonInteractive",
+    "-EncodedCommand",
+    encodedCommand,
+  ], {
+    encoding: "utf8",
+    env: { ...env, MEMORAX_CODE_WINDOWS_NPM_GLOBAL_BIN: globalBin },
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: 10_000,
+    windowsHide: true,
+  });
+  if (updated.error || updated.signal || updated.status !== 0) {
+    throw new Error("Windows user PATH update failed");
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(String(updated.stdout ?? "").trim());
+  } catch {
+    throw new Error("Windows user PATH update returned invalid output");
+  }
+  if (typeof parsed?.changed !== "boolean") {
+    throw new Error("Windows user PATH update returned an invalid result");
+  }
+  return { changed: parsed.changed };
+}
+
+function windowsPathKey(env) {
+  return Object.keys(env).find((key) => key.toLowerCase() === "path") ?? "Path";
+}
+
+function windowsPathContains(pathValue, expected, env) {
+  const normalizedExpected = normalizeWindowsPathEntry(expected, env);
+  return String(pathValue ?? "").split(";").some((entry) => (
+    normalizeWindowsPathEntry(entry, env) === normalizedExpected
+  ));
+}
+
+function normalizeWindowsPathEntry(value, env) {
+  const expanded = String(value ?? "")
+    .trim()
+    .replace(/^"|"$/g, "")
+    .replace(/%([^%]+)%/g, (match, name) => environmentValue(env, name) ?? match);
+  if (!expanded) return "";
+  return path.win32.normalize(expanded).replace(/[\\/]+$/, "").toLowerCase();
+}
+
+function environmentValue(env, name) {
+  const key = Object.keys(env).find((candidate) => candidate.toLowerCase() === name.toLowerCase());
+  return key === undefined ? undefined : env[key];
+}
+
+function windowsPowerShellCommand(env, fileExists) {
+  const systemRoot = environmentValue(env, "SystemRoot") ?? environmentValue(env, "WINDIR");
+  if (systemRoot) {
+    const candidate = path.win32.join(systemRoot, "System32", "WindowsPowerShell", "v1.0", "powershell.exe");
+    if (fileExists(candidate)) return candidate;
+  }
+  return "powershell.exe";
+}
+
+function result(status, reason, overrides = {}) {
+  return {
+    status,
+    ...(reason ? { reason } : {}),
+    processPathChanged: false,
+    userPathChanged: false,
+    restartRecommended: false,
+    ...overrides,
+  };
+}

--- a/packages/npm/memorax-code/lib/windows-user-path.mjs
+++ b/packages/npm/memorax-code/lib/windows-user-path.mjs
@@ -14,25 +14,49 @@ function Normalize-PathEntry([string]$Value) {
     ).TrimEnd('\')
 }
 
-$userPath = [Environment]::GetEnvironmentVariable("Path", "User")
-$entries = @($userPath -split ";" | Where-Object {
-    -not [string]::IsNullOrWhiteSpace($_)
-})
 $normalizedGlobalBin = Normalize-PathEntry $globalBin
-$present = @($entries | Where-Object {
-    (Normalize-PathEntry $_) -ieq $normalizedGlobalBin
-}).Count -gt 0
+$changed = $false
+$completed = $false
 
-if (-not $present) {
+for ($attempt = 0; $attempt -lt 3; $attempt++) {
+    $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+    $entries = @($userPath -split ";" | Where-Object {
+        -not [string]::IsNullOrWhiteSpace($_)
+    })
+    $present = @($entries | Where-Object {
+        (Normalize-PathEntry $_) -ieq $normalizedGlobalBin
+    }).Count -gt 0
+
+    if ($present) {
+        $completed = $true
+        break
+    }
+
     $separator = if ([string]::IsNullOrWhiteSpace($userPath) -or $userPath.TrimEnd().EndsWith(";")) { "" } else { ";" }
     $updatedPath = "$userPath$separator$globalBin"
     if ($updatedPath.Length -ge 32767) {
         throw "The updated user PATH would exceed the Windows environment limit."
     }
+
+    $latestUserPath = [Environment]::GetEnvironmentVariable("Path", "User")
+    if (-not [string]::Equals([string]$latestUserPath, [string]$userPath, [StringComparison]::Ordinal)) {
+        continue
+    }
+
     [Environment]::SetEnvironmentVariable("Path", $updatedPath, "User")
+    $changed = $true
+    $writtenUserPath = [Environment]::GetEnvironmentVariable("Path", "User")
+    if ([string]::Equals([string]$writtenUserPath, [string]$updatedPath, [StringComparison]::Ordinal)) {
+        $completed = $true
+        break
+    }
 }
 
-[Console]::Out.Write((@{ changed = -not $present } | ConvertTo-Json -Compress))
+if (-not $completed) {
+    throw "The Windows user PATH changed concurrently; retry setup."
+}
+
+[Console]::Out.Write((@{ changed = $changed } | ConvertTo-Json -Compress))
 `;
 
 export function ensureWindowsNpmGlobalPath(options = {}) {
@@ -67,7 +91,9 @@ export function ensureWindowsNpmGlobalPath(options = {}) {
   const currentPath = typeof env[pathKey] === "string" ? env[pathKey] : "";
   const processPathChanged = !windowsPathContains(currentPath, globalBin, env);
   if (processPathChanged) {
-    env[pathKey] = currentPath ? `${globalBin};${currentPath}` : globalBin;
+    env[pathKey] = currentPath
+      ? `${currentPath}${currentPath.trimEnd().endsWith(";") ? "" : ";"}${globalBin}`
+      : globalBin;
   }
 
   let userPathChanged = false;

--- a/packages/npm/memorax-code/test/automatic-update-entrypoint.test.mjs
+++ b/packages/npm/memorax-code/test/automatic-update-entrypoint.test.mjs
@@ -64,6 +64,7 @@ async function createFixture(t) {
     "lib/run-entrypoint.mjs",
     "lib/vscode-extension-command.mjs",
     "lib/windows-cli-invocation.mjs",
+    "lib/windows-user-path.mjs",
   ].map(async (relativePath) => {
     const target = join(root, relativePath);
     await mkdir(dirname(target), { recursive: true });

--- a/packages/npm/memorax-code/test/memorax-code-entrypoint.test.mjs
+++ b/packages/npm/memorax-code/test/memorax-code-entrypoint.test.mjs
@@ -337,6 +337,7 @@ async function createPackageFixture() {
     "lib/run-entrypoint.mjs",
     "lib/vscode-extension-command.mjs",
     "lib/windows-cli-invocation.mjs",
+    "lib/windows-user-path.mjs",
   ];
   for (const relativePath of copiedFiles) {
     const target = join(root, relativePath);

--- a/packages/npm/memorax-code/test/memorax-code-update.test.mjs
+++ b/packages/npm/memorax-code/test/memorax-code-update.test.mjs
@@ -34,6 +34,7 @@ async function createPackageFixture(version) {
   await cp(join(packageRoot, "lib", "resolve-codex-command.mjs"), join(root, "lib", "resolve-codex-command.mjs"));
   await cp(join(packageRoot, "lib", "resolve-codebuddy-command.mjs"), join(root, "lib", "resolve-codebuddy-command.mjs"));
   await cp(join(packageRoot, "lib", "windows-cli-invocation.mjs"), join(root, "lib", "windows-cli-invocation.mjs"));
+  await cp(join(packageRoot, "lib", "windows-user-path.mjs"), join(root, "lib", "windows-user-path.mjs"));
   await cp(join(packageRoot, "lib", "vscode-extension-command.mjs"), join(root, "lib", "vscode-extension-command.mjs"));
   const manifest = JSON.parse(await readFile(join(packageRoot, "package.json"), "utf8"));
   manifest.version = version;

--- a/packages/npm/memorax-code/test/windows-user-path.test.mjs
+++ b/packages/npm/memorax-code/test/windows-user-path.test.mjs
@@ -9,7 +9,7 @@ import {
 const NPM_GLOBAL_BIN = "C:\\Users\\tester\\AppData\\Roaming\\npm";
 const SYSTEM_PATH = "C:\\Windows\\System32";
 
-test("Windows setup adds the verified npm global bin to process and user PATH", () => {
+test("Windows setup appends the verified npm global bin without changing command precedence", () => {
   const env = { Path: SYSTEM_PATH };
   const calls = [];
 
@@ -25,7 +25,7 @@ test("Windows setup adds the verified npm global bin to process and user PATH", 
     },
   });
 
-  assert.equal(env.Path, `${NPM_GLOBAL_BIN};${SYSTEM_PATH}`);
+  assert.equal(env.Path, `${SYSTEM_PATH};${NPM_GLOBAL_BIN}`);
   assert.deepEqual(calls, [NPM_GLOBAL_BIN]);
   assert.deepEqual(result, {
     status: "updated",
@@ -66,7 +66,7 @@ test("Windows setup repairs a stale process even when the user PATH is current",
     updateUserPath: () => ({ changed: false }),
   });
 
-  assert.equal(env.PATH, `${NPM_GLOBAL_BIN};${SYSTEM_PATH}`);
+  assert.equal(env.PATH, `${SYSTEM_PATH};${NPM_GLOBAL_BIN}`);
   assert.deepEqual(result, {
     status: "updated",
     processPathChanged: true,
@@ -92,7 +92,7 @@ test("Windows setup is idempotent across repeated repairs", () => {
 
   assert.equal(ensureWindowsNpmGlobalPath(options).status, "updated");
   assert.equal(ensureWindowsNpmGlobalPath(options).status, "unchanged");
-  assert.equal(env.Path, `${NPM_GLOBAL_BIN};${SYSTEM_PATH}`);
+  assert.equal(env.Path, `${SYSTEM_PATH};${NPM_GLOBAL_BIN}`);
 });
 
 test("Windows setup keeps the process repair when the persistent update fails", () => {
@@ -108,7 +108,7 @@ test("Windows setup keeps the process repair when the persistent update fails", 
     },
   });
 
-  assert.equal(env.PATH, `${NPM_GLOBAL_BIN};${SYSTEM_PATH}`);
+  assert.equal(env.PATH, `${SYSTEM_PATH};${NPM_GLOBAL_BIN}`);
   assert.deepEqual(result, {
     status: "warning",
     reason: "user_path_update_failed",
@@ -211,4 +211,9 @@ test("Windows user PATH update passes the global bin without command interpolati
   assert.ok(calls[0].args.includes("-EncodedCommand"));
   assert.equal(calls[0].options.env.MEMORAX_CODE_WINDOWS_NPM_GLOBAL_BIN, NPM_GLOBAL_BIN);
   assert.doesNotMatch(calls[0].args.join(" "), /tester|AppData|Roaming/);
+  const encodedCommand = calls[0].args[calls[0].args.indexOf("-EncodedCommand") + 1];
+  const script = Buffer.from(encodedCommand, "base64").toString("utf16le");
+  assert.match(script, /for \(\$attempt = 0; \$attempt -lt 3; \$attempt\+\+\)/);
+  assert.match(script, /\$latestUserPath = \[Environment\]::GetEnvironmentVariable\("Path", "User"\)/);
+  assert.match(script, /\[string\]::Equals\(\[string\]\$latestUserPath, \[string\]\$userPath/);
 });

--- a/packages/npm/memorax-code/test/windows-user-path.test.mjs
+++ b/packages/npm/memorax-code/test/windows-user-path.test.mjs
@@ -1,0 +1,214 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  ensureWindowsNpmGlobalPath,
+  resolveWindowsNpmGlobalPrefix,
+  updateWindowsUserPath,
+} from "../lib/windows-user-path.mjs";
+
+const NPM_GLOBAL_BIN = "C:\\Users\\tester\\AppData\\Roaming\\npm";
+const SYSTEM_PATH = "C:\\Windows\\System32";
+
+test("Windows setup adds the verified npm global bin to process and user PATH", () => {
+  const env = { Path: SYSTEM_PATH };
+  const calls = [];
+
+  const result = ensureWindowsNpmGlobalPath({
+    env,
+    platform: "win32",
+    resolveGlobalPrefix: () => NPM_GLOBAL_BIN,
+    existsSync: (candidate) => candidate === `${NPM_GLOBAL_BIN}\\memorax-code.cmd`
+      || candidate === `${NPM_GLOBAL_BIN}\\memorax-cli.cmd`,
+    updateUserPath(globalBin) {
+      calls.push(globalBin);
+      return { changed: true };
+    },
+  });
+
+  assert.equal(env.Path, `${NPM_GLOBAL_BIN};${SYSTEM_PATH}`);
+  assert.deepEqual(calls, [NPM_GLOBAL_BIN]);
+  assert.deepEqual(result, {
+    status: "updated",
+    processPathChanged: true,
+    userPathChanged: true,
+    restartRecommended: true,
+  });
+});
+
+test("Windows setup recognizes an existing PATH entry case-insensitively", () => {
+  const env = { PATH: `${SYSTEM_PATH};${NPM_GLOBAL_BIN.toUpperCase()}\\` };
+
+  const result = ensureWindowsNpmGlobalPath({
+    env,
+    platform: "win32",
+    resolveGlobalPrefix: () => NPM_GLOBAL_BIN,
+    existsSync: () => true,
+    updateUserPath: () => ({ changed: false }),
+  });
+
+  assert.equal(env.PATH, `${SYSTEM_PATH};${NPM_GLOBAL_BIN.toUpperCase()}\\`);
+  assert.deepEqual(result, {
+    status: "unchanged",
+    processPathChanged: false,
+    userPathChanged: false,
+    restartRecommended: false,
+  });
+});
+
+test("Windows setup repairs a stale process even when the user PATH is current", () => {
+  const env = { PATH: SYSTEM_PATH };
+
+  const result = ensureWindowsNpmGlobalPath({
+    env,
+    platform: "win32",
+    resolveGlobalPrefix: () => NPM_GLOBAL_BIN,
+    existsSync: () => true,
+    updateUserPath: () => ({ changed: false }),
+  });
+
+  assert.equal(env.PATH, `${NPM_GLOBAL_BIN};${SYSTEM_PATH}`);
+  assert.deepEqual(result, {
+    status: "updated",
+    processPathChanged: true,
+    userPathChanged: false,
+    restartRecommended: true,
+  });
+});
+
+test("Windows setup is idempotent across repeated repairs", () => {
+  const env = { Path: SYSTEM_PATH };
+  let userPathChanged = true;
+  const options = {
+    env,
+    platform: "win32",
+    resolveGlobalPrefix: () => NPM_GLOBAL_BIN,
+    existsSync: () => true,
+    updateUserPath: () => {
+      const changed = userPathChanged;
+      userPathChanged = false;
+      return { changed };
+    },
+  };
+
+  assert.equal(ensureWindowsNpmGlobalPath(options).status, "updated");
+  assert.equal(ensureWindowsNpmGlobalPath(options).status, "unchanged");
+  assert.equal(env.Path, `${NPM_GLOBAL_BIN};${SYSTEM_PATH}`);
+});
+
+test("Windows setup keeps the process repair when the persistent update fails", () => {
+  const env = { PATH: SYSTEM_PATH };
+
+  const result = ensureWindowsNpmGlobalPath({
+    env,
+    platform: "win32",
+    resolveGlobalPrefix: () => NPM_GLOBAL_BIN,
+    existsSync: () => true,
+    updateUserPath: () => {
+      throw new Error("registry denied");
+    },
+  });
+
+  assert.equal(env.PATH, `${NPM_GLOBAL_BIN};${SYSTEM_PATH}`);
+  assert.deepEqual(result, {
+    status: "warning",
+    reason: "user_path_update_failed",
+    processPathChanged: true,
+    userPathChanged: false,
+    restartRecommended: false,
+  });
+});
+
+test("Windows setup does not change PATH when global shims are incomplete", () => {
+  const env = { PATH: SYSTEM_PATH };
+  let updateCalled = false;
+
+  const result = ensureWindowsNpmGlobalPath({
+    env,
+    platform: "win32",
+    resolveGlobalPrefix: () => NPM_GLOBAL_BIN,
+    existsSync: (candidate) => candidate.endsWith("memorax-code.cmd"),
+    updateUserPath: () => {
+      updateCalled = true;
+      return { changed: true };
+    },
+  });
+
+  assert.equal(env.PATH, SYSTEM_PATH);
+  assert.equal(updateCalled, false);
+  assert.deepEqual(result, {
+    status: "warning",
+    reason: "global_shims_missing",
+    processPathChanged: false,
+    userPathChanged: false,
+    restartRecommended: false,
+  });
+});
+
+test("non-Windows setup leaves PATH and user settings untouched", () => {
+  const env = { PATH: "/usr/bin" };
+  let resolveCalled = false;
+
+  const result = ensureWindowsNpmGlobalPath({
+    env,
+    platform: "linux",
+    resolveGlobalPrefix: () => {
+      resolveCalled = true;
+      return "/usr/local";
+    },
+    updateUserPath: () => {
+      throw new Error("must not run");
+    },
+  });
+
+  assert.equal(resolveCalled, false);
+  assert.equal(env.PATH, "/usr/bin");
+  assert.deepEqual(result, {
+    status: "skipped",
+    reason: "unsupported_platform",
+    processPathChanged: false,
+    userPathChanged: false,
+    restartRecommended: false,
+  });
+});
+
+test("Windows npm prefix resolution uses the npm JavaScript entrypoint", () => {
+  const npmCli = "C:\\Program Files\\nodejs\\node_modules\\npm\\bin\\npm-cli.js";
+  const calls = [];
+
+  const prefix = resolveWindowsNpmGlobalPrefix({
+    env: { MEMORAX_CODE_NPM_EXEC_PATH: npmCli },
+    platform: "win32",
+    nodePath: "C:\\Program Files\\nodejs\\node.exe",
+    existsSync: (candidate) => candidate === npmCli,
+    spawnSync(command, args, options) {
+      calls.push({ command, args, options });
+      return { status: 0, signal: null, stdout: `${NPM_GLOBAL_BIN}\r\n`, stderr: "" };
+    },
+  });
+
+  assert.equal(prefix, NPM_GLOBAL_BIN);
+  assert.equal(calls[0].command, "C:\\Program Files\\nodejs\\node.exe");
+  assert.deepEqual(calls[0].args, [npmCli, "prefix", "-g"]);
+  assert.equal(calls[0].options.windowsHide, true);
+});
+
+test("Windows user PATH update passes the global bin without command interpolation", () => {
+  const calls = [];
+  const systemRoot = "C:\\Windows";
+  const powerShell = `${systemRoot}\\System32\\WindowsPowerShell\\v1.0\\powershell.exe`;
+
+  const result = updateWindowsUserPath(NPM_GLOBAL_BIN, {
+    env: { SystemRoot: systemRoot, Path: SYSTEM_PATH },
+    existsSync: (candidate) => candidate === powerShell,
+    spawnSync(command, args, options) {
+      calls.push({ command, args, options });
+      return { status: 0, signal: null, stdout: '{"changed":true}', stderr: "" };
+    },
+  });
+
+  assert.deepEqual(result, { changed: true });
+  assert.equal(calls[0].command, powerShell);
+  assert.ok(calls[0].args.includes("-EncodedCommand"));
+  assert.equal(calls[0].options.env.MEMORAX_CODE_WINDOWS_NPM_GLOBAL_BIN, NPM_GLOBAL_BIN);
+  assert.doesNotMatch(calls[0].args.join(" "), /tester|AppData|Roaming/);
+});

--- a/scripts/build-npm-packages.mjs
+++ b/scripts/build-npm-packages.mjs
@@ -172,6 +172,7 @@ async function validateStaging(packageRoot) {
     "lib/vscode-extension-command.mjs",
     "lib/npm-invocation.mjs",
     "lib/windows-cli-invocation.mjs",
+    "lib/windows-user-path.mjs",
     "lib/trial-plugin-mark.mjs",
     "lib/trial-provision-client.mjs",
     "lib/trial-provision-flow.mjs",

--- a/scripts/npm-package-check.sh
+++ b/scripts/npm-package-check.sh
@@ -125,6 +125,7 @@ for relative in [
     "lib/setup-reconcile.mjs",
     "lib/trial-setup.mjs",
     "lib/windows-cli-invocation.mjs",
+    "lib/windows-user-path.mjs",
     "lib/memorax-code-adapter-common/src/backend-connection.mjs",
     "lib/memorax-code-adapter-common/src/config-utils.mjs",
     "lib/memorax-code-adapter-common/src/hooks/client-hook-launcher.mjs",
@@ -402,6 +403,7 @@ for relative in \
   lib/setup-reconcile.mjs \
   lib/trial-setup.mjs \
   lib/windows-cli-invocation.mjs \
+  lib/windows-user-path.mjs \
   lib/memorax-code-adapter-common/src/backend-connection.mjs \
   lib/memorax-code-adapter-common/src/config-utils.mjs \
   lib/memorax-code-adapter-common/src/hooks/client-hook-launcher.mjs \

--- a/scripts/npm-package-layout.mjs
+++ b/scripts/npm-package-layout.mjs
@@ -55,6 +55,7 @@ const rootLibFiles = new Set([
   "lib/trial-setup.mjs",
   "lib/vscode-extension-command.mjs",
   "lib/windows-cli-invocation.mjs",
+  "lib/windows-user-path.mjs",
 ]);
 const reviewedCredentialFiles = new Set([
   "linux-secret-service.mjs",

--- a/scripts/validate-npm-pack-json.mjs
+++ b/scripts/validate-npm-pack-json.mjs
@@ -80,6 +80,7 @@ for (const requiredPath of [
   "lib/trial-setup.mjs",
   "lib/vscode-extension-command.mjs",
   "lib/windows-cli-invocation.mjs",
+  "lib/windows-user-path.mjs",
   "lib/memorax-code-adapter-common/src/backend-connection.mjs",
   "lib/memorax-code-adapter-common/src/hooks/client-hook-launcher.mjs",
   "lib/memorax-code-adapter-common/src/clients/codex-plugin-artifact.mjs",


### PR DESCRIPTION
## Change Summary
Repair Windows npm global-command discovery during interactive setup so supported coding agents can invoke `memorax-code` and `memorax-cli` after a normal PATH refresh or restart. Document the one-time absolute `.cmd` bootstrap for shells that cannot initially resolve `memorax-code`.

## Implementation Highlights
- Resolve npm's global prefix through npm's JavaScript entrypoint, verify both MemoraX command shims, and add the prefix to the setup process PATH.
- Idempotently persist the verified prefix to the Windows user PATH through an encoded PowerShell boundary without `setx`, elevation, or machine-level changes.
- Keep setup non-blocking when persistent PATH repair fails and report actionable warnings and restart guidance.
- Ship the helper in the npm package layout and cover default setup, `--existing-account`, reconfigure, update isolation, failure, and idempotence paths.
- Keep the English, Chinese, npm package, and troubleshooting documentation aligned.

## Validation
- `node --test packages/npm/memorax-code/test/windows-user-path.test.mjs packages/npm/memorax-code/test/memorax-code-entrypoint.test.mjs packages/npm/memorax-code/test/memorax-code-update.test.mjs packages/npm/memorax-code/test/npm-package-layout.test.mjs packages/npm/memorax-code/test/npm-source-files.test.mjs`: 43 passed, 0 failed, 2 existing Windows-conditional skips.
- `node scripts/check-docs.mjs`: passed.
- `node scripts/sync-release-version.mjs --check`: passed for 0.1.9.
- `git diff --check`: passed.
- Built, packed, globally installed, and exercised a local npm tarball on Windows with the npm global prefix deliberately removed from both user and test-process PATH.

## Full End-to-End Validation Results
- Environment: Microsoft Windows 11 build 26200; Node.js v24.19.0; npm 11.17.0; package version 0.1.9.
- Scenario or matrix:
  - Removed the exact npm global prefix from Windows user PATH and the test PowerShell PATH while leaving Node.js/npm installed.
  - Confirmed `memorax-code.cmd` and `memorax-cli.cmd` existed but neither bare command was discoverable.
  - Installed the locally built tarball, then started interactive setup through the absolute `memorax-code.cmd` path.
  - Rebuilt a fresh-process environment from machine PATH plus the repaired user PATH and checked both bare commands, Backend, Codex, and CodeBuddy/WorkBuddy adapters.
- Command or workflow:
  - Built Backend and npm staging, then ran `npm pack`.
  - Installed with `npm install -g --force <local-tarball>`.
  - Bootstrapped with `& (Join-Path (npm prefix -g).Trim() "memorax-code.cmd") setup` in an interactive terminal.
  - Verified with `memorax-code --version`, `memorax-cli --version`, `npm list -g @memorax/memorax-code --depth=0`, `memorax-code status --json`, and `memorax-code-codebuddy status --json`.
- Result:
  - PASS: setup added the npm global prefix to Windows user PATH exactly once.
  - PASS: both bare commands resolved in the reconstructed fresh-process environment and reported 0.1.9.
  - PASS: Backend returned HTTP 200; Codex Skill was plugin-managed; CodeBuddy/WorkBuddy was installed, enabled, managed, and marketplace-ready.
  - PASS: installed `windows-user-path.mjs` matched the staged package file by SHA-256.
- Evidence or artifacts:
  - Tarball contained 417 files, including `lib/windows-user-path.mjs` and both CLI entrypoints.
  - Test tarball SHA-256: `722b5fed08ad57c09367a3027b6f15a1919b819bd882692672bb0f325af5bea6`.
  - Final user PATH contained one normalized npm global-prefix entry.
- Reason not run / remaining risk:
  - Processes already running before the user PATH change cannot inherit it; setup tells users to refresh or restart those coding agents.
  - A fully fresh Windows account was not created because the test preserved existing MemoraX and coding-agent data. The PATH-missing state itself was reproduced at both user and process scope.
  - The broad repository test suite still has pre-existing Windows baseline limitations around unprivileged symlink creation, POSIX chmod/owner/path assumptions, and unavailable `make`/`bash`; the scoped package and entrypoint tests above are green.