### PR TITLE
feat: add Trae Hook memory runtime

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -339,13 +339,16 @@ sequenceDiagram
 
 Important distinctions:
 
-- Hook or plugin event fields supply protocol, correlation, and retrieval
-  input. Their prompt or event text is not automatic writeback content
-  authority; OpenCode's separately supplied SDK records are validated as
-  client-native content.
-- Codex rollout JSONL, Claude Code transcript JSONL, DSH's exact persisted
-  Session Event Log interval, and OpenCode SDK session message records are the
-  content authorities for their respective clients.
+- Hook or plugin event fields normally supply protocol, correlation, and
+  retrieval input rather than automatic-writeback content. OpenCode's
+  separately supplied SDK records are validated as client-native content. Trae
+  is the narrow exception because it exposes no stable raw Session: its
+  validated, correlated `UserPromptSubmit` prompt and `Stop` final assistant
+  message are the primary Trae content authority, not a fallback.
+- Codex rollout JSONL, Claude Code and CodeBuddy/WorkBuddy transcript JSONL,
+  DSH's exact persisted Session Event Log interval, OpenCode SDK session
+  message records, and Trae's validated Hook pair are the content authorities
+  for their respective clients.
 - Required client/session/turn identity and repository scope fail closed when
   incomplete, conflicting, or unprovable.
 - A malformed or incomplete direct `.git` directory is the sole documented
@@ -366,6 +369,12 @@ Important distinctions:
   pending state. Local reminder evaluation remains independent of Backend
   recovery. Its `shell.env` event binds the native session identity and makes
   the packaged memory CLI available to agent-run shell commands.
+- Trae `UserPromptSubmit` creates a Turn ID from the native session ID, local
+  timestamp, and normalized prompt digest. Only one Turn is active per Session;
+  a new prompt interrupts the previous Turn. A matching `Stop` payload can
+  close and write back that Turn, while a late completion for an interrupted
+  Turn is rejected. This bounded live correlation does not add a pending queue
+  or reconstruct content from unrelated local files.
 
 ### 3.3 Manual memory CLI flow
 
@@ -407,7 +416,11 @@ sequenceDiagram
     Integration->>Authority: flush and read exact startSeq..endSeq interval
     Authority-->>Integration: persisted Session header and events
     Integration->>Service: correlation and exact persisted interval
-  else Codex or Claude Code
+  else Trae
+    Integration->>Authority: correlate UserPromptSubmit and Stop Hook payloads
+    Authority-->>Integration: matching prompt and final assistant message
+    Integration->>Service: validated Hook content and correlation
+  else Codex, Claude Code, or CodeBuddy/WorkBuddy
     Integration->>Service: client-qualified writeback correlation
     Service->>Authority: read the exact rollout or transcript Turn
     Authority-->>Service: matching native Turn
@@ -449,6 +462,11 @@ sequenceDiagram
 - Because OpenCode terminal notifications are event callbacks, the plugin
   serializes idle- and interruption-triggered SDK reads per session, tracks
   the resulting work, and drains already-started tasks during plugin disposal.
+- Trae accepts only the prompt digest bound into the Turn ID and the final
+  assistant message from the matching live Session's `Stop` event. A new prompt
+  marks the prior Turn interrupted before recording the replacement; late Stop
+  events cannot revive it. Because Trae has no raw Session authority, automatic
+  writeback is skipped when this Hook pair does not close cleanly.
 - When a degraded direct-`.git` scope upgrades to verified Git scope, the
   buffer runtime cancels and discards pending fallback turns for the same
   client and session before buffering under the Git scope. It does not migrate
@@ -511,6 +529,7 @@ src/
     dsh/                  DSH native event-interval interpretation
     opencode/             OpenCode retrieval, SDK message interpretation, and lifecycle participant
     codebuddy/            CodeBuddy native JSONL interpretation and lifecycle participant
+    trae/                 Trae Hook-content interpretation
   config/                 Backend and proxy/config interpretation
   entrypoints/            process and management-CLI orchestration
   lifecycle/
@@ -541,6 +560,7 @@ entrypoints and compatibility facades. It is not another implementation area.
 | `src/clients/claude` | Claude transcript/turn interpretation, Hook memory runtime, and lifecycle participant | No Codex format fallback; request runtime remains HTTP-composition independent |
 | `src/clients/dsh` | DSH Session header and exact persisted event-interval interpretation, request-time memory and normalized trace runtime, and lifecycle-participant delegation | No Hook-text, rollout, transcript, SDK-message, or latest-Turn fallback; Profile mutation stays in the DSH adapter, and request runtime remains HTTP-composition independent |
 | `src/clients/opencode` | OpenCode SDK message validation and text materialization, plugin memory runtime, and lifecycle participant | No Hook-text, database, rollout, or transcript fallback; request runtime remains HTTP-composition independent |
+| `src/clients/trae` | Trae Turn-ID validation, Hook-pair memory runtime, interruption handling, and trace normalization | Hook content is authoritative only for the exact validated Trae Turn; no raw-Session guess, pending queue, or cross-client fallback |
 | `src/memory` | Memory commands, retrieval, writeback, turn coordination, repository session pinning, manual CLI, and buffering/chunking | Client-neutral modules do not parse native transcript formats |
 | `src/repository` | Read-only repository identity | Scope derivation does not execute Git or use synchronous filesystem reads |
 | `src/provider/memorax` | MemoraX config interpretation, Search/Add payloads, HTTP transport, and normalized results | Independent from server routing and plugin lifecycle |
@@ -637,9 +657,9 @@ and
 
 | Concern | Authority | Derived or non-authoritative views |
 | --- | --- | --- |
-| Models, model-provider credentials, native tools, and model-provider traffic | Codex, Claude Code, DeepSeek Harness, CodeBuddy/WorkBuddy, or OpenCode | Backend and adapters must not proxy or persist this authority |
+| Models, model-provider credentials, native tools, and model-provider traffic | Codex, Claude Code, DeepSeek Harness, CodeBuddy/WorkBuddy, OpenCode, or Trae | Backend and adapters must not proxy or persist this authority |
 | Hook command identity | Versioned, client-qualified command plus validated required session/turn fields | Parsed HTTP request objects |
-| Automatic writeback content | Codex rollout JSONL, Claude Code transcript JSONL, CodeBuddy/WorkBuddy transcript JSONL, DSH's exact persisted Session Event Log interval, or OpenCode SDK session messages for the matching client and Turn | Hook or plugin text, trace, latest-Turn guesses, local database guesses, and another client's format are not fallbacks |
+| Automatic writeback content | Codex rollout JSONL, Claude Code transcript JSONL, CodeBuddy/WorkBuddy transcript JSONL, DSH's exact persisted Session Event Log interval, OpenCode SDK session messages, or Trae's validated `UserPromptSubmit`/`Stop` Hook pair for the matching client and Turn | Hook or plugin text is not a fallback outside Trae's primary authority; trace, latest-Turn guesses, local database guesses, and another client's format are never fallbacks |
 | Workspace and repository identity | Backend read-only resolution held by the live repository-session runtime; its only permitted scope transition is the same-root degraded-direct-`.git` to verified-Git upgrade | Project labels and Hook `cwd` |
 | Backend connection and managed-process ownership | Versioned private connection/token/PID records plus lifecycle lock/version validation | In-memory state in any one process |
 | Package replacement intent | Versioned private package-transition record plus its bounded lock | npm process state or the presence of installed package files |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -80,6 +80,12 @@ Please allow time for triage and remediation before public disclosure.
   retrieval, trace, or writeback. Repo Memory jobs run a bounded headless
   CodeBuddy process with `--dangerously-skip-permissions`; use this only for a
   Backend-authorized Git worktree and never for untrusted source.
+- Trae exposes no stable raw Session authority. For Trae only, the validated
+  prompt supplied by `UserPromptSubmit` and final assistant message supplied by
+  the matching `Stop` Hook are the automatic-writeback content authority. They
+  are bound to one active Turn with a prompt-derived Turn ID; a new prompt
+  interrupts the old Turn, and late or mismatched completion events do not
+  write back. Hook fields are not a fallback for any other client.
 - Initial Repo Memory builds use only the Git worktree returned by an
   authenticated Backend turn-start request. Backend or workspace-scope
   failures skip the build; client integrations do not fall back to
@@ -129,15 +135,15 @@ the generated configuration's automatic writeback; automatic retrieval
 remains disabled until explicitly enabled.
 
 Memory searches send the query and repository-scoped identity to MemoraX.
-When DSH or OpenCode automatic retrieval is enabled, each eligible direct user
+When DSH, OpenCode, or Trae automatic retrieval is enabled, each eligible direct user
 prompt is used as the search query.
 Active adds and automatic writeback send the selected content needed to create
 memory. Automatic writeback may include selected user instructions and the
-matching final assistant response from an exact Codex rollout, Claude Code
-transcript, DSH persisted Session Event Log interval, or OpenCode SDK
-session-message turn. It does not send the retained trace file, raw transcript
-path, raw DSH interval, SDK message records, or trace-only provenance as part
-of that payload.
+matching final assistant response from an exact Codex rollout, Claude Code or
+CodeBuddy/WorkBuddy transcript, DSH persisted Session Event Log interval,
+OpenCode SDK session-message Turn, or Trae's validated Hook pair. It does not
+send the retained trace file, raw transcript path, raw DSH interval, SDK
+message records, or trace-only provenance as part of that payload.
 
 Automatic writeback bounds each selected message to its configured Add limit,
 then applies a local best-effort detector before hashing, buffering, chunking,
@@ -185,7 +191,7 @@ the product creates or tightens the home to mode `0700` and newly seeded
 configuration to mode `0600`; Windows relies on the current user's filesystem
 ACLs.
 
-Codex, Claude Code, CodeBuddy/WorkBuddy, DSH, and OpenCode local trace capture is enabled by default.
+Codex, Claude Code, CodeBuddy/WorkBuddy, DSH, OpenCode, and Trae local trace capture is enabled by default.
 Depending on the enabled client capabilities, traces may include prompts,
 responses, recalled memory, writeback content, reminder text, and local paths.
 Trace files stay under `MEMORAX_CODE_HOME`. The shipped package has no trace
@@ -232,7 +238,7 @@ cleanup runs.
   retained trace files, private memories, `.env.local`, or machine-specific
   diagnostic state.
 - Preserve workspace traversal and symlink protections, client/session
-  isolation, exact-transcript writeback authority, bounded parsing, and
+  isolation, each client's documented writeback authority, bounded parsing, and
   fail-closed behavior for uncertain identity or runtime records.
 - Use isolated client and MemoraX Code homes for lifecycle or destructive
   tests.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -396,16 +396,16 @@ installations do not require a standalone `opencode` executable in `PATH`.
 
 ## Local traces
 
-`[trace.codex]`, `[trace.claude]`, `[trace.dsh]`, `[trace.opencode]`, and `[trace.codebuddy]`
+`[trace.codex]`, `[trace.claude]`, `[trace.dsh]`, `[trace.opencode]`, `[trace.codebuddy]`, and `[trace.trae]`
 support the same fields:
 
