### PR TITLE
fix: prefer WorkBuddy home on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Coding agents are good at the task in front of them, but a new session often
 starts without the architecture, failed attempts, repository rules, or working
 preferences established before it.
 
-MemoraX Code gives Codex, Claude Code, CodeBuddy/WorkBuddy, DeepSeek Harness, and OpenCode a shared
+MemoraX Code gives Codex, Claude Code, WorkBuddy, DeepSeek Harness, and OpenCode a shared
 memory layer for that context.
 It can recall prior engineering knowledge, capture reusable lessons from
 completed work, maintain repository knowledge, and carry your procedures and
@@ -53,7 +53,7 @@ and validation sooner.
 ## Quick Start
 
 Prepare Node.js 20+ (Node.js 24 LTS recommended) and at least one of Codex,
-Claude Code, CodeBuddy/WorkBuddy, DeepSeek Harness, or OpenCode. Python 3 is
+Claude Code, WorkBuddy, DeepSeek Harness, or OpenCode. Python 3 is
 required for Repo Memory operations. Each coding-agent harness retains its own
 runtime requirements; current DeepSeek Harness releases require Node.js
 `^22.19.0 || >=24.0.0`. DSH may be installed globally or initialized
@@ -170,7 +170,7 @@ See [Configuration](docs/configuration.md) for supported settings and
 ### Try Cross-Session Memory
 
 Clone the example repository from the product website, then open Codex, Claude
-Code, CodeBuddy/WorkBuddy, DeepSeek Harness, or OpenCode in the project directory:
+Code, WorkBuddy, DeepSeek Harness, or OpenCode in the project directory:
 
 ```bash
 git clone https://github.com/SWE-agent/test-repo.git
@@ -178,7 +178,7 @@ cd test-repo
 ```
 
 Invoke the Skill as `$memorax-code` in Codex or `/memorax-code` in Claude Code
-or DeepSeek Harness. In OpenCode, CodeBuddy, or WorkBuddy, ask the agent to use
+or DeepSeek Harness. In OpenCode or WorkBuddy, ask the agent to use
 the `memorax-code` skill by name. The prompts below use its product name and
 work in all supported clients.
 
@@ -234,7 +234,7 @@ writing when the durable intent or target is unclear.
 | **Procedure reuse** | Records reusable task procedures and reminds future agents to apply them. |
 | **Background Repo Memory maintenance** | Automatically organizes repository structure, entry points, and history evidence in the background, then updates them according to policy to reduce repeated searching and summarization. |
 | **Active memory control** | Lets you search and add memory through the bundled MemoraX Code skill or the CLI. |
-| **Client integration** | Integrates with Codex, Claude Code, CodeBuddy/WorkBuddy, DeepSeek Harness, and OpenCode to trigger memory retrieval, reminders, and writeback. Automatic quota reminders are currently available in Codex, Claude Code, CodeBuddy/WorkBuddy, and OpenCode. |
+| **Client integration** | Integrates with Codex, Claude Code, WorkBuddy, DeepSeek Harness, and OpenCode to trigger memory retrieval, reminders, and writeback. Automatic quota reminders are currently available in Codex, Claude Code, WorkBuddy, and OpenCode. |
 | **Local observability** | Uses content-controlled local trace and reconciliation records to inspect activity counts, retrieval, and writeback status. |
 
 ## Your Memory, Your Control
@@ -296,11 +296,8 @@ above remains available and follows the installed release channel while
 preserving configuration. Restart or refresh a client when a release changes
 integration assets that the running client has already loaded.
 
-On Windows, the managed WorkBuddy plugin prefers `%USERPROFILE%\.workbuddy`
-and preserves an existing `%USERPROFILE%\.codebuddy` home for legacy CodeBuddy
-installations. `CODEBUDDY_HOME` or `WORKBUDDY_HOME` remains an explicit override.
-When both homes exist, setup removes only the legacy MemoraX-managed plugin state
-from `.codebuddy`; unrelated CodeBuddy data remains unchanged.
+On Windows, the managed WorkBuddy plugin installs to `%USERPROFILE%\.workbuddy`
+by default. `WORKBUDDY_HOME` remains an explicit override.
 Its status remains `hook-runtime=unverified` until WorkBuddy executes the installed Hook at least once.
 
 ### Windows Upgrade Note

--- a/README.md
+++ b/README.md
@@ -299,6 +299,8 @@ integration assets that the running client has already loaded.
 On Windows, the managed WorkBuddy plugin prefers `%USERPROFILE%\.workbuddy`
 and preserves an existing `%USERPROFILE%\.codebuddy` home for legacy CodeBuddy
 installations. `CODEBUDDY_HOME` or `WORKBUDDY_HOME` remains an explicit override.
+When both homes exist, setup removes only the legacy MemoraX-managed plugin state
+from `.codebuddy`; unrelated CodeBuddy data remains unchanged.
 Its status remains `hook-runtime=unverified` until WorkBuddy executes the installed Hook at least once.
 
 ### Windows Upgrade Note

--- a/README.md
+++ b/README.md
@@ -296,7 +296,9 @@ above remains available and follows the installed release channel while
 preserving configuration. Restart or refresh a client when a release changes
 integration assets that the running client has already loaded.
 
-On Windows, the managed WorkBuddy plugin defaults to `%USERPROFILE%\.codebuddy`.
+On Windows, the managed WorkBuddy plugin prefers `%USERPROFILE%\.workbuddy`
+and preserves an existing `%USERPROFILE%\.codebuddy` home for legacy CodeBuddy
+installations. `CODEBUDDY_HOME` or `WORKBUDDY_HOME` remains an explicit override.
 Its status remains `hook-runtime=unverified` until WorkBuddy executes the installed Hook at least once.
 
 ### Windows Upgrade Note

