### PR TITLE
fix: use Windows cmd shim for MemoraX skill commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ If the initial setup does not work as expected, check these common cases:
 | Installation fails with an unsupported Node.js version | Run `node --version` and upgrade to Node.js 20 or later before reinstalling MemoraX Code. |
 | The package installed but setup did not start | This is expected. Run the appropriate setup command above from a normal interactive terminal. |
 | Windows reports that `memorax-code` or `memorax-cli` is not recognized | Follow the Windows PATH steps below. Both commands are installed by the same package; do not install a separate `memorax-cli` package. |
-| Search, retrieval, or writeback is unavailable after setup | Run `memorax-code status` and `memorax-cli status`, then follow the detailed troubleshooting guide. |
+| Search, retrieval, or writeback is unavailable after setup | Run `memorax-code status` and the platform memory command (`memorax-cli.cmd status` in Windows PowerShell, `memorax-cli status` on macOS and Linux), then follow the detailed troubleshooting guide. |
 
 #### Windows: `memorax-code` or `memorax-cli` Is Not Found
 
@@ -136,6 +136,11 @@ $env:Path = "$NpmGlobalBin;$env:Path"
 & (Join-Path $NpmGlobalBin "memorax-code.cmd") setup
 & (Join-Path $NpmGlobalBin "memorax-cli.cmd") status
 ```
+
+In Windows PowerShell, use `memorax-cli.cmd` for all MemoraX memory commands,
+including `status`, `search`, and `add`. Do not invoke `memorax-cli.ps1` or
+change PowerShell execution policy; restrictive policies may block npm's
+PowerShell shim even though the `.cmd` shim works normally.
 
 The first two lines repair `PATH` for the current PowerShell process. If setup
 reports that it could not update the persistent Windows user `PATH`, add the

--- a/README.zh.md
+++ b/README.zh.md
@@ -101,7 +101,7 @@ memorax-code account --show-mark-id
 | 因 Node.js 版本不受支持导致安装失败 | 运行 `node --version` 检查版本，并升级到 Node.js 20 或更高版本后重新安装 MemoraX Code。 |
 | npm 包已安装，但没有进入安装引导 | 这是正常行为。请在正常的交互式终端中选择并运行上方适合您的安装引导命令。 |
 | Windows 提示无法识别 `memorax-code` 或 `memorax-cli` | 按照下方 Windows PATH 步骤处理。这两个命令由同一个包安装，不要单独安装 `memorax-cli` 包。 |
-| 完成安装引导后，搜索、召回或写回仍不可用 | 运行 `memorax-code status` 和 `memorax-cli status`，然后按照详细的故障排查指南处理。 |
+| 完成安装引导后，搜索、召回或写回仍不可用 | 运行 `memorax-code status` 和对应平台的记忆命令（Windows PowerShell 使用 `memorax-cli.cmd status`，macOS 和 Linux 使用 `memorax-cli status`），然后按照详细的故障排查指南处理。 |
 
 #### Windows：找不到 `memorax-code` 或 `memorax-cli`
 
@@ -121,6 +121,11 @@ $env:Path = "$NpmGlobalBin;$env:Path"
 & (Join-Path $NpmGlobalBin "memorax-code.cmd") setup
 & (Join-Path $NpmGlobalBin "memorax-cli.cmd") status
 ```