-| Field | Codex environment | Claude environment | DSH environment | OpenCode environment | CodeBuddy/WorkBuddy environment | Fallback |
-| --- | --- | --- | --- | --- | --- | --- |
-| `enabled` | `MEMORAX_CODE_CODEX_TRACE_ENABLED` | `MEMORAX_CODE_CLAUDE_TRACE_ENABLED` | `MEMORAX_CODE_DSH_TRACE_ENABLED` | `MEMORAX_CODE_OPENCODE_TRACE_ENABLED` | `MEMORAX_CODE_CODEBUDDY_TRACE_ENABLED` | `true` |
-| `capture_content` | `MEMORAX_CODE_CODEX_TRACE_CAPTURE_CONTENT` | `MEMORAX_CODE_CLAUDE_TRACE_CAPTURE_CONTENT` | `MEMORAX_CODE_DSH_TRACE_CAPTURE_CONTENT` | `MEMORAX_CODE_OPENCODE_TRACE_CAPTURE_CONTENT` | `MEMORAX_CODE_CODEBUDDY_TRACE_CAPTURE_CONTENT` | `true` |
-| `retention_days` | `MEMORAX_CODE_CODEX_TRACE_RETENTION_DAYS` | `MEMORAX_CODE_CLAUDE_TRACE_RETENTION_DAYS` | `MEMORAX_CODE_DSH_TRACE_RETENTION_DAYS` | `MEMORAX_CODE_OPENCODE_TRACE_RETENTION_DAYS` | `MEMORAX_CODE_CODEBUDDY_TRACE_RETENTION_DAYS` | `7` |
-| `max_event_chars` | `MEMORAX_CODE_CODEX_TRACE_MAX_EVENT_CHARS` | `MEMORAX_CODE_CLAUDE_TRACE_MAX_EVENT_CHARS` | `MEMORAX_CODE_DSH_TRACE_MAX_EVENT_CHARS` | `MEMORAX_CODE_OPENCODE_TRACE_MAX_EVENT_CHARS` | `MEMORAX_CODE_CODEBUDDY_TRACE_MAX_EVENT_CHARS` | `20000` |
-| `max_file_bytes` | `MEMORAX_CODE_CODEX_TRACE_MAX_FILE_BYTES` | `MEMORAX_CODE_CLAUDE_TRACE_MAX_FILE_BYTES` | `MEMORAX_CODE_DSH_TRACE_MAX_FILE_BYTES` | `MEMORAX_CODE_OPENCODE_TRACE_MAX_FILE_BYTES` | `MEMORAX_CODE_CODEBUDDY_TRACE_MAX_FILE_BYTES` | `52428800` |
+| Field | Codex environment | Claude environment | DSH environment | OpenCode environment | CodeBuddy/WorkBuddy environment | Trae environment | Fallback |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `enabled` | `MEMORAX_CODE_CODEX_TRACE_ENABLED` | `MEMORAX_CODE_CLAUDE_TRACE_ENABLED` | `MEMORAX_CODE_DSH_TRACE_ENABLED` | `MEMORAX_CODE_OPENCODE_TRACE_ENABLED` | `MEMORAX_CODE_CODEBUDDY_TRACE_ENABLED` | `MEMORAX_CODE_TRAE_TRACE_ENABLED` | `true` |
+| `capture_content` | `MEMORAX_CODE_CODEX_TRACE_CAPTURE_CONTENT` | `MEMORAX_CODE_CLAUDE_TRACE_CAPTURE_CONTENT` | `MEMORAX_CODE_DSH_TRACE_CAPTURE_CONTENT` | `MEMORAX_CODE_OPENCODE_TRACE_CAPTURE_CONTENT` | `MEMORAX_CODE_CODEBUDDY_TRACE_CAPTURE_CONTENT` | `MEMORAX_CODE_TRAE_TRACE_CAPTURE_CONTENT` | `true` |
+| `retention_days` | `MEMORAX_CODE_CODEX_TRACE_RETENTION_DAYS` | `MEMORAX_CODE_CLAUDE_TRACE_RETENTION_DAYS` | `MEMORAX_CODE_DSH_TRACE_RETENTION_DAYS` | `MEMORAX_CODE_OPENCODE_TRACE_RETENTION_DAYS` | `MEMORAX_CODE_CODEBUDDY_TRACE_RETENTION_DAYS` | `MEMORAX_CODE_TRAE_TRACE_RETENTION_DAYS` | `7` |
+| `max_event_chars` | `MEMORAX_CODE_CODEX_TRACE_MAX_EVENT_CHARS` | `MEMORAX_CODE_CLAUDE_TRACE_MAX_EVENT_CHARS` | `MEMORAX_CODE_DSH_TRACE_MAX_EVENT_CHARS` | `MEMORAX_CODE_OPENCODE_TRACE_MAX_EVENT_CHARS` | `MEMORAX_CODE_CODEBUDDY_TRACE_MAX_EVENT_CHARS` | `MEMORAX_CODE_TRAE_TRACE_MAX_EVENT_CHARS` | `20000` |
+| `max_file_bytes` | `MEMORAX_CODE_CODEX_TRACE_MAX_FILE_BYTES` | `MEMORAX_CODE_CLAUDE_TRACE_MAX_FILE_BYTES` | `MEMORAX_CODE_DSH_TRACE_MAX_FILE_BYTES` | `MEMORAX_CODE_OPENCODE_TRACE_MAX_FILE_BYTES` | `MEMORAX_CODE_CODEBUDDY_TRACE_MAX_FILE_BYTES` | `MEMORAX_CODE_TRAE_TRACE_MAX_FILE_BYTES` | `52428800` |
 
 Depending on the enabled client capabilities, content capture can include
 prompts, responses, recalled memory, writeback content, reminder text, and
@@ -417,6 +417,10 @@ export, or public collector.
 DSH trace contains only normalized lifecycle and memory-operation events. Its
 native Session Event Log and raw events remain local to DSH; MemoraX Code does
 not copy that log into trace.
+
+Trae trace contains only normalized lifecycle and memory-operation events from
+the validated Hook pair. Trae does not expose a raw Session authority for
+MemoraX Code to copy.
 
 ## Backend runtime settings
 