--- a/README.zh.md
+++ b/README.zh.md
@@ -254,7 +254,8 @@ DeepSeek Harness 或 OpenCode。
 
 Windows 上，托管的 WorkBuddy 插件优先安装到 `%USERPROFILE%\.workbuddy`；如果仅存在旧版
 `%USERPROFILE%\.codebuddy`，则继续沿用该目录以兼容旧 CodeBuddy 安装。
-`CODEBUDDY_HOME` 或 `WORKBUDDY_HOME` 可显式覆盖默认目录。在 WorkBuddy 至少成功执行一次
+两者同时存在时，setup 只清理 `.codebuddy` 中旧的 MemoraX 托管插件状态，不影响其他 CodeBuddy
+数据。`CODEBUDDY_HOME` 或 `WORKBUDDY_HOME` 可显式覆盖默认目录。在 WorkBuddy 至少成功执行一次
 已安装 Hook 前，状态会保持为 `hook-runtime=unverified`。
 
 ### Windows 升级提示

--- a/README.zh.md
+++ b/README.zh.md
@@ -252,8 +252,10 @@ Hook 的精确哈希，然后静默信任这些 Hook。身份变化或 Hook 校�
 客户端已经加载的集成资产，请重启或刷新 Codex、Claude Code、CodeBuddy/WorkBuddy、
 DeepSeek Harness 或 OpenCode。
 
-Windows 上，托管的 WorkBuddy 插件默认安装到 `%USERPROFILE%\.codebuddy`。在 WorkBuddy 至少成功
-执行一次已安装 Hook 前，状态会保持为 `hook-runtime=unverified`。
+Windows 上，托管的 WorkBuddy 插件优先安装到 `%USERPROFILE%\.workbuddy`；如果仅存在旧版
+`%USERPROFILE%\.codebuddy`，则继续沿用该目录以兼容旧 CodeBuddy 安装。
+`CODEBUDDY_HOME` 或 `WORKBUDDY_HOME` 可显式覆盖默认目录。在 WorkBuddy 至少成功执行一次
+已安装 Hook 前，状态会保持为 `hook-runtime=unverified`。
 
 ### Windows 升级提示
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -39,7 +39,7 @@
 Coding Agent 擅长解决眼前的问题，但新会话不会自动继承此前积累的架构认知、踩坑经验、仓库规则
 和协作偏好。
 
-MemoraX Code 让 Codex、Claude Code、CodeBuddy/WorkBuddy、DeepSeek Harness 和 OpenCode 共享一套能够持续积累的记忆。
+MemoraX Code 让 Codex、Claude Code、WorkBuddy、DeepSeek Harness 和 OpenCode 共享一套能够持续积累的记忆。
 它会沉淀代码任务中的工程经验，持续整理仓库知识，并在后续任务中找回相关的工作流程和偏好。
 
 它追求的不是“记得更多”，而是在需要时带回与当前任务相关的 Memory，让 Agent 减少重复搜索和试错，
@@ -48,7 +48,7 @@ MemoraX Code 让 Codex、Claude Code、CodeBuddy/WorkBuddy、DeepSeek Harness �
 ## 快速开始
 
 开始前，请确保已安装 Node.js 20 或更高版本（推荐 Node.js 24 LTS），以及 Codex、Claude Code、
-CodeBuddy/WorkBuddy、DeepSeek Harness 或 OpenCode 中的至少一个。Repo Memory 操作还需要 Python 3。
+WorkBuddy、DeepSeek Harness 或 OpenCode 中的至少一个。Repo Memory 操作还需要 Python 3。
 各 Coding Agent Harness 仍需满足自身的运行时要求；当前 DeepSeek Harness 版本要求 Node.js
 `^22.19.0 || >=24.0.0`。DSH 可全局安装，也可事先通过其官方 `npx` 流程完成初始化。
 
@@ -151,7 +151,7 @@ setup 或上述兜底命令修改持久化 `PATH` 后，请打开一个新终端
 
 ### 体验跨会话记忆
 
-克隆示例仓库，并在项目目录中打开 Codex、Claude Code、CodeBuddy/WorkBuddy、DeepSeek Harness 或 OpenCode：
+克隆示例仓库，并在项目目录中打开 Codex、Claude Code、WorkBuddy、DeepSeek Harness 或 OpenCode：
 
 ```bash
 git clone https://github.com/SWE-agent/test-repo.git
@@ -159,7 +159,7 @@ cd test-repo
 ```
 
 在 Codex 中使用 `$memorax-code`，在 Claude Code 或 DeepSeek Harness 中使用 `/memorax-code`
-调用该 Skill。在 OpenCode、CodeBuddy 或 WorkBuddy 中，直接让 Agent 使用名为 `memorax-code` 的 Skill。
+调用该 Skill。在 OpenCode 或 WorkBuddy 中，直接让 Agent 使用名为 `memorax-code` 的 Skill。
 下面的指令使用产品名称，所有客户端均可直接理解。
 
 在同一个会话中依次发送以下指令：
@@ -204,7 +204,7 @@ MemoraX Code 会先比较含义：语义相同的请求不重复写入；长期�
 | **Procedure 自动复用** | 记录可复用的任务流程，并在后续任务中自动提醒 Agent 按流程执行。 |
 | **Repo Memory 后台整理** | 在后台整理仓库结构、代码入口和历史证据，并按策略自动更新，避免反复搜索和总结。 |
 | **主动记忆控制** | 使用内置的 MemoraX Code Skill 或 CLI，主动查找和添加记忆。 |
