### PR TITLE
fix: repair missing Codex plugin registration

### DIFF
--- a/packages/npm/memorax-code/bin/memorax-code-setup.mjs
+++ b/packages/npm/memorax-code/bin/memorax-code-setup.mjs
@@ -210,7 +210,7 @@ const codexClientNewlyEnabled = codexClientEnabled
   && existingSetup
   && !previousClients.includes("codex");
 const codexPluginRequiresActivation = codexClientEnabled
-  && codexPreflight.pluginCache.versions.length === 0;
+  && codexPreflight.pluginRegistration.ready !== true;
 const codexHooksBeforeUpdate = codexClientEnabled
   && existingSetup
   && !codexClientNewlyEnabled
@@ -981,11 +981,21 @@ function runCodexPreflight({ integrationSelected = true } = {}) {
   }
   const pluginCache = installedPluginCache();
   log(`Existing Codex plugin cache: ${pluginCache.versions.length > 0 ? `found (${pluginCache.versions.join(", ")})` : "not installed"}`);
+  const pluginRegistration = inspectCodexPluginRegistrationForSetup();
+  if (!pluginRegistration.verified) {
+    log("Codex plugin state: could not be verified; setup will attempt a full activation.");
+  } else if (!pluginRegistration.registered) {
+    log("Codex plugin state: not installed in Codex; setup will repair it.");
+  } else if (!pluginRegistration.enabled) {
+    log("Codex plugin state: disabled; setup will attempt to enable it.");
+  } else {
+    log(`Codex plugin state: enabled${pluginRegistration.version ? ` (${pluginRegistration.version})` : ""}.`);
+  }
   log(`Codex client process: ${codexClientRunning() ? "running" : "not detected"}`);
   log(integrationSelected
     ? "Keeping Codex provider config unchanged and enabling the shared memory hook integration."
     : "Keeping Codex provider config unchanged while checking whether to enable its integration.");
-  return { ok: true, pluginCache };
+  return { ok: true, pluginCache, pluginRegistration };
 }
 
 function runClaudePreflight({ integrationSelected = true } = {}) {
@@ -1051,6 +1061,38 @@ function installedPluginCache() {
     }
   }
   return { marketplaceName: CLI_MARKETPLACE_NAME, versions: [] };
