### PR TITLE
chore: bump release version to 0.1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,30 @@ behavior.
 
 ## Unreleased
 
-### Changed
+## [0.1.10] - 2026-09-01
 
-- Moved automatic-update scheduling from client SessionStart events to the
-  managed Backend, so a continuously running installation keeps checking on
-  its persisted cadence without requiring a new coding-agent session.
+### Added
+
+- Added managed CodeBuddy/WorkBuddy integration with native Turn tracking,
+  completed-Turn writeback, interrupted-Turn handling, Skill reminders, quota
+  notices, Repo Memory maintenance, local traces, and supported setup on
+  macOS, Linux, and Windows.
+- Added automatic updates owned by the managed Backend. Stable and preview
+  installations check their release channel every eight hours, retry failures
+  after 15 minutes, install the exact resolved version, reconcile enabled
+  clients non-interactively, silently trust verified Codex Hook changes, and
+  replace the Backend process without requiring a new client session.
+
+### Fixed
+
+- Completed manual update reconciliation when the managed Backend was already
+  stopped, including client integration assets, Codex Hook trust, setup state,
+  and Backend recovery.
+- Repaired the Windows user `PATH` during interactive setup when npm's global
+  command directory is missing, while preserving existing command priority.
+- Repaired missing or disabled Codex plugin registrations even when a valid
+  versioned plugin cache already exists, preventing the CLI and active Codex
+  plugin from remaining on different versions.
 
 ## [0.1.9] - 2026-08-28
 
@@ -137,6 +156,7 @@ Later upgrades do not require this workaround.
 - Required a non-empty MemoraX user ID and API key during interactive setup,
   with clearer registration guidance.
 
+[0.1.10]: https://www.npmjs.com/package/@memorax/memorax-code/v/0.1.10
 [0.1.9]: https://www.npmjs.com/package/@memorax/memorax-code/v/0.1.9
 [0.1.8]: https://www.npmjs.com/package/@memorax/memorax-code/v/0.1.8
 [0.1.7]: https://www.npmjs.com/package/@memorax/memorax-code/v/0.1.7

--- a/packages/npm/memorax-code/package.json
+++ b/packages/npm/memorax-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax/memorax-code",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Persistent coding memory for Codex, Claude Code, CodeBuddy/WorkBuddy, DeepSeek Harness, and OpenCode.",
   "license": "MIT",
   "type": "module",

--- a/packages/ts/memorax-code-backend/package-lock.json
+++ b/packages/ts/memorax-code-backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@memorax-code/backend",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@memorax-code/backend",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "dependencies": {
         "smol-toml": "^1.7.0"
       },

--- a/packages/ts/memorax-code-backend/package.json
+++ b/packages/ts/memorax-code-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/backend",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "private": true,
   "type": "module",
   "description": "Local memory integration, lifecycle, trace, and diagnostics for MemoraX Code.",

--- a/packages/ts/memorax-code-claude-adapter/.claude-plugin/plugin.json
+++ b/packages/ts/memorax-code-claude-adapter/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorax-code-claude-adapter",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Memory skill and local hooks for MemoraX Code in Claude Code.",
   "author": {
     "name": "MemoraX Code Maintainers"

--- a/packages/ts/memorax-code-claude-adapter/hooks/runtime-shell.json
+++ b/packages/ts/memorax-code-claude-adapter/hooks/runtime-shell.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
-  "shellVersion": "0.1.9",
+  "shellVersion": "0.1.10",
   "runtimeAbi": 1
 }

--- a/packages/ts/memorax-code-claude-adapter/package.json
+++ b/packages/ts/memorax-code-claude-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/claude-adapter",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "private": true,
   "type": "module",
   "description": "Claude Code Hook adapter for MemoraX Code memory services.",

--- a/packages/ts/memorax-code-codebuddy-adapter/.codebuddy-plugin/plugin.json
+++ b/packages/ts/memorax-code-codebuddy-adapter/.codebuddy-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorax-code-codebuddy-adapter",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "MemoraX Code memory integration for CodeBuddy and WorkBuddy.",
   "hooks": "./hooks/hooks.json",
   "skills": ["./skills/memorax-code"]

--- a/packages/ts/memorax-code-codebuddy-adapter/package.json
+++ b/packages/ts/memorax-code-codebuddy-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/codebuddy-adapter",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "private": true,
   "type": "module",
   "description": "CodeBuddy and WorkBuddy Hook adapter for MemoraX Code memory services.",