-| **客户端集成** | 与 Codex、Claude Code、CodeBuddy/WorkBuddy、DeepSeek Harness 和 OpenCode 集成，触发记忆检索、提醒和写入。目前 Codex、Claude Code、CodeBuddy/WorkBuddy 和 OpenCode 支持自动额度提醒。 |
+| **客户端集成** | 与 Codex、Claude Code、WorkBuddy、DeepSeek Harness 和 OpenCode 集成，触发记忆检索、提醒和写入。目前 Codex、Claude Code、WorkBuddy 和 OpenCode 支持自动额度提醒。 |
 | **本地可观测性** | 通过受内容控制的本地 trace 和 reconciliation 记录查看活动统计、召回与写入状态。 |
 
 ## 你的记忆，由你控制
@@ -249,13 +249,11 @@ Hook 的精确哈希，然后静默信任这些 Hook。身份变化或 Hook 校�
 如需关闭后台检查，请在启动或重启托管 Backend 前设置
 `MEMORAX_CODE_AUTO_UPDATE=false`。客户端启动 Hook 只负责确保 Backend 可用，不负责更新
 节奏。上面的手动更新命令仍然可用，会沿用当前发布通道并保留配置。如果新版本修改了运行中
-客户端已经加载的集成资产，请重启或刷新 Codex、Claude Code、CodeBuddy/WorkBuddy、
+客户端已经加载的集成资产，请重启或刷新 Codex、Claude Code、WorkBuddy、
 DeepSeek Harness 或 OpenCode。
 
-Windows 上，托管的 WorkBuddy 插件优先安装到 `%USERPROFILE%\.workbuddy`；如果仅存在旧版
-`%USERPROFILE%\.codebuddy`，则继续沿用该目录以兼容旧 CodeBuddy 安装。
-两者同时存在时，setup 只清理 `.codebuddy` 中旧的 MemoraX 托管插件状态，不影响其他 CodeBuddy
-数据。`CODEBUDDY_HOME` 或 `WORKBUDDY_HOME` 可显式覆盖默认目录。在 WorkBuddy 至少成功执行一次
+Windows 上，托管的 WorkBuddy 插件默认安装到 `%USERPROFILE%\.workbuddy`；
+`WORKBUDDY_HOME` 可显式覆盖默认目录。在 WorkBuddy 至少成功执行一次
 已安装 Hook 前，状态会保持为 `hook-runtime=unverified`。
 
 ### Windows 升级提示

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -209,8 +209,9 @@ native plugin layout:
 └── skills/memorax-code/
 ```
 
-`CODEBUDDY_HOME` or `WORKBUDDY_HOME` overrides the default root. Windows uses
-`%USERPROFILE%\.codebuddy`; other platforms use `~/.workbuddy`. The Skill is
+`CODEBUDDY_HOME` or `WORKBUDDY_HOME` overrides the default root. Windows prefers
+`%USERPROFILE%\.workbuddy` and falls back to an existing `%USERPROFILE%\.codebuddy`
+for legacy CodeBuddy installations; other platforms use `~/.workbuddy`. The Skill is
 materialized from the canonical MemoraX Code Skill and is owned by the managed
 marketplace plugin; user files outside that plugin are not modified.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -211,7 +211,9 @@ native plugin layout:
 
 `CODEBUDDY_HOME` or `WORKBUDDY_HOME` overrides the default root. Windows prefers
 `%USERPROFILE%\.workbuddy` and falls back to an existing `%USERPROFILE%\.codebuddy`
-for legacy CodeBuddy installations; other platforms use `~/.workbuddy`. The Skill is
+for legacy CodeBuddy installations. When both homes exist, setup removes only the
+legacy MemoraX-managed plugin state from `.codebuddy`; other platforms use
+`~/.workbuddy`. The Skill is
 materialized from the canonical MemoraX Code Skill and is owned by the managed
 marketplace plugin; user files outside that plugin are not modified.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -268,8 +268,9 @@ memorax-code start --clients codebuddy
 memorax-code-codebuddy status --json
 ```
 
-On Windows, the managed plugin defaults to `%USERPROFILE%\.codebuddy`, while
-`CODEBUDDY_HOME` or `WORKBUDDY_HOME` remains an explicit override. A
+On Windows, the managed plugin prefers `%USERPROFILE%\.workbuddy` and falls back
+to an existing `%USERPROFILE%\.codebuddy` for legacy CodeBuddy installations,
+while `CODEBUDDY_HOME` or `WORKBUDDY_HOME` remains an explicit override. A
 `codebuddyHooks.status` value of `unverified` means the files are configured but
 the current plugin version has not yet produced a real Hook event. Restart or
 refresh WorkBuddy, submit one prompt, and check status again. `observed` means

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -270,7 +270,9 @@ memorax-code-codebuddy status --json
 
 On Windows, the managed plugin prefers `%USERPROFILE%\.workbuddy` and falls back
 to an existing `%USERPROFILE%\.codebuddy` for legacy CodeBuddy installations,
-while `CODEBUDDY_HOME` or `WORKBUDDY_HOME` remains an explicit override. A
+while `CODEBUDDY_HOME` or `WORKBUDDY_HOME` remains an explicit override. If both
+homes exist, setup removes only the MemoraX-managed plugin registration,
+marketplace, and cache from `.codebuddy`; unrelated data remains untouched. A
 `codebuddyHooks.status` value of `unverified` means the files are configured but
 the current plugin version has not yet produced a real Hook event. Restart or
 refresh WorkBuddy, submit one prompt, and check status again. `observed` means