+}
+
+function inspectCodexPluginRegistrationForSetup() {
+  const result = runNodeMemoraxCodeCommand(["codex-plugin", "registration", "--json"], {
+    print: false,
+    timeout: 10_000,
+  });
+  if (result.status !== 0) {
+    return { verified: false, ready: false, registered: false, enabled: false };
+  }
+  try {
+    const report = JSON.parse(String(result.stdout ?? ""));
+    if (!report
+      || report.ok !== true
+      || report.action !== "codex-plugin-registration"
+      || typeof report.available !== "boolean"
+      || typeof report.registered !== "boolean"
+      || typeof report.enabled !== "boolean"
+      || (report.version !== undefined && typeof report.version !== "string")) {
+      return { verified: false, ready: false, registered: false, enabled: false };
+    }
+    return {
+      verified: true,
+      ready: report.registered && report.enabled,
+      available: report.available,
+      registered: report.registered,
+      enabled: report.enabled,
+      ...(report.version ? { version: report.version } : {}),
+    };
+  } catch {
+    return { verified: false, ready: false, registered: false, enabled: false };
+  }
 }
 
 function installedPluginCacheVersions(marketplaceName) {

--- a/packages/npm/memorax-code/test/setup.test.mjs
+++ b/packages/npm/memorax-code/test/setup.test.mjs
@@ -131,7 +131,7 @@ async function startMockMemorax({ status = 200, body = { success: true, data: { 
   };
 }
 
-async function runSetup({ existingCache = false, explicitCache = false, hookRuntimeFailure, failStartOnce = false, connectionAuthorityFailure = false, runtimeAuthorityFailureCode, officialMode = false, codexConfig, memoraxCodeConfig, memoraxCodeConfigMode, emptyClaudeSettings = false, claudeAvailable = true, claudeVersionFails = false, claudeSettingsText, codexAvailable = true, codexAppOnly = false, vscodeOnly = false, dshProfiles = [], opencodeAvailable = false, opencodeXdgAvailable = false, opencodeCliAvailable = false, codebuddyAvailable = false, skipCodexPluginInstall = false, skipClaudeAdapterInstall = false, skipOpenCodeAdapterInstall = false, skipCodeBuddyAdapterInstall = false, unavailableStatus = false, prefixedStatus = false, input = "", interactive = true, npmCommand = "install", updateMode = false, setupMode = "automatic", memoraxVerify, memoraxEnv = {}, memoryStatusFixture, trialProvisionFailure = false, hookSnapshot = [], hookUpdatePlan = [], hookFullReview = false, hookFullReviewMissing = false, hookSnapshotFails = false, hookCheckFails = false, hookTrustFails = false, detectedUserId = "memory-user", detectedLanguage = "zh", ttyOverride } = {}) {
+async function runSetup({ existingCache = false, explicitCache = false, codexRegistered, hookRuntimeFailure, failStartOnce = false, connectionAuthorityFailure = false, runtimeAuthorityFailureCode, officialMode = false, codexConfig, memoraxCodeConfig, memoraxCodeConfigMode, emptyClaudeSettings = false, claudeAvailable = true, claudeVersionFails = false, claudeSettingsText, codexAvailable = true, codexAppOnly = false, vscodeOnly = false, dshProfiles = [], opencodeAvailable = false, opencodeXdgAvailable = false, opencodeCliAvailable = false, codebuddyAvailable = false, skipCodexPluginInstall = false, skipClaudeAdapterInstall = false, skipOpenCodeAdapterInstall = false, skipCodeBuddyAdapterInstall = false, unavailableStatus = false, prefixedStatus = false, input = "", interactive = true, npmCommand = "install", updateMode = false, setupMode = "automatic", memoraxVerify, memoraxEnv = {}, memoryStatusFixture, trialProvisionFailure = false, hookSnapshot = [], hookUpdatePlan = [], hookFullReview = false, hookFullReviewMissing = false, hookSnapshotFails = false, hookCheckFails = false, hookTrustFails = false, detectedUserId = "memory-user", detectedLanguage = "zh", ttyOverride } = {}) {
   const root = await mkdtemp(join(tmpdir(), "memorax-code-setup-"));
   const binDir = join(root, "bin");
   const codexHome = join(root, "codex-home");
@@ -287,6 +287,11 @@ async function runSetup({ existingCache = false, explicitCache = false, hookRunt
     `if (process.env.MEMORAX_CODE_DSH_ADAPTER_OPTIONAL === '1') appendFileSync(${JSON.stringify(logPath)}, 'dsh-adapter-optional ' + process.argv[2] + '\\n');`,
     `if (process.argv[2] === 'codex-plugin') appendFileSync(${JSON.stringify(logPath)}, 'codex-runtime ' + (process.env.CODEX_CLI_PATH ?? '') + '\\n');`,
     "if (process.argv[2] === '--version') { console.log('memorax-code 0.1.1-test'); process.exit(0); }",
+    "if (process.argv[2] === 'codex-plugin' && process.argv[3] === 'registration') {",
+    `  const registered = ${JSON.stringify(codexRegistered ?? (existingCache || explicitCache))};`,
+    "  console.log(JSON.stringify({ ok: true, action: 'codex-plugin-registration', available: registered, registered, enabled: registered, version: registered ? '0.1.0' : undefined }));",
+    "  process.exit(0);",
+    "}",
     `const hookSnapshot = ${JSON.stringify(hookSnapshot)};`,
     `const hookUpdatePlan = ${JSON.stringify(hookUpdatePlan)};`,
     "if (process.argv[2] === 'codex-plugin' && process.argv[3] === 'hooks') {",
@@ -736,6 +741,36 @@ test("setup update mode skips MemoraX credentials and silently trusts verified H
     assert.match(config, /api_key = "existing-api-key"/);
     assert.match(config, /user_id = "existing-user-id"/);
     assert.match(config, /output_language = "en"/);
+  } finally {
+    await rm(run.root, { recursive: true, force: true });
+  }
+});
+
+test("setup repairs missing Codex registration even when the plugin cache exists", async () => {
+  const run = await runSetup({
+    claudeAvailable: false,
+    codexRegistered: false,
+    existingCache: true,
+    interactive: true,
+    memoraxCodeConfig: [
+      "[clients]",
+      "codex = true",
+      "claude = false",
+      "dsh = false",
+      "opencode = false",
+      "codebuddy = false",
+      "",
+    ].join("\n"),
+    updateMode: true,
+  });
+  try {
+    assert.equal(run.result.code, 0, run.result.stderr);
+    assert.match(run.log, /^memorax-code codex-plugin registration --json$/m);
+    assert.match(run.log, /^memorax-code codex-plugin install --json$/m);
+    assert.match(run.log, /^memorax-code codex-plugin activate --yes$/m);
+    assert.doesNotMatch(run.log, /^memorax-code codex-plugin hooks /m);
+    assert.doesNotMatch(run.log, /^memorax-code codex-plugin trust-hooks /m);
+    await assertSetupComplete(run);
   } finally {
     await rm(run.root, { recursive: true, force: true });
   }

--- a/packages/ts/memorax-code-backend/src/clients/codex/plugin-install.ts
+++ b/packages/ts/memorax-code-backend/src/clients/codex/plugin-install.ts
@@ -20,7 +20,9 @@ import { resolveWindowsCliInvocation } from "../../shared/windows-cli-invocation
 
 const PLUGIN_NAME = "memorax-code-codex-adapter";
 const CLI_MARKETPLACE_NAME = "memorax-code";
+const PLUGIN_ID = `${PLUGIN_NAME}@${CLI_MARKETPLACE_NAME}`;
 const ADAPTER_COMMON_NAME = "memorax-code-adapter-common";
+const PLUGIN_LIST_TIMEOUT_MS = 10_000;
 
 type MarketplaceEntry = {
   name: string;
@@ -53,6 +55,18 @@ export type CodexPluginActivateOptions = CodexPluginInstallOptions & {
   yes?: boolean;
 };
 
+export type CodexPluginRegistrationReport = {
+  ok: true;
+  action: "codex-plugin-registration";
+  codexHome: string;
+  codexCommand: string;
+  workspace: string;
+  available: boolean;
+  registered: boolean;
+  enabled: boolean;
+  version?: string;
+};
+
 export type CodexPluginInstallReport = {
   ok: boolean;
   action: "codex-plugin-install";
@@ -74,6 +88,8 @@ export type CodexPluginActivateReport = {
   workspace: string;
   marketplaceAdd: CodexPluginCommandResult;
   pluginAdd: CodexPluginCommandResult;
+  registrationBefore: CodexPluginRegistrationReport;
+  registration: CodexPluginRegistrationReport;
   hooks: CodexHook[];
   trustedHooks: number;
   configPath: string;
@@ -245,20 +261,46 @@ export async function activateCodexPlugin(options: CodexPluginActivateOptions = 
   if (!existsSync(join(cliMarketplaceRoot, ".agents", "plugins", "marketplace.json"))) {
     await stageCodexCliMarketplace(install);
   }
+  const registrationBefore = await inspectCodexPluginRegistration({
+    ...options,
+    codexHome: install.codexHome,
+    codexCommand,
+    workspace,
+  });
   let marketplaceAdd: CodexPluginCommandResult;
   let pluginAdd: CodexPluginCommandResult;
-  if (install.registrationMode === "bootstrap") {
-    marketplaceAdd = await runCommand(codexCommand, ["plugin", "marketplace", "add", cliMarketplaceRoot, "--json"], { cwd: workspace, env });
-    if (!marketplaceAdd.ok) {
-      throw new Error(`codex plugin marketplace add failed: ${marketplaceAdd.stderr || marketplaceAdd.stdout || "unknown error"}`);
+  if (!registrationBefore.registered || !registrationBefore.enabled) {
+    if (registrationBefore.available) {
+      marketplaceAdd = skippedPluginCommand("marketplace_registration_preserved");
+    } else {
+      marketplaceAdd = await runCommand(codexCommand, ["plugin", "marketplace", "add", cliMarketplaceRoot, "--json"], { cwd: workspace, env });
+      if (!marketplaceAdd.ok) {
+        throw new Error(`codex plugin marketplace add failed: ${marketplaceAdd.stderr || marketplaceAdd.stdout || "unknown error"}`);
+      }
     }
-    pluginAdd = await runCommand(codexCommand, ["plugin", "add", `${PLUGIN_NAME}@${CLI_MARKETPLACE_NAME}`, "--json"], { cwd: workspace, env });
+    pluginAdd = await runCommand(codexCommand, ["plugin", "add", PLUGIN_ID, "--json"], { cwd: workspace, env });
     if (!pluginAdd.ok) {
       throw new Error(`codex plugin add failed: ${pluginAdd.stderr || pluginAdd.stdout || "unknown error"}`);
     }
   } else {
     marketplaceAdd = skippedPluginCommand("versioned_installation_preserved");
     pluginAdd = skippedPluginCommand("versioned_installation_preserved");
+  }
+  const registration = await inspectCodexPluginRegistration({
+    ...options,
+    codexHome: install.codexHome,
+    codexCommand,
+    workspace,
+  });
+  const expectedVersion = stringField(
+    await readJsonRecord(join(install.pluginSourcePath, ".codex-plugin", "plugin.json")),
+    "version",
+  );
+  if (!registration.registered || !registration.enabled) {
+    throw new Error("Codex plugin registration was not enabled after activation");
+  }
+  if (!expectedVersion || registration.version !== expectedVersion) {
+    throw new Error(`Codex plugin registration version does not match ${expectedVersion ?? "the installed plugin"}`);
   }
   await removePersonalMarketplaceEntry(bootstrapMarketplacePath);
   const hooks = await listMemoraxCodeHooks(codexCommand, workspace, env);
@@ -282,10 +324,38 @@ export async function activateCodexPlugin(options: CodexPluginActivateOptions = 
     workspace,
     marketplaceAdd,
     pluginAdd,
+    registrationBefore,
+    registration,
     hooks,
     trustedHooks: hooks.length,
     configPath,
     startsBackend: false,
+  };
+}
+
+export async function inspectCodexPluginRegistration(
+  options: Pick<CodexPluginActivateOptions, "codexHome" | "homeDir" | "codexCommand" | "workspace"> = {},
+): Promise<CodexPluginRegistrationReport> {
+  const home = resolveHome(options.homeDir);
+  const codexHome = resolveCodexHome(options.codexHome, home);
+  const codexCommand = options.codexCommand ?? process.env.CODEX_CLI_PATH ?? "codex";
+  const workspace = resolve(options.workspace ?? process.cwd());
+  const result = await runCommand(codexCommand, ["plugin", "list", "--json"], {
+    cwd: workspace,
+    env: { ...process.env, HOME: home, CODEX_HOME: codexHome },
+    timeoutMs: PLUGIN_LIST_TIMEOUT_MS,
+  });
+  if (!result.ok) {
+    throw new Error(`codex plugin list failed: ${result.stderr || result.stdout || "unknown error"}`);
+  }
+  const state = parseCodexPluginList(result.stdout);
+  return {
+    ok: true,
+    action: "codex-plugin-registration",
+    codexHome,
+    codexCommand,
+    workspace,
+    ...state,
   };
 }
 
@@ -589,6 +659,62 @@ function skippedPluginCommand(reason: string): CodexPluginCommandResult {
   return { ok: true, stdout: "", stderr: "", skipped: true, reason };
 }
 
+function parseCodexPluginList(stdout: string): {
+  available: boolean;
+  registered: boolean;
+  enabled: boolean;
+  version?: string;
+} {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch {
+    throw new Error("codex plugin list returned invalid JSON");
+  }
+  if (!isRecord(parsed) || !Array.isArray(parsed.installed) || !Array.isArray(parsed.available)) {
+    throw new Error("codex plugin list returned an invalid registry payload");
+  }
+  const installed = matchingPluginEntry(parsed.installed, "installed");
+  const available = matchingPluginEntry(parsed.available, "available");
+  if (!installed) {
+    return {
+      available: available !== undefined,
+      registered: false,
+      enabled: false,
+    };
+  }
+  const version = typeof installed.version === "string" ? nonEmpty(installed.version) : undefined;
+  if (installed.installed !== true
+    || typeof installed.enabled !== "boolean"
+    || !version) {
+    throw new Error("codex plugin list returned an invalid MemoraX Code registration");
+  }
+  return {
+    available: true,
+    registered: true,
+    enabled: installed.enabled,
+    version,
+  };
+}
+
+function matchingPluginEntry(entries: unknown[], collection: string): Record<string, unknown> | undefined {
+  const matches = entries.filter((entry): entry is Record<string, unknown> => isRecord(entry) && (
+    entry.pluginId === PLUGIN_ID
+    || (entry.name === PLUGIN_NAME && entry.marketplaceName === CLI_MARKETPLACE_NAME)
+  ));
+  if (matches.length > 1) {
+    throw new Error(`codex plugin list returned duplicate MemoraX Code ${collection} entries`);
+  }
+  const entry = matches[0];
+  if (!entry) return undefined;
+  if (entry.pluginId !== PLUGIN_ID
+    || entry.name !== PLUGIN_NAME
+    || entry.marketplaceName !== CLI_MARKETPLACE_NAME) {
+    throw new Error(`codex plugin list returned an invalid MemoraX Code ${collection} entry`);
+  }
+  return entry;
+}
+
 function pluginEntry(sourcePath: string): MarketplaceEntry {
   return {
     name: PLUGIN_NAME,
@@ -619,7 +745,11 @@ function marketplaceName(marketplace: MarketplaceFile): string {
   return nonEmpty(typeof marketplace.name === "string" ? marketplace.name : undefined) ?? "personal";
 }
 
-function runCommand(command: string, args: string[], options: { cwd: string; env: NodeJS.ProcessEnv }): Promise<{ ok: boolean; stdout: string; stderr: string }> {
+function runCommand(
+  command: string,
+  args: string[],
+  options: { cwd: string; env: NodeJS.ProcessEnv; timeoutMs?: number },
+): Promise<{ ok: boolean; stdout: string; stderr: string }> {
   return new Promise((resolveResult) => {
     let invocation;
     try {
@@ -639,13 +769,31 @@ function runCommand(command: string, args: string[], options: { cwd: string; env
     });
     let stdout = "";
     let stderr = "";
+    let settled = false;
+    let timeout: NodeJS.Timeout | undefined;
+    const finish = (result: { ok: boolean; stdout: string; stderr: string }) => {
+      if (settled) return;
+      settled = true;
+      if (timeout) clearTimeout(timeout);
+      resolveResult(result);
+    };
+    if (options.timeoutMs) {
+      timeout = setTimeout(() => {
+        child.kill();
+        finish({
+          ok: false,
+          stdout,
+          stderr: stderr || `command timed out after ${options.timeoutMs}ms`,
+        });
+      }, options.timeoutMs);
+    }
     child.stdout.on("data", (chunk) => { stdout += String(chunk); });
     child.stderr.on("data", (chunk) => { stderr += String(chunk); });
     child.on("error", (error) => {
-      resolveResult({ ok: false, stdout, stderr: stderr || error.message });
+      finish({ ok: false, stdout, stderr: stderr || error.message });
     });
     child.on("close", (code) => {
-      resolveResult({ ok: code === 0, stdout, stderr });
+      finish({ ok: code === 0, stdout, stderr });
     });
   });
 }

--- a/packages/ts/memorax-code-backend/src/clients/codex/plugin-install.ts
+++ b/packages/ts/memorax-code-backend/src/clients/codex/plugin-install.ts
@@ -340,7 +340,7 @@ export async function inspectCodexPluginRegistration(
   const codexHome = resolveCodexHome(options.codexHome, home);
   const codexCommand = options.codexCommand ?? process.env.CODEX_CLI_PATH ?? "codex";
   const workspace = resolve(options.workspace ?? process.cwd());
-  const result = await runCommand(codexCommand, ["plugin", "list", "--json"], {
+  const result = await runCommand(codexCommand, ["plugin", "list", "--available", "--json"], {
     cwd: workspace,
     env: { ...process.env, HOME: home, CODEX_HOME: codexHome },
     timeoutMs: PLUGIN_LIST_TIMEOUT_MS,

--- a/packages/ts/memorax-code-backend/src/entrypoints/backend-cli.ts
+++ b/packages/ts/memorax-code-backend/src/entrypoints/backend-cli.ts
@@ -33,7 +33,11 @@ import {
   startBackendAutomaticUpdateScheduler,
   type AutomaticUpdateScheduler,
 } from "../lifecycle/automatic-update-scheduler.js";
-import { activateCodexPlugin, installCodexPlugin } from "../clients/codex/plugin-install.js";
+import {
+  activateCodexPlugin,
+  inspectCodexPluginRegistration,
+  installCodexPlugin,
+} from "../clients/codex/plugin-install.js";
 import { inspectCodexPluginHooks, trustCodexPluginHooks, type CodexHook } from "../clients/codex/plugin-hooks.js";
 import {
   collectMemoraxCodeStatus,
@@ -431,7 +435,7 @@ function isClientHookRuntimeGeneration(
 }
 
 type CodexPluginCommandReport = Awaited<ReturnType<
-  typeof installCodexPlugin | typeof activateCodexPlugin | typeof inspectCodexPluginHooks | typeof trustCodexPluginHooks
+  typeof installCodexPlugin | typeof activateCodexPlugin | typeof inspectCodexPluginRegistration | typeof inspectCodexPluginHooks | typeof trustCodexPluginHooks
 >>;
 
 async function runCodexPluginCommand(argv: string[]): Promise<CodexPluginCommandReport> {
@@ -444,6 +448,13 @@ async function runCodexPluginCommand(argv: string[]): Promise<CodexPluginCommand
       codexCommand: argValue(argv, "--codex-command"),
       workspace: argValue(argv, "--workspace"),
       yes: argv.includes("--yes"),
+    });
+  }
+  if (subcommand === "registration") {
+    return await inspectCodexPluginRegistration({
+      codexHome: argValue(argv, "--codex-home"),
+      codexCommand: argValue(argv, "--codex-command"),
+      workspace: argValue(argv, "--workspace"),
     });
   }
   if (subcommand === "hooks") {
@@ -487,6 +498,14 @@ function printCodexPluginInstallResult(report: CodexPluginCommandReport): void {
     console.log(`trusted hooks: ${report.trustedHooks}`);
     if (report.requiresFullReview) console.log("incremental trust: blocked by plugin marketplace identity change");
     console.log(`config: ${report.configPath}`);
+    console.log("backend: not started");
+    return;
+  }
+  if (report.action === "codex-plugin-registration") {
+    console.log(`codex home: ${report.codexHome}`);
+    console.log(`registered: ${report.registered ? "yes" : "no"}`);
+    console.log(`enabled: ${report.enabled ? "yes" : "no"}`);
+    if (report.version) console.log(`version: ${report.version}`);
     console.log("backend: not started");
     return;
   }

--- a/packages/ts/memorax-code-backend/test/clients/codex/codex-plugin-install.test.mjs
+++ b/packages/ts/memorax-code-backend/test/clients/codex/codex-plugin-install.test.mjs
@@ -784,20 +784,42 @@ test("codex-plugin activate installs through Codex CLI and trusts MemoraX Code h
   const codexHome = join(home, "codex-home");
   const workspace = join(root, "workspace");
   const fakeCodex = join(root, "fake-codex.mjs");
+  const marketplaceRegistrationPath = join(root, "codex-marketplace-registration");
+  const registrationPath = join(root, "codex-plugin-registration");
+  const bundledVersion = JSON.parse(await readFile(bundledCodexManifestPath, "utf8")).version;
   try {
     await mkdir(workspace, { recursive: true });
     await mkdir(codexHome, { recursive: true });
     await writeFile(join(codexHome, "config.toml"), "[hooks.state]\n");
     await writeFile(fakeCodex, `#!/usr/bin/env node
 import { createInterface } from "node:readline";
-import { appendFileSync } from "node:fs";
+import { appendFileSync, existsSync, writeFileSync } from "node:fs";
 
 appendFileSync(${JSON.stringify(join(root, "codex-calls.log"))}, JSON.stringify(process.argv.slice(2)) + "\\n");
+if (process.argv.slice(2).join(" ") === "plugin list --json") {
+  const registered = existsSync(${JSON.stringify(registrationPath)});
+  const available = existsSync(${JSON.stringify(marketplaceRegistrationPath)});
+  const entry = {
+    pluginId: "memorax-code-codex-adapter@memorax-code",
+    name: "memorax-code-codex-adapter",
+    marketplaceName: "memorax-code",
+    version: ${JSON.stringify(bundledVersion)},
+    installed: registered,
+    enabled: registered
+  };
+  console.log(JSON.stringify({
+    installed: registered ? [entry] : [],
+    available: !registered && available ? [entry] : []
+  }));
+  process.exit(0);
+}
 if (process.argv[2] === "plugin" && process.argv[3] === "marketplace" && process.argv[4] === "add") {
+  writeFileSync(${JSON.stringify(marketplaceRegistrationPath)}, "registered\\n");
   console.log("Added marketplace");
   process.exit(0);
 }
 if (process.argv[2] === "plugin" && process.argv[3] === "add") {
+  writeFileSync(${JSON.stringify(registrationPath)}, "registered\\n");
   console.log("Added plugin");
   process.exit(0);
 }
@@ -878,6 +900,11 @@ rl.on("line", (line) => {
     assert.equal(report.ok, true);
     assert.equal(report.action, "codex-plugin-activate");
     assert.equal(report.install.registrationMode, "bootstrap");
+    assert.equal(report.registrationBefore.registered, false);
+    assert.equal(report.registrationBefore.enabled, false);
+    assert.equal(report.registration.registered, true);
+    assert.equal(report.registration.enabled, true);
+    assert.equal(report.registration.version, bundledVersion);
     assert.equal(report.trustedHooks, 1);
     assert.equal(report.startsBackend, false);
     const calls = await readFile(join(root, "codex-calls.log"), "utf8");
@@ -959,6 +986,8 @@ rl.on("line", (line) => {
     assert.equal(repeated.code, 0, `${repeated.stdout}\n${repeated.stderr}`);
     const repeatedReport = JSON.parse(repeated.stdout);
     assert.equal(repeatedReport.install.registrationMode, "versioned-update");
+    assert.equal(repeatedReport.registrationBefore.registered, true);
+    assert.equal(repeatedReport.registration.registered, true);
     assert.deepEqual(repeatedReport.marketplaceAdd, {
       ok: true,
       stdout: "",
@@ -1004,6 +1033,42 @@ rl.on("line", (line) => {
       name: "unrelated-plugin",
       custom: "preserved",
     }]);
+
+    await rm(registrationPath, { force: true });
+    const repaired = await runMemoraxCode([
+      "codex-plugin",
+      "activate",
+      "--codex-command",
+      fakeCodex,
+      "--workspace",
+      workspace,
+      "--yes",
+      "--json",
+    ], {
+      HOME: home,
+      CODEX_HOME: codexHome,
+    });
+    assert.equal(repaired.code, 0, `${repaired.stdout}\n${repaired.stderr}`);
+    const repairedReport = JSON.parse(repaired.stdout);
+    assert.equal(repairedReport.install.registrationMode, "versioned-update");
+    assert.equal(repairedReport.registrationBefore.registered, false);
+    assert.equal(repairedReport.registrationBefore.available, true);
+    assert.equal(repairedReport.registration.registered, true);
+    assert.equal(repairedReport.marketplaceAdd.ok, true);
+    assert.equal(repairedReport.marketplaceAdd.skipped, true);
+    assert.equal(repairedReport.marketplaceAdd.reason, "marketplace_registration_preserved");
+    assert.equal(repairedReport.pluginAdd.ok, true);
+    assert.equal(repairedReport.pluginAdd.skipped, undefined);
+    const repairedCalls = (await readFile(join(root, "codex-calls.log"), "utf8"))
+      .trim()
+      .split(/\r?\n/)
+      .map((line) => JSON.parse(line));
+    assert.equal(repairedCalls.filter((args) => (
+      args[0] === "plugin" && args[1] === "marketplace" && args[2] === "add"
+    )).length, 1);
+    assert.equal(repairedCalls.filter((args) => (
+      args[0] === "plugin" && args[1] === "add"
+    )).length, 2);
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/packages/ts/memorax-code-backend/test/clients/codex/codex-plugin-install.test.mjs
+++ b/packages/ts/memorax-code-backend/test/clients/codex/codex-plugin-install.test.mjs
@@ -795,10 +795,12 @@ test("codex-plugin activate installs through Codex CLI and trusts MemoraX Code h
 import { createInterface } from "node:readline";
 import { appendFileSync, existsSync, writeFileSync } from "node:fs";
 
-appendFileSync(${JSON.stringify(join(root, "codex-calls.log"))}, JSON.stringify(process.argv.slice(2)) + "\\n");
-if (process.argv.slice(2).join(" ") === "plugin list --json") {
+const args = process.argv.slice(2);
+appendFileSync(${JSON.stringify(join(root, "codex-calls.log"))}, JSON.stringify(args) + "\\n");
+if (args[0] === "plugin" && args[1] === "list" && args.includes("--json")) {
   const registered = existsSync(${JSON.stringify(registrationPath)});
   const available = existsSync(${JSON.stringify(marketplaceRegistrationPath)});
+  const includeAvailable = args.includes("--available");
   const entry = {
     pluginId: "memorax-code-codex-adapter@memorax-code",
     name: "memorax-code-codex-adapter",
@@ -809,16 +811,20 @@ if (process.argv.slice(2).join(" ") === "plugin list --json") {
   };
   console.log(JSON.stringify({
     installed: registered ? [entry] : [],
-    available: !registered && available ? [entry] : []
+    available: includeAvailable && !registered && available ? [entry] : []
   }));
   process.exit(0);
 }
-if (process.argv[2] === "plugin" && process.argv[3] === "marketplace" && process.argv[4] === "add") {
+if (args[0] === "plugin" && args[1] === "marketplace" && args[2] === "add") {
+  if (existsSync(${JSON.stringify(marketplaceRegistrationPath)})) {
+    console.error("marketplace is already added from a different source");
+    process.exit(1);
+  }
   writeFileSync(${JSON.stringify(marketplaceRegistrationPath)}, "registered\\n");
   console.log("Added marketplace");
   process.exit(0);
 }
-if (process.argv[2] === "plugin" && process.argv[3] === "add") {
+if (args[0] === "plugin" && args[1] === "add") {
   writeFileSync(${JSON.stringify(registrationPath)}, "registered\\n");
   console.log("Added plugin");
   process.exit(0);
@@ -1063,6 +1069,13 @@ rl.on("line", (line) => {
       .trim()
       .split(/\r?\n/)
       .map((line) => JSON.parse(line));
+    const registrationInspections = repairedCalls.filter((args) => (
+      args[0] === "plugin" && args[1] === "list"
+    ));
+    assert.equal(registrationInspections.length, 6);
+    assert(registrationInspections.every((args) => (
+      args.join(" ") === "plugin list --available --json"
+    )));
     assert.equal(repairedCalls.filter((args) => (
       args[0] === "plugin" && args[1] === "marketplace" && args[2] === "add"
     )).length, 1);


### PR DESCRIPTION
## Summary

- inspect the real Codex plugin registration during setup instead of treating an existing cache as proof of activation
- repair a missing or disabled registration through the existing install and silent activation flow
- expose a structured `codex-plugin registration --json` check for setup reconciliation
- keep cache validation as the package-content readiness check

## Regression scenario

A versioned MemoraX plugin cache may still exist while `codex plugin list --json` has no installed MemoraX entry. Before this change, setup skipped activation and left Codex on a missing or stale registration. Setup now detects that split state and repairs it.

## Verification

- `npm run typecheck --prefix packages/ts/memorax-code-backend`
- `npm test --prefix packages/ts/memorax-code-backend` — 502 passed, 2 platform skips
- `node --test packages/npm/memorax-code/test/setup.test.mjs` — 20 passed
- `make npm-package-check` — 255 passed, 2 platform integration skips
- isolated macOS reproduction and repair: passed
- Docker Linux reproduction and repair: passed
- Windows 11 / Node 24.19.0 / npm 11.17.0 / Codex CLI 0.151.0 E2E: passed, including missing registration repair, 6/6 trusted Hooks, setup completion, and Backend health