--- a/packages/ts/memorax-code-backend/src/clients/trae/memory-hook-runtime.ts
+++ b/packages/ts/memorax-code-backend/src/clients/trae/memory-hook-runtime.ts
@@ -1,0 +1,407 @@
+import {
+  createAutomaticMemoryWritebackRuntime,
+  type AutomaticMemoryWritebackEnqueue,
+  type AutomaticMemoryWritebackRejectionReason,
+  type AutomaticMemoryWritebackRuntime,
+} from "../../memory/automatic-writeback.js";
+import { retrieveAutomaticMemoryContext } from "../../memory/automatic-retrieval.js";
+import {
+  claimQuotaNotice,
+  createPendingQuotaNoticeRuntime,
+  type PendingQuotaNoticeRuntime,
+  type QuotaNoticeClaimer,
+} from "../../memory/quota-notice.js";
+import type {
+  MemoryHookTurnStartResult,
+  TraeTurnStartCommand,
+  TraeWritebackCommand,
+} from "../../memory/hook-command.js";
+import type { MemoryDiagnosticLogger, MemoryObservabilityHook } from "../../memory/observability.js";
+import {
+  createMemoryTurnCoordinator,
+  type MemoryTurnCoordinator,
+  type MemoryTurnState,
+  type MemoryTurnWritebackSkipReason,
+} from "../../memory/turn-coordinator.js";
+import {
+  createRepositoryMemorySessionRuntime,
+  resolvedRepoMemoryWorktree,
+  type ConfiguredRepositoryMemoryResult,
+  type RepositoryMemorySessionRuntime,
+} from "../../memory/repository-session.js";
+import type { RepositoryMemoryScopeFailureReason } from "../../repository/scope.js";
+import { traceContextFromTraeHookBody, type TraceContext } from "../../trace/context.js";
+import {
+  markCurrentTraceTurnOutcome,
+  recordTraceEvent,
+  traceTurnEventId,
+  writeCurrentTraceTurn,
+} from "../../trace/store.js";
+
+export type TraeMemoryHookWritebackSkipReason =
+  | "turn_metadata_mismatch"
+  | "interrupted"
+  | "config_missing"
+  | RepositoryMemoryScopeFailureReason
+  | AutomaticMemoryWritebackRejectionReason
+  | MemoryTurnWritebackSkipReason;
+
+export type TraeMemoryHookWritebackResult =
+  | { ok: true; scheduled: true }
+  | { ok: true; scheduled: false; reason: TraeMemoryHookWritebackSkipReason };
+
+export type TraeMemoryHookRuntimeOptions = {
+  automaticWriteback?: AutomaticMemoryWritebackEnqueue;
+  diagnosticLogger?: MemoryDiagnosticLogger;
+  env?: Record<string, string | undefined>;
+  fetchImpl?: typeof fetch;
+  claimQuotaNotice?: QuotaNoticeClaimer;
+  now?: () => number;
+  ttlMs?: number;
+  maxEntries?: number;
+  cleanupIntervalMs?: number;
+  memoryObservability?: MemoryObservabilityHook;
+  memoraxCodeHome?: string;
+  pendingQuotaNotice?: PendingQuotaNoticeRuntime;
+  repositoryMemorySession?: RepositoryMemorySessionRuntime;
+  turnCoordinator?: MemoryTurnCoordinator;
+};
+
+export type TraeMemoryHookRuntime = {
+  recordTurnStart(command: TraeTurnStartCommand): Promise<MemoryHookTurnStartResult>;
+  writeback(command: TraeWritebackCommand): Promise<TraeMemoryHookWritebackResult>;
+  size(): number;
+  close(): void;
+};
+
+const TRAE_MEMORY_TURN_CLIENT = "trae" as const;
+
+export function createTraeMemoryHookRuntime(
+  options: TraeMemoryHookRuntimeOptions = {},
+): TraeMemoryHookRuntime {
+  const now = options.now ?? (() => Date.now());
+  const pendingQuotaNotice = options.pendingQuotaNotice ?? createPendingQuotaNoticeRuntime({
+    claimQuotaNotice: options.claimQuotaNotice,
+    diagnosticLogger: options.diagnosticLogger,
+    env: options.env,
+  });
+  const ownsPendingQuotaNotice = options.pendingQuotaNotice === undefined;
+  const automaticWritebackRuntime: {
+    enqueue: AutomaticMemoryWritebackEnqueue;
+    discardForScopeUpgrade?: AutomaticMemoryWritebackRuntime["discardForScopeUpgrade"];
+    close?: () => void;
+  } | undefined = options.turnCoordinator
+    ? undefined
+    : options.automaticWriteback
+      ? { enqueue: options.automaticWriteback }
+      : createAutomaticMemoryWritebackRuntime({
+        diagnosticLogger: options.diagnosticLogger,
+        queueQuotaNotice: pendingQuotaNotice.queue,
+      });
+  const turnCoordinator = options.turnCoordinator ?? createMemoryTurnCoordinator({
+    automaticWriteback: automaticWritebackRuntime!.enqueue,
+    now,
+    ttlMs: options.ttlMs,
+    maxEntries: options.maxEntries,
+    cleanupIntervalMs: options.cleanupIntervalMs,
+  });
+  const ownsTurnCoordinator = options.turnCoordinator === undefined;
+  const repositoryMemorySession = options.repositoryMemorySession ?? createRepositoryMemorySessionRuntime({
+    onScopeUpgrade: automaticWritebackRuntime?.discardForScopeUpgrade,
+  });
+  const ownsRepositoryMemorySession = options.repositoryMemorySession === undefined;
+  const retrievalTurns = new Set<string>();
+  const interruptedTurns = new Set<string>();
+  const activeTurns = new Map<string, MemoryTurnState>();
+  const runtimeTurnLimit = positiveInteger(options.maxEntries, 256);
+
+  return {
+    async recordTurnStart(command) {
+      turnCoordinator.pruneExpired();
+      const commandKey = traeRuntimeTurnKey(command.sessionId, command.turnId);
+      if (interruptedTurns.has(commandKey)) return { ok: true };
+      const previous = activeTurns.get(command.sessionId) ?? turnCoordinator.latestTurn({
+        client: TRAE_MEMORY_TURN_CLIENT,
+        sessionId: command.sessionId,
+        excludeClientTurnId: command.turnId,
+      });
+      if (previous && previous.clientTurnId !== command.turnId) {
+        await interruptPreviousTurn(turnCoordinator, previous, options, now);
+        rememberBounded(
+          interruptedTurns,
+          traeRuntimeTurnKey(previous.sessionId, previous.clientTurnId),
+          runtimeTurnLimit,
+        );
+      }
+      const createdAt = now();
+      const traceContext = traceContextFromTraeHookBody(command, new Date(createdAt).toISOString());
+      const repositoryMemory = await resolveHookRepositoryMemory(command, options, repositoryMemorySession);
+      const repoMemoryWorktree = resolvedRepoMemoryWorktree(repositoryMemory);
+      const turn = turnCoordinator.recordTurnStart({
+        client: TRAE_MEMORY_TURN_CLIENT,
+        sessionId: command.sessionId,
+        clientTurnId: command.turnId,
+        cwd: command.cwd,
+        workspaceKind: command.workspaceKind,
+        createdAt,
+        traceContext,
+        repositoryMemory,
+      });
+      activeTurns.delete(command.sessionId);
+      activeTurns.set(command.sessionId, turn);
+      while (activeTurns.size > runtimeTurnLimit) {
+        const oldestSessionId = activeTurns.keys().next().value;
+        if (typeof oldestSessionId !== "string") break;
+        activeTurns.delete(oldestSessionId);
+      }
+      await recordTraceBestEffort("trae_memory.turn_start_event", recordTraceEvent({
+        eventId: traceTurnEventId(traceContext, "turn_start"),
+        memoraxCodeHome: options.memoraxCodeHome,
+        env: options.env,
+        traceContext,
+        type: "turn_start",
+        source: "trae-hook",
+        operation: "query",
+        ok: true,
+        request: { prompt: command.prompt, cwd: command.cwd },
+      }), options.diagnosticLogger);
+      await recordTraceBestEffort("trae_memory.current_turn_write", writeCurrentTraceTurn(
+        traceContext,
+        {
+          client: "trae",
+          memoraxCodeHome: options.memoraxCodeHome,
+          env: options.env,
+          now: () => new Date(now()),
+        },
+      ), options.diagnosticLogger);
+
+      const retrievalKey = JSON.stringify([command.sessionId, command.turnId]);
+      if (retrievalTurns.has(retrievalKey)) {
+        return { ok: true, ...(repoMemoryWorktree ? { repoMemoryWorktree } : {}) };
+      }
+      retrievalTurns.add(retrievalKey);
+      trimBounded(retrievalTurns, runtimeTurnLimit);
+      const pendingUserNotice = repositoryMemory.ok
+        ? await pendingQuotaNotice.claim(repositoryMemory.memory.config)
+        : undefined;
+      const retrieval = await retrieveAutomaticMemoryContext({
+        diagnosticLogger: options.diagnosticLogger,
+        claimQuotaNotice: options.claimQuotaNotice ?? claimQuotaNotice,
+        env: options.env ?? process.env,
+        fetchImpl: options.fetchImpl,
+        memoryObservability: options.memoryObservability,
+        memoryObservabilitySource: "trae_hook_retrieval",
+        query: command.prompt,
+        repositoryMemory,
+        sessionKey: command.sessionId,
+        traceContext,
+      });
+      const userNotice = [pendingUserNotice, retrieval.userNotice].filter(Boolean).join("\n");
+      return {
+        ok: true,
+        ...(repoMemoryWorktree ? { repoMemoryWorktree } : {}),
+        ...(retrieval.context ? { additionalContext: retrieval.context } : {}),
+        ...(userNotice ? { userNotice } : {}),
+      };
+    },
+
+    async writeback(command) {
+      turnCoordinator.pruneExpired();
+      const commandKey = traeRuntimeTurnKey(command.sessionId, command.turnId);
+      const activeTurn = activeTurns.get(command.sessionId);
+      if (
+        interruptedTurns.has(commandKey)
+        || (activeTurn && activeTurn.clientTurnId !== command.turnId)
+      ) {
+        rememberBounded(interruptedTurns, commandKey, runtimeTurnLimit);
+        return { ok: true, scheduled: false, reason: "interrupted" };
+      }
+      const key = traeTurnKey(command.sessionId, command.turnId);
+      const entry = turnCoordinator.getTurn(key) ?? activeTurn;
+      const traceContext = entry?.traceContext ?? traceContextFromTraeHookBody(command);
+      const repositoryMemory = await resolveHookRepositoryMemory(command, options, repositoryMemorySession);
+      await recordCompletedTurn(traceContext, command, options, now);
+      const completed = await turnCoordinator.completeMaterializedTurn({
+        key,
+        metadata: entry,
+        resolveRepositoryMemory: async () => repositoryMemory,
+        userText: command.prompt,
+        assistantText: command.lastAssistantMessage,
+        writeback: {
+          client: "trae",
+          sessionKey: command.sessionId,
+          env: options.env ?? process.env,
+          fetchImpl: options.fetchImpl,
+          memoryObservability: options.memoryObservability,
+          memoryObservabilitySource: "trae_hook_writeback",
+          traceContext,
+        },
+      });
+      await recordMaterializedTurn(traceContext, command, options);
+      if (activeTurn?.clientTurnId === command.turnId) activeTurns.delete(command.sessionId);
+      options.diagnosticLogger?.("trae_memory.writeback", {
+        scheduled: completed.scheduled,
+        ...(!completed.scheduled ? { reason: completed.reason } : {}),
+        sessionId: command.sessionId,
+        turnId: command.turnId,
+        metadataDisposition: completed.metadataDisposition,
+      });
+      return completed.scheduled
+        ? { ok: true, scheduled: true }
+        : { ok: true, scheduled: false, reason: completed.reason };
+    },
+
+    size() {
+      return turnCoordinator.size(TRAE_MEMORY_TURN_CLIENT);
+    },
+
+    close() {
+      retrievalTurns.clear();
+      interruptedTurns.clear();
+      activeTurns.clear();
+      if (ownsTurnCoordinator) turnCoordinator.close();
+      if (ownsRepositoryMemorySession) repositoryMemorySession.close();
+      automaticWritebackRuntime?.close?.();
+      if (ownsPendingQuotaNotice) pendingQuotaNotice.close();
+    },
+  };
+}
+
+async function interruptPreviousTurn(
+  coordinator: MemoryTurnCoordinator,
+  previous: MemoryTurnState,
+  options: TraeMemoryHookRuntimeOptions,
+  now: () => number,
+): Promise<void> {
+  await recordTraceBestEffort("trae_memory.interrupted_turn_end", recordTraceEvent({
+    eventId: traceTurnEventId(previous.traceContext, "turn_end"),
+    memoraxCodeHome: options.memoraxCodeHome,
+    env: options.env,
+    traceContext: previous.traceContext,
+    type: "turn_end",
+    source: "trae-hook",
+    operation: "writeback",
+    ok: true,
+    outcome: "interrupted",
+  }), options.diagnosticLogger);
+  await recordTraceBestEffort("trae_memory.interrupted_current_turn", markCurrentTraceTurnOutcome(
+    previous.traceContext,
+    "interrupted",
+    {
+      client: "trae",
+      memoraxCodeHome: options.memoraxCodeHome,
+      env: options.env,
+      now: () => new Date(now()),
+    },
+  ), options.diagnosticLogger);
+  coordinator.discardTurn(previous, "interrupted");
+}
+
+async function recordCompletedTurn(
+  traceContext: TraceContext | undefined,
+  command: TraeWritebackCommand,
+  options: TraeMemoryHookRuntimeOptions,
+  now: () => number,
+): Promise<void> {
+  await recordTraceBestEffort("trae_memory.turn_end", recordTraceEvent({
+    eventId: traceTurnEventId(traceContext, "turn_end"),
+    memoraxCodeHome: options.memoraxCodeHome,
+    env: options.env,
+    traceContext,
+    type: "turn_end",
+    source: "trae-hook",
+    operation: "writeback",
+    ok: true,
+    outcome: "completed",
+    response: { assistant: command.lastAssistantMessage },
+  }), options.diagnosticLogger);
+  await recordTraceBestEffort("trae_memory.current_turn_close", markCurrentTraceTurnOutcome(
+    traceContext,
+    "completed",
+    {
+      client: "trae",
+      memoraxCodeHome: options.memoraxCodeHome,
+      env: options.env,
+      now: () => new Date(now()),
+    },
+  ), options.diagnosticLogger);
+}
+
+async function recordMaterializedTurn(
+  traceContext: TraceContext | undefined,
+  command: TraeWritebackCommand,
+  options: TraeMemoryHookRuntimeOptions,
+): Promise<void> {
+  await recordTraceBestEffort("trae_memory.turn_materialized", recordTraceEvent({
+    eventId: traceTurnEventId(traceContext, "turn_materialized"),
+    memoraxCodeHome: options.memoraxCodeHome,
+    env: options.env,
+    traceContext,
+    type: "turn_materialized",
+    source: "trae-hook",
+    operation: "writeback",
+    ok: true,
+    request: { prompt: command.prompt },
+    response: { assistant: command.lastAssistantMessage },
+  }), options.diagnosticLogger);
+}
+
+async function resolveHookRepositoryMemory(
+  command: TraeTurnStartCommand | TraeWritebackCommand,
+  options: TraeMemoryHookRuntimeOptions,
+  repository: RepositoryMemorySessionRuntime,
+): Promise<ConfiguredRepositoryMemoryResult> {
+  return await repository.resolve({
+    client: "trae",
+    sessionId: command.sessionId,
+    workspaceRoot: command.cwd,
+    workspaceKind: command.workspaceKind,
+    memoraxCodeHome: options.memoraxCodeHome ?? options.env?.MEMORAX_CODE_HOME,
+    env: options.env,
+  });
+}
+
+function traeTurnKey(sessionId: string, turnId: string): {
+  client: "trae";
+  sessionId: string;
+  clientTurnId: string;
+} {
+  return { client: "trae", sessionId, clientTurnId: turnId };
+}
+
+function traeRuntimeTurnKey(sessionId: string, turnId: string): string {
+  return JSON.stringify([sessionId, turnId]);
+}
+
+function rememberBounded(values: Set<string>, value: string, limit: number): void {
+  values.add(value);
+  trimBounded(values, limit);
+}
+
+function trimBounded(values: Set<string>, limit: number): void {
+  while (values.size > limit) {
+    const oldest = values.values().next().value;
+    if (typeof oldest !== "string") return;
+    values.delete(oldest);
+  }
+}
+
+async function recordTraceBestEffort(
+  label: string,
+  promise: Promise<unknown>,
+  diagnosticLogger?: MemoryDiagnosticLogger,
+): Promise<void> {
+  try {
+    await promise;
+  } catch (error) {
+    diagnosticLogger?.("trae_trace.write_failed", {
+      label,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+function positiveInteger(value: unknown, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}

--- a/packages/ts/memorax-code-backend/src/clients/trae/memory-hook-runtime.ts
+++ b/packages/ts/memorax-code-backend/src/clients/trae/memory-hook-runtime.ts
@@ -113,9 +113,10 @@ export function createTraeMemoryHookRuntime(
   const retrievalTurns = new Set<string>();
   const interruptedTurns = new Set<string>();
   const activeTurns = new Map<string, MemoryTurnState>();
+  const turnStartOperations = new Map<string, Promise<MemoryHookTurnStartResult>>();
   const runtimeTurnLimit = positiveInteger(options.maxEntries, 256);
 
-  return {
+  const runtime: TraeMemoryHookRuntime = {
     async recordTurnStart(command) {
       turnCoordinator.pruneExpired();
       const commandKey = traeRuntimeTurnKey(command.sessionId, command.turnId);
@@ -259,10 +260,22 @@ export function createTraeMemoryHookRuntime(
       retrievalTurns.clear();
       interruptedTurns.clear();
       activeTurns.clear();
+      turnStartOperations.clear();
       if (ownsTurnCoordinator) turnCoordinator.close();
       if (ownsRepositoryMemorySession) repositoryMemorySession.close();
       automaticWritebackRuntime?.close?.();
       if (ownsPendingQuotaNotice) pendingQuotaNotice.close();
+    },
+  };
+
+  return {
+    ...runtime,
+    recordTurnStart(command) {
+      return queueSessionTurnStart(
+        turnStartOperations,
+        command.sessionId,
+        () => runtime.recordTurnStart(command),
+      );
     },
   };
 }
@@ -399,6 +412,23 @@ async function recordTraceBestEffort(
       error: error instanceof Error ? error.message : String(error),
     });
   }
+}
+
+function queueSessionTurnStart(
+  operations: Map<string, Promise<MemoryHookTurnStartResult>>,
+  sessionId: string,
+  operation: () => Promise<MemoryHookTurnStartResult>,
+): Promise<MemoryHookTurnStartResult> {
+  const previous: Promise<unknown> = operations.get(sessionId) ?? Promise.resolve();
+  const queued = previous
+    .catch(() => undefined)
+    .then(operation);
+  operations.set(sessionId, queued);
+  const clear = () => {
+    if (operations.get(sessionId) === queued) operations.delete(sessionId);
+  };
+  void queued.then(clear, clear);
+  return queued;
 }
 
 function positiveInteger(value: unknown, fallback: number): number {

--- a/packages/ts/memorax-code-backend/src/clients/trae/turn-id.ts
+++ b/packages/ts/memorax-code-backend/src/clients/trae/turn-id.ts
@@ -1,0 +1,23 @@
+import { createHash } from "node:crypto";
+
+export type TraeTurnIdentity = Readonly<{
+  createdAt: number;
+  promptDigest: string;
+}>;
+
+export function traePromptDigest(prompt: string): string {
+  return createHash("sha256").update(prompt.trim()).digest("hex");
+}
+
+export function parseTraeTurnId(input: {
+  sessionId: string;
+  turnId: string;
+}): TraeTurnIdentity | undefined {
+  const prefix = `${input.sessionId}:`;
+  if (!input.turnId.startsWith(prefix)) return undefined;
+  const match = /^([1-9]\d*):([a-f0-9]{64})$/.exec(input.turnId.slice(prefix.length));
+  if (!match) return undefined;
+  const createdAt = Number(match[1]);
+  if (!Number.isSafeInteger(createdAt)) return undefined;
+  return { createdAt, promptDigest: match[2] };
+}

--- a/packages/ts/memorax-code-backend/src/config/memorax-code.ts
+++ b/packages/ts/memorax-code-backend/src/config/memorax-code.ts
@@ -108,6 +108,13 @@ export type MemoraxCodeConfig = Readonly<{
       max_event_chars?: number;
       max_file_bytes?: number;
     }>;
+    trae?: Readonly<{
+      enabled?: boolean;
+      capture_content?: boolean;
+      retention_days?: number;
+      max_event_chars?: number;
+      max_file_bytes?: number;
+    }>;
   }>;
 }>;
 
@@ -181,6 +188,10 @@ export function renderDefaultMemoraxCodeConfig(): string {
     "[trace.codebuddy]",
     "enabled = true # Enable local CodeBuddy session memory trace collection.",
     "capture_content = true # Store content in local CodeBuddy trace events.",
+    "",
+    "[trace.trae]",
+    "enabled = true # Enable local Trae session memory trace collection.",
+    "capture_content = true # Store content in local Trae trace events.",
     "",
   ].join("\n");
 }
@@ -264,6 +275,7 @@ function normalizeMemoraxCodeConfig(value: unknown): MemoraxCodeConfig {
   const traceDsh = recordValue(trace?.dsh);
   const traceOpenCode = recordValue(trace?.opencode);
   const traceCodeBuddy = recordValue(trace?.codebuddy);
+  const traceTrae = recordValue(trace?.trae);
 
   return (prune({
     clients: prune({
@@ -356,6 +368,13 @@ function normalizeMemoraxCodeConfig(value: unknown): MemoraxCodeConfig {
         retention_days: numberField(traceCodeBuddy, "retention_days"),
         max_event_chars: numberField(traceCodeBuddy, "max_event_chars"),
         max_file_bytes: numberField(traceCodeBuddy, "max_file_bytes"),
+      }),
+      trae: prune({
+        enabled: booleanField(traceTrae, "enabled"),
+        capture_content: booleanField(traceTrae, "capture_content"),
+        retention_days: numberField(traceTrae, "retention_days"),
+        max_event_chars: numberField(traceTrae, "max_event_chars"),
+        max_file_bytes: numberField(traceTrae, "max_file_bytes"),
       }),
     }),
   }) ?? {}) as MemoraxCodeConfig;

--- a/packages/ts/memorax-code-backend/src/memory/automatic-writeback.ts
+++ b/packages/ts/memorax-code-backend/src/memory/automatic-writeback.ts
@@ -39,7 +39,7 @@ import {
 } from "./payload-redaction.js";
 import type { MemoraxQuotaSnapshot } from "../provider/memorax/quota.js";
 
-export type AutomaticMemoryWritebackClient = "codex" | "claude-code" | "opencode" | "dsh" | "codebuddy";
+export type AutomaticMemoryWritebackClient = "codex" | "claude-code" | "opencode" | "dsh" | "codebuddy" | "trae";
 
 export type AutomaticMemoryWritebackOptions = {
   client: AutomaticMemoryWritebackClient;

--- a/packages/ts/memorax-code-backend/src/memory/hook-command.ts
+++ b/packages/ts/memorax-code-backend/src/memory/hook-command.ts
@@ -1,10 +1,11 @@
 import { isRecord } from "../shared/record.js";
 import { codeBuddyPromptDigest, parseCodeBuddyTurnId } from "../clients/codebuddy/turn-id.js";
+import { parseTraeTurnId, traePromptDigest } from "../clients/trae/turn-id.js";
 
 export const MEMORY_HOOK_COMMAND_VERSION = 1 as const;
 export const INVALID_MEMORY_HOOK_COMMAND = "invalid memory Hook command";
 
-export type MemoryHookClient = "codex" | "claude-code" | "opencode" | "dsh" | "codebuddy";
+export type MemoryHookClient = "codex" | "claude-code" | "opencode" | "dsh" | "codebuddy" | "trae";
 
 const BASE_COMMAND_KEYS = [
   "version",
@@ -19,6 +20,7 @@ const TURN_START_KEYS: Readonly<Record<MemoryHookClient, ReadonlySet<string>>> =
   opencode: new Set([...BASE_COMMAND_KEYS, "userMessageId", "prompt"]),
   dsh: new Set(["version", "client", "sessionId", "turn", "startSeq", "cwd", "prompt"]),
   codebuddy: new Set([...BASE_COMMAND_KEYS, "turnId", "prompt", "transcriptPath"]),
+  trae: new Set([...BASE_COMMAND_KEYS, "turnId", "prompt"]),
 };
 const WRITEBACK_KEYS: Readonly<Record<MemoryHookClient, ReadonlySet<string>>> = {
   codex: new Set([...BASE_COMMAND_KEYS, "turnId", "lastAssistantMessage", "transcriptPath"]),
@@ -46,6 +48,7 @@ const WRITEBACK_KEYS: Readonly<Record<MemoryHookClient, ReadonlySet<string>>> = 
     "events",
   ]),
   codebuddy: new Set([...BASE_COMMAND_KEYS, "turnId", "transcriptPath"]),
+  trae: new Set([...BASE_COMMAND_KEYS, "turnId", "prompt", "lastAssistantMessage"]),
 };
 const SKILL_REMINDER_KEYS: Readonly<Record<MemoryHookClient, ReadonlySet<string>>> = {
   codex: new Set([...BASE_COMMAND_KEYS, "turnId", "transcriptPath", "content", "triggers"]),
@@ -53,6 +56,7 @@ const SKILL_REMINDER_KEYS: Readonly<Record<MemoryHookClient, ReadonlySet<string>
   dsh: new Set(["version", "client", "sessionId", "turn", "cwd", "content", "triggers"]),
   opencode: new Set([...BASE_COMMAND_KEYS, "userMessageId", "content", "triggers"]),
   codebuddy: new Set([...BASE_COMMAND_KEYS, "turnId", "transcriptPath", "content", "triggers"]),
+  trae: new Set([...BASE_COMMAND_KEYS, "turnId", "content", "triggers"]),
 };
 
 type MemoryHookCommandBase<Client extends MemoryHookClient> = Readonly<{
@@ -93,12 +97,18 @@ export type CodeBuddyTurnStartCommand = MemoryHookCommandBase<"codebuddy"> & Rea
   transcriptPath: string;
 }>;
 