--- a/packages/npm/memorax-code/lib/resolve-codebuddy-command.mjs
+++ b/packages/npm/memorax-code/lib/resolve-codebuddy-command.mjs
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { delimiter, join, win32 } from "node:path";
 import {
@@ -80,10 +81,20 @@ export function ensureCodeBuddyCommandEnv(options = {}) {
   return resolved;
 }
 
-export function defaultCodeBuddyHome(env = process.env, homeDir = homedir(), platform = process.platform) {
-  return nonEmpty(env.CODEBUDDY_HOME)
-    ?? nonEmpty(env.WORKBUDDY_HOME)
-    ?? (platform === "win32" ? win32.join(homeDir, ".codebuddy") : join(homeDir, ".workbuddy"));
+export function defaultCodeBuddyHome(
+  env = process.env,
+  homeDir = homedir(),
+  platform = process.platform,
+  pathExists = existsSync,
+) {
+  const configured = nonEmpty(env.CODEBUDDY_HOME) ?? nonEmpty(env.WORKBUDDY_HOME);
+  if (configured) return configured;
+  if (platform !== "win32") return join(homeDir, ".workbuddy");
+  const workBuddyHome = win32.join(homeDir, ".workbuddy");
+  const legacyCodeBuddyHome = win32.join(homeDir, ".codebuddy");
+  return pathExists(workBuddyHome) || !pathExists(legacyCodeBuddyHome)
+    ? workBuddyHome
+    : legacyCodeBuddyHome;
 }
 
 function defaultWindowsRoots(env, homeDir) {

--- a/packages/npm/memorax-code/test/codebuddy-command.test.mjs
+++ b/packages/npm/memorax-code/test/codebuddy-command.test.mjs
@@ -48,9 +48,22 @@ test("CodeBuddy resolver finds the Windows WorkBuddy script under LocalAppData P
   }), { command, source: "app-bundled" });
 });
 