+
+在 Windows PowerShell 中，所有 MemoraX 记忆命令（包括 `status`、`search`
+和 `add`）都应使用 `memorax-cli.cmd`。不要调用 `memorax-cli.ps1`，也不要修改
+PowerShell 执行策略；严格的执行策略可能阻止 npm 的 PowerShell shim，但不影响
+`.cmd` shim 正常工作。
 
 前两行只修复当前 PowerShell 进程的 `PATH`。如果 setup 提示无法更新持久化的
 Windows 用户级 `PATH`，可执行一次以下命令：

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -12,6 +12,12 @@ memorax-code-opencode doctor
 memorax-code logs
 ```
 
+In Windows PowerShell, use `memorax-cli.cmd` everywhere this guide shows
+`memorax-cli`. If an unqualified command fails with `UnauthorizedAccess` or
+`PSSecurityException` because PowerShell selected `memorax-cli.ps1`, rerun the
+same command once with `memorax-cli.cmd`, preserving its arguments and working
+directory. Do not run `Set-ExecutionPolicy` for MemoraX commands.
+
 `memorax-code status` checks the Backend and selected client integrations,
 including DSH and OpenCode. `memorax-cli status` checks credentials, scope, and
 memory switches without printing secrets. Codex, Claude Code, and OpenCode

--- a/packages/ts/memorax-code-backend/src/clients/claude/transcript-turn.ts
+++ b/packages/ts/memorax-code-backend/src/clients/claude/transcript-turn.ts
@@ -596,11 +596,11 @@ function isMemoraxCliExecutable(word: string | undefined): boolean {
 function isNamedExecutable(word: string | undefined, name: string): boolean {
   if (!word) return false;
   const normalized = word.replaceAll("\\", "/");
-  if (normalized === name || normalized === `${name}.mjs`) return true;
+  if (normalized === name || normalized === `${name}.cmd` || normalized === `${name}.mjs`) return true;
   const absolute = normalized.startsWith("/") || /^[A-Za-z]:\//u.test(normalized);
   if (!absolute) return false;
   const basename = normalized.slice(normalized.lastIndexOf("/") + 1);
-  return basename === name || basename === `${name}.mjs`;
+  return basename === name || basename === `${name}.cmd` || basename === `${name}.mjs`;
 }
 
 function claudeMemoryActivities(

--- a/packages/ts/memorax-code-backend/src/clients/codex/rollout-turn.ts
+++ b/packages/ts/memorax-code-backend/src/clients/codex/rollout-turn.ts
@@ -446,7 +446,7 @@ function activityCandidatesFromResponseItem(payload: JsonRecord): CodexTurnActiv
     });
   }
 
-  const memoryCliPattern = /(?:["']?cmd["']?\s*:\s*\\?["'`]|&&|\|\||;)\s*memorax-cli\s+(search|add)\b/giu;
+  const memoryCliPattern = /(?:["']?cmd["']?\s*:\s*\\?["'`]|&&|\|\||;)\s*memorax-cli(?:\.cmd)?\s+(search|add)\b/giu;
   for (const match of input.matchAll(memoryCliPattern)) {
     candidates.push({
       offset: match.index,

--- a/packages/ts/memorax-code-backend/test/clients/claude/claude-transcript-completed-turn.test.mjs
+++ b/packages/ts/memorax-code-backend/test/clients/claude/claude-transcript-completed-turn.test.mjs
@@ -290,7 +290,7 @@ test("Claude transcript coalesces ancestor and descendant end_turn snapshots", (
         id: "tool-lineage-search",
         name: "Bash",
         input: {
-          command: "memorax-cli search --query private-lineage-query",
+          command: "memorax-cli.cmd search --query private-lineage-query",
           description: "private lineage reason",
         },
       }],

--- a/packages/ts/memorax-code-backend/test/clients/codex/codex-rollout-turn.test.mjs
+++ b/packages/ts/memorax-code-backend/test/clients/codex/codex-rollout-turn.test.mjs
@@ -237,7 +237,7 @@ test("Codex rollout reader records ordered repo-memory and memory CLI activities
     customToolCall(`const r = await tools.exec_command({ cmd: "sed -n '1,200p' ${pluginRoot}/skills/memorax-code/references/repo-build.md" });`),
     customToolCall(`const r = await tools.exec_command({ cmd: "type ${windowsPluginRoot}\\skills\\memorax-code\\references\\repo-build.md" });`),
     customToolCall(`const r = await tools.exec_command({ cmd: "sed -n '1,200p' ${pluginRoot}/skills/memorax-code/references/repo-read.md && sed -n '1,200p' ${pluginRoot}/skills/memorax-code/references/repo-update.md" });`),
-    customToolCall('const r = await tools.exec_command({"cmd":"memorax-cli search --query \\"prior context\\""});'),
+    customToolCall('const r = await tools.exec_command({"cmd":"memorax-cli.cmd search --query \\"prior context\\""});'),
     customToolCall('const r = await tools.exec_command({ cmd: "git status --short" });'),
     customToolCall('const r = await tools.exec_command({ cmd: "memorax-cli add --message \\"reusable lesson\\"" });'),
     agentMessage("Done.", "final_answer"),

--- a/packages/ts/memorax-code-codex-adapter/skills/memorax-code/SKILL.md
+++ b/packages/ts/memorax-code-codex-adapter/skills/memorax-code/SKILL.md
@@ -74,7 +74,9 @@ Examples:
 
 ## Shared Rules
 
-For MemoraX Code coding memory, run `memorax-cli` from the active task workspace. The installed Hook and session binding supply the authoritative workspace root; do not run Git commands to discover or replace it. The Backend resolves repository scope from that trusted workspace and read-only filesystem Git metadata.
+For MemoraX Code coding memory, run the platform command from the active task workspace. In Windows PowerShell, use `memorax-cli.cmd`; on macOS and Linux, use `memorax-cli`. Never invoke `memorax-cli.ps1`. Never run `Set-ExecutionPolicy` or otherwise change PowerShell execution policy for MemoraX commands. If an unqualified Windows invocation is blocked before the CLI starts with `UnauthorizedAccess` or `PSSecurityException`, retry the same command once with `memorax-cli.cmd`, preserving all arguments, the active workspace, and environment variables.
+
+The installed Hook and session binding supply the authoritative workspace root; do not run Git commands to discover or replace it. The Backend resolves repository scope from that trusted workspace and read-only filesystem Git metadata.
 
 Repo memory and personal memory remain local `.repo_memory` authorities. Resolve their repository root exactly as described by the selected reference, including its Git requirements.
 

--- a/packages/ts/memorax-code-codex-adapter/skills/memorax-code/references/memorax-add.md
+++ b/packages/ts/memorax-code-codex-adapter/skills/memorax-code/references/memorax-add.md
@@ -21,7 +21,10 @@ Select the executable before constructing any Add command. In Windows PowerShell
 
 For a proactive add, write all generated prose in `--memory`, `--reason`, and the confirmation in the language of the user's current request; preserve exact code, API, path, workflow, and project identifiers.
 
-Run from the active task workspace. Pass the memory and reason directly. Put every dynamically generated `--memory` and `--reason` value in single quotes, never double quotes. Treat `$HOME`, backticks, and `$(command)` as literal text inside those quotes. Replace each literal single quote in a value with the exact POSIX sequence `'\''`.
+Run from the active task workspace. Pass the memory and reason directly. Put every dynamically generated `--memory` and `--reason` value in single quotes, never double quotes. Apply the escaping rule for the active shell:
+
+- Windows PowerShell: single quotes keep `$HOME`, backticks, and `$(command)` literal. Replace each literal single quote in a value with two single quotes (`''`); for example, `don't` becomes `'don''t'`.
+- macOS and Linux: Treat `$HOME`, backticks, and `$(command)` as literal text inside the quotes. Replace each literal single quote in a value with the exact POSIX sequence `'\''`.
 
 Windows PowerShell:
 

--- a/packages/ts/memorax-code-codex-adapter/skills/memorax-code/references/memorax-add.md
+++ b/packages/ts/memorax-code-codex-adapter/skills/memorax-code/references/memorax-add.md
@@ -17,9 +17,19 @@ Do not add positive repair lessons based only on unverified edits or assistant s
 
 ## Add Workflow
 
+Select the executable before constructing any Add command. In Windows PowerShell, use `memorax-cli.cmd`; on macOS and Linux, use `memorax-cli`. Never invoke `memorax-cli.ps1`. Never run `Set-ExecutionPolicy` or otherwise change PowerShell execution policy for MemoraX commands. If an unqualified Windows invocation is blocked before the CLI starts with `UnauthorizedAccess` or `PSSecurityException`, retry that command once with `memorax-cli.cmd`, preserving all arguments, the active workspace, and environment variables.
+
 For a proactive add, write all generated prose in `--memory`, `--reason`, and the confirmation in the language of the user's current request; preserve exact code, API, path, workflow, and project identifiers.
 
 Run from the active task workspace. Pass the memory and reason directly. Put every dynamically generated `--memory` and `--reason` value in single quotes, never double quotes. Treat `$HOME`, backticks, and `$(command)` as literal text inside those quotes. Replace each literal single quote in a value with the exact POSIX sequence `'\''`.
+
+Windows PowerShell:
+
+```powershell
+memorax-cli.cmd add --memory 'Concise reusable memory.' --type procedural --reason 'Capture reusable coding memory.'
+```
+
+macOS and Linux:
 
 ```bash
 memorax-cli add \
@@ -49,7 +59,7 @@ anchors: <stable repository source, tests, or public docs>
 
 Keep the card under 1,100 characters when practical. It must guide future investigation while still requiring live-code inspection.
 
-Pass a completed multi-line card as one single-quoted `--memory` argument:
+Pass a completed multi-line card as one single-quoted `--memory` argument. On Windows PowerShell, the command must start with `memorax-cli.cmd add`; on macOS and Linux, use the form shown below.
 
 ```bash
 memorax-cli add \
@@ -69,7 +79,7 @@ anchors: stable/source/path' \
   --reason 'Capture verified reusable coding memory.'
 ```
 
-If add fails, report the exact failure and do not retry automatically, bypass the CLI, or call MemoraX directly.
+Except for the pre-start Windows shim correction above, if add fails, report the exact failure and do not retry automatically, bypass the CLI, or call MemoraX directly. Do not retry Add after the CLI may have started.
 
 If a successful Add result reports `workspaceScopeFallbackReason: git_metadata_invalid`, malformed or incomplete metadata inside a direct `.git` directory was downgraded to the normalized local folder scope. Add has already been submitted with the reported `effectiveUserId`. Present its `userNotice` once without pausing the current task or asking the user to repair Git first, then continue the current task. After the repository or `.git` metadata is repaired, later Search, Add, and automatic writeback in the same client session automatically use the restored Git repository scope.
 

--- a/packages/ts/memorax-code-codex-adapter/skills/memorax-code/references/memorax-search.md
+++ b/packages/ts/memorax-code-codex-adapter/skills/memorax-code/references/memorax-search.md
@@ -52,7 +52,10 @@ State a fact-sized relationship that can change the next action: a target under 
 
 For a complementary first-round pair, each query must stand alone and cover a different decision boundary. Use a complementary pair only when the provided context gives each decision boundary a distinct exact code, API, path, workflow, or project identifier; otherwise keep one focused combined query that preserves both user-stated facts. Do not merely restate the same question with synonyms. If the user describes only one tightly coupled decision, emit exactly one query. Use one or two stable exact identifiers when they sharpen the query, and integrate them grammatically instead of appending search tags or filler. Use only user-provided anchors and stable terms from live code or documentation; do not reconstruct unseen fact wording from recalled memory.
 
-Pass the query directly with `--query`. Put every dynamically generated query in single quotes, never double quotes. Treat `$HOME`, backticks, and `$(command)` as literal text inside those quotes. Replace each literal single quote in the value with the exact POSIX sequence `'\''`.
+Pass the query directly with `--query`. Put every dynamically generated query in single quotes, never double quotes. Apply the escaping rule for the active shell:
+
+- Windows PowerShell: single quotes keep `$HOME`, backticks, and `$(command)` literal. Replace each literal single quote in the value with two single quotes (`''`); for example, `don't` becomes `'don''t'`.
+- macOS and Linux: Treat `$HOME`, backticks, and `$(command)` as literal text inside the quotes. Replace each literal single quote in the value with the exact POSIX sequence `'\''`.
 
 Use these actual output shapes as examples. They are queries themselves, not full user prompts or instructions for the user. Each Chinese/English pair is a language variant: choose the one matching the user, never run both merely because both are shown. The comments explain the example only and are not part of emitted query text.
 

--- a/packages/ts/memorax-code-codex-adapter/skills/memorax-code/references/memorax-search.md
+++ b/packages/ts/memorax-code-codex-adapter/skills/memorax-code/references/memorax-search.md
@@ -4,6 +4,8 @@ Use these instructions only to search reusable coding memory through `memorax-cl
 
 ## Scope
 
+Select the executable before constructing any Search command. In Windows PowerShell, use `memorax-cli.cmd`; on macOS and Linux, use `memorax-cli`. Never invoke `memorax-cli.ps1`. Never run `Set-ExecutionPolicy` or otherwise change PowerShell execution policy for MemoraX commands. If an unqualified Windows invocation is blocked before the CLI starts with `UnauthorizedAccess` or `PSSecurityException`, retry the same command once with `memorax-cli.cmd`, preserving all arguments, the active workspace, and environment variables.
+
 Run the CLI from the active task workspace. The installed Hook and session binding supply the authoritative workspace root; do not run `git rev-parse`, infer the root from Git metadata, or substitute an unrelated working directory. Do not make `memorax-cli status` a mandatory preflight; use it only to diagnose a configuration or scope failure.
 
 Coding memory uses `<MemoraX base username>@<normalized repository name>` for Git workspaces and the normalized folder name for genuine non-Git directories. MemoraX Code resolves `.git`, `gitdir`, and `commondir` without executing Git. Linked worktrees share one repository scope; another clone, repository, or non-Git directory retains a different local session key even when its readable name matches.
@@ -12,7 +14,7 @@ If a successful Search result reports `workspaceScopeFallbackReason: git_metadat
 
 Require a readable active workspace binding. A CLI command from a linked worktree of the bound repository is valid. If `memorax-cli search` reports `workspace_scope_mismatch` or `workspace_scope_unavailable`, do not bypass the scope or fall back to an unscoped username. Do not change the CLI working directory and retry. Tell the user that memory search was not executed and no request was sent to MemoraX, then present the CLI's `userAction` in natural language. Continue the current task using only live code and documentation.
 
-If `memorax-cli` is not on `PATH`, or memory is disabled, unconfigured, or unavailable, report that briefly and continue with live code or documentation. Authenticate through MemoraX Code configuration; never recover credentials from shell history or place tokens in prompts. Treat injected memory as a hypothesis and verify it against the current checkout.
+If the selected platform command is not on `PATH`, or memory is disabled, unconfigured, or unavailable, report that briefly and continue with live code or documentation. Authenticate through MemoraX Code configuration; never recover credentials from shell history or place tokens in prompts. Treat injected memory as a hypothesis and verify it against the current checkout.
 
 ## Search Decision
 
@@ -53,6 +55,14 @@ For a complementary first-round pair, each query must stand alone and cover a di
 Pass the query directly with `--query`. Put every dynamically generated query in single quotes, never double quotes. Treat `$HOME`, backticks, and `$(command)` as literal text inside those quotes. Replace each literal single quote in the value with the exact POSIX sequence `'\''`.
 
 Use these actual output shapes as examples. They are queries themselves, not full user prompts or instructions for the user. Each Chinese/English pair is a language variant: choose the one matching the user, never run both merely because both are shown. The comments explain the example only and are not part of emitted query text.
+
+On Windows PowerShell, the first example must be invoked as:
+
+```powershell
+memorax-cli.cmd search --query 'Trace 生产版本：升级后到达的记录中，应以哪个客户端版本字段判断由旧插件产生，而非新版本上传进程？'
+```
+
+On macOS and Linux, use the `memorax-cli search` forms below. For other Windows examples, preserve every argument but replace the leading executable with `memorax-cli.cmd`.
 
 ```bash
 # One tightly coupled decision: emit one query.

--- a/packages/ts/memorax-code-codex-adapter/test/memorax-code-skill.test.mjs
+++ b/packages/ts/memorax-code-codex-adapter/test/memorax-code-skill.test.mjs
@@ -144,6 +144,24 @@ test("memorax-code retries read-only search once after transport or sandbox fail
   assert.match(memoraxSearch, /If no approved mode[\s\S]*report the exact CLI failure/);
 });
 
+test("memorax-code selects the Windows cmd shim without changing execution policy", () => {
+  const skill = readSkillFile("SKILL.md");
+  const memoraxSearch = readSkillFile("references/memorax-search.md");
+  const memoraxAdd = readSkillFile("references/memorax-add.md");
+
+  for (const guidance of [skill, memoraxSearch, memoraxAdd]) {
+    assert.match(guidance, /Windows PowerShell[\s\S]*`memorax-cli\.cmd`/);
+    assert.match(guidance, /macOS and Linux[\s\S]*`memorax-cli`/);
+    assert.match(guidance, /Never invoke `memorax-cli\.ps1`/);
+    assert.match(guidance, /Never run `Set-ExecutionPolicy`/);
+  }
+  assert.match(memoraxSearch, /memorax-cli\.cmd search --query '/);
+  assert.match(memoraxAdd, /memorax-cli\.cmd add --memory '/);
+  assert.match(skill, /retry the same command once with `memorax-cli\.cmd`[\s\S]*preserving all arguments, the active workspace, and environment variables/);
+  assert.match(memoraxAdd, /blocked before the CLI starts[\s\S]*retry that command once with `memorax-cli\.cmd`/);
+  assert.match(memoraxAdd, /Do not retry Add after the CLI may have started/);
+});
+
 test("memorax-code uses POSIX-safe direct CLI arguments", () => {
   const memoraxSearch = readSkillFile("references/memorax-search.md");
   const memoraxAdd = readSkillFile("references/memorax-add.md");

--- a/packages/ts/memorax-code-codex-adapter/test/memorax-code-skill.test.mjs
+++ b/packages/ts/memorax-code-codex-adapter/test/memorax-code-skill.test.mjs
@@ -160,6 +160,11 @@ test("memorax-code selects the Windows cmd shim without changing execution polic
   assert.match(skill, /retry the same command once with `memorax-cli\.cmd`[\s\S]*preserving all arguments, the active workspace, and environment variables/);
   assert.match(memoraxAdd, /blocked before the CLI starts[\s\S]*retry that command once with `memorax-cli\.cmd`/);
   assert.match(memoraxAdd, /Do not retry Add after the CLI may have started/);
+  for (const reference of [memoraxSearch, memoraxAdd]) {
+    assert.match(reference, /Windows PowerShell:[\s\S]*two single quotes \(`''`\)/);
+    assert.match(reference, /`don't` becomes `'don''t'`/);
+    assert.match(reference, /macOS and Linux:[\s\S]*exact POSIX sequence/);
+  }
 });
 
 test("memorax-code uses POSIX-safe direct CLI arguments", () => {


### PR DESCRIPTION
## Change Summary
Use the npm `.cmd` shim for MemoraX Skill Add/Search commands in Windows PowerShell so restrictive execution policies do not select and block the `.ps1` shim.

## Implementation Highlights
- Select `memorax-cli.cmd` on Windows PowerShell while retaining `memorax-cli` on macOS and Linux.
- Explicitly forbid `memorax-cli.ps1` and `Set-ExecutionPolicy`, with one pre-start retry rule that preserves all arguments, workspace, and environment.
- Keep Add non-retriable once the CLI may have started, and cover the platform contract in the canonical shared Skill tests.

## Validation
- `npm test --prefix packages/ts/memorax-code-codex-adapter` — 229 passed.
- `make npm-package-check` — 255 passed, 2 skipped; package allowlist validation passed for 417 files.
- `git diff --check` — passed.

## Full End-to-End Validation Results
- Environment: Windows 11, Node.js 24.19.0, npm 11.17.0, Trae CN 3.3.95.
- Scenario or matrix: restrictive PowerShell policy with proactive MemoraX Add and Search from a fresh Trae session.
- Command or workflow: the Agent followed the canonical Skill and invoked `memorax-cli.cmd` directly.
- Result: Add and Search both succeeded on the first invocation; `.ps1` was not invoked and no `Set-ExecutionPolicy` command ran. The same canonical Skill source is materialized for supported clients.
- Evidence or artifacts: redacted Windows E2E report supplied during development; no private transcript or local path is included here.
- Reason not run / remaining risk: the focused PR does not alter the CLI implementation itself; behavior depends on agents following the shipped Skill instruction.