--- a/packages/ts/memorax-code-codex-adapter/.codex-plugin/plugin.json
+++ b/packages/ts/memorax-code-codex-adapter/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorax-code-codex-adapter",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Codex adapter, memory skill, and local hooks for MemoraX Code.",
   "author": {
     "name": "MemoraX AI"

--- a/packages/ts/memorax-code-codex-adapter/hooks/runtime-shell.json
+++ b/packages/ts/memorax-code-codex-adapter/hooks/runtime-shell.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
-  "shellVersion": "0.1.9",
+  "shellVersion": "0.1.10",
   "runtimeAbi": 1
 }

--- a/packages/ts/memorax-code-codex-adapter/package.json
+++ b/packages/ts/memorax-code-codex-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/codex-adapter",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "private": true,
   "type": "module",
   "description": "Codex Hook and memory integration for MemoraX Code.",

--- a/packages/ts/memorax-code-dsh-adapter/package.json
+++ b/packages/ts/memorax-code-dsh-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/dsh-memorax-code",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "private": true,
   "type": "module",
   "description": "DeepSeek Harness native memory adapter for MemoraX Code.",

--- a/packages/ts/memorax-code-opencode-adapter/package.json
+++ b/packages/ts/memorax-code-opencode-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/opencode-adapter",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "private": true,
   "type": "module",
   "description": "OpenCode plugin adapter for MemoraX Code memory services.",

--- a/scripts/npm-package-check.sh
+++ b/scripts/npm-package-check.sh
@@ -43,6 +43,9 @@ scripts/build-npm-packages.sh "$out_dir"
     make test-npm-package
 )
 
+# Keep the live registry from replacing the staged future release during smoke tests.
+export MEMORAX_CODE_AUTO_UPDATE=false
+
 package_version="$(node -e 'const fs = require("fs"); const pkg = JSON.parse(fs.readFileSync(process.argv[1], "utf8")); console.log(pkg.version);' "$out_dir/memorax-code/package.json")"
 
 python3 - <<'PY_STAGED_PACKAGE' "$out_dir/memorax-code" "packages/npm/memorax-code/shipped-docs.json"


### PR DESCRIPTION
## Change Summary

Prepare the stable MemoraX Code 0.1.10 release and record the user-facing changes since 0.1.9.

## Implementation Highlights

- Update the canonical npm version to 0.1.10 and synchronize Backend, Codex, Claude Code, CodeBuddy/WorkBuddy, DeepSeek Harness, and OpenCode release metadata.
- Finalize the 0.1.10 changelog for the managed WorkBuddy integration, Backend-scheduled automatic updates, and install/update reconciliation fixes.
- Keep installed-package smoke tests isolated from the live npm release channel so an unpublished future version cannot be replaced by the current `latest`; automatic-update behavior remains covered by the preceding unit tests.

## Validation

- `node scripts/sync-release-version.mjs --check`
- `make docs-check`
- `make test`
- `make npm-package-check`
- `make npm-publish-dry-run`
- `git diff --check`

## Full End-to-End Validation Results

- Environment: isolated macOS release worktree based on `origin/main` at `f61c8c7`.
- Scenario or matrix: release-version synchronization, complete repository tests, installed tarball lifecycle smoke tests, package allowlist validation, and npm publish dry-run.
- Result:
  - Backend: 502 passed, 2 skipped; typecheck passed.
  - Codex: 228 passed; Claude Code: 65 passed; DeepSeek Harness: 28 passed; OpenCode: 35 passed; CodeBuddy/WorkBuddy: 20 passed.
  - npm package tests: 255 passed, 2 platform-dependent credential tests skipped.
  - Installed package smoke and update/reinstall lifecycle passed; 417 files passed the package allowlist.
  - npm publish dry-run completed for `@memorax/memorax-code@0.1.10` with the `latest` tag and public access.
- Package-check note: the initial release run exposed that a Backend started by the smoke test could follow live `latest=0.1.9` and replace the staged 0.1.10 package before publication. The smoke phase now sets the documented automatic-update opt-out after automatic-update unit tests complete; the direct `make npm-package-check` rerun passed.
- Evidence or artifacts: commit `1ed9314`; generated `dist/` artifacts are intentionally not committed.
- Reason not run / remaining risk: the real macOS, Linux, and Windows client E2E matrices were completed in the underlying feature and fix PRs and were not repeated for this metadata-and-release-tooling change. Registry publication, the final tag, and the GitHub Release remain deferred until this PR is merged.