+export type TraeTurnStartCommand = MemoryHookCommandBase<"trae"> & Readonly<{
+  turnId: string;
+  prompt: string;
+}>;
+
 export type TurnStartCommand =
   | CodexTurnStartCommand
   | ClaudeTurnStartCommand
   | OpenCodeTurnStartCommand
   | DshTurnStartCommand
-  | CodeBuddyTurnStartCommand;
+  | CodeBuddyTurnStartCommand
+  | TraeTurnStartCommand;
 
 export type MemoryHookTurnStartResult = Readonly<{
   ok: true;
@@ -139,12 +149,19 @@ export type CodeBuddyWritebackCommand = MemoryHookCommandBase<"codebuddy"> & Rea
   transcriptPath: string;
 }>;
 
+export type TraeWritebackCommand = MemoryHookCommandBase<"trae"> & Readonly<{
+  turnId: string;
+  prompt: string;
+  lastAssistantMessage: string;
+}>;
+
 export type WritebackCommand =
   | CodexWritebackCommand
   | ClaudeWritebackCommand
   | OpenCodeWritebackCommand
   | DshWritebackCommand
-  | CodeBuddyWritebackCommand;
+  | CodeBuddyWritebackCommand
+  | TraeWritebackCommand;
 
 export type SkillReminderTrigger = "cadence" | "post_compaction";
 