-test("CodeBuddy resolver defaults Windows plugin state to .codebuddy", () => {
+test("CodeBuddy resolver prefers WorkBuddy state and preserves legacy CodeBuddy state", () => {
   assert.equal(
-    defaultCodeBuddyHome({}, "C:\\Users\\tester", "win32"),
+    defaultCodeBuddyHome({}, "C:\\Users\\tester", "win32", () => false),
+    "C:\\Users\\tester\\.workbuddy",
+  );
+  assert.equal(
+    defaultCodeBuddyHome(
+      {},
+      "C:\\Users\\tester",
+      "win32",
+      (path) => path.endsWith("\\.codebuddy"),
+    ),
     "C:\\Users\\tester\\.codebuddy",
+  );
+  assert.equal(
+    defaultCodeBuddyHome({}, "C:\\Users\\tester", "win32", () => true),
+    "C:\\Users\\tester\\.workbuddy",
   );
 });

--- a/packages/ts/memorax-code-codebuddy-adapter/hooks/runtime-hook.mjs
+++ b/packages/ts/memorax-code-codebuddy-adapter/hooks/runtime-hook.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
 import { appendFile, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -40,7 +41,7 @@ const codeBuddyHome = commonStringValue(process.env.CODEBUDDY_HOME)
   ?? commonStringValue(packageMetadata.codeBuddyHome)
   ?? commonStringValue(input?.codebuddy_home)
   ?? commonStringValue(input?.codeBuddyHome)
-  ?? join(homedir(), process.platform === "win32" ? ".codebuddy" : ".workbuddy");
+  ?? defaultCodeBuddyHome();
 try {
   await writeCodeBuddyRuntimeObservation({ memoraxCodeHome: home, codeBuddyHome, pluginRoot });
 } catch (error) {
@@ -238,6 +239,15 @@ async function bindMemoryCliTraceSession(sessionId) {
 }
 function shellSingleQuote(value) { return `'${value.replaceAll("'", "'\"'\"'")}'`; }
 function stringValue(value) { return typeof value === "string" && value.trim() ? value.trim() : undefined; }
+
+function defaultCodeBuddyHome() {
+  const workBuddyHome = join(homedir(), ".workbuddy");
+  if (process.platform !== "win32") return workBuddyHome;
+  const legacyCodeBuddyHome = join(homedir(), ".codebuddy");
+  return existsSync(workBuddyHome) || !existsSync(legacyCodeBuddyHome)
+    ? workBuddyHome
+    : legacyCodeBuddyHome;
+}
 
 function provisionalTurnId(sessionId, boundary, prompt) {
   return `${sessionId}:${boundary}:${createHash("sha256").update(prompt.trim()).digest("hex")}`;

--- a/packages/ts/memorax-code-codebuddy-adapter/src/config.mjs
+++ b/packages/ts/memorax-code-codebuddy-adapter/src/config.mjs
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { chmod, cp, mkdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join, relative, sep, win32 } from "node:path";
@@ -19,10 +19,20 @@ const PLUGIN_NAME = "memorax-code-codebuddy-adapter";
 const MARKETPLACE_NAME = "memorax-code-local";
 const PLUGIN_ID = `${PLUGIN_NAME}@${MARKETPLACE_NAME}`;
 
-export function defaultCodeBuddyHome(env = process.env, homeDir = homedir(), platform = process.platform) {
-  return env.CODEBUDDY_HOME?.trim()
-    || env.WORKBUDDY_HOME?.trim()
-    || (platform === "win32" ? win32.join(homeDir, ".codebuddy") : join(homeDir, ".workbuddy"));
+export function defaultCodeBuddyHome(
+  env = process.env,
+  homeDir = homedir(),
+  platform = process.platform,
+  pathExists = existsSync,
+) {
+  const configured = env.CODEBUDDY_HOME?.trim() || env.WORKBUDDY_HOME?.trim();
+  if (configured) return configured;
+  if (platform !== "win32") return join(homeDir, ".workbuddy");
+  const workBuddyHome = win32.join(homeDir, ".workbuddy");
+  const legacyCodeBuddyHome = win32.join(homeDir, ".codebuddy");
+  return pathExists(workBuddyHome) || !pathExists(legacyCodeBuddyHome)
+    ? workBuddyHome
+    : legacyCodeBuddyHome;
 }
 // CodeBuddy stores installed plugin caches under the marketplace namespace.
 export function codeBuddyInstallPath(home = defaultCodeBuddyHome()) { return join(home, "plugins", "cache", MARKETPLACE_NAME, PLUGIN_NAME, VERSION); }

--- a/packages/ts/memorax-code-codebuddy-adapter/src/config.mjs
+++ b/packages/ts/memorax-code-codebuddy-adapter/src/config.mjs
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { chmod, cp, mkdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
-import { dirname, join, relative, sep, win32 } from "node:path";
+import { basename, dirname, join, relative, sep, win32 } from "node:path";
 import { fileURLToPath } from "node:url";
 import { resolveHookCodeBuddyCommand } from "../../memorax-code-adapter-common/src/clients/codebuddy-command.mjs";
 import {
@@ -71,20 +71,21 @@ export async function enableCodeBuddyAdapter(options = {}) {
     settings.enabledPlugins[PLUGIN_ID] = true;
   });
   await updateLegacyRegistry(home, { installPath, enabled: true });
+  await removeLegacyManagedInstallation(home, platform);
   return { ok: true, action: "enable", runtime: "codebuddy", integration: "hooks", installed: true, enabled: true, codeBuddyHome: home, installPath, marketplace: MARKETPLACE_NAME, pluginId: PLUGIN_ID, marketplacePath: localPluginPath, codebuddyHooks: { ok: true, configured: true, runtimeObserved: false, status: "unverified" }, codebuddySkills: { ok: true, status: "installed", managed: true, memoraxCode: true, path: join(localPluginPath, "skills", "memorax-code", "SKILL.md") } };
 }
 
 export async function disableCodeBuddyAdapter(options = {}) {
   const home = options.codeBuddyHome ?? defaultCodeBuddyHome();
+  const platform = options.platform ?? process.platform;
   const registryPath = installedRegistryPath(home);
-  const installed = await pathExists(marketplacePluginPath(home)) || await pathExists(codeBuddyInstallPath(home));
-  if (!installed) return { ok: true, action: "disable", runtime: "codebuddy", installed: false, enabled: false, codeBuddyHome: home, statePath: registryPath, marketplace: MARKETPLACE_NAME, pluginId: PLUGIN_ID };
-  await updateSettings(home, (settings) => {
-    settings.enabledPlugins = recordValue(settings.enabledPlugins);
-    settings.enabledPlugins[PLUGIN_ID] = false;
-  });
-  await updateLegacyRegistry(home, { installPath: codeBuddyInstallPath(home), enabled: false });
-  return { ok: true, action: "disable", runtime: "codebuddy", installed: true, enabled: false, codeBuddyHome: home, statePath: registryPath, marketplace: MARKETPLACE_NAME, pluginId: PLUGIN_ID };
+  const legacyHome = legacyCodeBuddyHome(home, platform);
+  const installed = await managedCodeBuddyInstallationExists(home);
+  const legacyInstalled = legacyHome ? await managedCodeBuddyInstallationExists(legacyHome) : false;
+  if (!installed && !legacyInstalled) return { ok: true, action: "disable", runtime: "codebuddy", installed: false, enabled: false, codeBuddyHome: home, statePath: registryPath, marketplace: MARKETPLACE_NAME, pluginId: PLUGIN_ID };
+  if (installed) await disableManagedCodeBuddyInstallation(home);
+  if (legacyInstalled) await disableManagedCodeBuddyInstallation(legacyHome);
+  return { ok: true, action: "disable", runtime: "codebuddy", installed: true, enabled: false, codeBuddyHome: home, statePath: registryPath, marketplace: MARKETPLACE_NAME, pluginId: PLUGIN_ID, legacyCodeBuddyHome: legacyInstalled ? legacyHome : undefined, legacyManaged: legacyInstalled };
 }
 
 export async function readCodeBuddyAdapterStatus(options = {}) {
@@ -104,28 +105,73 @@ export async function readCodeBuddyAdapterStatus(options = {}) {
   const skillInstalled = await pathExists(skillPath);
   const enabled = settings.enabledPlugins?.[PLUGIN_ID] === true;
   const marketplaceReady = Boolean(known[MARKETPLACE_NAME]);
+  const legacyHome = legacyCodeBuddyHome(home, platform);
+  const legacyManaged = legacyHome ? await managedCodeBuddyInstallationExists(legacyHome) : false;
   const hookConfigured = installedRoots.length > 0
     && (await Promise.all(installedRoots.map((root) => codeBuddyHookManifestConfigured(root, platform)))).every(Boolean);
   const observation = await readCodeBuddyRuntimeObservation(memoraxCodeHome);
   const runtimeObserved = hookConfigured && observationMatches(observation, home, platform);
-  return { ok: true, action: "status", runtime: "codebuddy", integration: "hooks", installed, enabled, managed: installed && marketplaceReady, codeBuddyHome: home, installPath, marketplace: MARKETPLACE_NAME, pluginId: PLUGIN_ID, marketplaceReady, codebuddyHooks: { ok: hookConfigured, configured: hookConfigured, runtimeObserved, status: hookConfigured ? (runtimeObserved ? "observed" : "unverified") : "invalid", observationPath: codeBuddyRuntimeObservationPath(memoraxCodeHome) }, codebuddySkills: { ok: skillInstalled, status: skillInstalled ? "installed" : "missing", managed: skillInstalled, memoraxCode: skillInstalled, path: skillPath } };
+  return { ok: true, action: "status", runtime: "codebuddy", integration: "hooks", installed, enabled, managed: installed && marketplaceReady, codeBuddyHome: home, installPath, marketplace: MARKETPLACE_NAME, pluginId: PLUGIN_ID, marketplaceReady, legacyCodeBuddyHome: legacyManaged ? legacyHome : undefined, legacyManaged, codebuddyHooks: { ok: hookConfigured, configured: hookConfigured, runtimeObserved, status: hookConfigured ? (runtimeObserved ? "observed" : "unverified") : "invalid", observationPath: codeBuddyRuntimeObservationPath(memoraxCodeHome) }, codebuddySkills: { ok: skillInstalled, status: skillInstalled ? "installed" : "missing", managed: skillInstalled, memoraxCode: skillInstalled, path: skillPath } };
 }
 
 export async function removeCodeBuddyPluginInstallation(options = {}) {
   const home = options.codeBuddyHome ?? defaultCodeBuddyHome();
-  const installed = await pathExists(marketplacePluginPath(home)) || await pathExists(codeBuddyInstallPath(home));
-  if (!installed) return { ok: true, action: "codebuddy-plugin-remove", runtime: "codebuddy", installed: false, enabled: false, removed: false, codeBuddyHome: home, marketplace: MARKETPLACE_NAME, pluginId: PLUGIN_ID };
-  const status = await disableCodeBuddyAdapter({ codeBuddyHome: home });
+  const platform = options.platform ?? process.platform;
+  const legacyHome = legacyCodeBuddyHome(home, platform);
+  const removed = await removeManagedCodeBuddyInstallation(home);
+  const legacyRemoved = legacyHome ? await removeManagedCodeBuddyInstallation(legacyHome) : false;
+  return { ok: true, action: "codebuddy-plugin-remove", runtime: "codebuddy", installed: false, enabled: false, removed: removed || legacyRemoved, codeBuddyHome: home, statePath: installedRegistryPath(home), marketplace: MARKETPLACE_NAME, pluginId: PLUGIN_ID };
+}
+
+async function disableManagedCodeBuddyInstallation(home) {
   await updateSettings(home, (settings) => {
+    settings.enabledPlugins = recordValue(settings.enabledPlugins);
+    settings.enabledPlugins[PLUGIN_ID] = false;
+  });
+  await updateLegacyRegistry(home, { installPath: codeBuddyInstallPath(home), enabled: false });
+}
+
+async function removeLegacyManagedInstallation(home, platform) {
+  const legacyHome = legacyCodeBuddyHome(home, platform);
+  return legacyHome ? await removeManagedCodeBuddyInstallation(legacyHome) : false;
+}
+
+async function removeManagedCodeBuddyInstallation(home) {
+  if (!await managedCodeBuddyInstallationExists(home)) return false;
+  await updateJsonRecordIfPresent(codeBuddySettingsPath(home), (settings) => {
     settings.enabledPlugins = recordValue(settings.enabledPlugins);
     delete settings.enabledPlugins[PLUGIN_ID];
   });
-  await updateKnownMarketplace(home, false);
-  await updateRegistry(home, (registry) => { delete registry[PLUGIN_ID]; });
-  await rm(codeBuddyInstallPath(home), { recursive: true, force: true });
-  await rm(legacyCodeBuddyInstallPath(home), { recursive: true, force: true });
+  await updateJsonRecordIfPresent(knownMarketplacesPath(home), (known) => {
+    delete known[MARKETPLACE_NAME];
+  });
+  await updateJsonRecordIfPresent(installedRegistryPath(home), (value) => {
+    value.version = 2;
+    value.plugins = recordValue(value.plugins);
+    delete value.plugins[PLUGIN_ID];
+  });
+  await rm(codeBuddyPluginCacheRoot(home), { recursive: true, force: true });
+  await rm(legacyCodeBuddyPluginCacheRoot(home), { recursive: true, force: true });
   await rm(marketplaceRoot(home), { recursive: true, force: true });
-  return { ...status, action: "codebuddy-plugin-remove", installed: false, enabled: false, removed: true };
+  return true;
+}
+
+async function managedCodeBuddyInstallationExists(home) {
+  if (await pathExists(marketplaceRoot(home))
+    || await pathExists(codeBuddyPluginCacheRoot(home))
+    || await pathExists(legacyCodeBuddyPluginCacheRoot(home))) return true;
+  const settings = await readJsonRecord(codeBuddySettingsPath(home));
+  const known = await readJsonRecord(knownMarketplacesPath(home));
+  const registry = await readJsonRecord(installedRegistryPath(home));
+  return Object.hasOwn(recordValue(settings.enabledPlugins), PLUGIN_ID)
+    || Object.hasOwn(known, MARKETPLACE_NAME)
+    || Object.hasOwn(recordValue(registry.plugins), PLUGIN_ID);
+}
+
+function legacyCodeBuddyHome(home, platform) {
+  return platform === "win32" && basename(home).toLowerCase() === ".workbuddy"
+    ? join(dirname(home), ".codebuddy")
+    : undefined;
 }
 
 async function readRegistry(home) {
@@ -206,6 +252,11 @@ async function updateJsonRecord(path, mutate) {
     await rm(lockPath, { force: true });
   }
 }
+
+async function updateJsonRecordIfPresent(path, mutate) {
+  if (await pathExists(path)) await updateJsonRecord(path, mutate);
+}
+
 async function readJsonRecord(path) {
   try {
     const value = JSON.parse(await readFile(path, "utf8"));
@@ -235,6 +286,8 @@ function readPluginVersion() {
   return manifest.version.trim();
 }
 function legacyCodeBuddyInstallPath(home) { return join(home, "plugins", "cache", PLUGIN_NAME, VERSION); }
+function codeBuddyPluginCacheRoot(home) { return dirname(codeBuddyInstallPath(home)); }
+function legacyCodeBuddyPluginCacheRoot(home) { return dirname(legacyCodeBuddyInstallPath(home)); }
 
 async function materializeCanonicalSkill(destination) {
   const packagedSkill = join(ROOT, "skills", "memorax-code");

--- a/packages/ts/memorax-code-codebuddy-adapter/test/config.test.mjs
+++ b/packages/ts/memorax-code-codebuddy-adapter/test/config.test.mjs
@@ -19,13 +19,31 @@ import { codeBuddyHookCommand } from "../src/hook-manifest.mjs";
 import { writeCodeBuddyRuntimeObservation } from "../src/runtime-observation.mjs";
 import { resolveHookCodeBuddyCommand } from "../../memorax-code-adapter-common/src/clients/codebuddy-command.mjs";
 
-test("uses the CodeBuddy CLI home by default on Windows", () => {
+test("prefers the WorkBuddy home on Windows while preserving a legacy CodeBuddy home", () => {
   assert.equal(
-    defaultCodeBuddyHome({}, "C:\\Users\\tester", "win32"),
+    defaultCodeBuddyHome({}, "C:\\Users\\tester", "win32", () => false),
+    "C:\\Users\\tester\\.workbuddy",
+  );
+  assert.equal(
+    defaultCodeBuddyHome(
+      {},
+      "C:\\Users\\tester",
+      "win32",
+      (path) => path.endsWith("\\.codebuddy"),
+    ),
     "C:\\Users\\tester\\.codebuddy",
   );
   assert.equal(
-    defaultCodeBuddyHome({ WORKBUDDY_HOME: "D:\\WorkBuddyData" }, "C:\\Users\\tester", "win32"),
+    defaultCodeBuddyHome({}, "C:\\Users\\tester", "win32", () => true),
+    "C:\\Users\\tester\\.workbuddy",
+  );
+  assert.equal(
+    defaultCodeBuddyHome(
+      { WORKBUDDY_HOME: "D:\\WorkBuddyData" },
+      "C:\\Users\\tester",
+      "win32",
+      () => false,
+    ),
     "D:\\WorkBuddyData",
   );
 });

--- a/packages/ts/memorax-code-codebuddy-adapter/test/config.test.mjs
+++ b/packages/ts/memorax-code-codebuddy-adapter/test/config.test.mjs
@@ -167,6 +167,76 @@ test("installs and removes an isolated CodeBuddy plugin registry entry", async (
   assert.equal(await readFile(join(home, "skills", "user-skill", "SKILL.md"), "utf8"), "user-owned\n");
 });
 
+test("reconciles a managed legacy .codebuddy home when .workbuddy is selected", async () => {
+  const profile = await mkdtemp(join(tmpdir(), "memorax-codebuddy-migration-"));
+  const workBuddyHome = join(profile, ".workbuddy");
+  const legacyHome = join(profile, ".codebuddy");
+  const memoraxCodeHome = join(profile, ".memorax-code");
+  await mkdir(join(legacyHome, "plugins"), { recursive: true });
+  await mkdir(join(legacyHome, "skills", "user-skill"), { recursive: true });
+  await writeFile(join(legacyHome, "skills", "user-skill", "SKILL.md"), "user-owned\n");
+  await writeFile(codeBuddySettingsPath(legacyHome), JSON.stringify({ enabledPlugins: {
+    "user-plugin@user-marketplace": true,
+  }}));
+  await writeFile(knownMarketplacesPath(legacyHome), JSON.stringify({
+    "user-marketplace": { type: "directory", source: { path: "/user/marketplace" } },
+  }));
+  await writeFile(join(legacyHome, "plugins", "installed_plugins.json"), JSON.stringify({ version: 2, plugins: {
+    "user-plugin@user-marketplace": [{ scope: "user", installPath: "/user/plugin", enabled: true }],
+  }}));
+  await enableCodeBuddyAdapter({ codeBuddyHome: legacyHome, platform: "win32" });
+  await mkdir(join(legacyHome, "plugins", "cache", "memorax-code-local", "memorax-code-codebuddy-adapter", "0.1.9"), { recursive: true });
+  await mkdir(join(legacyHome, "plugins", "cache", "memorax-code-codebuddy-adapter", "0.1.9"), { recursive: true });
+  await mkdir(workBuddyHome, { recursive: true });
+
+  const legacyStatus = await readCodeBuddyAdapterStatus({
+    codeBuddyHome: workBuddyHome,
+    memoraxCodeHome,
+    platform: "win32",
+  });
+  assert.equal(legacyStatus.installed, false);
+  assert.equal(legacyStatus.legacyManaged, true);
+  assert.equal(legacyStatus.legacyCodeBuddyHome, legacyHome);
+
+  const disabled = await disableCodeBuddyAdapter({ codeBuddyHome: workBuddyHome, platform: "win32" });
+  assert.equal(disabled.installed, true);
+  assert.equal(disabled.legacyManaged, true);
+  assert.equal(disabled.legacyCodeBuddyHome, legacyHome);
+  const disabledLegacySettings = JSON.parse(await readFile(codeBuddySettingsPath(legacyHome), "utf8"));
+  assert.equal(disabledLegacySettings.enabledPlugins["memorax-code-codebuddy-adapter@memorax-code-local"], false);
+
+  await enableCodeBuddyAdapter({
+    codeBuddyHome: workBuddyHome,
+    memoraxCodeHome,
+    platform: "win32",
+  });
+  assert.equal(await exists(marketplaceRoot(legacyHome)), false);
+  assert.equal(await exists(join(legacyHome, "plugins", "cache", "memorax-code-local", "memorax-code-codebuddy-adapter")), false);
+  assert.equal(await exists(join(legacyHome, "plugins", "cache", "memorax-code-codebuddy-adapter")), false);
+  const migratedLegacySettings = JSON.parse(await readFile(codeBuddySettingsPath(legacyHome), "utf8"));
+  assert.equal(migratedLegacySettings.enabledPlugins["memorax-code-codebuddy-adapter@memorax-code-local"], undefined);
+  assert.equal(migratedLegacySettings.enabledPlugins["user-plugin@user-marketplace"], true);
+  const migratedLegacyKnown = JSON.parse(await readFile(knownMarketplacesPath(legacyHome), "utf8"));
+  assert.equal(migratedLegacyKnown["memorax-code-local"], undefined);
+  assert.ok(migratedLegacyKnown["user-marketplace"]);
+  const migratedLegacyRegistry = JSON.parse(await readFile(join(legacyHome, "plugins", "installed_plugins.json"), "utf8"));
+  assert.equal(migratedLegacyRegistry.plugins["memorax-code-codebuddy-adapter@memorax-code-local"], undefined);
+  assert.ok(migratedLegacyRegistry.plugins["user-plugin@user-marketplace"]);
+  assert.equal(await readFile(join(legacyHome, "skills", "user-skill", "SKILL.md"), "utf8"), "user-owned\n");
+
+  await enableCodeBuddyAdapter({ codeBuddyHome: legacyHome, platform: "win32" });
+  const removed = await removeCodeBuddyPluginInstallation({
+    codeBuddyHome: workBuddyHome,
+    platform: "win32",
+  });
+  assert.equal(removed.removed, true);
+  assert.equal(await exists(marketplaceRoot(workBuddyHome)), false);
+  assert.equal(await exists(marketplaceRoot(legacyHome)), false);
+  const removedLegacyRegistry = JSON.parse(await readFile(join(legacyHome, "plugins", "installed_plugins.json"), "utf8"));
+  assert.equal(removedLegacyRegistry.plugins["memorax-code-codebuddy-adapter@memorax-code-local"], undefined);
+  assert.ok(removedLegacyRegistry.plugins["user-plugin@user-marketplace"]);
+});
+
 test("installs the complete plugin when the package lives under node_modules", async () => {
   const root = await mkdtemp(join(tmpdir(), "memorax-codebuddy-node-modules-"));
   const libraryRoot = join(root, "node_modules", "@memorax", "memorax-code", "lib");


### PR DESCRIPTION
## Change Summary
Prefer the native `%USERPROFILE%\.workbuddy` home for new Windows WorkBuddy installations while preserving and safely reconciling legacy `%USERPROFILE%\.codebuddy` installations.

## Implementation Highlights
- Apply the same explicit-override and Windows fallback order in setup command resolution, adapter configuration, and the runtime Hook fallback.
- When `.workbuddy` is selected, detect and reconcile only the MemoraX-managed registration, marketplace, cache, and enabled state in sibling `.codebuddy`; preserve unrelated plugins, Skills, and user data.
- Cover status, disable, update/enable, and removal across both homes, and update the English and Chinese documentation.

## Validation
- `node --test packages/npm/memorax-code/test/codebuddy-command.test.mjs packages/ts/memorax-code-codebuddy-adapter/test/config.test.mjs packages/ts/memorax-code-codebuddy-adapter/test/runtime-hook.test.mjs` — 23 passed, 0 failed.
- `node scripts/build-npm-packages.mjs --out-dir dist/pr131-review-fix` — npm staging validation passed.
- Built and installed a local `0.1.10` npm package into an isolated Windows new-user environment, then exercised the real WorkBuddy desktop application.

## Full End-to-End Validation Results
- Environment: Windows; Node `v24.19.0`; npm `11.17.0`; WorkBuddy `5.3.14`; bundled CodeBuddy runtime `2.115.0`.
- Scenario or matrix: New user with both homes absent; regression coverage also exercises both homes present with a managed legacy `.codebuddy` installation and unrelated user-owned plugin/Skill state.
- Command or workflow: Installed the local npm package, ran `memorax-code setup`, opened a fresh WorkBuddy task, explicitly invoked the `memorax-code` Skill, and performed one manual Coding Memory Search. The dual-home migration matrix runs through status, disable, enable, and remove in the adapter integration test.
- Result: PASS. Setup created `.workbuddy` and did not create `.codebuddy`; WorkBuddy listed the managed plugin, loaded the native `memorax-code` Skill, ran exactly one manual Search with exit code 0, returned the exact expected assistant response, observed SessionStart/Stop Hooks, kept automatic Search disabled, and scheduled automatic writeback. The migration regression removes all MemoraX-managed legacy versions while preserving unrelated registry entries and user Skills.
- Evidence or artifacts: WorkBuddy logs recorded the active plugin under the isolated `.workbuddy` marketplace, successful `Skill "memorax-code"` execution, successful `memorax-cli search`, completed turn outcome, and Stop Hook exit code 0. `memorax-code-codebuddy status --json` reported installed/enabled/managed/marketplaceReady with `codebuddyHooks.status=observed` and plugin version `0.1.10`. Session ID and temporary paths were redacted.
- Reason not run / remaining risk: Immediate post-writeback Search returned `No memory context returned`, so remote writeback materialization was not independently verified; the Stop Hook did receive an accepted scheduled response and cleared its pending record. This does not affect the Windows home-selection or dual-home migration regressions covered by this PR.