### PR TITLE
chore: bump release version to 0.1.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ behavior.
 
 ## Unreleased
 
+## [0.1.11] - 2026-09-01
+
+### Fixed
+
+- Updated Windows WorkBuddy setup to prefer `%USERPROFILE%\\.workbuddy` for
+  new installations while safely reconciling only MemoraX-managed plugin state
+  from legacy `%USERPROFILE%\\.codebuddy` homes, preserving unrelated plugins,
+  Skills, and user data.
+
 ## [0.1.10] - 2026-09-01
 
 ### Added

--- a/packages/npm/memorax-code/package.json
+++ b/packages/npm/memorax-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax/memorax-code",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Persistent coding memory for Codex, Claude Code, CodeBuddy/WorkBuddy, DeepSeek Harness, and OpenCode.",
   "license": "MIT",
   "type": "module",

--- a/packages/ts/memorax-code-backend/package-lock.json
+++ b/packages/ts/memorax-code-backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@memorax-code/backend",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@memorax-code/backend",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "dependencies": {
         "smol-toml": "^1.7.0"
       },

--- a/packages/ts/memorax-code-backend/package.json
+++ b/packages/ts/memorax-code-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/backend",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "private": true,
   "type": "module",
   "description": "Local memory integration, lifecycle, trace, and diagnostics for MemoraX Code.",

--- a/packages/ts/memorax-code-claude-adapter/.claude-plugin/plugin.json
+++ b/packages/ts/memorax-code-claude-adapter/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorax-code-claude-adapter",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Memory skill and local hooks for MemoraX Code in Claude Code.",
   "author": {
     "name": "MemoraX Code Maintainers"

--- a/packages/ts/memorax-code-claude-adapter/hooks/runtime-shell.json
+++ b/packages/ts/memorax-code-claude-adapter/hooks/runtime-shell.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
-  "shellVersion": "0.1.10",
+  "shellVersion": "0.1.11",
   "runtimeAbi": 1
 }

--- a/packages/ts/memorax-code-claude-adapter/package.json
+++ b/packages/ts/memorax-code-claude-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/claude-adapter",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "private": true,
   "type": "module",
   "description": "Claude Code Hook adapter for MemoraX Code memory services.",

--- a/packages/ts/memorax-code-codebuddy-adapter/.codebuddy-plugin/plugin.json
+++ b/packages/ts/memorax-code-codebuddy-adapter/.codebuddy-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorax-code-codebuddy-adapter",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "MemoraX Code memory integration for CodeBuddy and WorkBuddy.",
   "hooks": "./hooks/hooks.json",
   "skills": ["./skills/memorax-code"]

--- a/packages/ts/memorax-code-codebuddy-adapter/package.json
+++ b/packages/ts/memorax-code-codebuddy-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/codebuddy-adapter",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "private": true,
   "type": "module",
   "description": "CodeBuddy and WorkBuddy Hook adapter for MemoraX Code memory services.",

--- a/packages/ts/memorax-code-codex-adapter/.codex-plugin/plugin.json
+++ b/packages/ts/memorax-code-codex-adapter/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorax-code-codex-adapter",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Codex adapter, memory skill, and local hooks for MemoraX Code.",
   "author": {
     "name": "MemoraX AI"

--- a/packages/ts/memorax-code-codex-adapter/hooks/runtime-shell.json
+++ b/packages/ts/memorax-code-codex-adapter/hooks/runtime-shell.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
-  "shellVersion": "0.1.10",
+  "shellVersion": "0.1.11",
   "runtimeAbi": 1
 }

--- a/packages/ts/memorax-code-codex-adapter/package.json
+++ b/packages/ts/memorax-code-codex-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/codex-adapter",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "private": true,
   "type": "module",
   "description": "Codex Hook and memory integration for MemoraX Code.",

--- a/packages/ts/memorax-code-dsh-adapter/package.json
+++ b/packages/ts/memorax-code-dsh-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/dsh-memorax-code",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "private": true,
   "type": "module",
   "description": "DeepSeek Harness native memory adapter for MemoraX Code.",

--- a/packages/ts/memorax-code-opencode-adapter/package.json
+++ b/packages/ts/memorax-code-opencode-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/opencode-adapter",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "private": true,
   "type": "module",
   "description": "OpenCode plugin adapter for MemoraX Code memory services.",


### PR DESCRIPTION
## Change Summary

Prepare the stable MemoraX Code 0.1.11 release and record the user-facing change since 0.1.10.

## Implementation Highlights

- Update the canonical npm version to 0.1.11 and synchronize Backend, Codex, Claude Code, WorkBuddy, DeepSeek Harness, and OpenCode release metadata.
- Add the 0.1.11 changelog entry for the Windows WorkBuddy home-selection and legacy `.codebuddy` reconciliation fix from PR #131.
- Keep this PR release-only: no runtime implementation or test behavior changes are included.

## Validation

- `node scripts/sync-release-version.mjs --check`
- `make docs-check`
- `make test`
- `make npm-package-check`
- `make npm-publish-dry-run`
- `git diff --check`

## Full End-to-End Validation Results

- Environment: isolated macOS release worktree based on current `origin/main` at `cf006a7`.
- Scenario or matrix: release-version synchronization, complete repository tests, installed tarball lifecycle smoke tests, package allowlist validation, and npm publish dry-run.
- Result:
  - Backend: 502 passed, 2 skipped; typecheck passed.
  - Codex: 228 passed; Claude Code: 65 passed; DeepSeek Harness: 28 passed; OpenCode: 35 passed; WorkBuddy: 21 passed.
  - npm package tests: 255 passed, 2 platform-dependent credential tests skipped.
  - Package staging, installed-package smoke tests, and lifecycle checks passed; 417 files passed the package allowlist.
  - npm publish dry-run completed for `@memorax/memorax-code@0.1.11` with the `latest` tag and public access; package size 452.0 kB, shasum `c7ea03f310108316f47ac2529cc04e0f8d360b1b`.
- Evidence or artifacts: commit `8aa224f`; generated `dist/` artifacts are intentionally not committed.
- Reason not run / remaining risk: the real Windows WorkBuddy E2E was completed in PR #131 and was not repeated for this metadata-only release change. Registry publication, the final tag, and the GitHub Release remain deferred until this PR is merged.