@@ -182,12 +199,19 @@ export type CodeBuddySkillReminderCommand = MemoryHookCommandBase<"codebuddy"> &
   triggers: SkillReminderTrigger[];
 }>;
 
+export type TraeSkillReminderCommand = MemoryHookCommandBase<"trae"> & Readonly<{
+  turnId: string;
+  content: string;
+  triggers: SkillReminderTrigger[];
+}>;
+
 export type SkillReminderCommand =
   | CodexSkillReminderCommand
   | ClaudeSkillReminderCommand
   | DshSkillReminderCommand
   | OpenCodeSkillReminderCommand
-  | CodeBuddySkillReminderCommand;
+  | CodeBuddySkillReminderCommand
+  | TraeSkillReminderCommand;
 
 export type MemoryHookCommandParseResult<Command> =
   | { ok: true; command: Command }
@@ -199,7 +223,9 @@ export function parseTurnStartCommand(
   if (!isRecord(value)) return invalidCommand();
   const base = parseCommandBase(value, TURN_START_KEYS);
   if (!base) return invalidCommand();
-  const prompt = requiredStringField(value, "prompt");
+  const prompt = base.client === "trae"
+    ? requiredContentField(value, "prompt")
+    : requiredStringField(value, "prompt");
   if (!prompt) return invalidCommand();
   if (base.client === "dsh") {
     const turn = positiveSafeIntegerField(value, "turn");
@@ -250,6 +276,11 @@ export function parseTurnStartCommand(
     const transcriptPath = requiredStringField(value, "transcriptPath");
     if (!turnId || !transcriptPath || !validCodeBuddyTurnId(turnId, base.sessionId, prompt)) return invalidCommand();
     return { ok: true, command: { ...base, client: "codebuddy", turnId, prompt, transcriptPath } };
+  }
+  if (base.client === "trae") {
+    const turnId = requiredStringField(value, "turnId");
+    if (!turnId || !validTraeTurnId(turnId, base.sessionId, prompt)) return invalidCommand();
+    return { ok: true, command: { ...base, client: "trae", turnId, prompt } };
   }
   const promptId = requiredStringField(value, "promptId");
   const transcriptPath = requiredStringField(value, "transcriptPath");
@@ -321,6 +352,15 @@ export function parseWritebackCommand(
     const transcriptPath = requiredStringField(value, "transcriptPath");
     if (!turnId || !transcriptPath || !validCodeBuddyTurnId(turnId, base.sessionId)) return invalidCommand();
     return { ok: true, command: { ...base, client: "codebuddy", turnId, transcriptPath } };
+  }
+  if (base.client === "trae") {
+    const turnId = requiredStringField(value, "turnId");
+    const prompt = requiredContentField(value, "prompt");
+    const lastAssistantMessage = requiredContentField(value, "lastAssistantMessage");
+    if (!turnId || !prompt || !lastAssistantMessage || !validTraeTurnId(turnId, base.sessionId, prompt)) {
+      return invalidCommand();
+    }
+    return { ok: true, command: { ...base, client: "trae", turnId, prompt, lastAssistantMessage } };
   }
   const lastAssistantMessage = requiredStringField(value, "lastAssistantMessage");
   if (!lastAssistantMessage) return invalidCommand();
@@ -398,6 +438,11 @@ export function parseSkillReminderCommand(
     if (!turnId || !transcriptPath || !validCodeBuddyTurnId(turnId, base.sessionId)) return invalidCommand();
     return { ok: true, command: { ...base, client: "codebuddy", turnId, transcriptPath, content, triggers } };
   }
+  if (base.client === "trae") {
+    const turnId = requiredStringField(value, "turnId");
+    if (!turnId || !parseTraeTurnId({ sessionId: base.sessionId, turnId })) return invalidCommand();
+    return { ok: true, command: { ...base, client: "trae", turnId, content, triggers } };
+  }
   const transcriptPath = requiredStringField(value, "transcriptPath");
   if (!transcriptPath) return invalidCommand();
   if (base.client === "codex") {
@@ -443,6 +488,7 @@ function parseCommandBase(
     && client !== "opencode"
     && client !== "dsh"
     && client !== "codebuddy"
+    && client !== "trae"
   ) return undefined;
   const clientKeys = allowedKeys[client];
   if (!clientKeys || Object.keys(value).some((key) => !clientKeys.has(key))) return undefined;
@@ -518,6 +564,11 @@ function optionalStringField(
 function validCodeBuddyTurnId(turnId: string, sessionId: string, prompt?: string): boolean {
   const identity = parseCodeBuddyTurnId({ sessionId, turnId });
   return Boolean(identity && (prompt === undefined || identity.promptDigest === codeBuddyPromptDigest(prompt)));
+}
+
+function validTraeTurnId(turnId: string, sessionId: string, prompt: string): boolean {
+  const identity = parseTraeTurnId({ sessionId, turnId });
+  return Boolean(identity && identity.promptDigest === traePromptDigest(prompt));
 }
 
 function invalidCommand<Command>(): MemoryHookCommandParseResult<Command> {

--- a/packages/ts/memorax-code-backend/src/memory/observability.ts
+++ b/packages/ts/memorax-code-backend/src/memory/observability.ts
@@ -13,6 +13,8 @@ export type MemoryObservabilitySource =
   | "opencode_plugin_writeback"
   | "codebuddy_hook_retrieval"
   | "codebuddy_hook_writeback"
+  | "trae_hook_retrieval"
+  | "trae_hook_writeback"
   | "memory_cli"
   | "unknown";
 

--- a/packages/ts/memorax-code-backend/src/memory/reminder-trace-recorder.ts
+++ b/packages/ts/memorax-code-backend/src/memory/reminder-trace-recorder.ts
@@ -9,6 +9,7 @@ import {
   traceContextFromHookBody,
   traceContextFromOpenCodeHookBody,
   traceContextFromCodeBuddyHookBody,
+  traceContextFromTraeHookBody,
   type TraceContext,
 } from "../trace/context.js";
 import { recordTraceEvent } from "../trace/store.js";
@@ -70,6 +71,7 @@ function traceContextForReminder(command: SkillReminderCommand): TraceContext | 
   if (command.client === "claude-code") return traceContextFromClaudeHookBody(command);
   if (command.client === "dsh") return traceContextFromDshSkillReminder(command);
   if (command.client === "codebuddy") return traceContextFromCodeBuddyHookBody(command);
+  if (command.client === "trae") return traceContextFromTraeHookBody(command);
   return traceContextFromOpenCodeHookBody(command);
 }
 
@@ -78,6 +80,7 @@ function reminderSource(command: SkillReminderCommand): string {
   if (command.client === "claude-code") return "claude-hook";
   if (command.client === "dsh") return "dsh-cordis";
   if (command.client === "codebuddy") return "codebuddy-hook";
+  if (command.client === "trae") return "trae-hook";
   return "opencode-plugin";
 }
 

--- a/packages/ts/memorax-code-backend/src/memory/service.ts
+++ b/packages/ts/memorax-code-backend/src/memory/service.ts
@@ -18,6 +18,7 @@ import {
   type OpenCodeMemoryHookWritebackResult,
 } from "../clients/opencode/memory-hook-runtime.js";
 import { createCodeBuddyMemoryHookRuntime, type CodeBuddyMemoryHookWritebackResult } from "../clients/codebuddy/memory-hook-runtime.js";
+import { createTraeMemoryHookRuntime, type TraeMemoryHookWritebackResult } from "../clients/trae/memory-hook-runtime.js";
 import { createMemoryTurnCoordinator } from "./turn-coordinator.js";
 import {
   createRepositoryMemorySessionRuntime,
@@ -39,7 +40,8 @@ type MemoryHookWritebackResult =
   | ClaudeMemoryHookWritebackResult
   | OpenCodeMemoryHookWritebackResult
   | DshMemoryHookWritebackResult
-  | CodeBuddyMemoryHookWritebackResult;
+  | CodeBuddyMemoryHookWritebackResult
+  | TraeMemoryHookWritebackResult;
 
 export type MemoryService = {
   recordTurnStart(command: TurnStartCommand): Promise<MemoryHookTurnStartResult>;
@@ -97,6 +99,12 @@ export function createMemoryService(options: MemoryServiceOptions = {}): MemoryS
     repositoryMemorySession,
     turnCoordinator,
   });
+  const traeHook = createTraeMemoryHookRuntime({
+    ...options,
+    pendingQuotaNotice,
+    repositoryMemorySession,
+    turnCoordinator,
+  });
   let closed = false;
   return {
     async recordTurnStart(command) {
@@ -111,6 +119,8 @@ export function createMemoryService(options: MemoryServiceOptions = {}): MemoryS
           return await dshHook.recordTurnStart(command);
         case "codebuddy":
           return await codeBuddyHook.recordTurnStart(command);
+        case "trae":
+          return await traeHook.recordTurnStart(command);
       }
       return unsupportedMemoryHookCommand(command);
     },
@@ -126,6 +136,8 @@ export function createMemoryService(options: MemoryServiceOptions = {}): MemoryS
           return await dshHook.writeback(command);
         case "codebuddy":
           return await codeBuddyHook.writeback(command);
+        case "trae":
+          return await traeHook.writeback(command);
       }
       return unsupportedMemoryHookCommand(command);
     },
@@ -140,6 +152,7 @@ export function createMemoryService(options: MemoryServiceOptions = {}): MemoryS
       openCodeHook.close();
       dshHook.close();
       codeBuddyHook.close();
+      traeHook.close();
       turnCoordinator.close();
       repositoryMemorySession.close();
       automaticWriteback.close();

--- a/packages/ts/memorax-code-backend/src/memory/writeback-buffer.ts
+++ b/packages/ts/memorax-code-backend/src/memory/writeback-buffer.ts
@@ -12,7 +12,7 @@ import {
 import type { TraceContext } from "../trace/context.js";
 
 export type MemoryWritebackBufferDecision = {
-  client: "codex" | "claude-code" | "opencode" | "dsh" | "codebuddy";
+  client: "codex" | "claude-code" | "opencode" | "dsh" | "codebuddy" | "trae";
   sessionKey: string;
   idempotencyKey: string;
   messages: WritebackMessage[];

--- a/packages/ts/memorax-code-backend/src/trace/config.ts
+++ b/packages/ts/memorax-code-backend/src/trace/config.ts
@@ -5,7 +5,7 @@ import { loadMemoraxCodeConfig, type MemoraxCodeConfig } from "../config/memorax
 import { isTraceClient, type TraceClient } from "./context.js";
 
 export const TRACE_CLIENTS: readonly TraceClient[] = ["codex", "claude", "dsh", "opencode"];
-export const TRACE_RUNTIME_CLIENTS: readonly TraceClient[] = [...TRACE_CLIENTS, "codebuddy"];
+export const TRACE_RUNTIME_CLIENTS: readonly TraceClient[] = [...TRACE_CLIENTS, "codebuddy", "trae"];
 
 export type ClientTraceConfig = Readonly<{
   enabled: boolean;
@@ -20,6 +20,7 @@ export type ClaudeTraceConfig = ClientTraceConfig;
 export type DshTraceConfig = ClientTraceConfig;
 export type OpenCodeTraceConfig = ClientTraceConfig;
 export type CodeBuddyTraceConfig = ClientTraceConfig;
+export type TraeTraceConfig = ClientTraceConfig;
 
 export type ClientTracePaths = Readonly<{
   root: string;
@@ -36,6 +37,7 @@ export type ClaudeTracePaths = ClientTracePaths;
 export type DshTracePaths = ClientTracePaths;
 export type OpenCodeTracePaths = ClientTracePaths;
 export type CodeBuddyTracePaths = ClientTracePaths;
+export type TraeTracePaths = ClientTracePaths;
 
 export const CODEX_TRACE_DEFAULT_CONFIG: CodexTraceConfig = {
   enabled: true,
@@ -73,12 +75,17 @@ export const CODEBUDDY_TRACE_DEFAULT_CONFIG: CodeBuddyTraceConfig = {
   ...OPENCODE_TRACE_DEFAULT_CONFIG,
 };
 
+export const TRAE_TRACE_DEFAULT_CONFIG: TraeTraceConfig = {
+  ...OPENCODE_TRACE_DEFAULT_CONFIG,
+};
+
 const TRACE_DEFAULT_CONFIGS: Readonly<Record<TraceClient, ClientTraceConfig>> = {
   codex: CODEX_TRACE_DEFAULT_CONFIG,
   claude: CLAUDE_TRACE_DEFAULT_CONFIG,
   dsh: DSH_TRACE_DEFAULT_CONFIG,
   opencode: OPENCODE_TRACE_DEFAULT_CONFIG,
   codebuddy: CODEBUDDY_TRACE_DEFAULT_CONFIG,
+  trae: TRAE_TRACE_DEFAULT_CONFIG,
 };
 
 const TRACE_ENV_PREFIXES: Readonly<Record<TraceClient, string>> = {
@@ -87,6 +94,7 @@ const TRACE_ENV_PREFIXES: Readonly<Record<TraceClient, string>> = {
   dsh: "MEMORAX_CODE_DSH_TRACE",
   opencode: "MEMORAX_CODE_OPENCODE_TRACE",
   codebuddy: "MEMORAX_CODE_CODEBUDDY_TRACE",
+  trae: "MEMORAX_CODE_TRAE_TRACE",
 };
 
 export const TRACE_CLEANUP_DEBOUNCE_MS = 60 * 60 * 1000;
@@ -131,6 +139,13 @@ export function codeBuddyTraceConfigFromEnv(
   return clientTraceConfigFromEnv("codebuddy", env, fileConfig);
 }
 
+export function traeTraceConfigFromEnv(
+  env: Record<string, string | undefined> = process.env,
+  fileConfig?: MemoraxCodeConfig,
+): TraeTraceConfig {
+  return clientTraceConfigFromEnv("trae", env, fileConfig);
+}
+
 export function clientTraceConfigFromEnv(
   client: TraceClient,
   env: Record<string, string | undefined> = process.env,
@@ -172,6 +187,10 @@ export function openCodeTracePaths(memoraxCodeHome = memoraxCodeHomeForTrace(pro
 
 export function codeBuddyTracePaths(memoraxCodeHome = memoraxCodeHomeForTrace(process.env)): CodeBuddyTracePaths {
   return clientTracePaths("codebuddy", memoraxCodeHome);
+}
+
+export function traeTracePaths(memoraxCodeHome = memoraxCodeHomeForTrace(process.env)): TraeTracePaths {
+  return clientTracePaths("trae", memoraxCodeHome);
 }
 
 export function clientTracePaths(

--- a/packages/ts/memorax-code-backend/src/trace/context.ts
+++ b/packages/ts/memorax-code-backend/src/trace/context.ts
@@ -12,9 +12,10 @@ export type TraceContextOrigin =
   | "dsh-session-event-log"
   | "opencode-hook-body"
   | "codebuddy-hook-body"
+  | "trae-hook-body"
   | "current-turn-file"
   | "manual";
-export type TraceClient = "codex" | "claude" | "dsh" | "opencode" | "codebuddy";
+export type TraceClient = "codex" | "claude" | "dsh" | "opencode" | "codebuddy" | "trae";
 
 export type TraceRelatedTurn = Readonly<{
   turnId?: string;
@@ -131,6 +132,28 @@ export function traceContextFromCodeBuddyHookBody(
   });
 }
 
+export function traceContextFromTraeHookBody(
+  body: unknown,
+  capturedAt = new Date().toISOString(),
+): TraceContext | undefined {
+  if (!isRecord(body)) return undefined;
+  const sessionId = stringField(body, "session_id") ?? stringField(body, "sessionId");
+  const turnId = stringField(body, "turn_id") ?? stringField(body, "turnId");
+  if (!sessionId || !turnId) return undefined;
+  const cwd = stringField(body, "cwd");
+  return pruneTraceContext({
+    schemaVersion: "1",
+    client: "trae",
+    sessionId,
+    turnId,
+    cwd,
+    memoryProject: resolveMemoryProject(cwd),
+    workspaceKind: stringField(body, "workspace_kind") ?? stringField(body, "workspaceKind"),
+    contextOrigin: "trae-hook-body",
+    capturedAt,
+  });
+}
+
 export function traceContextFromDshTurnStart(
   body: unknown,
   capturedAt = new Date().toISOString(),
@@ -212,7 +235,12 @@ function pruneRecord<T extends Record<string, unknown>>(value: T): T {
 }
 
 export function isTraceClient(value: unknown): value is TraceClient {
-  return value === "codex" || value === "claude" || value === "dsh" || value === "opencode" || value === "codebuddy";
+  return value === "codex"
+    || value === "claude"
+    || value === "dsh"
+    || value === "opencode"
+    || value === "codebuddy"
+    || value === "trae";
 }
 
 function traceContextFromDshBody(

--- a/packages/ts/memorax-code-backend/test/clients/trae/trae-memory-hook.test.mjs
+++ b/packages/ts/memorax-code-backend/test/clients/trae/trae-memory-hook.test.mjs
@@ -10,6 +10,7 @@ import {
   parseTurnStartCommand,
   parseWritebackCommand,
 } from "../../../dist/memory/hook-command.js";
+import { createRepositoryMemorySessionRuntime } from "../../../dist/memory/repository-session.js";
 import { traeTracePaths } from "../../../dist/trace/config.js";
 
 test("Trae Hook commands keep a closed content-authority schema", () => {
@@ -129,6 +130,69 @@ test("Trae runtime interrupts a replaced active Turn without writing it back", a
     }]);
   } finally {
     runtime.close();
+    await fixture.cleanup();
+  }
+});
+
+test("Trae runtime serializes overlapping Turn starts for one Session", async () => {
+  const fixture = await createFixture("overlapping-starts");
+  const writes = [];
+  const baseRepositoryMemorySession = createRepositoryMemorySessionRuntime();
+  let resolveCalls = 0;
+  let markFirstResolveStarted;
+  let releaseFirstResolve;
+  const firstResolveStarted = new Promise((resolve) => {
+    markFirstResolveStarted = resolve;
+  });
+  const firstResolveGate = new Promise((resolve) => {
+    releaseFirstResolve = resolve;
+  });
+  const repositoryMemorySession = {
+    async resolve(input) {
+      resolveCalls += 1;
+      if (resolveCalls === 1) {
+        markFirstResolveStarted();
+        await firstResolveGate;
+      }
+      return await baseRepositoryMemorySession.resolve(input);
+    },
+    close() {
+      baseRepositoryMemorySession.close();
+    },
+  };
+  const runtime = createTraeMemoryHookRuntime({
+    env: configuredEnv(fixture.home, { MEMORAX_CODE_TRAE_TRACE_ENABLED: "false" }),
+    automaticWriteback: (request) => {
+      writes.push(request);
+      return { accepted: true };
+    },
+    repositoryMemorySession,
+  });
+  const first = turnStart("trae-overlapping-session", "Start the first Trae turn.", fixture.workspace, 1_700_000_000_001);
+  const second = turnStart("trae-overlapping-session", "Replace it with the second Trae turn.", fixture.workspace, 1_700_000_000_002);
+  const starts = [];
+  try {
+    starts.push(runtime.recordTurnStart(first));
+    await firstResolveStarted;
+    starts.push(runtime.recordTurnStart(second));
+    assert.equal(resolveCalls, 1, "the second start must wait for the first Session operation");
+    releaseFirstResolve();
+    await Promise.all(starts);
+
+    assert.deepEqual(await runtime.writeback({
+      ...first,
+      lastAssistantMessage: "The first completion arrived late.",
+    }), { ok: true, scheduled: false, reason: "interrupted" });
+    assert.deepEqual(await runtime.writeback({
+      ...second,
+      lastAssistantMessage: "The second turn completed.",
+    }), { ok: true, scheduled: true });
+    assert.deepEqual(writes.map(({ userText }) => userText), [second.prompt]);
+  } finally {
+    releaseFirstResolve();
+    await Promise.allSettled(starts);
+    runtime.close();
+    repositoryMemorySession.close();
     await fixture.cleanup();
   }
 });

--- a/packages/ts/memorax-code-backend/test/clients/trae/trae-memory-hook.test.mjs
+++ b/packages/ts/memorax-code-backend/test/clients/trae/trae-memory-hook.test.mjs
@@ -1,0 +1,350 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { createTraeMemoryHookRuntime } from "../../../dist/clients/trae/memory-hook-runtime.js";
+import {
+  parseSkillReminderCommand,
+  parseTurnStartCommand,
+  parseWritebackCommand,
+} from "../../../dist/memory/hook-command.js";
+import { traeTracePaths } from "../../../dist/trace/config.js";
+
+test("Trae Hook commands keep a closed content-authority schema", () => {
+  const sessionId = "trae-schema-session";
+  const prompt = "  Keep the exact Trae prompt.  ";
+  const turnId = traeTurnId(sessionId, prompt);
+  const start = {
+    version: 1,
+    client: "trae",
+    sessionId,
+    turnId,
+    prompt,
+    cwd: "/workspace/trae",
+    workspaceKind: "project",
+  };
+  const writeback = {
+    version: 1,
+    client: "trae",
+    sessionId,
+    turnId,
+    prompt,
+    lastAssistantMessage: "  Keep the exact Trae answer.  ",
+    cwd: "/workspace/trae",
+    workspaceKind: "project",
+  };
+
+  assert.deepEqual(parseTurnStartCommand(start), { ok: true, command: start });
+  assert.deepEqual(parseWritebackCommand(writeback), { ok: true, command: writeback });
+  assert.equal(parseSkillReminderCommand({
+    version: 1,
+    client: "trae",
+    sessionId,
+    turnId,
+    cwd: "/workspace/trae",
+    content: "Use the memorax-code skill when prior work may help.",
+    triggers: ["cadence"],
+  }).ok, true);
+
+  for (const [name, parser, command] of [
+    ["foreign transcript authority", parseTurnStartCommand, { ...start, transcriptPath: "/tmp/session.jsonl" }],
+    ["cross-session turn id", parseTurnStartCommand, { ...start, turnId: traeTurnId("other-session", prompt) }],
+    ["prompt-mismatched turn id", parseTurnStartCommand, { ...start, prompt: "Different prompt." }],
+    ["non-canonical timestamp", parseTurnStartCommand, { ...start, turnId: `${sessionId}:01:${"a".repeat(64)}` }],
+    ["missing assistant authority", parseWritebackCommand, { ...writeback, lastAssistantMessage: " " }],
+    ["foreign message collection", parseWritebackCommand, { ...writeback, messages: [] }],
+    ["foreign reminder transcript", parseSkillReminderCommand, {
+      version: 1,
+      client: "trae",
+      sessionId,
+      turnId,
+      content: "Do not accept foreign authority.",
+      triggers: ["cadence"],
+      transcriptPath: "/tmp/session.jsonl",
+    }],
+  ]) {
+    assert.equal(parser(command).ok, false, name);
+  }
+});
+
+test("Trae runtime writes exact Hook content once for a repeated completed Turn", async () => {
+  const fixture = await createFixture("exact-writeback");
+  const requests = [];
+  const runtime = createTraeMemoryHookRuntime({
+    env: configuredEnv(fixture.home, { MEMORAX_CODE_TRAE_TRACE_ENABLED: "false" }),
+    fetchImpl: memoraxFetch(requests),
+  });
+  const prompt = "  Preserve this Trae prompt exactly.  ";
+  const assistant = "  Preserve this Trae response exactly.  ";
+  const command = turnStart("trae-exact-session", prompt, fixture.workspace);
+  try {
+    assert.deepEqual(await runtime.recordTurnStart(command), { ok: true });
+    const writeback = {
+      ...command,
+      lastAssistantMessage: assistant,
+    };
+    assert.deepEqual(await runtime.writeback(writeback), { ok: true, scheduled: true });
+    assert.deepEqual(await runtime.writeback(writeback), { ok: true, scheduled: true });
+    await waitFor(() => requests.length === 1, "Trae writeback did not settle");
+    assert.deepEqual(requests[0].body.messages.map(({ role, content }) => ({ role, content })), [
+      { role: "user", content: prompt.trim() },
+      { role: "assistant", content: assistant.trim() },
+    ]);
+    assert.match(requests[0].body.metadata.idempotency_key, /^automatic:trae:/);
+  } finally {
+    runtime.close();
+    await fixture.cleanup();
+  }
+});
+
+test("Trae runtime interrupts a replaced active Turn without writing it back", async () => {
+  const fixture = await createFixture("interrupted");
+  const writes = [];
+  const runtime = createTraeMemoryHookRuntime({
+    env: configuredEnv(fixture.home, { MEMORAX_CODE_TRAE_TRACE_ENABLED: "false" }),
+    automaticWriteback: (request) => {
+      writes.push(request);
+      return { accepted: true };
+    },
+  });
+  const first = turnStart("trae-interrupted-session", "Cancel the first Trae turn.", fixture.workspace, 1_700_000_000_001);
+  const second = turnStart("trae-interrupted-session", "Continue with the next Trae turn.", fixture.workspace, 1_700_000_000_002);
+  try {
+    await runtime.recordTurnStart(first);
+    await runtime.recordTurnStart(second);
+    assert.equal(runtime.size(), 1);
+    assert.deepEqual(await runtime.writeback({
+      ...first,
+      lastAssistantMessage: "This stale completion must not be retained.",
+    }), { ok: true, scheduled: false, reason: "interrupted" });
+    assert.deepEqual(await runtime.writeback({
+      ...second,
+      lastAssistantMessage: "The replacement turn completed.",
+    }), { ok: true, scheduled: true });
+    assert.deepEqual(writes.map(({ userText, assistantText }) => ({ userText, assistantText })), [{
+      userText: second.prompt,
+      assistantText: "The replacement turn completed.",
+    }]);
+  } finally {
+    runtime.close();
+    await fixture.cleanup();
+  }
+});
+
+test("Trae runtime preserves interruption authority after coordinator metadata expires", async () => {
+  const fixture = await createFixture("expired-interruption");
+  const writes = [];
+  let now = 1_700_000_000_000;
+  const runtime = createTraeMemoryHookRuntime({
+    env: configuredEnv(fixture.home, { MEMORAX_CODE_TRAE_TRACE_ENABLED: "false" }),
+    automaticWriteback: (request) => {
+      writes.push(request);
+      return { accepted: true };
+    },
+    now: () => now,
+    ttlMs: 5,
+    cleanupIntervalMs: 60_000,
+  });
+  const first = turnStart("trae-expired-session", "Run a long Trae task.", fixture.workspace, now);
+  const second = turnStart("trae-expired-session", "Replace the long Trae task.", fixture.workspace, now + 10);
+  try {
+    await runtime.recordTurnStart(first);
+    now += 10;
+    await runtime.recordTurnStart(second);
+    assert.deepEqual(await runtime.writeback({
+      ...first,
+      lastAssistantMessage: "This late completion must remain interrupted.",
+    }), { ok: true, scheduled: false, reason: "interrupted" });
+    assert.deepEqual(await runtime.writeback({
+      ...second,
+      lastAssistantMessage: "The replacement completed.",
+    }), { ok: true, scheduled: true });
+    assert.deepEqual(writes.map(({ userText }) => userText), [second.prompt]);
+  } finally {
+    runtime.close();
+    await fixture.cleanup();
+  }
+});
+
+test("Trae complete Hook payload restores writeback after Backend runtime restart", async () => {
+  const fixture = await createFixture("restart");
+  const env = configuredEnv(fixture.home, { MEMORAX_CODE_TRAE_TRACE_ENABLED: "false" });
+  const command = turnStart("trae-restart-session", "Persist across a Backend restart.", fixture.workspace);
+  const beforeRestart = createTraeMemoryHookRuntime({
+    env,
+    automaticWriteback: () => ({ accepted: true }),
+  });
+  await beforeRestart.recordTurnStart(command);
+  beforeRestart.close();
+
+  const writes = [];
+  const afterRestart = createTraeMemoryHookRuntime({
+    env,
+    automaticWriteback: (request) => {
+      writes.push(request);
+      return { accepted: true };
+    },
+  });
+  try {
+    assert.deepEqual(await afterRestart.writeback({
+      ...command,
+      lastAssistantMessage: "The complete Stop payload restored the turn.",
+    }), { ok: true, scheduled: true });
+    assert.equal(afterRestart.size(), 0);
+    assert.deepEqual(writes.map(({ userText, assistantText }) => ({ userText, assistantText })), [{
+      userText: command.prompt,
+      assistantText: "The complete Stop payload restored the turn.",
+    }]);
+  } finally {
+    afterRestart.close();
+    await fixture.cleanup();
+  }
+});
+
+test("Trae runtime fails closed when a session changes physical workspace", async () => {
+  const fixture = await createFixture("scope-mismatch");
+  const otherWorkspace = join(fixture.root, "other-workspace");
+  await mkdir(otherWorkspace);
+  const writes = [];
+  const runtime = createTraeMemoryHookRuntime({
+    env: configuredEnv(fixture.home, { MEMORAX_CODE_TRAE_TRACE_ENABLED: "false" }),
+    automaticWriteback: (request) => {
+      writes.push(request);
+      return { accepted: true };
+    },
+  });
+  const command = turnStart("trae-scope-session", "Keep the original workspace authority.", fixture.workspace);
+  try {
+    await runtime.recordTurnStart(command);
+    assert.deepEqual(await runtime.writeback({
+      ...command,
+      cwd: otherWorkspace,
+      lastAssistantMessage: "Do not cross the workspace boundary.",
+    }), { ok: true, scheduled: false, reason: "workspace_scope_mismatch" });
+    assert.equal(writes.length, 0);
+  } finally {
+    runtime.close();
+    await fixture.cleanup();
+  }
+});
+
+test("Trae trace records interrupted and completed Turn lifecycles", async () => {
+  const fixture = await createFixture("trace");
+  const sessionId = "trae-trace-session";
+  const writes = [];
+  const runtime = createTraeMemoryHookRuntime({
+    memoraxCodeHome: fixture.home,
+    env: configuredEnv(fixture.home),
+    automaticWriteback: (request) => {
+      writes.push(request);
+      return { accepted: true };
+    },
+  });
+  const first = turnStart(sessionId, "Interrupt this Trae turn.", fixture.workspace, 1_700_000_000_011);
+  const second = turnStart(sessionId, "Complete this Trae turn.", fixture.workspace, 1_700_000_000_012);
+  try {
+    await runtime.recordTurnStart(first);
+    await runtime.recordTurnStart(second);
+    await runtime.writeback({ ...second, lastAssistantMessage: "Trae completed the second turn." });
+
+    const events = (await readFile(traeTracePaths(fixture.home).eventsJsonl(sessionId), "utf8"))
+      .trim()
+      .split(/\r?\n/)
+      .map((line) => JSON.parse(line));
+    assert.deepEqual(events.map(({ type, outcome }) => ({ type, outcome })), [
+      { type: "turn_start", outcome: undefined },
+      { type: "turn_end", outcome: "interrupted" },
+      { type: "turn_start", outcome: undefined },
+      { type: "turn_end", outcome: "completed" },
+      { type: "turn_materialized", outcome: undefined },
+    ]);
+    assert.deepEqual(events.map((event) => event.trace.turn_id), [
+      first.turnId,
+      first.turnId,
+      second.turnId,
+      second.turnId,
+      second.turnId,
+    ]);
+    assert.equal(events.every((event) => event.trace.client === "trae"), true);
+    assert.equal(events.every((event) => event.trace.context_origin === "trae-hook-body"), true);
+    assert.equal(writes.length, 1);
+    const current = JSON.parse(await readFile(
+      traeTracePaths(fixture.home).sessionCurrentTurnPath(sessionId),
+      "utf8",
+    ));
+    assert.equal(current.turn_state, "completed");
+    assert.equal(current.trace.turn_id, second.turnId);
+  } finally {
+    runtime.close();
+    await fixture.cleanup();
+  }
+});
+
+function turnStart(sessionId, prompt, cwd, createdAt = 1_700_000_000_000) {
+  return {
+    version: 1,
+    client: "trae",
+    sessionId,
+    turnId: traeTurnId(sessionId, prompt, createdAt),
+    prompt,
+    cwd,
+    workspaceKind: "project",
+  };
+}
+
+function traeTurnId(sessionId, prompt, createdAt = 1_700_000_000_000) {
+  const digest = createHash("sha256").update(prompt.trim()).digest("hex");
+  return `${sessionId}:${createdAt}:${digest}`;
+}
+
+async function createFixture(name) {
+  const root = await mkdtemp(join(tmpdir(), `memorax-code-trae-${name}-`));
+  const home = join(root, "home");
+  const workspace = join(root, "workspace");
+  await Promise.all([
+    mkdir(home, { recursive: true }),
+    mkdir(workspace, { recursive: true }),
+  ]);
+  return {
+    root,
+    home,
+    workspace,
+    cleanup: () => rm(root, { recursive: true, force: true }),
+  };
+}
+
+function configuredEnv(home, overrides = {}) {
+  return {
+    MEMORAX_CODE_HOME: home,
+    MEMORAX_CODE_MEMORY_RETRIEVAL_ENABLED: "false",
+    MEMORAX_CODE_MEMORY_WRITEBACK_ENABLED: "true",
+    MEMORAX_CODE_MEMORY_WRITEBACK_BUFFER_ENABLED: "false",
+    MEMORAX_CODE_MEMORAX_ENDPOINT: "http://memorax.test",
+    MEMORAX_CODE_MEMORAX_API_KEY: "secret",
+    MEMORAX_CODE_MEMORAX_USER_ID: "trae-user",
+    ...overrides,
+  };
+}
+
+function memoraxFetch(requests) {
+  return async (url, init) => {
+    requests.push({ url: String(url), body: JSON.parse(init.body) });
+    return new Response(JSON.stringify({
+      success: true,
+      data: { task_id: `trae-write-${requests.length}`, status: "completed" },
+    }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  };
+}
+
+async function waitFor(predicate, message, timeoutMs = 1_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error(message);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}

--- a/packages/ts/memorax-code-backend/test/transport/http/memory-hook.test.mjs
+++ b/packages/ts/memorax-code-backend/test/transport/http/memory-hook.test.mjs
@@ -75,7 +75,40 @@ test("Backend memory hook endpoints record and write back a turn", async () => {
     });
     assert.equal(writeback.status, 200);
     assert.deepEqual(await writeback.json(), { ok: true, scheduled: true });
-    await waitFor(() => requests.length === 1, "HTTP hook writeback did not call MemoraX add");
+
+    const traePrompt = "HTTP Trae Hook prompt.";
+    const traeTurn = traeTurnId("session-http-trae", traePrompt);
+    const traeStart = await originalFetch(`${url}/memory/turn-start`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        version: 1,
+        client: "trae",
+        sessionId: "session-http-trae",
+        turnId: traeTurn,
+        prompt: traePrompt,
+        cwd: TEST_WORKSPACE,
+      }),
+    });
+    assert.equal(traeStart.status, 200);
+    assert.deepEqual(await traeStart.json(), GIT_TURN_START_RESULT);
+
+    const traeWriteback = await originalFetch(`${url}/memory/writeback`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        version: 1,
+        client: "trae",
+        sessionId: "session-http-trae",
+        turnId: traeTurn,
+        prompt: traePrompt,
+        lastAssistantMessage: "HTTP Trae Hook answer.",
+        cwd: TEST_WORKSPACE,
+      }),
+    });
+    assert.equal(traeWriteback.status, 200);
+    assert.deepEqual(await traeWriteback.json(), { ok: true, scheduled: true });
+    await waitFor(() => requests.length === 2, "HTTP Hook writebacks did not call MemoraX add");
   } finally {
     await new Promise((resolve) => server.close(resolve));
     globalThis.fetch = originalFetch;
@@ -167,6 +200,23 @@ test("Backend memory hook endpoints reject commands outside the closed schema", 
     sessionId: "session-codebuddy-writeback",
     turnId: codeBuddyTurnId("session-codebuddy-writeback", 0, "CodeBuddy writeback."),
     transcriptPath: "/tmp/codebuddy.jsonl",
+  };
+  const traeTurnStart = {
+    version: 1,
+    client: "trae",
+    sessionId: "session-trae-turn-start",
+    turnId: traeTurnId("session-trae-turn-start", "Trae turn start."),
+    prompt: "Trae turn start.",
+    cwd: "/workspace/trae",
+  };
+  const traeWriteback = {
+    version: 1,
+    client: "trae",
+    sessionId: "session-trae-writeback",
+    turnId: traeTurnId("session-trae-writeback", "Trae writeback."),
+    prompt: "Trae writeback.",
+    lastAssistantMessage: "Trae Hook answer.",
+    cwd: "/workspace/trae",
   };
   try {
     for (const [caseName, path, body] of [
@@ -279,6 +329,22 @@ test("Backend memory hook endpoints reject commands outside the closed schema", 
         ...codeBuddyWriteback,
         turnId: `${codeBuddyWriteback.sessionId}:00:${"a".repeat(64)}`,
       }],
+      ["transcript field on Trae turn-start", "/memory/turn-start", {
+        ...traeTurnStart,
+        transcriptPath: "/tmp/trae.jsonl",
+      }],
+      ["cross-session Trae turn id", "/memory/turn-start", {
+        ...traeTurnStart,
+        turnId: traeTurnId("other-session", traeTurnStart.prompt),
+      }],
+      ["prompt-mismatched Trae turn id", "/memory/writeback", {
+        ...traeWriteback,
+        prompt: "Different Trae prompt.",
+      }],
+      ["foreign messages on Trae writeback", "/memory/writeback", {
+        ...traeWriteback,
+        messages: [],
+      }],
     ]) {
       const response = await fetch(`${url}${path}`, {
         method: "POST",
@@ -301,6 +367,10 @@ function codeBuddyTurnId(sessionId, boundary, prompt) {
   return `${sessionId}:${boundary}:${createHash("sha256").update(prompt.trim()).digest("hex")}`;
 }
 
+function traeTurnId(sessionId, prompt, createdAt = 1_700_000_000_000) {
+  return `${sessionId}:${createdAt}:${createHash("sha256").update(prompt.trim()).digest("hex")}`;
+}
+
 test("Backend memory hook endpoints write client-isolated trace events", async () => {
   const { fetchImpl, requests } = memoraxAddFetch();
   const sessionHome = await mkdtemp(join(tmpdir(), "memorax-code-hook-trace-"));
@@ -315,6 +385,7 @@ test("Backend memory hook endpoints write client-isolated trace events", async (
     MEMORAX_CODE_DSH_TRACE_ENABLED: undefined,
     MEMORAX_CODE_CODEBUDDY_TRACE_ENABLED: undefined,
     MEMORAX_CODE_OPENCODE_TRACE_ENABLED: undefined,
+    MEMORAX_CODE_TRAE_TRACE_ENABLED: undefined,
   });
   const originalFetch = globalThis.fetch;
   globalThis.fetch = fetchImpl;
@@ -523,6 +594,27 @@ test("Backend memory hook endpoints write client-isolated trace events", async (
     assert.equal(codeBuddyReminder.status, 200);
     assert.deepEqual(await codeBuddyReminder.json(), { ok: true });
 
+    const traeReminderTurnId = traeTurnId(
+      "session-trace-hook",
+      "MemoraX Code reminder in Trae.",
+    );
+    const traeReminder = await originalFetch(`${url}/memory/skill-reminder`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        version: 1,
+        client: "trae",
+        sessionId: "session-trace-hook",
+        turnId: traeReminderTurnId,
+        cwd: TEST_WORKSPACE,
+        workspaceKind: "project",
+        content: "MemoraX Code reminder: use the memorax-code skill in Trae.",
+        triggers: ["cadence"],
+      }),
+    });
+    assert.equal(traeReminder.status, 200);
+    assert.deepEqual(await traeReminder.json(), { ok: true });
+
     const writeback = await originalFetch(`${url}/memory/writeback`, {
       method: "POST",
       headers: { "content-type": "application/json" },
@@ -627,6 +719,23 @@ test("Backend memory hook endpoints write client-isolated trace events", async (
     assert.deepEqual(codeBuddyEvents[0].response, {
       role: "developer",
       content: "MemoraX Code reminder: use the memorax-code-codebuddy-adapter:memorax-code skill in WorkBuddy.",
+    });
+    const traeEventsPath = clientTracePaths("trae", sessionHome).eventsJsonl("session-trace-hook");
+    await waitForFile(traeEventsPath, /skill_reminder/, "Trae reminder trace event was not written");
+    const traeEvents = (await readFile(traeEventsPath, "utf8")).trim().split("\n").map((line) => JSON.parse(line));
+    assert.equal(traeEvents.length, 1);
+    assert.equal(traeEvents[0].type, "skill_reminder");
+    assert.equal(traeEvents[0].source, "trae-hook");
+    assert.equal(traeEvents[0].operation, "reminder");
+    assert.equal(traeEvents[0].trace.client, "trae");
+    assert.equal(traeEvents[0].trace.session_id, "session-trace-hook");
+    assert.equal(traeEvents[0].trace.turn_id, traeReminderTurnId);
+    assert.equal(traeEvents[0].trace.context_origin, "trae-hook-body");
+    assert.equal(traeEvents[0].trace.transcript_path, undefined);
+    assert.deepEqual(traeEvents[0].request.triggers, ["cadence"]);
+    assert.deepEqual(traeEvents[0].response, {
+      role: "developer",
+      content: "MemoraX Code reminder: use the memorax-code skill in Trae.",
     });
     const turnEnd = events.find((event) => event.type === "turn_end");
     assert.equal(turnEnd.source, "codex-hook");

--- a/scripts/check-local-trace-only.mjs
+++ b/scripts/check-local-trace-only.mjs
@@ -58,6 +58,7 @@ const reviewedNetworkSources = new Set([
   "packages/ts/memorax-code-opencode-adapter/src/plugin.mjs",
   "packages/ts/memorax-code-opencode-adapter/src/repo-memory-server-runner.mjs",
   "packages/ts/memorax-code-backend/src/clients/codebuddy/memory-hook-runtime.ts",
+  "packages/ts/memorax-code-backend/src/clients/trae/memory-hook-runtime.ts",
   "packages/ts/memorax-code-codebuddy-adapter/hooks/runtime-hook.mjs",
 ]);
 


### PR DESCRIPTION
## Change Summary

Add the Backend-side Trae Hook memory runtime so validated `UserPromptSubmit` and `Stop` events can drive repository-scoped retrieval, writeback, trace, and Skill reminders without raw-Session guesses or cross-client fallbacks.

## Implementation Highlights

- Validate Trae Turn IDs against the native Session ID, timestamp, and normalized prompt digest, and accept only the exact correlated Hook pair as Trae's content authority.
- Keep one bounded active Turn per Session so a replacement prompt interrupts the prior Turn even after generic coordinator metadata expires; late completions cannot reactivate or write back interrupted Turns.
- Integrate Trae with repository scope, automatic writeback buffering, optional retrieval, observability, local trace, and Skill reminder handling while keeping automatic Search disabled by default.
- Document the Trae authority and trace boundary. Trae detection, setup lifecycle, Hook/Skill registration, npm packaging, and `[clients].trae` remain intentionally outside this Backend-only PR.

## Validation

- `npm run typecheck --prefix packages/ts/memorax-code-backend`
- `npm run build --prefix packages/ts/memorax-code-backend`
- Backend full test suite: 510 passed, 2 skipped.
- Focused Trae and HTTP contract suite: 12 passed.
- `make docs-check`
- `make test-npm-package`: 255 passed, 2 skipped.
- Local-only trace contract check.
- Clean object-level merge with latest `origin/main` at `a4e6cc0`, followed by typecheck, build, focused tests, documentation checks, and trace checks on the merged tree.

## Full End-to-End Validation Results

- Environment: Standalone PR2 merge-state validation on macOS; real Trae client registration is intentionally absent from this Backend-only split.
- Scenario or matrix: Backend command parsing, Turn correlation, interruption after metadata expiry, restart recovery, repository-scope rejection, writeback idempotency, trace isolation, Skill reminder trace, and HTTP schema rejection.
- Command or workflow: Backend typecheck/build and the automated suites listed under Validation; no Trae adapter was installed from this isolated PR.
- Result: All automated validation passed. A standalone real-client Trae E2E was not applicable to PR2 alone.
- Evidence or artifacts: Redacted test counts and commands are listed above; no private transcript, credential, or machine-specific artifact is attached.
- Reason not run / remaining risk: Real Trae Hook delivery requires the adapter setup and packaging changes reserved for the subsequent PR. The combined Trae implementation was previously exercised on macOS, Docker Linux, and Windows before being split; adapter-to-Backend payload integration will be revalidated when that PR is reviewed.

