### PR TITLE
feat: add managed Trae Hook adapter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,10 +40,13 @@ same change, then run the matching verification profile in Section 5.
 - Hook commands are versioned and client-qualified. Required session, turn, or
   prompt correlation must be validated at the HTTP boundary; incomplete,
   conflicting, unknown, or client-inapplicable identities fail closed.
-- Codex rollout JSONL, Claude Code transcript JSONL, and matching OpenCode SDK
-  session-message records are the only content authorities for their
-  respective automatic writeback. Hook or plugin text, local trace,
-  latest-turn guesses, or another client's format are not fallbacks.
+- Codex rollout JSONL, Claude Code and CodeBuddy/WorkBuddy transcript JSONL,
+  DSH's exact persisted Session Event Log interval, matching OpenCode SDK
+  session-message records, and Trae's validated `UserPromptSubmit`/`Stop` Hook
+  pair are the content authorities for their respective automatic writeback.
+  Hook or plugin text is not a fallback outside Trae's narrow primary-authority
+  exception; local trace, latest-turn guesses, and another client's format are
+  never fallbacks.
 - Session, turn metadata, trace, and operational identity always include the
   client. Equal native IDs from different clients must remain isolated.
 - A live session is pinned to its resolved workspace and repository scope.
@@ -77,8 +80,8 @@ same change, then run the matching verification profile in Section 5.
   trace artifacts, trace-only provenance, and local transcript paths stay
   local.
 - `memorax-code` is the shared user-facing skill. Changes must work in Codex,
-  Claude Code, and OpenCode packaging and must keep triggers, metadata,
-  references, and resource paths valid.
+  Claude Code, DSH, OpenCode, CodeBuddy/WorkBuddy, and Trae packaging and must
+  keep triggers, metadata, references, and resource paths valid.
 - Packaged skills must address product users. Do not include maintainer
   runbooks, private paths, unpublished plans, secrets, internal fixtures, or
   local diagnostic artifacts.
@@ -98,10 +101,16 @@ boundaries:
 - **Codex**: `npm test --prefix packages/ts/memorax-code-codex-adapter`.
 - **Claude Code**:
   `npm test --prefix packages/ts/memorax-code-claude-adapter`.
+- **DeepSeek Harness**:
+  `npm test --prefix packages/ts/memorax-code-dsh-adapter`.
 - **OpenCode**:
   `npm test --prefix packages/ts/memorax-code-opencode-adapter`.
+- **CodeBuddy/WorkBuddy**:
+  `npm test --prefix packages/ts/memorax-code-codebuddy-adapter`.
+- **Trae**:
+  `npm test --prefix packages/ts/memorax-code-trae-adapter`.
 - **Adapter-common/shared Hook**: `adapter-common` has no standalone suite. Run
-  affected Backend tests and all three adapter suites; add
+  affected Backend tests and all six adapter suites; add
   `make npm-package-check` when staged runtime or package layout changes.
 - **Trace/local-only boundary**: for trace, provider, or outbound transport,
   run `make test-npm-package` in addition to affected package tests.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -25,14 +25,14 @@ authoritative.
 ## 2. System Shape and Package Ownership
 
 MemoraX Code integrates Codex, Claude Code, DeepSeek Harness (DSH), OpenCode,
-and CodeBuddy/WorkBuddy with one local Backend. The Backend is a capability-oriented modular
-monolith. The clients retain ownership of models, model-provider credentials,
-native tools, model-provider traffic, and native transcript or message
-creation.
+CodeBuddy/WorkBuddy, and Trae with one local Backend. The Backend is a
+capability-oriented modular monolith. The clients retain ownership of models,
+model-provider credentials, native tools, model-provider traffic, and native
+transcript, message, or Hook-event creation.
 
 Around the Backend are:
 
-- five client deployment adapters;
+- six client deployment adapters;
 - one lower-level shared runtime source layer;
 - one npm assembly and installed-CLI layer; and
 - repository automation that builds, validates, stages, and tests artifacts.
@@ -45,6 +45,7 @@ flowchart LR
     DSH["DeepSeek Harness"]
     OpenCode["OpenCode"]
     CodeBuddy["CodeBuddy / WorkBuddy"]
+    Trae["Trae"]
   end
 
   subgraph Adapters["Client integrations"]
@@ -53,6 +54,7 @@ flowchart LR
     DshAdapter["DSH adapter<br/>Cordis Turn bridge, Profile lifecycle"]
     OpenCodeAdapter["OpenCode adapter<br/>plugin, installer, skill artifact"]
     CodeBuddyAdapter["CodeBuddy adapter<br/>Hooks, transcript bridge, skill"]
+    TraeAdapter["Trae adapter<br/>Global Hooks, skill"]
   end
 
   Common["adapter-common<br/>records, locks, Hook and Repo Memory helpers"]
@@ -71,6 +73,7 @@ flowchart LR
   DshAdapter -. "artifact source" .-> Build
   OpenCodeAdapter -. "artifact source" .-> Build
   CodeBuddyAdapter -. "artifact source" .-> Build
+  TraeAdapter -. "artifact source" .-> Build
   Build -->|"assembles"| Artifact
   Artifact -->|"launches"| Backend
   Artifact -->|"trial provision"| MemoraX
@@ -80,17 +83,21 @@ flowchart LR
   ClaudeAdapter --> Common
   DshAdapter --> Common
   OpenCodeAdapter --> Common
+  CodeBuddyAdapter --> Common
+  TraeAdapter --> Common
 
   Codex --> CodexAdapter
   Claude --> ClaudeAdapter
   DSH --> DshAdapter
   OpenCode --> OpenCodeAdapter
   CodeBuddy --> CodeBuddyAdapter
+  Trae --> TraeAdapter
   CodexAdapter -. "versioned local Hook HTTP" .-> Backend
   ClaudeAdapter -. "versioned local Hook HTTP" .-> Backend
   DshAdapter -. "versioned local plugin HTTP" .-> Backend
   OpenCodeAdapter -. "versioned local plugin HTTP" .-> Backend
   CodeBuddyAdapter -. "versioned local Hook HTTP" .-> Backend
+  TraeAdapter -. "versioned local Hook HTTP" .-> Backend
 
   Backend --> MemoraX
   Backend --> Local
@@ -110,18 +117,19 @@ relationships; the arrow labels distinguish them. It is not an import graph.
 | `packages/ts/memorax-code-dsh-adapter` | DSH Cordis Turn listener, personal-context composition, shared-skill and supervised Repo Memory integration, exact persisted-event interval validation, local Backend wire protocol, Profile lifecycle, per-user runtime-bundle materialization, and durable runtime authority | Backend-side event interpretation, MemoraX request execution, or DSH provider and session ownership | `src/plugin.mjs`, `src/profile-lifecycle.mjs`, `hooks/repo-memory-job.mjs`, and the adapter tests |
 | `packages/ts/memorax-code-opencode-adapter` | OpenCode plugin runtime, managed thin-loader installation, automatic retrieval, SDK-backed writeback, shell-session identity, workspace runtime evidence and diagnostics, a materialized shared skill, and supervised Repo Memory maintenance and missing-bundle initialization | OpenCode message interpretation inside the Backend or model-provider configuration | `src/plugin.mjs`, `src/plugin-install.mjs`, `src/cli.mjs`, `src/repo-memory-server-runner.mjs`, and the OpenCode materialization mapping in `scripts/npm-source-files.mjs` |
 | `packages/ts/memorax-code-codebuddy-adapter` | CodeBuddy/WorkBuddy plugin manifest, SessionStart/UserPromptSubmit/Stop Hooks, native JSONL transcript bridge, memory retrieval/writeback, trace/reconciliation, Skill materialization, and supervised Repo Memory maintenance | CodeBuddy transcript interpretation inside the Backend or model-provider configuration | `.codebuddy-plugin`, `hooks`, `src`, and `skills/memorax-code` |
+| `packages/ts/memorax-code-trae-adapter` | Trae application discovery, marker-owned SessionStart/UserPromptSubmit/Stop Hook merging, content-addressed runtime generation, shared-Skill materialization, runtime observation, and lifecycle diagnostics | Trae provider settings, application-level Global Hooks activation, or a guessed native Session | `hooks/runtime-hook.mjs`, `src/config.mjs`, `src/adapter-paths.mjs`, and the adapter tests |
 | `packages/npm/memorax-code` | Installed executable wrappers, foreground and automatic update reconciliation, trial identity and credential provisioning, package-transition handling, update, npm lifecycle scripts, manifest, and release-package source | Backend lifecycle semantics, uninstall orchestration, or artifact staging | `bin`, `lib/automatic-update.mjs`, `lib/setup-reconcile.mjs`, `lib/package-transition.mjs`, `lib/trial-setup.mjs`, `lib/run-entrypoint.mjs`, and `package.json` |
 | `scripts` | Backend build orchestration, staging/materialization, package layout, documentation, and local-only data gates | Product runtime authority | Package-build/check scripts and executable contract scripts |
 | `.github` | Issue and pull-request contribution templates | Product runtime behavior | `.github/ISSUE_TEMPLATE` and `.github/pull_request_template.md` |
 
 `memorax-code-adapter-common` is a source layer consumed by the Backend and all
-five adapters; it is not an independently deployed service. The npm artifact
+six adapters; it is not an independently deployed service. The npm artifact
 assembles all runtime trees, but package assembly does not make the npm wrapper
 the owner of their behavior.
 
 ### 2.2 Physical dependency directions
 
-- The Backend and the Codex, Claude Code, DSH, OpenCode, and CodeBuddy deployment adapters
+- The Backend and the Codex, Claude Code, DSH, OpenCode, CodeBuddy, and Trae deployment adapters
   may import adapter-common. Adapter-common must not import those higher-level
   components back.
 - Adapter Hook and plugin runtimes do not import Backend implementation. They
@@ -132,8 +140,8 @@ the owner of their behavior.
 - The npm layer locates staged entrypoints. `scripts` owns how source is
   materialized into that staged layout.
 - The canonical user-facing `memorax-code` skill lives in the Codex adapter.
-  Packaging materializes the Claude Code, DSH, and OpenCode artifacts from that
-  source; do not maintain independent skill copies.
+  Packaging materializes the Claude Code, DSH, OpenCode, CodeBuddy, and Trae
+  artifacts from that source; do not maintain independent skill copies.
 
 Client integration is deliberately not physically symmetric. Codex plugin
 material belongs to the Codex adapter, while current install, activation, and
@@ -141,9 +149,12 @@ Hook-trust glue lives in Backend `clients/codex`. The Claude Code installer
 lives in the Claude adapter. The DSH adapter owns Profile discovery and
 mutation plus per-user runtime generation materialization. The OpenCode adapter
 installs an auto-discovered thin loader and shared skill without editing
-OpenCode provider configuration. These implementations are loaded by their
-Backend lifecycle participants. Preserve the participant contract and each
-client's actual authority instead of forcing matching directory shapes.
+OpenCode provider configuration. The CodeBuddy adapter owns its marketplace
+plugin, while the Trae adapter merges only marker-owned Global Hooks and
+materializes the shared Skill without changing provider settings. These
+implementations are loaded by their Backend lifecycle participants. Preserve
+the participant contract and each client's actual authority instead of forcing
+matching directory shapes.
 
 ## 3. Runtime Flows
 
@@ -247,7 +258,9 @@ The principal control-plane locations are:
   disablement, and removal. OpenCode's participant delegates plugin and skill
   materialization to `memorax-code-opencode-adapter/src/plugin-install.mjs`;
   DSH's participant delegates Profile and runtime-bundle lifecycle to
-  `memorax-code-dsh-adapter/src/profile-lifecycle.mjs`.
+  `memorax-code-dsh-adapter/src/profile-lifecycle.mjs`; and Trae's participant
+  delegates Hook merging, runtime generation, and Skill materialization to
+  `memorax-code-trae-adapter/src/config.mjs`.
 
 Staging and activation are separate decisions. A failed Backend start must not
 replace the currently authoritative Hook generation. Cross-process lifecycle
@@ -300,6 +313,16 @@ OpenCode doctor combines managed-artifact status, that local evidence, and a
 live Backend health check. This evidence proves only that the plugin executed
 in a workspace; it is not session, transcript, repository-scope, or lifecycle
 authority.
+
+Trae lifecycle discovery accepts an explicit data home, an existing default
+data home, or a platform application installation. Its adapter materializes a
+content-addressed runtime under `$MEMORAX_CODE_HOME/adapters/trae`, merges one
+marker-owned command into each required event in Trae's `hooks.json`, and
+installs the canonical Skill under the Trae data home. Existing user Hooks are
+preserved, and an unmanaged Skill at the target path fails closed. Trae owns
+the application-level Global Hooks switch; setup reports the required one-time
+manual activation until the runtime records a real Hook observation. Stop and
+uninstall remove only marker-owned Hook entries and the managed Skill.
 
 Foreground setup in the npm layer derives the versioned trial device identity,
 calls the MemoraX trial-provision endpoint, and commits the returned API key and
@@ -477,32 +500,37 @@ sequenceDiagram
 ### 3.5 Repo Memory coordination
 
 Repo Memory is repository-local guidance under `.repo_memory`, not a MemoraX
-provider response. In all five clients, an accepted turn-start result exposes
-a worktree to the maintenance-aware adapter integration only for a verified
-Git scope. Codex and Claude Code Hooks, DSH's native pre-step integration, and OpenCode's awaited
-`chat.message` handler may schedule a missing bundle build using adapter-common
-supervision, locking, and job-policy helpers. They must use the Backend-resolved
-worktree rather than adapter-local workspace input.
+provider response. In all six clients, an accepted turn-start result exposes a
+worktree to the adapter integration only for a verified Git scope. Codex,
+Claude Code, and CodeBuddy/WorkBuddy Hooks, DSH's native pre-step integration,
+and OpenCode's awaited `chat.message` handler may schedule a missing bundle
+build using adapter-common supervision, locking, and job-policy helpers. They
+must use the Backend-resolved worktree rather than adapter-local workspace
+input. Trae consumes existing Repo Memory context and exposes the shared Skill,
+but does not schedule background work because no supported headless Trae worker
+exists.
 
-Codex and OpenCode keep the generic shared Skill reminder available when the
-Backend or repository scope is unavailable. Codex, DSH, and OpenCode enable
-their User Profile and Procedure Memory builders only when the current
+Codex, OpenCode, and Trae keep the generic shared Skill reminder available when
+the Backend or repository scope is unavailable. Codex, DSH, OpenCode, and Trae
+enable their User Profile and Procedure Memory builders only when the current
 turn-start result includes a Backend-resolved worktree, and those builders read
 that worktree. The original client workspace remains metadata when an accepted
 turn's reminder is traced; it is not repository-local content authority.
 
-A relevant repo-read can invoke supervised maintenance in all five clients.
-The runner validates the bundle and selects a background build, update, or
-no-op according to policy. DSH maintenance runs through an enabled, managed
-headless-capable Profile. For OpenCode, both on-demand maintenance and
-first-eligible-prompt initialization run through a short-lived subagent session.
+A relevant repo-read can invoke supervised maintenance in the five
+headless-capable client integrations. The runner validates the bundle and
+selects a background build, update, or no-op according to policy. DSH
+maintenance runs through an enabled, managed headless-capable Profile. For
+OpenCode, both on-demand maintenance and first-eligible-prompt initialization
+run through a short-lived subagent session.
 The detached worker reuses the active OpenCode server when it is reachable.
 Because standalone `opencode run` exposes only process-local server authority,
 the worker owns an authenticated, loopback-only `opencode serve` process with
 a process-local database when session creation cannot reach that authority,
 and closes it afterward.
 Desktop-only installations with a reachable server do not require a standalone
-OpenCode CLI.
+OpenCode CLI. Trae remains outside this supervised path until it exposes a
+suitable headless execution authority.
 
 ## 4. Backend Modular Monolith
 
@@ -529,7 +557,7 @@ src/
     dsh/                  DSH native event-interval interpretation
     opencode/             OpenCode retrieval, SDK message interpretation, and lifecycle participant
     codebuddy/            CodeBuddy native JSONL interpretation and lifecycle participant
-    trae/                 Trae Hook-content interpretation
+    trae/                 Trae Hook-content interpretation and lifecycle participant
   config/                 Backend and proxy/config interpretation
   entrypoints/            process and management-CLI orchestration
   lifecycle/
@@ -560,7 +588,8 @@ entrypoints and compatibility facades. It is not another implementation area.
 | `src/clients/claude` | Claude transcript/turn interpretation, Hook memory runtime, and lifecycle participant | No Codex format fallback; request runtime remains HTTP-composition independent |
 | `src/clients/dsh` | DSH Session header and exact persisted event-interval interpretation, request-time memory and normalized trace runtime, and lifecycle-participant delegation | No Hook-text, rollout, transcript, SDK-message, or latest-Turn fallback; Profile mutation stays in the DSH adapter, and request runtime remains HTTP-composition independent |
 | `src/clients/opencode` | OpenCode SDK message validation and text materialization, plugin memory runtime, and lifecycle participant | No Hook-text, database, rollout, or transcript fallback; request runtime remains HTTP-composition independent |
-| `src/clients/trae` | Trae Turn-ID validation, Hook-pair memory runtime, interruption handling, and trace normalization | Hook content is authoritative only for the exact validated Trae Turn; no raw-Session guess, pending queue, or cross-client fallback |
+| `src/clients/codebuddy` | CodeBuddy/WorkBuddy native transcript interpretation, Hook memory runtime, and lifecycle participant | No Hook-payload or latest-Turn fallback; plugin mutation stays in the adapter, and request runtime remains HTTP-composition independent |
+| `src/clients/trae` | Trae Turn-ID validation, Hook-pair memory runtime, interruption handling, trace normalization, and lifecycle participant | Hook content is authoritative only for the exact validated Trae Turn; no raw-Session guess, pending queue, or cross-client fallback |
 | `src/memory` | Memory commands, retrieval, writeback, turn coordination, repository session pinning, manual CLI, and buffering/chunking | Client-neutral modules do not parse native transcript formats |
 | `src/repository` | Read-only repository identity | Scope derivation does not execute Git or use synchronous filesystem reads |
 | `src/provider/memorax` | MemoraX config interpretation, Search/Add payloads, HTTP transport, and normalized results | Independent from server routing and plugin lifecycle |
@@ -739,6 +768,7 @@ flowchart TD
   DshSource["DSH adapter"]
   OpenCodeSource["OpenCode adapter"]
   CodeBuddySource["CodeBuddy adapter"]
+  TraeSource["Trae adapter"]
   Stage["npm staging tree"]
   Materialize["skill and marketplace materialization"]
   Gates["layout, source, symlink, and local-only gates"]
@@ -754,6 +784,7 @@ flowchart TD
   DshSource --> Stage
   OpenCodeSource --> Stage
   CodeBuddySource --> Stage
+  TraeSource --> Stage
   Stage --> Materialize
   Materialize --> Gates
   Gates --> Pack
@@ -768,9 +799,10 @@ flowchart TD
   content-addressed generation under `$MEMORAX_CODE_HOME/adapters/dsh/runtime`
   and installs the generation into managed Profiles; the Profile artifact
   excludes lifecycle control-plane source.
-- The Claude Code skill and marketplace and the OpenCode skill artifact are
-  materialized from canonical sources; packaging may rewrite contained
-  relative imports for the staged topology.
+- The Claude Code skill and marketplace and the DSH, OpenCode,
+  CodeBuddy/WorkBuddy, and Trae skill artifacts are materialized from canonical
+  sources; packaging may rewrite contained relative imports for the staged
+  topology.
 - OpenCode lifecycle installation writes only a managed thin loader and the
   materialized skill into the client's auto-discovery directories. It does not
   edit `opencode.json` or `opencode.jsonc`. Desktop discovery does not require
@@ -781,8 +813,8 @@ flowchart TD
 - Artifact gates reject undeclared paths, unsafe symlinks, cache/build debris,
   and local-only data-boundary violations.
 - Installed-package tests isolate `MEMORAX_CODE_HOME`, `CODEX_HOME`,
-  `CLAUDE_CONFIG_DIR`, `DSH_HOME`, and `OPENCODE_CONFIG_DIR` so lifecycle and
-  client integration checks do not reuse developer state.
+  `CLAUDE_CONFIG_DIR`, `DSH_HOME`, `OPENCODE_CONFIG_DIR`, and `TRAE_CN_HOME` so
+  lifecycle and client integration checks do not reuse developer state.
 
 Root architecture and contributor guidance are repository documents, while
 `shipped-docs.json` remains the authority for user documentation included in
@@ -818,10 +850,10 @@ Placement rules:
 - Backend behavior tests build and exercise `dist`; architecture tests inspect
   `src` directly.
 - The Backend suite discovers nested tests recursively. Codex, Claude Code,
-  DSH, and OpenCode adapter suites currently discover only flat
+  DSH, OpenCode, CodeBuddy/WorkBuddy, and Trae adapter suites currently discover only flat
   `test/*.test.mjs`; their package scripts must change before tests are nested.
 - Adapter-common has no standalone suite. Its changes are verified through all
-  affected consumers: Backend, all five adapters, and package checks when
+  affected consumers: Backend, all six adapters, and package checks when
   staged runtime layout is involved.
 - Before moving, splitting, or renaming tests, search `scripts` and `.github`
   for explicit paths and test-name patterns.
@@ -837,8 +869,8 @@ uses those named profiles rather than copying commands here.
 | Hook HTTP or adapter-visible command schema | `test/transport/http` and affected adapter suites | Backend source boundaries and package shape when staged | Backend + Adapter-common/shared Hook; add Install/artifacts when staged package shape changes |
 | Backend root entrypoint or compatibility facade | Entrypoint, architecture, and npm package tests | Source boundaries and package shape | Backend + Install/artifacts |
 | Client-native parsing or identity | `test/clients/<client>` | Source boundaries | Backend |
-| Client adapter plugin or Hook deployment | Matching adapter suite and affected Backend contract tests | Package shape when staged | Codex, Claude Code, DSH, OpenCode, or CodeBuddy/WorkBuddy; add Adapter-common/shared Hook for shared Hook source and Install/artifacts for staged package shape |
-| Adapter-common | Affected Backend tests and all five adapter suites | Package shape when staged layout changes | Adapter-common/shared Hook; add Install/artifacts when staged runtime or package layout changes |
+| Client adapter plugin or Hook deployment | Matching adapter suite and affected Backend contract tests | Package shape when staged | Codex, Claude Code, DSH, OpenCode, CodeBuddy/WorkBuddy, or Trae; add Adapter-common/shared Hook for shared Hook source and Install/artifacts for staged package shape |
+| Adapter-common | Affected Backend tests and all six adapter suites | Package shape when staged layout changes | Adapter-common/shared Hook; add Install/artifacts when staged runtime or package layout changes |
 | MemoraX provider, trace, or outbound transport | Matching Backend tests | Local-only trace boundary | Backend + Trace/local-only boundary |
 | Test relocation | Moved owning suite | Platform-specific consumers | Matching named profile |
 | Packaging/materialization | npm package tests and artifact gates | Package shape and local-only trace boundary | Install/artifacts |

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-ts test-codex-adapter test-claude-adapter test-dsh-adapter test-dsh-e2e test-opencode-adapter test-opencode-e2e test-codebuddy-adapter test-npm-package docs-check npm-package-build npm-package-check npm-publish-dry-run release-version-check clean
+.PHONY: test test-ts test-codex-adapter test-claude-adapter test-dsh-adapter test-dsh-e2e test-opencode-adapter test-opencode-e2e test-codebuddy-adapter test-trae-adapter test-npm-package docs-check npm-package-build npm-package-check npm-publish-dry-run release-version-check clean
 
 NPM ?= npm
 
@@ -13,6 +13,7 @@ test-ts:
 	$(MAKE) test-dsh-adapter
 	$(MAKE) test-opencode-adapter
 	$(MAKE) test-codebuddy-adapter
+	$(MAKE) test-trae-adapter
 
 test-codex-adapter:
 	$(NPM) test --prefix packages/ts/memorax-code-codex-adapter
@@ -31,6 +32,9 @@ test-opencode-adapter:
 
 test-codebuddy-adapter:
 	$(NPM) test --prefix packages/ts/memorax-code-codebuddy-adapter
+
+test-trae-adapter:
+	$(NPM) test --prefix packages/ts/memorax-code-trae-adapter
 
 test-opencode-e2e:
 	$(NPM) ci --prefix packages/ts/memorax-code-backend

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ Coding agents are good at the task in front of them, but a new session often
 starts without the architecture, failed attempts, repository rules, or working
 preferences established before it.
 
-MemoraX Code gives Codex, Claude Code, WorkBuddy, DeepSeek Harness, and OpenCode a shared
-memory layer for that context.
+MemoraX Code gives Codex, Claude Code, WorkBuddy, DeepSeek Harness,
+OpenCode, and Trae a shared memory layer for that context.
 It can recall prior engineering knowledge, capture reusable lessons from
 completed work, maintain repository knowledge, and carry your procedures and
 preferences into future sessions.
@@ -53,7 +53,7 @@ and validation sooner.
 ## Quick Start
 
 Prepare Node.js 20+ (Node.js 24 LTS recommended) and at least one of Codex,
-Claude Code, WorkBuddy, DeepSeek Harness, or OpenCode. Python 3 is
+Claude Code, WorkBuddy, DeepSeek Harness, OpenCode, or Trae. Python 3 is
 required for Repo Memory operations. Each coding-agent harness retains its own
 runtime requirements; current DeepSeek Harness releases require Node.js
 `^22.19.0 || >=24.0.0`. DSH may be installed globally or initialized
@@ -104,6 +104,10 @@ registered.
 
 Both setup paths automatically detect supported coding agents. Restart or
 refresh every detected coding agent after setup.
+
+For Trae, setup installs the managed Skill and Global Hooks, but Trae does not
+expose a reliable programmatic switch for Global Hooks. Open Trae Settings,
+enable **Global Hooks** once, then start a new Trae session.
 
 ### Installation Troubleshooting
 
@@ -175,7 +179,7 @@ See [Configuration](docs/configuration.md) for supported settings and
 ### Try Cross-Session Memory
 
 Clone the example repository from the product website, then open Codex, Claude
-Code, WorkBuddy, DeepSeek Harness, or OpenCode in the project directory:
+Code, WorkBuddy, DeepSeek Harness, OpenCode, or Trae in the project directory:
 
 ```bash
 git clone https://github.com/SWE-agent/test-repo.git
@@ -183,9 +187,9 @@ cd test-repo
 ```
 
 Invoke the Skill as `$memorax-code` in Codex or `/memorax-code` in Claude Code
-or DeepSeek Harness. In OpenCode or WorkBuddy, ask the agent to use
-the `memorax-code` skill by name. The prompts below use its product name and
-work in all supported clients.
+or DeepSeek Harness. In OpenCode, WorkBuddy, or Trae, ask the agent
+to use the `memorax-code` skill by name. The prompts below use its product name
+and work in all supported clients.
 
 Send these prompts in order in the same session:
 
@@ -237,9 +241,9 @@ writing when the durable intent or target is unclear.
 | **Background memory writeback** | Extracts reusable knowledge from completed turns and writes it to Coding Memory in the background. |
 | **Preference continuity** | Records User Profile preferences and injects them into future tasks on a configured cadence. |
 | **Procedure reuse** | Records reusable task procedures and reminds future agents to apply them. |
-| **Background Repo Memory maintenance** | Automatically organizes repository structure, entry points, and history evidence in the background, then updates them according to policy to reduce repeated searching and summarization. |
+| **Background Repo Memory maintenance** | Automatically organizes repository structure, entry points, and history evidence in supported headless-capable clients, then updates them according to policy to reduce repeated searching and summarization. Trae can use the Skill for Repo Memory, but does not currently expose a headless worker for automatic maintenance. |
 | **Active memory control** | Lets you search and add memory through the bundled MemoraX Code skill or the CLI. |
-| **Client integration** | Integrates with Codex, Claude Code, WorkBuddy, DeepSeek Harness, and OpenCode to trigger memory retrieval, reminders, and writeback. Automatic quota reminders are currently available in Codex, Claude Code, WorkBuddy, and OpenCode. |
+| **Client integration** | Integrates with Codex, Claude Code, WorkBuddy, DeepSeek Harness, OpenCode, and Trae to trigger memory retrieval, reminders, and writeback. Automatic quota reminders are currently available in Codex, Claude Code, WorkBuddy, OpenCode, and Trae. |
 | **Local observability** | Uses content-controlled local trace and reconciliation records to inspect activity counts, retrieval, and writeback status. |
 
 ## Your Memory, Your Control

--- a/README.zh.md
+++ b/README.zh.md
@@ -39,7 +39,8 @@
 Coding Agent 擅长解决眼前的问题，但新会话不会自动继承此前积累的架构认知、踩坑经验、仓库规则
 和协作偏好。
 
-MemoraX Code 让 Codex、Claude Code、WorkBuddy、DeepSeek Harness 和 OpenCode 共享一套能够持续积累的记忆。
+MemoraX Code 让 Codex、Claude Code、WorkBuddy、DeepSeek Harness、OpenCode 和 Trae
+共享一套能够持续积累的记忆。
 它会沉淀代码任务中的工程经验，持续整理仓库知识，并在后续任务中找回相关的工作流程和偏好。
 
 它追求的不是“记得更多”，而是在需要时带回与当前任务相关的 Memory，让 Agent 减少重复搜索和试错，
@@ -48,7 +49,7 @@ MemoraX Code 让 Codex、Claude Code、WorkBuddy、DeepSeek Harness 和 OpenCode
 ## 快速开始
 
 开始前，请确保已安装 Node.js 20 或更高版本（推荐 Node.js 24 LTS），以及 Codex、Claude Code、
-WorkBuddy、DeepSeek Harness 或 OpenCode 中的至少一个。Repo Memory 操作还需要 Python 3。
+WorkBuddy、DeepSeek Harness、OpenCode 或 Trae 中的至少一个。Repo Memory 操作还需要 Python 3。
 各 Coding Agent Harness 仍需满足自身的运行时要求；当前 DeepSeek Harness 版本要求 Node.js
 `^22.19.0 || >=24.0.0`。DSH 可全局安装，也可事先通过其官方 `npx` 流程完成初始化。
 
@@ -91,6 +92,9 @@ memorax-code account --show-mark-id
 获取 Mark ID 后，再前往 MemoraX 注册。当前暂不支持为已经注册的账号补绑 Mark ID。
 
 两种安装引导都会自动检测受支持的 Coding Agent。完成后，请重启或刷新检测到的 Coding Agent。
+
+对于 Trae，setup 会安装受管 Skill 和 Global Hooks，但 Trae 没有提供可靠的程序化开关。
+请在 Trae 设置中手动开启一次 **Global Hooks**，然后新建 Trae 会话。
 
 ### 安装故障排查
 
@@ -156,7 +160,7 @@ setup 或上述兜底命令修改持久化 `PATH` 后，请打开一个新终端
 
 ### 体验跨会话记忆
 
-克隆示例仓库，并在项目目录中打开 Codex、Claude Code、WorkBuddy、DeepSeek Harness 或 OpenCode：
+克隆示例仓库，并在项目目录中打开 Codex、Claude Code、WorkBuddy、DeepSeek Harness、OpenCode 或 Trae：
 
 ```bash
 git clone https://github.com/SWE-agent/test-repo.git
@@ -164,7 +168,7 @@ cd test-repo
 ```
 
 在 Codex 中使用 `$memorax-code`，在 Claude Code 或 DeepSeek Harness 中使用 `/memorax-code`
-调用该 Skill。在 OpenCode 或 WorkBuddy 中，直接让 Agent 使用名为 `memorax-code` 的 Skill。
+调用该 Skill。在 OpenCode、WorkBuddy 或 Trae 中，直接让 Agent 使用名为 `memorax-code` 的 Skill。
 下面的指令使用产品名称，所有客户端均可直接理解。
 
 在同一个会话中依次发送以下指令：
@@ -207,9 +211,9 @@ MemoraX Code 会先比较含义：语义相同的请求不重复写入；长期�
 | **后台写入记忆** | 任务完成后，在后台提取可复用知识并写入 Coding Memory。 |
 | **用户偏好延续** | 在 User Profile 中记录用户偏好，并按设定周期将其带入后续任务。 |
 | **Procedure 自动复用** | 记录可复用的任务流程，并在后续任务中自动提醒 Agent 按流程执行。 |
-| **Repo Memory 后台整理** | 在后台整理仓库结构、代码入口和历史证据，并按策略自动更新，避免反复搜索和总结。 |
+| **Repo Memory 后台整理** | 在支持无头任务的客户端中后台整理仓库结构、代码入口和历史证据，并按策略自动更新，避免反复搜索和总结。Trae 可通过 Skill 使用 Repo Memory，但目前没有可供自动维护使用的无头 worker。 |
 | **主动记忆控制** | 使用内置的 MemoraX Code Skill 或 CLI，主动查找和添加记忆。 |
-| **客户端集成** | 与 Codex、Claude Code、WorkBuddy、DeepSeek Harness 和 OpenCode 集成，触发记忆检索、提醒和写入。目前 Codex、Claude Code、WorkBuddy 和 OpenCode 支持自动额度提醒。 |
+| **客户端集成** | 与 Codex、Claude Code、WorkBuddy、DeepSeek Harness、OpenCode 和 Trae 集成，触发记忆检索、提醒和写入。目前 Codex、Claude Code、WorkBuddy、OpenCode 和 Trae 支持自动额度提醒。 |
 | **本地可观测性** | 通过受内容控制的本地 trace 和 reconciliation 记录查看活动统计、召回与写入状态。 |
 
 ## 你的记忆，由你控制
@@ -255,7 +259,7 @@ Hook 的精确哈希，然后静默信任这些 Hook。身份变化或 Hook 校�
 `MEMORAX_CODE_AUTO_UPDATE=false`。客户端启动 Hook 只负责确保 Backend 可用，不负责更新
 节奏。上面的手动更新命令仍然可用，会沿用当前发布通道并保留配置。如果新版本修改了运行中
 客户端已经加载的集成资产，请重启或刷新 Codex、Claude Code、WorkBuddy、
-DeepSeek Harness 或 OpenCode。
+DeepSeek Harness、OpenCode 或 Trae。
 
 Windows 上，托管的 WorkBuddy 插件默认安装到 `%USERPROFILE%\.workbuddy`；
 `WORKBUDDY_HOME` 可显式覆盖默认目录。在 WorkBuddy 至少成功执行一次

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,8 +1,8 @@
 # Security Policy
 
-MemoraX Code is a local-first integration for Codex, Claude Code, CodeBuddy/WorkBuddy,
-DeepSeek Harness (DSH), and OpenCode with an optional external bind mode and required
-communication with MemoraX for cloud-backed memory. Security reports should
+MemoraX Code is a local-first integration for Codex, Claude Code,
+CodeBuddy/WorkBuddy, DeepSeek Harness (DSH), OpenCode, and Trae with an optional
+external bind mode and required communication with MemoraX for cloud-backed memory. Security reports should
 distinguish the local Backend, client-owned provider traffic, and MemoraX
 memory traffic.
 
@@ -29,7 +29,7 @@ Please allow time for triage and remediation before public disclosure.
 
 ### Client and local Backend
 
-- Codex, Claude Code, CodeBuddy/WorkBuddy, DeepSeek Harness, and OpenCode own provider credentials,
+- Codex, Claude Code, CodeBuddy/WorkBuddy, DeepSeek Harness, OpenCode, and Trae own provider credentials,
   models, native tools, and provider traffic. MemoraX Code does not proxy
   model-provider traffic and does not need client provider credentials.
 - The managed Backend binds to loopback by default. External binding requires
@@ -80,12 +80,17 @@ Please allow time for triage and remediation before public disclosure.
   retrieval, trace, or writeback. Repo Memory jobs run a bounded headless
   CodeBuddy process with `--dangerously-skip-permissions`; use this only for a
   Backend-authorized Git worktree and never for untrusted source.
+- The managed Trae adapter merges only marker-owned `SessionStart`,
+  `UserPromptSubmit`, and `Stop` entries into Trae's `hooks.json`, refuses to
+  replace an unmanaged `memorax-code` Skill, and removes only managed assets.
+  Trae owns the application-level Global Hooks switch; MemoraX Code cannot
+  enable it reliably and requires the user to do so once in Trae Settings.
 - Trae exposes no stable raw Session authority. For Trae only, the validated
   prompt supplied by `UserPromptSubmit` and final assistant message supplied by
   the matching `Stop` Hook are the automatic-writeback content authority. They
-  are bound to one active Turn with a prompt-derived Turn ID; a new prompt
-  interrupts the old Turn, and late or mismatched completion events do not
-  write back. Hook fields are not a fallback for any other client.
+  are bound to one active Turn with a prompt-derived Turn ID; a new
+  prompt interrupts the old Turn, and late or mismatched completion events do
+  not write back. Hook fields are not a fallback for any other client.
 - Initial Repo Memory builds use only the Git worktree returned by an
   authenticated Backend turn-start request. Backend or workspace-scope
   failures skip the build; client integrations do not fall back to

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,13 +39,13 @@ are not a compatibility contract.
 
 ## New configuration
 
-The generated template selects the existing client integrations, including the optional CodeBuddy/WorkBuddy adapter, disables automatic
-retrieval, enables automatic writeback, sets the preferred language to Chinese
-(`zh`), uses a five-turn skill reminder and the adaptive repository-update
-policy, and enables content-bearing local traces for Codex, Claude Code,
-CodeBuddy/WorkBuddy, and OpenCode. Foreground setup may narrow `[clients]` to
-clients detected on the host. The tables below list all fallbacks, including
-tuning fields omitted from the generated file.
+The generated template selects the existing client integrations, including the
+optional CodeBuddy/WorkBuddy and Trae adapters, disables automatic retrieval,
+enables automatic writeback, sets the preferred language to Chinese (`zh`),
+uses a five-turn skill reminder and the adaptive repository-update policy, and
+enables content-bearing local traces for every supported client. Foreground
+setup may narrow `[clients]` to clients detected on the host. The tables below
+list all fallbacks, including tuning fields omitted from the generated file.
 
 On POSIX systems MemoraX Code creates `$MEMORAX_CODE_HOME` with mode `0700`
 and a new `config.toml` with mode `0600`. Windows relies on the current user's
@@ -54,15 +54,16 @@ filesystem ACLs.
 ## Client selection
 
 If `[clients]` is absent, lifecycle commands select Codex, Claude Code, DSH,
-and OpenCode; CodeBuddy is opt-in unless detected during installation. If it is present, `codex`, `claude`, `dsh`, `opencode`, and `codebuddy` are
-boolean fields. Omitted `codex`, `claude`, or `opencode` values are disabled;
-an omitted `dsh` value remains enabled so configurations written before DSH
-support can discover an existing local Harness. Set `dsh = false` explicitly
-to disable that integration. The command-line override accepts a
-comma-separated subset:
+and OpenCode; CodeBuddy/WorkBuddy and Trae are opt-in unless detected during
+foreground setup. If the table is present, `codex`, `claude`, `dsh`,
+`opencode`, `codebuddy`, and `trae` are boolean fields. Omitted `codex`,
+`claude`, `opencode`, `codebuddy`, or `trae` values are disabled; an omitted
+`dsh` value remains enabled so configurations written before DSH support can
+discover an existing local Harness. Set `dsh = false` explicitly to disable
+that integration. The command-line override accepts a comma-separated subset:
 
 ```text
---clients codex|claude|dsh|opencode|codebuddy|<comma-separated subset>|all|none
+--clients codex|claude|dsh|opencode|codebuddy|trae|<comma-separated subset>|all|none
 ```
 
 Foreground `memorax-code setup` refreshes `[clients]` from the clients
@@ -70,7 +71,9 @@ available at that time. OpenCode is available when its explicit, XDG, or
 default configuration directory exists, or when `opencode` is on `PATH`.
 DSH is available when at least one valid Profile exists under
 `$DSH_HOME/profiles`; `DSH_HOME` defaults to `~/.dsh`. An explicit
-`[clients].dsh = false` is preserved.
+`[clients].dsh = false` is preserved. Trae is available when its data home or
+application is detected. `TRAE_CN_HOME`, then `TRAE_HOME`, overrides its
+default `~/.trae-cn` data home.
 
 On later setup runs, enabled client intent is preserved. Each newly available
 disabled client is offered for activation with a default of yes; declining
@@ -81,7 +84,7 @@ Automatic update reconciliation also preserves the exact persisted selection;
 it does not offer or enable a newly detected client.
 
 Client selection controls managed client-integration lifecycle only. It does
-not change Codex, Claude Code, DSH, or OpenCode provider settings.
+not change any coding agent's provider settings.
 `--clients none` runs the Backend without managing a client integration.
 
 ## Setup, automatic update, and package-transition state
@@ -89,8 +92,10 @@ not change Codex, Claude Code, DSH, or OpenCode provider settings.
 npm installation and foreground setup are separate operations.
 `npm install -g @memorax/memorax-code` installs or replaces package files
 without reading terminal input. `memorax-code setup` owns client detection,
-connection setup, configuration writes, Codex Hook activation or review, and
-final readiness checks.
+connection setup, configuration writes, client integration activation or
+review, and final readiness checks. Trae setup installs the managed Hook
+entries but cannot turn on Trae's application-level Global Hooks setting; the
+user must enable that setting once in Trae Settings.
 
 Default setup reuses a complete effective connection. Otherwise it detects the
 logged-in operating-system username and maps the system language to `zh` or
@@ -222,6 +227,38 @@ does not receive a `/c/Users/...` plugin path. `memorax-code-codebuddy status
 --json` reports `codebuddyHooks.status` as `unverified` until a real WorkBuddy
 Hook executes, `observed` afterward, and `invalid` when the installed Hook
 manifest or runtime is incomplete. Restart or refresh WorkBuddy after setup.
+
+## Trae integration paths
+
+The managed Trae Global Hooks and shared Skill use Trae's data home:
+
+```text
+~/.trae-cn/hooks.json
+~/.trae-cn/skills/memorax-code/
+```
+
+`TRAE_CN_HOME`, then `TRAE_HOME`, overrides the default root; lifecycle
+commands can override it for one invocation with `--trae-home`. The ownership
+record and content-addressed Hook runtime live under
+`$MEMORAX_CODE_HOME/adapters/trae/`. Setup merges one marked MemoraX Code Hook
+into each of `SessionStart`, `UserPromptSubmit`, and `Stop`, preserves other
+Trae Hooks and settings, and refuses to replace an unmanaged
+`skills/memorax-code` directory. Disable and uninstall remove only entries
+marked as MemoraX Code-owned and the managed Skill.
+
+Trae does not expose a reliable programmatic switch for application-level
+Global Hooks. After the first setup, enable **Global Hooks** once in Trae
+Settings and start a new session. `memorax-code-trae status --json` reports the
+Hook runtime as `unverified` until Trae executes a managed Hook, then as
+`observed`; it also reports when this one-time activation may still be needed.
+
+Trae does not currently expose a stable raw Session or a headless CLI. The
+adapter therefore correlates the prompt from `UserPromptSubmit` with the final
+assistant message from `Stop` and uses that closed, validated Hook pair as
+Trae's automatic-writeback content authority. It does not guess from another
+Turn or maintain a pending queue. The Skill can still perform explicit Repo
+Memory work, but automatic background Repo Memory jobs are unavailable in
+Trae until the client provides a suitable headless worker.
 
 The managed loader records the exact MemoraX Code home, OpenCode configuration
 directory, installed Node runtime, and `memorax-code` entrypoint. When the
@@ -373,12 +410,14 @@ Supported policies are `every-commit`, `commit-count`, `daily`,
 `pull-request`, `pull-request-or-daily`, and `adaptive`. Invalid policy values
 fall back to `adaptive`.
 
-In Codex, Claude Code, CodeBuddy/WorkBuddy, DSH, and OpenCode, the first eligible prompt starts a
-background build only when the Backend has authorized a Git worktree and that
-worktree has no `.repo_memory/PROFILE.md`. If the Backend or workspace
-authority is unavailable, the client integration skips that attempt instead
-of falling back to its local workspace path. DSH schedules this work through
-its native pre-step integration rather than a Hook.
+In Codex, Claude Code, CodeBuddy/WorkBuddy, DSH, and OpenCode, the first
+eligible prompt starts a background build only when the Backend has authorized
+a Git worktree and that worktree has no `.repo_memory/PROFILE.md`. If the
+Backend or workspace authority is unavailable, the client integration skips
+that attempt instead of falling back to its local workspace path. DSH schedules
+this work through its native pre-step integration rather than a Hook. Trae
+receives the shared Skill, User Profile, and Procedure reminders, but does not
+start this background build because Trae has no supported headless worker.
 
 CodeBuddy/WorkBuddy repository jobs run the headless client under a bounded
 worker. `MEMORAX_CODE_REPO_MEMORY_JOB_TIMEOUT_MS` sets the client execution
@@ -388,16 +427,18 @@ the grace period before the worker force-terminates a client that ignores
 `codebuddy_timeout` (or `<runner>_timeout`) in the job state, so a stalled
 headless client cannot leave an active job and repository marker indefinitely.
 
-A relevant repo-read runs supervised maintenance in all supported clients. The
-configured policy may select a build, update, or no-op. DSH maintenance
-requires an enabled, managed Profile that includes `@deepseek-ai/dsh-headless`.
-OpenCode executes the job through its active local server. Desktop-only
-installations do not require a standalone `opencode` executable in `PATH`.
+A relevant repo-read runs supervised maintenance in the five headless-capable
+client integrations. The configured policy may select a build, update, or
+no-op. DSH maintenance requires an enabled, managed Profile that includes
+`@deepseek-ai/dsh-headless`. OpenCode executes the job through its active local
+server. Desktop-only installations do not require a standalone `opencode`
+executable in `PATH`. Trae users can invoke the Skill explicitly, but Trae is
+not an automatic maintenance runner.
 
 ## Local traces
 
-`[trace.codex]`, `[trace.claude]`, `[trace.dsh]`, `[trace.opencode]`, `[trace.codebuddy]`, and `[trace.trae]`
-support the same fields:
+`[trace.codex]`, `[trace.claude]`, `[trace.dsh]`, `[trace.opencode]`,
+`[trace.codebuddy]`, and `[trace.trae]` support the same fields:
 
 | Field | Codex environment | Claude environment | DSH environment | OpenCode environment | CodeBuddy/WorkBuddy environment | Trae environment | Fallback |
 | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -469,6 +510,8 @@ memorax-code-codex doctor
 memorax-code-claude doctor
 memorax-code status --clients dsh
 memorax-code-opencode doctor
+memorax-code-codebuddy status --json
+memorax-code-trae status --json
 ```
 
 The status commands do not print the MemoraX API key or Backend token.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -9,6 +9,8 @@ memorax-code-codex doctor
 memorax-code-claude doctor
 memorax-code status --clients dsh
 memorax-code-opencode doctor
+memorax-code-codebuddy status --json
+memorax-code-trae status --json
 memorax-code logs
 ```
 
@@ -19,10 +21,11 @@ same command once with `memorax-cli.cmd`, preserving its arguments and working
 directory. Do not run `Set-ExecutionPolicy` for MemoraX commands.
 
 `memorax-code status` checks the Backend and selected client integrations,
-including DSH and OpenCode. `memorax-cli status` checks credentials, scope, and
-memory switches without printing secrets. Codex, Claude Code, and OpenCode
-also provide client-specific `doctor` commands; DSH uses the shared lifecycle
-status.
+including DSH, OpenCode, CodeBuddy/WorkBuddy, and Trae. `memorax-cli status`
+checks credentials, scope, and memory switches without printing secrets.
+Codex, Claude Code, and OpenCode provide client-specific `doctor` commands;
+CodeBuddy/WorkBuddy and Trae provide adapter status commands, and DSH uses the
+shared lifecycle status.
 
 ## Package installed, but setup did not start
 
@@ -182,8 +185,9 @@ Memory write and memory search reminders are tracked independently. A reminder
 is emitted when the corresponding remaining quota reaches 10% or less and
 again at 0%; raw quota counts are not shown.
 
-Automatic quota reminders are currently supported in Codex, Claude Code, and
-OpenCode. DeepSeek Harness does not currently surface these reminders.
+Automatic quota reminders are currently supported in Codex, Claude Code,
+CodeBuddy/WorkBuddy, OpenCode, and Trae. DeepSeek Harness does not currently
+surface these reminders.
 
 A guest reminder displays the complete Mark ID when the ready local trial
 identity matches the active API key. Registered-account reminders do not
@@ -289,6 +293,33 @@ If WorkBuddy still reports a Hook command containing `/c/Users/...`, it is
 loading a stale plugin manifest. Rerun the start command above and fully
 restart WorkBuddy. Do not manually edit the installed Hook command.
 
+## Trae Global Hooks or Skill is inactive
+
+```sh
+memorax-code start --clients trae
+memorax-code-trae status --json
+```
+
+Trae uses `TRAE_CN_HOME`, then `TRAE_HOME`, and otherwise defaults to
+`~/.trae-cn`. Setup merges the managed `SessionStart`, `UserPromptSubmit`, and
+`Stop` entries into `hooks.json` and installs the shared Skill without
+replacing unrelated Hooks. If status reports `globalHooksActivationRequired`
+or a Hook status of `unverified`, open Trae Settings, enable **Global Hooks**
+once, fully restart or refresh Trae, start a new session, and submit one
+prompt. A subsequent status should report `observed`.
+
+If status reports `hooks_invalid`, repair the existing Trae `hooks.json`
+syntax before rerunning the start command. If it reports `skill_conflict`, an
+unmanaged `skills/memorax-code` directory already exists; preserve or move that
+directory deliberately before asking MemoraX Code to manage the Skill. Do not
+copy generated runtime files or edit entries containing
+`--memorax-code-trae-hook-v1` by hand.
+
+Trae currently provides no stable raw Session or headless CLI. Automatic
+writeback therefore requires a matching `UserPromptSubmit` and `Stop` Hook
+pair, and automatic background Repo Memory jobs are not available. Explicit
+Search/Add and Skill-driven Repo Memory remain available.
+
 ## DeepSeek Harness Profile integration is inactive
 
 ```sh
@@ -361,6 +392,7 @@ memorax-code-codex doctor
 memorax-code-claude doctor
 memorax-code status --clients dsh
 memorax-code-opencode doctor
+memorax-code-trae status --json
 /usr/sbin/scutil --proxy
 /bin/launchctl getenv NO_PROXY
 /bin/launchctl getenv no_proxy
@@ -379,6 +411,7 @@ memorax-code-codex doctor
 memorax-code-claude doctor
 memorax-code status --clients dsh
 memorax-code-opencode doctor
+memorax-code-trae status --json
 ```
 
 Common causes are:

--- a/packages/npm/memorax-code/README.md
+++ b/packages/npm/memorax-code/README.md
@@ -1,13 +1,13 @@
 # @memorax/memorax-code
 
-MemoraX Code adds persistent coding memory to Codex, Claude Code, DeepSeek
-Harness, and OpenCode.
+MemoraX Code adds persistent coding memory to Codex, Claude Code,
+CodeBuddy/WorkBuddy, DeepSeek Harness, OpenCode, and Trae.
 
 ## Requirements
 
 - Node.js 20 or newer (Node.js 24 LTS recommended) and npm.
-- At least one of Codex, Claude Code, DeepSeek Harness, OpenCode Desktop, or
-  the OpenCode CLI.
+- At least one of Codex, Claude Code, CodeBuddy/WorkBuddy, DeepSeek Harness,
+  OpenCode Desktop or CLI, or Trae.
 - Python 3 only for Repo Memory operations.
 
 ## Install
@@ -67,6 +67,9 @@ $env:Path = "$NpmGlobalBin;$env:Path"
 After the first installation, restart or refresh the detected coding agents
 before opening a new session. In Codex, enable **MemoraX Code Codex Adapter**
 from Plugins or `/plugins` if it is not already enabled.
+For Trae, open Settings and enable **Global Hooks** once before starting a new
+Trae session; setup installs the managed Hooks and Skill but cannot switch that
+Trae setting reliably.
 
 ## Verify
 

--- a/packages/npm/memorax-code/bin/memorax-code-setup.mjs
+++ b/packages/npm/memorax-code/bin/memorax-code-setup.mjs
@@ -22,6 +22,10 @@ import { discoverDshProfiles } from "../lib/dsh-plugin-install.mjs";
 import { ensureClaudeCommandEnv } from "../lib/resolve-claude-command.mjs";
 import { ensureCodexCommandEnv } from "../lib/resolve-codex-command.mjs";
 import { defaultCodeBuddyHome, ensureCodeBuddyCommandEnv } from "../lib/resolve-codebuddy-command.mjs";
+import {
+  defaultTraeHome,
+  traeInstallationDetected,
+} from "../lib/memorax-code-trae-adapter/src/adapter-paths.mjs";
 import { reconcileSetup } from "../lib/setup-reconcile.mjs";
 import { detectSetupMemoryPreferences } from "../lib/setup-memory-preferences.mjs";
 import { ensureTrialSetupCredential } from "../lib/trial-setup.mjs";
@@ -46,6 +50,7 @@ const skipCodexPluginInstall = truthyEnv(process.env.MEMORAX_CODE_SKIP_CODEX_PLU
 const skipClaudeAdapterInstall = truthyEnv(process.env.MEMORAX_CODE_SKIP_CLAUDE_ADAPTER_INSTALL);
 const skipOpenCodeAdapterInstall = truthyEnv(process.env.MEMORAX_CODE_SKIP_OPENCODE_ADAPTER_INSTALL);
 const skipCodeBuddyAdapterInstall = truthyEnv(process.env.MEMORAX_CODE_SKIP_CODEBUDDY_ADAPTER_INSTALL);
+const skipTraeAdapterInstall = truthyEnv(process.env.MEMORAX_CODE_SKIP_TRAE_ADAPTER_INSTALL);
 const updateMode = truthyEnv(process.env.MEMORAX_CODE_SETUP_UPDATE);
 const automaticUpdateMode = truthyEnv(process.env.MEMORAX_CODE_SETUP_AUTOMATIC_UPDATE);
 const setupMode = setupModeFromEnvironment(process.env.MEMORAX_CODE_SETUP_MODE);
@@ -114,7 +119,7 @@ try {
   process.exit(1);
 }
 runCommonPreflight();
-const requestedClients = ["codex", "claude", "opencode", "codebuddy"];
+const requestedClients = ["codex", "claude", "opencode", "codebuddy", "trae"];
 const codexPreflight = requestedClients.includes("codex") && !skipCodexPluginInstall
   ? runCodexPreflight({
       integrationSelected: !existingSetup || previousClients.includes("codex"),
@@ -135,11 +140,17 @@ const codebuddyPreflight = requestedClients.includes("codebuddy") && !skipCodeBu
       integrationSelected: !existingSetup || previousClients.includes("codebuddy"),
     })
   : { ok: true };
+const traePreflight = requestedClients.includes("trae") && !skipTraeAdapterInstall
+  ? runTraePreflight({
+      integrationSelected: !existingSetup || previousClients.includes("trae"),
+    })
+  : { ok: true };
 const detectedClients = requestedClients.filter((client) => {
   if (client === "codex") return !skipCodexPluginInstall && codexPreflight.ok;
   if (client === "claude") return !skipClaudeAdapterInstall && claudePreflight.ok;
   if (client === "opencode") return !skipOpenCodeAdapterInstall && opencodePreflight.ok;
-  return !skipCodeBuddyAdapterInstall && codebuddyPreflight.ok;
+  if (client === "codebuddy") return !skipCodeBuddyAdapterInstall && codebuddyPreflight.ok;
+  return !skipTraeAdapterInstall && traePreflight.ok;
 });
 const selectedClients = automaticUpdateMode
   ? previousClients
@@ -168,6 +179,9 @@ if (requestedClients.includes("opencode") && !skipOpenCodeAdapterInstall && !ope
 }
 if (requestedClients.includes("codebuddy") && !skipCodeBuddyAdapterInstall && !codebuddyPreflight.ok) {
   log("CodeBuddy/WorkBuddy runtime was not detected; skipping its adapter setup.");
+}
+if (requestedClients.includes("trae") && !skipTraeAdapterInstall && !traePreflight.ok) {
+  log("Trae runtime or data directory was not detected; skipping its adapter setup.");
 }
 if (writeClientSelectionConfig(selectedClients) === "failed") {
   printPostinstallSummary("not-verified");
@@ -206,6 +220,7 @@ const codexClientEnabled = installClients.includes("codex");
 const claudeClientEnabled = installClients.includes("claude");
 const opencodeClientEnabled = installClients.includes("opencode");
 const codebuddyClientEnabled = installClients.includes("codebuddy");
+const traeClientEnabled = installClients.includes("trae");
 const codexClientNewlyEnabled = codexClientEnabled
   && existingSetup
   && !previousClients.includes("codex");
@@ -269,6 +284,11 @@ const codebuddySkipReason = setupClientSkipReason({
   selected: selectedClients.includes("codebuddy"),
   enabled: codebuddyClientEnabled,
 });
+const traeSkipReason = setupClientSkipReason({
+  explicitlySkipped: skipTraeAdapterInstall,
+  selected: selectedClients.includes("trae"),
+  enabled: traeClientEnabled,
+});
 
 const backendAndAdapters = await startBackendAndCheck({
   skipCodexAdapter,
@@ -283,6 +303,9 @@ const backendAndAdapters = await startBackendAndCheck({
   skipCodeBuddyAdapter: !codebuddyClientEnabled,
   codebuddyAdapterRequired: codebuddyClientEnabled,
   codebuddySkipReason,
+  skipTraeAdapter: !traeClientEnabled,
+  traeAdapterRequired: traeClientEnabled,
+  traeSkipReason,
 });
 const backendAndAdaptersStatus = backendAndAdapters.status;
 if (backendAndAdaptersStatus === "enabled") {
@@ -295,12 +318,15 @@ if (backendAndAdaptersStatus === "enabled") {
     dshAdapterEnabled: backendAndAdapters.dshAdapterEnabled,
     opencodeAdapterEnabled: !skipOpenCodeAdapter,
     codebuddyAdapterEnabled: codebuddyClientEnabled,
+    traeAdapterEnabled: traeClientEnabled,
+    traeGlobalHooksActivationRequired: backendAndAdapters.traeGlobalHooksActivationRequired,
   });
   printCommonCommands({
     codexAdapterEnabled: !skipCodexAdapter,
     claudeAdapterEnabled: !skipClaudeAdapter,
     opencodeAdapterEnabled: !skipOpenCodeAdapter,
     codebuddyAdapterEnabled: codebuddyClientEnabled,
+    traeAdapterEnabled: traeClientEnabled,
   });
 }
 printPostinstallSummary(
@@ -399,7 +425,7 @@ async function chooseUpdateClients(previousClients, detectedClients, scriptedAns
   } finally {
     rl?.close();
   }
-  return ["codex", "claude", "opencode", "codebuddy"].filter((client) => selected.has(client));
+  return ["codex", "claude", "opencode", "codebuddy", "trae"].filter((client) => selected.has(client));
 }
 
 async function configureMemoraxMemoryFromAnswers(answers, detectedPreferences, {
@@ -758,6 +784,7 @@ function readPersistedClientSelection() {
       clients.claude ? "claude" : undefined,
       clients.opencode === true ? "opencode" : undefined,
       clients.codebuddy === true ? "codebuddy" : undefined,
+      clients.trae === true ? "trae" : undefined,
     ].filter(Boolean);
   } catch {
     return undefined;
@@ -790,7 +817,8 @@ function setManagedClientSelection(text, clients) {
   const withOpenCode = setTomlField(text, "clients", "opencode", String(clients.includes("opencode")));
   const withClaude = setTomlField(withOpenCode, "clients", "claude", String(clients.includes("claude")));
   const withCodeBuddy = setTomlField(withClaude, "clients", "codebuddy", String(clients.includes("codebuddy")));
-  return setTomlField(withCodeBuddy, "clients", "codex", String(clients.includes("codex")));
+  const withTrae = setTomlField(withCodeBuddy, "clients", "trae", String(clients.includes("trae")));
+  return setTomlField(withTrae, "clients", "codex", String(clients.includes("codex")));
 }
 
 function writeMemoraxConfig({ userId, endpoint, outputLanguage, apiKey }) {
@@ -844,6 +872,7 @@ function defaultMemoraxCodeConfig() {
     "dsh = true # Manage the DeepSeek Harness adapter when Profiles exist.",
     "opencode = true # Manage the OpenCode adapter.",
     "codebuddy = true # Manage the CodeBuddy/WorkBuddy adapter.",
+    "trae = true # Manage the Trae adapter.",
     "",
     "# MemoraX remote-memory connection.",
     "[memorax]",
@@ -892,6 +921,10 @@ function defaultMemoraxCodeConfig() {
     "[trace.codebuddy]",
     "enabled = true # Enable local CodeBuddy session memory trace collection.",
     "capture_content = true # Store content in local CodeBuddy trace events.",
+    "",
+    "[trace.trae]",
+    "enabled = true # Enable local Trae session memory trace collection.",
+    "capture_content = true # Store content in local Trae trace events.",
     "",
   ].join("\n");
 }
@@ -964,6 +997,9 @@ function runCommonPreflight() {
   }
   if (skipCodeBuddyAdapterInstall) {
     log("CodeBuddy/WorkBuddy adapter setup is disabled for this setup; other client setup can still continue.");
+  }
+  if (skipTraeAdapterInstall) {
+    log("Trae adapter setup is disabled for this setup; other client setup can still continue.");
   }
   return {};
 }
@@ -1053,6 +1089,18 @@ function runCodeBuddyPreflight({ integrationSelected = true } = {}) {
   return { ok: true };
 }
 
+function runTraePreflight({ integrationSelected = true } = {}) {
+  const home = defaultTraeHome();
+  const detected = traeInstallationDetected();
+  log(`Trae data directory: ${existsSync(home) ? `found (${home})` : "not detected"}`);
+  log(`Trae application: ${detected ? "detected" : "not detected"}`);
+  if (!detected) return { ok: false };
+  log(integrationSelected
+    ? "Keeping Trae provider settings unchanged and installing the shared memory Global Hooks and Skill."
+    : "Keeping Trae provider settings unchanged while checking whether to enable its integration.");
+  return { ok: true };
+}
+
 function installedPluginCache() {
   for (const marketplaceName of [CLI_MARKETPLACE_NAME, PERSONAL_MARKETPLACE_NAME]) {
     const versions = installedPluginCacheVersions(marketplaceName);
@@ -1121,6 +1169,9 @@ async function startBackendAndCheck({
   skipCodeBuddyAdapter = false,
   codebuddyAdapterRequired = !skipCodeBuddyAdapter,
   codebuddySkipReason,
+  skipTraeAdapter = false,
+  traeAdapterRequired = !skipTraeAdapter,
+  traeSkipReason,
 } = {}) {
   const adapterFlags = clientLifecycleFlags({ clientMode });
   const startArgs = ["start", ...adapterFlags];
@@ -1142,6 +1193,7 @@ async function startBackendAndCheck({
       claudeAdapterRequired,
       opencodeAdapterRequired,
       codebuddyAdapterRequired,
+      traeAdapterRequired,
     }),
     onEvent: (event) => {
       if (event.type === "start" && event.attempt === 1) {
@@ -1174,6 +1226,8 @@ async function startBackendAndCheck({
           opencodeSkipReason,
           skipCodeBuddyAdapter,
           codebuddySkipReason,
+          skipTraeAdapter,
+          traeSkipReason,
         });
       }
     },
@@ -1185,6 +1239,9 @@ async function startBackendAndCheck({
       : false,
     dshAdapterUnavailable: result.status === "enabled" && statusResult
       ? dshAdapterUnavailable(statusResult)
+      : false,
+    traeGlobalHooksActivationRequired: result.status === "enabled" && statusResult
+      ? traeGlobalHooksActivationRequired(statusResult)
       : false,
   };
 }
@@ -1198,6 +1255,8 @@ function printReconcileFailure(result, {
   opencodeSkipReason,
   skipCodeBuddyAdapter,
   codebuddySkipReason,
+  skipTraeAdapter,
+  traeSkipReason,
 }) {
   if (result.reason === "hook-runtime-activation-failed") {
     logRed("Client Hook runtime activation failed; automatic lifecycle recovery was skipped.");
@@ -1216,6 +1275,7 @@ function printReconcileFailure(result, {
       claudeSkipReason,
       opencodeSkipReason,
       codebuddySkipReason,
+      traeSkipReason,
     });
   }
 }
@@ -1228,6 +1288,11 @@ function dshAdapterReady(statusResult) {
 function dshAdapterUnavailable(statusResult) {
   const output = `${statusResult.stdout ?? ""}\n${statusResult.stderr ?? ""}`;
   return /\bDSH adapter:\s*unavailable\b/im.test(stripAnsi(output));
+}
+
+function traeGlobalHooksActivationRequired(statusResult) {
+  const output = `${statusResult.stdout ?? ""}\n${statusResult.stderr ?? ""}`;
+  return /\bTrae adapter:\s*ok\b[^\r\n]*\bhook-runtime=unverified\b/im.test(stripAnsi(output));
 }
 
 function pendingClientHookRuntimeEnv() {
@@ -1252,10 +1317,10 @@ function clientLifecycleFlags({ clientMode = "all" } = {}) {
 }
 
 function clientModeFor(clients, { includeDsh = false } = {}) {
-  const selected = ["codex", "claude", "dsh", "opencode", "codebuddy"].filter((client) => (
+  const selected = ["codex", "claude", "dsh", "opencode", "codebuddy", "trae"].filter((client) => (
     client === "dsh" ? includeDsh : clients.includes(client)
   ));
-  if (selected.length === 5) return "all";
+  if (selected.length === 6) return "all";
   return selected.length > 0 ? selected.join(",") : "none";
 }
 
@@ -1273,6 +1338,7 @@ function clientSelectionMessage(clients, { dshSelected = false } = {}) {
       "DeepSeek Harness",
       clients.includes("opencode") ? "OpenCode" : undefined,
       clients.includes("codebuddy") ? "CodeBuddy/WorkBuddy" : undefined,
+      clients.includes("trae") ? "Trae" : undefined,
     ].filter(Boolean);
     return `Configuring MemoraX Code for ${joinedLabels(labels)}.`;
   }
@@ -1280,11 +1346,13 @@ function clientSelectionMessage(clients, { dshSelected = false } = {}) {
   const hasClaude = clients.includes("claude");
   const hasOpenCode = clients.includes("opencode");
   const hasCodeBuddy = clients.includes("codebuddy");
+  const hasTrae = clients.includes("trae");
   const labels = [
     hasCodex ? "Codex" : undefined,
     hasClaude ? "Claude Code" : undefined,
     hasOpenCode ? "OpenCode" : undefined,
     hasCodeBuddy ? "CodeBuddy/WorkBuddy" : undefined,
+    hasTrae ? "Trae" : undefined,
   ].filter(Boolean);
   if (labels.length > 0) return `Configuring MemoraX Code for ${joinedLabels(labels)}.`;
   return "Skipping client adapter setup for this setup.";
@@ -1294,7 +1362,8 @@ function clientLabel(client) {
   if (client === "codex") return "Codex";
   if (client === "claude") return "Claude Code";
   if (client === "opencode") return "OpenCode";
-  return "CodeBuddy/WorkBuddy";
+  if (client === "codebuddy") return "CodeBuddy/WorkBuddy";
+  return "Trae";
 }
 
 function detectedClientMessage(clients, dshProfiles = []) {
@@ -1453,12 +1522,15 @@ function printNextSteps({
   dshAdapterEnabled = false,
   opencodeAdapterEnabled = true,
   codebuddyAdapterEnabled = true,
+  traeAdapterEnabled = true,
+  traeGlobalHooksActivationRequired = false,
 } = {}) {
   const clientText = enabledClientText({
     codexAdapterEnabled,
     claudeAdapterEnabled,
     opencodeAdapterEnabled,
     codebuddyAdapterEnabled,
+    traeAdapterEnabled,
   });
   if (clientText && existingSetup) {
     logGreen(`${bold("The new Hook runtime is active")}; existing sessions with the stable shell select it on their next user prompt.`);
@@ -1474,11 +1546,15 @@ function printNextSteps({
   if (codexAdapterEnabled && !existingSetup) {
     logGreen(`After restart, ${bold("enable the MemoraX Code Codex Adapter plugin")} from Codex Plugins or CLI \`/plugins\` if it is not already enabled.`);
   }
+  if (traeAdapterEnabled && traeGlobalHooksActivationRequired) {
+    logGreen(`${bold("Open Trae Settings and enable Global Hooks once")}, then start a new Trae session.`);
+  }
   const statusCommands = statusCommandText({
     codexAdapterEnabled,
     claudeAdapterEnabled,
     opencodeAdapterEnabled,
     codebuddyAdapterEnabled,
+    traeAdapterEnabled,
   });
   if (clientText || !dshAdapterEnabled) {
     log(`If MemoraX Code is not active ${existingSetup ? "on the next prompt" : "in new sessions"}, run ${statusCommands}.`);
@@ -1493,12 +1569,14 @@ function enabledClientText({
   claudeAdapterEnabled = true,
   opencodeAdapterEnabled = true,
   codebuddyAdapterEnabled = true,
+  traeAdapterEnabled = true,
 } = {}) {
   const labels = [
     codexAdapterEnabled ? "Codex" : undefined,
     claudeAdapterEnabled ? "Claude Code" : undefined,
     opencodeAdapterEnabled ? "OpenCode" : undefined,
     codebuddyAdapterEnabled ? "CodeBuddy/WorkBuddy" : undefined,
+    traeAdapterEnabled ? "Trae" : undefined,
   ].filter(Boolean);
   if (labels.length < 2) return labels[0] ?? "";
   if (labels.length === 2) return `${labels[0]} or ${labels[1]}`;
@@ -1510,12 +1588,14 @@ function statusCommandText({
   claudeAdapterEnabled = true,
   opencodeAdapterEnabled = true,
   codebuddyAdapterEnabled = true,
+  traeAdapterEnabled = true,
 } = {}) {
   const commands = ["`memorax-code status`"];
   if (codexAdapterEnabled) commands.push("`memorax-code-codex status`");
   if (claudeAdapterEnabled) commands.push("`memorax-code-claude status`");
   if (opencodeAdapterEnabled) commands.push("`memorax-code-opencode status`");
   if (codebuddyAdapterEnabled) commands.push("`memorax-code-codebuddy status`");
+  if (traeAdapterEnabled) commands.push("`memorax-code-trae status`");
   if (commands.length === 1) return commands[0];
   if (commands.length === 2) return `${commands[0]} and ${commands[1]}`;
   return `${commands.slice(0, -1).join(", ")}, and ${commands.at(-1)}`;
@@ -1595,19 +1675,21 @@ function readMemoraxInstallStatus() {
   }
 }
 
-function printUnavailableDiagnostics({ codexSkipReason, claudeSkipReason, opencodeSkipReason, codebuddySkipReason } = {}) {
+function printUnavailableDiagnostics({ codexSkipReason, claudeSkipReason, opencodeSkipReason, codebuddySkipReason, traeSkipReason } = {}) {
   logRed("MemoraX Code is not enabled for new client sessions.");
-  logRed("Check `memorax-code status`, the selected adapter status commands, and `memorax-code-codebuddy status` for Backend and integration details.");
-  logRed("If Codex, Claude Code, OpenCode, CodeBuddy/WorkBuddy, or DeepSeek Harness is open, restart or refresh it after fixing the reported status.");
+  logRed("Check `memorax-code status` and the selected adapter status commands for Backend and integration details.");
+  logRed("If Codex, Claude Code, OpenCode, CodeBuddy/WorkBuddy, Trae, or DeepSeek Harness is open, restart or refresh it after fixing the reported status.");
   if (codexSkipReason) printCodexSkippedDiagnostics(codexSkipReason);
   if (claudeSkipReason) printClaudeSkippedDiagnostics(claudeSkipReason);
   if (opencodeSkipReason) printOpenCodeSkippedDiagnostics(opencodeSkipReason);
   if (codebuddySkipReason) printCodeBuddySkippedDiagnostics(codebuddySkipReason);
+  if (traeSkipReason) printTraeSkippedDiagnostics(traeSkipReason);
   printCommonCommands({
     codexAdapterEnabled: !codexSkipReason,
     claudeAdapterEnabled: !claudeSkipReason,
     opencodeAdapterEnabled: !opencodeSkipReason,
     codebuddyAdapterEnabled: !codebuddySkipReason,
+    traeAdapterEnabled: !traeSkipReason,
   });
 }
 
@@ -1631,6 +1713,11 @@ function printOpenCodeSkippedDiagnostics() {
 function printCodeBuddySkippedDiagnostics() {
   logRed("CodeBuddy/WorkBuddy adapter setup was skipped for this setup, so MemoraX Code left the CodeBuddy integration unchanged.");
   log("Run `memorax-code start --clients codebuddy` after installing CodeBuddy/WorkBuddy, then restart or refresh it.");
+}
+
+function printTraeSkippedDiagnostics() {
+  logRed("Trae adapter setup was skipped for this setup, so MemoraX Code left Trae unchanged.");
+  log("Run `memorax-code start --clients trae` after installing Trae, then enable Global Hooks in Trae Settings and start a new session.");
 }
 
 function printFailureSuggestions() {
@@ -1663,6 +1750,7 @@ function printCommonCommands({
   claudeAdapterEnabled = true,
   opencodeAdapterEnabled = true,
   codebuddyAdapterEnabled = true,
+  traeAdapterEnabled = true,
 } = {}) {
   log("Common commands:");
   log("- `memorax-code status`: check the local backend and adapter state.");
@@ -1673,6 +1761,7 @@ function printCommonCommands({
   if (claudeAdapterEnabled) log("- `memorax-code-claude sessions`: verify recent native Claude Code session registration.");
   if (opencodeAdapterEnabled) log("- `memorax-code-opencode doctor`: verify the managed OpenCode plugin, runtime evidence, and Backend health.");
   if (codebuddyAdapterEnabled) log("- `memorax-code-codebuddy status`: verify the managed CodeBuddy/WorkBuddy plugin and Hook integration.");
+  if (traeAdapterEnabled) log("- `memorax-code-trae status`: verify the managed Trae Global Hooks and Skill integration.");
 }
 
 function memoraxCodeEnabled(statusResult, {
@@ -1680,6 +1769,7 @@ function memoraxCodeEnabled(statusResult, {
   claudeAdapterRequired = true,
   opencodeAdapterRequired = true,
   codebuddyAdapterRequired = true,
+  traeAdapterRequired = true,
 } = {}) {
   const output = `${statusResult.stdout ?? ""}\n${statusResult.stderr ?? ""}`;
   const normalized = stripAnsi(output);
@@ -1692,12 +1782,14 @@ function memoraxCodeEnabled(statusResult, {
   const claudeAdapterOk = /Claude adapter:\s*ok\b/im.test(normalized);
   const opencodeAdapterOk = /OpenCode adapter:\s*ok\b/im.test(normalized);
   const codebuddyAdapterOk = /CodeBuddy adapter:\s*ok\b/im.test(normalized);
+  const traeAdapterOk = /Trae adapter:\s*ok\b/im.test(normalized);
   return backendOk
     && serviceOk
     && (!codexAdapterRequired || codexAdapterOk)
     && (!claudeAdapterRequired || claudeAdapterOk)
     && (!opencodeAdapterRequired || opencodeAdapterOk)
-    && (!codebuddyAdapterRequired || codebuddyAdapterOk);
+    && (!codebuddyAdapterRequired || codebuddyAdapterOk)
+    && (!traeAdapterRequired || traeAdapterOk);
 }
 
 function log(message) {

--- a/packages/npm/memorax-code/bin/memorax-code-trae.mjs
+++ b/packages/npm/memorax-code/bin/memorax-code-trae.mjs
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+import { runTraeAdapterCli } from "../lib/run-entrypoint.mjs";
+
+await runTraeAdapterCli();

--- a/packages/npm/memorax-code/lib/run-entrypoint.mjs
+++ b/packages/npm/memorax-code/lib/run-entrypoint.mjs
@@ -104,6 +104,12 @@ export async function runCodeBuddyAdapterCli() {
   await import(pathToFileURL(entrypoint).href);
 }
 
+export async function runTraeAdapterCli() {
+  if (!ensureSupportedNodeRuntime()) return;
+  const entrypoint = join(packageRoot, "lib", "memorax-code-trae-adapter", "src", "cli.mjs");
+  await import(pathToFileURL(entrypoint).href);
+}
+
 function ensureSupportedNodeRuntime() {
   const message = unsupportedNodeVersionMessage();
   if (!message) return true;

--- a/packages/npm/memorax-code/package.json
+++ b/packages/npm/memorax-code/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@memorax/memorax-code",
   "version": "0.1.11",
-  "description": "Persistent coding memory for Codex, Claude Code, CodeBuddy/WorkBuddy, DeepSeek Harness, and OpenCode.",
+  "description": "Persistent coding memory for Codex, Claude Code, CodeBuddy/WorkBuddy, DeepSeek Harness, OpenCode, and Trae.",
   "license": "MIT",
   "type": "module",
   "homepage": "https://github.com/memorax-ai/memorax-code#readme",
@@ -19,6 +19,7 @@
     "dsh",
     "opencode",
     "codebuddy",
+    "trae",
     "memory",
     "memorax"
   ],
@@ -29,7 +30,8 @@
     "memorax-code-claude": "bin/memorax-code-claude.mjs",
     "memorax-code-codex": "bin/memorax-code-codex.mjs",
     "memorax-code-opencode": "bin/memorax-code-opencode.mjs",
-    "memorax-code-codebuddy": "bin/memorax-code-codebuddy.mjs"
+    "memorax-code-codebuddy": "bin/memorax-code-codebuddy.mjs",
+    "memorax-code-trae": "bin/memorax-code-trae.mjs"
   },
   "files": [
     "bin",

--- a/packages/npm/memorax-code/test/npm-package-layout.test.mjs
+++ b/packages/npm/memorax-code/test/npm-package-layout.test.mjs
@@ -17,6 +17,7 @@ test("single npm package layout accepts declared paths and rejects unknown trees
   assert.equal(isAllowedNpmPackPath("bin/memorax-code-plugin-postinstall.mjs"), true);
   assert.equal(isAllowedNpmPackPath("bin/memorax-code-setup.mjs"), true);
   assert.equal(isAllowedNpmPackPath("bin/memorax-code-opencode.mjs"), true);
+  assert.equal(isAllowedNpmPackPath("bin/memorax-code-trae.mjs"), true);
   assert.equal(isAllowedNpmPackPath("lib/automatic-update.mjs"), true);
   assert.equal(isAllowedNpmPackPath("lib/node-version.mjs"), true);
   assert.equal(isAllowedNpmPackPath("lib/dsh-plugin-install.mjs"), true);
@@ -58,6 +59,11 @@ test("single npm package layout accepts declared paths and rejects unknown trees
 test("CodeBuddy adapter ships the canonical MemoraX skill", () => {
   assert.equal(isAllowedNpmPackPath("lib/memorax-code-codebuddy-adapter/skills/memorax-code/SKILL.md"), true);
   assert.equal(isAllowedNpmPackPath("lib/memorax-code-codebuddy-adapter/skills/memorax-code/references/memorax-search.md"), true);
+});
+
+test("Trae adapter ships the canonical MemoraX skill and Hook runtime", () => {
+  assert.equal(isAllowedNpmPackPath("lib/memorax-code-trae-adapter/skills/memorax-code/SKILL.md"), true);
+  assert.equal(isAllowedNpmPackPath("lib/memorax-code-trae-adapter/hooks/runtime-hook.mjs"), true);
 });
 
 test("credential runtime allowlist accepts only reviewed main and marketplace files", () => {

--- a/packages/npm/memorax-code/test/npm-source-files.test.mjs
+++ b/packages/npm/memorax-code/test/npm-source-files.test.mjs
@@ -103,6 +103,17 @@ test("CodeBuddy shared skill stages directly from tracked Codex skill sources", 
   );
 });
 
+test("Trae shared skill stages directly from tracked Codex skill sources", () => {
+  assert.ok(npmMainSourceTrees.some((mapping) => (
+    mapping.source === "packages/ts/memorax-code-codex-adapter/skills/memorax-code"
+    && mapping.destination === "lib/memorax-code-trae-adapter/skills/memorax-code"
+  )));
+  assert.equal(
+    npmMainSourceTrees.some((mapping) => mapping.source === "packages/ts/memorax-code-trae-adapter/skills"),
+    false,
+  );
+});
+
 test("Codex plugin assets are declared npm source trees", () => {
   assert.ok(npmMainSourceTrees.some((mapping) => (
     mapping.source === "packages/ts/memorax-code-codex-adapter/assets"

--- a/packages/npm/memorax-code/test/setup.test.mjs
+++ b/packages/npm/memorax-code/test/setup.test.mjs
@@ -131,7 +131,7 @@ async function startMockMemorax({ status = 200, body = { success: true, data: { 
   };
 }
 
-async function runSetup({ existingCache = false, explicitCache = false, codexRegistered, hookRuntimeFailure, failStartOnce = false, connectionAuthorityFailure = false, runtimeAuthorityFailureCode, officialMode = false, codexConfig, memoraxCodeConfig, memoraxCodeConfigMode, emptyClaudeSettings = false, claudeAvailable = true, claudeVersionFails = false, claudeSettingsText, codexAvailable = true, codexAppOnly = false, vscodeOnly = false, dshProfiles = [], opencodeAvailable = false, opencodeXdgAvailable = false, opencodeCliAvailable = false, codebuddyAvailable = false, skipCodexPluginInstall = false, skipClaudeAdapterInstall = false, skipOpenCodeAdapterInstall = false, skipCodeBuddyAdapterInstall = false, unavailableStatus = false, prefixedStatus = false, input = "", interactive = true, npmCommand = "install", updateMode = false, setupMode = "automatic", memoraxVerify, memoraxEnv = {}, memoryStatusFixture, trialProvisionFailure = false, hookSnapshot = [], hookUpdatePlan = [], hookFullReview = false, hookFullReviewMissing = false, hookSnapshotFails = false, hookCheckFails = false, hookTrustFails = false, detectedUserId = "memory-user", detectedLanguage = "zh", ttyOverride } = {}) {
+async function runSetup({ existingCache = false, explicitCache = false, codexRegistered, hookRuntimeFailure, failStartOnce = false, connectionAuthorityFailure = false, runtimeAuthorityFailureCode, officialMode = false, codexConfig, memoraxCodeConfig, memoraxCodeConfigMode, emptyClaudeSettings = false, claudeAvailable = true, claudeVersionFails = false, claudeSettingsText, codexAvailable = true, codexAppOnly = false, vscodeOnly = false, dshProfiles = [], opencodeAvailable = false, opencodeXdgAvailable = false, opencodeCliAvailable = false, codebuddyAvailable = false, traeAvailable = false, skipCodexPluginInstall = false, skipClaudeAdapterInstall = false, skipOpenCodeAdapterInstall = false, skipCodeBuddyAdapterInstall = false, skipTraeAdapterInstall = false, unavailableStatus = false, prefixedStatus = false, input = "", interactive = true, npmCommand = "install", updateMode = false, setupMode = "automatic", memoraxVerify, memoraxEnv = {}, memoryStatusFixture, trialProvisionFailure = false, hookSnapshot = [], hookUpdatePlan = [], hookFullReview = false, hookFullReviewMissing = false, hookSnapshotFails = false, hookCheckFails = false, hookTrustFails = false, detectedUserId = "memory-user", detectedLanguage = "zh", ttyOverride } = {}) {
   const root = await mkdtemp(join(tmpdir(), "memorax-code-setup-"));
   const binDir = join(root, "bin");
   const codexHome = join(root, "codex-home");
@@ -141,6 +141,7 @@ async function runSetup({ existingCache = false, explicitCache = false, codexReg
   const memoraxCodeHome = join(root, "memorax-code-home");
   const home = join(root, "home");
   const workbuddyHome = join(home, ".workbuddy");
+  const traeHome = join(home, ".trae-cn");
   const fakeBin = join(root, "fake-bin");
   const libDir = join(root, "lib");
   const nodeModulesDir = join(root, "node_modules");
@@ -155,6 +156,19 @@ async function runSetup({ existingCache = false, explicitCache = false, codexReg
     "  const code = process.env.MEMORAX_CODE_TEST_DSH_DISCOVERY_ERROR;",
     "  if (code) throw Object.assign(new Error('profile discovery failed'), { code });",
     "  return JSON.parse(process.env.MEMORAX_CODE_TEST_DSH_PROFILES ?? '[]');",
+    "}",
+    "",
+  ].join("\n"));
+  const traeAdapterDir = join(libDir, "memorax-code-trae-adapter", "src");
+  await mkdir(traeAdapterDir, { recursive: true });
+  await writeFile(join(traeAdapterDir, "adapter-paths.mjs"), [
+    "import { homedir } from 'node:os';",
+    "import { join, resolve } from 'node:path';",
+    "export function defaultTraeHome(env = process.env, home = homedir()) {",
+    "  return resolve(env.TRAE_CN_HOME || env.TRAE_HOME || join(home, '.trae-cn'));",
+    "}",
+    "export function traeInstallationDetected(env = process.env) {",
+    "  return env.MEMORAX_CODE_TEST_TRAE_AVAILABLE === '1';",
     "}",
     "",
   ].join("\n"));
@@ -355,11 +369,12 @@ async function runSetup({ existingCache = false, explicitCache = false, codexReg
     "if (process.argv[2] === 'stop') console.error('fake memorax-code stop output');",
     "const clientsIndex = process.argv.indexOf('--clients');",
     "const clientMode = clientsIndex >= 0 ? process.argv[clientsIndex + 1] : 'all';",
-    "const selectedClients = new Set(clientMode === 'all' ? ['codex', 'claude', 'dsh', 'opencode', 'codebuddy'] : clientMode.split(','));",
+    "const selectedClients = new Set(clientMode === 'all' ? ['codex', 'claude', 'dsh', 'opencode', 'codebuddy', 'trae'] : clientMode.split(','));",
     "const codexEnabled = selectedClients.has('codex');",
     "const claudeEnabled = selectedClients.has('claude');",
     "const opencodeEnabled = selectedClients.has('opencode');",
     "const codebuddyEnabled = selectedClients.has('codebuddy');",
+    "const traeEnabled = selectedClients.has('trae');",
     "const dshEnabled = selectedClients.has('dsh') && process.env.MEMORAX_CODE_TEST_DSH_ENABLED === '1';",
     "if (process.argv[2] === 'status' && process.env.MEMORAX_CODE_TEST_UNAVAILABLE_STATUS === '1') {",
     "  console.error('memorax-code: ok');",
@@ -376,6 +391,7 @@ async function runSetup({ existingCache = false, explicitCache = false, codexReg
     "    if (claudeEnabled) console.error('[MemoraX Code Backend]: Claude adapter: \\x1b[32mok\\x1b[0m integration=hooks skills=ok');",
     "    if (opencodeEnabled) console.error('[MemoraX Code Backend]: OpenCode adapter: \\x1b[32mok\\x1b[0m integration=plugin skills=ok');",
     "    if (codebuddyEnabled) console.error('[MemoraX Code Backend]: CodeBuddy adapter: \\x1b[32mok\\x1b[0m integration=hooks skills=ok');",
+    "    if (traeEnabled) console.error('[MemoraX Code Backend]: Trae adapter: \\x1b[32mok\\x1b[0m integration=hooks skills=installed hook-runtime=unverified');",
     "    if (dshEnabled) console.error('[MemoraX Code Backend]: DSH adapter: \\x1b[32mok\\x1b[0m integration=plugin profiles=ok');",
     "    process.exit(0);",
     "  }",
@@ -385,6 +401,7 @@ async function runSetup({ existingCache = false, explicitCache = false, codexReg
     "  if (claudeEnabled) console.error('claude adapter: ok integration=hooks skills=ok');",
     "  if (opencodeEnabled) console.error('opencode adapter: ok integration=plugin skills=ok');",
     "  if (codebuddyEnabled) console.error('codebuddy adapter: ok integration=hooks skills=ok');",
+    "  if (traeEnabled) console.error('trae adapter: ok integration=hooks skills=installed hook-runtime=unverified');",
     "  if (dshEnabled) console.error('dsh adapter: ok integration=plugin profiles=ok');",
     "}",
     "process.exit(0);",
@@ -478,6 +495,7 @@ async function runSetup({ existingCache = false, explicitCache = false, codexReg
       "",
     ]);
   }
+  if (traeAvailable) await mkdir(traeHome, { recursive: true });
   const cacheMarketplace = existingCache ? "personal" : explicitCache ? "memorax-code" : undefined;
   if (cacheMarketplace) {
     const cacheDir = join(codexHome, "plugins", "cache", cacheMarketplace, "memorax-code-codex-adapter", "0.1.0");
@@ -560,6 +578,8 @@ async function runSetup({ existingCache = false, explicitCache = false, codexReg
     OPENCODE_CONFIG_DIR: opencodeAvailable ? opencodeConfigDir : "",
     XDG_CONFIG_HOME: opencodeXdgAvailable ? xdgConfigHome : "",
     WORKBUDDY_HOME: workbuddyHome,
+    TRAE_CN_HOME: traeHome,
+    TRAE_HOME: "",
     MEMORAX_CODE_HOME: memoraxCodeHome,
     PATH: codexAppOnly || vscodeOnly
       ? fakeBin
@@ -573,6 +593,8 @@ async function runSetup({ existingCache = false, explicitCache = false, codexReg
     MEMORAX_CODE_SKIP_CLAUDE_ADAPTER_INSTALL: skipClaudeAdapterInstall ? "1" : "0",
     MEMORAX_CODE_SKIP_OPENCODE_ADAPTER_INSTALL: skipOpenCodeAdapterInstall ? "1" : "0",
     MEMORAX_CODE_SKIP_CODEBUDDY_ADAPTER_INSTALL: skipCodeBuddyAdapterInstall ? "1" : "0",
+    MEMORAX_CODE_SKIP_TRAE_ADAPTER_INSTALL: skipTraeAdapterInstall ? "1" : "0",
+    MEMORAX_CODE_TEST_TRAE_AVAILABLE: traeAvailable ? "1" : "0",
     MEMORAX_CODE_TEST_FAIL_START_ONCE: failStartOnce ? "1" : "0",
     MEMORAX_CODE_TEST_RUNTIME_AUTHORITY_FAILURE: runtimeAuthorityFailureCode
       ?? (connectionAuthorityFailure ? "BACKEND_CONNECTION_AUTHORITY_INVALID" : ""),
@@ -633,6 +655,7 @@ async function runSetup({ existingCache = false, explicitCache = false, codexReg
     codexHome,
     claudeHome,
     opencodeConfigDir,
+    traeHome,
     memoraxEndpoint: memoraxServer?.url,
     memoraxRequests: memoraxServer?.requests ?? [],
     activeHookRuntimeBefore,
@@ -824,6 +847,29 @@ test("setup fresh install auto-detects CodeBuddy and starts the WorkBuddy adapte
 });
 
 
+test("setup fresh install auto-detects Trae and requests one-time Global Hooks activation", async () => {
+  const run = await runSetup({
+    codexAvailable: false,
+    claudeAvailable: false,
+    traeAvailable: true,
+  });
+  try {
+    assert.equal(run.result.code, 0, run.result.stderr);
+    assert.match(run.result.stderr, /Trae data directory: found/);
+    assert.match(run.result.stderr, /Trae application: detected/);
+    assert.match(run.result.stderr, /Keeping Trae provider settings unchanged and installing the shared memory Global Hooks and Skill/);
+    assert.match(run.log, /^memorax-code start --clients dsh,trae$/m);
+    assert.match(run.log, /^memorax-code status --clients dsh,trae$/m);
+    assert.match(run.result.stderr, /Open Trae Settings and enable Global Hooks once/);
+    const config = await readFile(join(run.memoraxCodeHome, "config.toml"), "utf8");
+    assert.match(config, /trae = true/);
+    assert.match(config, /\[trace\.trae\]/);
+  } finally {
+    await rm(run.root, { recursive: true, force: true });
+  }
+});
+
+
 test("setup seeds the default MemoraX Code config around trial memory preferences", async () => {
   const run = await runSetup({ interactive: true });
   try {
@@ -857,6 +903,8 @@ test("setup seeds the default MemoraX Code config around trial memory preference
     assert.match(config, /capture_content = true # Store content in local OpenCode trace events\./);
     assert.match(config, /\[trace\.codebuddy\]/);
     assert.match(config, /capture_content = true # Store content in local CodeBuddy trace events\./);
+    assert.match(config, /\[trace\.trae\]/);
+    assert.match(config, /capture_content = true # Store content in local Trae trace events\./);
     assert.deepEqual(activeTomlSections(config), [
       "clients",
       "memorax",
@@ -870,6 +918,7 @@ test("setup seeds the default MemoraX Code config around trial memory preference
       "trace.codex",
       "trace.dsh",
       "trace.opencode",
+      "trace.trae",
     ]);
     assert.doesNotMatch(
       config,
@@ -1071,7 +1120,7 @@ test("interactive setup after reinstall automatically reuses a complete MemoraX 
     assert.match(run.result.stderr, /Automatic writeback: Disabled by effective configuration/);
     assert.equal(
       await readFile(join(run.memoraxCodeHome, "config.toml"), "utf8"),
-      existingConfig.replace("[clients]\n", "[clients]\ncodebuddy = false\nopencode = false\n"),
+      existingConfig.replace("[clients]\n", "[clients]\ntrae = false\ncodebuddy = false\nopencode = false\n"),
     );
     await assertSetupComplete(run);
   } finally {
@@ -1227,7 +1276,7 @@ test("setup reports unavailable status and prints red diagnostics instead of usa
     assert.match(run.result.stderr, /\[MemoraX Code Backend\]: claude adapter: ok integration=hooks skills=ok/);
     assert.match(run.result.stderr, /Backend and selected adapters: .*Unavailable/);
     assert.match(run.result.stderr, /MemoraX Code is not enabled for new client sessions/);
-    assert.match(run.result.stderr, /Check `memorax-code status`, the selected adapter status commands, and `memorax-code-codebuddy status`/);
+    assert.match(run.result.stderr, /Check `memorax-code status` and the selected adapter status commands/);
     assert.doesNotMatch(run.result.stderr, /Restart or refresh Codex/);
     assert.doesNotMatch(run.result.stderr, /enable the MemoraX Code Codex Adapter plugin/);
     assert.match(run.result.stderr, /\[MemoraX Code Setup\]: Common commands:/);
@@ -1247,6 +1296,7 @@ test("automatic update setup is non-interactive and preserves disabled clients",
     "dsh = false",
     "opencode = false",
     "codebuddy = false",
+    "trae = false",
     "",
     "[memorax]",
     'endpoint = "https://existing-memorax.example"',
@@ -1259,6 +1309,7 @@ test("automatic update setup is non-interactive and preserves disabled clients",
   ].join("\n");
   const run = await runSetup({
     codebuddyAvailable: true,
+    traeAvailable: true,
     dshProfiles: ["default"],
     existingCache: true,
     hookSnapshot: [],
@@ -1282,6 +1333,7 @@ test("automatic update setup is non-interactive and preserves disabled clients",
     assert.match(config, /dsh = false/);
     assert.match(config, /opencode = false/);
     assert.match(config, /codebuddy = false/);
+    assert.match(config, /trae = false/);
     await assertSetupComplete(run);
   } finally {
     await rm(run.root, { recursive: true, force: true });
@@ -1312,8 +1364,8 @@ test("automatic update setup preserves configured and legacy DSH client intent",
     assert.match(run.result.stderr, /Claude Code runtime was not detected; skipping its adapter setup/);
     assert.match(run.result.stderr, /OpenCode runtime or configuration was not detected; skipping its adapter setup/);
     assert.match(run.result.stderr, /CodeBuddy\/WorkBuddy runtime was not detected; skipping its adapter setup/);
-    assert.match(run.log, /^memorax-code start --clients all$/m);
-    assert.match(run.log, /^memorax-code status --clients all$/m);
+    assert.match(run.log, /^memorax-code start --clients codex,claude,dsh,opencode,codebuddy$/m);
+    assert.match(run.log, /^memorax-code status --clients codex,claude,dsh,opencode,codebuddy$/m);
     await assertSetupComplete(run);
   } finally {
     await rm(run.root, { recursive: true, force: true });

--- a/packages/ts/memorax-code-backend/src/clients/trae/lifecycle.ts
+++ b/packages/ts/memorax-code-backend/src/clients/trae/lifecycle.ts
@@ -1,0 +1,63 @@
+import type {
+  AdapterLifecycleParticipant,
+  AdapterPluginLifecycleReport,
+  AdapterReport,
+} from "../../lifecycle/participant.js";
+
+export const traeAdapterLifecycle = {
+  async status({ argv, serviceOptions }) {
+    try {
+      return await (await load()).readTraeAdapterStatus(options(argv, serviceOptions));
+    } catch (error) {
+      return { ok: false, action: "status", error: error instanceof Error ? error.message : String(error) };
+    }
+  },
+  async prepareEnable({ argv, serviceOptions }) {
+    try {
+      return await (await load()).enableTraeAdapter(options(argv, serviceOptions));
+    } catch (error) {
+      return { ok: false, action: "enable", error: error instanceof Error ? error.message : String(error) };
+    }
+  },
+  async disable({ argv, serviceOptions }) {
+    try {
+      return await (await load()).disableTraeAdapter(options(argv, serviceOptions));
+    } catch (error) {
+      return { ok: false, action: "disable", error: error instanceof Error ? error.message : String(error) };
+    }
+  },
+  async remove({ argv, serviceOptions }) {
+    try {
+      return await (await load()).removeTraeAdapterInstallation(options(argv, serviceOptions));
+    } catch (error) {
+      return {
+        ok: false,
+        action: "trae-adapter-remove",
+        reason: "adapter_remove_failed",
+        message: error instanceof Error ? error.message : String(error),
+      };
+    }
+  },
+} satisfies AdapterLifecycleParticipant<AdapterPluginLifecycleReport>;
+
+function options(argv: string[], serviceOptions: { home?: string }): Record<string, unknown> {
+  const traeHome = argValue(argv, "--trae-home");
+  return {
+    ...(traeHome ? { traeHome } : {}),
+    memoraxCodeHome: serviceOptions.home,
+  };
+}
+
+async function load(): Promise<{
+  enableTraeAdapter(options: Record<string, unknown>): Promise<AdapterReport>;
+  disableTraeAdapter(options: Record<string, unknown>): Promise<AdapterReport>;
+  readTraeAdapterStatus(options: Record<string, unknown>): Promise<AdapterReport>;
+  removeTraeAdapterInstallation(options: Record<string, unknown>): Promise<AdapterPluginLifecycleReport>;
+}> {
+  return await import(new URL("../../../../memorax-code-trae-adapter/src/config.mjs", import.meta.url).href);
+}
+
+function argValue(argv: string[], name: string): string | undefined {
+  const index = argv.indexOf(name);
+  return index >= 0 ? argv[index + 1] : undefined;
+}

--- a/packages/ts/memorax-code-backend/src/config/memorax-code.ts
+++ b/packages/ts/memorax-code-backend/src/config/memorax-code.ts
@@ -17,6 +17,7 @@ export type MemoraxCodeConfig = Readonly<{
     dsh?: boolean;
     opencode?: boolean;
     codebuddy?: boolean;
+    trae?: boolean;
   }>;
   memorax?: Readonly<{
     endpoint?: string;
@@ -284,6 +285,7 @@ function normalizeMemoraxCodeConfig(value: unknown): MemoraxCodeConfig {
       dsh: booleanField(clients, "dsh"),
       opencode: booleanField(clients, "opencode"),
       codebuddy: booleanField(clients, "codebuddy"),
+      trae: booleanField(clients, "trae"),
     }),
     memorax: prune({
       endpoint: stringField(memorax, "endpoint"),
@@ -388,7 +390,7 @@ function validateRawLifecycleConfig(value: unknown, path: string): void {
   if (rawClients !== undefined) {
     const clients = tableValue(rawClients);
     if (!clients) throw invalidLifecycleConfig(path, "clients must be a table");
-    for (const field of ["codex", "claude", "dsh", "opencode", "codebuddy"] as const) {
+    for (const field of ["codex", "claude", "dsh", "opencode", "codebuddy", "trae"] as const) {
       if (clients[field] !== undefined && typeof clients[field] !== "boolean") {
         throw invalidLifecycleConfig(path, `clients.${field} must be a boolean`);
       }

--- a/packages/ts/memorax-code-backend/src/entrypoints/backend-cli.ts
+++ b/packages/ts/memorax-code-backend/src/entrypoints/backend-cli.ts
@@ -79,9 +79,9 @@ export function runBackendCli(argv = process.argv): void {
       `Usage: ${usageName} [${commands}] [--backend-url URL] [--backend-token TOKEN] [--home DIR]`,
       "[--host HOST] [--port PORT] [--rotate] [--show]",
       "[--codex-command CMD]",
-      "[--codex-home DIR] [--claude-home DIR] [--dsh-home DIR] [--opencode-config-dir DIR] [--codebuddy-home DIR]",
+      "[--codex-home DIR] [--claude-home DIR] [--dsh-home DIR] [--opencode-config-dir DIR] [--codebuddy-home DIR] [--trae-home DIR]",
       "[--dsh-command CMD] [--dsh-adapter-root DIR] [--memorax-code-command CMD]",
-      "[--clients codex|claude|dsh|opencode|codebuddy|CLIENT,...|all|none]",
+      "[--clients codex|claude|dsh|opencode|codebuddy|trae|CLIENT,...|all|none]",
       "[--json]",
       "[--marketplace-path FILE] [--plugin-source-path DIR] [--claude-command CMD] [--help]",
       "[--yes]",
@@ -240,6 +240,7 @@ async function startRawBackendServer(
         dshAdapterRoot: argValue(argv, "--dsh-adapter-root"),
         openCodeConfigDir: argValue(argv, "--opencode-config-dir"),
         codeBuddyHome: argValue(argv, "--codebuddy-home"),
+        traeHome: argValue(argv, "--trae-home"),
         codexCommand: argValue(argv, "--codex-command"),
         claudeCommand: argValue(argv, "--claude-command"),
         dshCommand: argValue(argv, "--dsh-command"),
@@ -568,6 +569,7 @@ function printMemoraxCodeStatus(report: MemoraxCodeStatusReport): void {
   if (report.dshAdapter) backendLog(`DSH adapter: ${dshAdapterStatusLine(report.dshAdapter)}`);
   if (report.opencodeAdapter) backendLog(`OpenCode adapter: ${adapterStatusLine(report.opencodeAdapter)}`);
   if (report.codebuddyAdapter) backendLog(`CodeBuddy adapter: ${adapterStatusLine(report.codebuddyAdapter)}`);
+  if (report.traeAdapter) backendLog(`Trae adapter: ${adapterStatusLine(report.traeAdapter)}`);
   if (!suppressBackendGuidance()) {
     for (const line of statusGuidance(report)) backendLog(line);
   }
@@ -677,6 +679,7 @@ function printLifecycleResult(report: MemoraxCodeLifecycleReport): void {
   if (report.dshAdapter) backendLog(`DSH adapter: ${dshAdapterStatusLine(report.dshAdapter)}`);
   if (report.opencodeAdapter) backendLog(`OpenCode adapter: ${adapterStatusLine(report.opencodeAdapter)}`);
   if (report.codebuddyAdapter) backendLog(`CodeBuddy adapter: ${adapterStatusLine(report.codebuddyAdapter)}`);
+  if (report.traeAdapter) backendLog(`Trae adapter: ${adapterStatusLine(report.traeAdapter)}`);
   if (report.codexPlugin) {
     const removed = report.codexPlugin.removedPaths.length;
     const marketplace = report.codexPlugin.marketplaceChanged ? " marketplace=updated" : " marketplace=unchanged";
@@ -850,6 +853,9 @@ function statusGuidance(report: MemoraxCodeStatusReport): string[] {
     }
     return [
       green("MemoraX Code is ready; sessions with the stable plugin shell use the active Hook runtime on their next user prompt."),
+      ...(report.traeAdapter?.globalHooksActivationRequired
+        ? ["Trae requires one manual step: open Trae Settings and enable Global Hooks, then start a new Trae session."]
+        : []),
       ...(optionalDshUnavailable
         ? [`DSH integration is unavailable: ${report.dshAdapter?.reason ?? "not available"}.`]
         : []),
@@ -898,6 +904,12 @@ function statusGuidance(report: MemoraxCodeStatusReport): string[] {
       "Run `memorax-code start`, then restart or refresh OpenCode.",
     ];
   }
+  if (report.traeAdapter && !isAdapterReady(report.traeAdapter)) {
+    return [
+      red("Trae adapter is not enabled."),
+      "Run `memorax-code start --clients trae`, then enable Global Hooks in Trae Settings if this is the first setup.",
+    ];
+  }
   return [
     red("MemoraX Code needs attention."),
     "Run `memorax-code status` and `memorax-code logs` for details.",
@@ -937,9 +949,11 @@ function adapterStatusLine(report: AdapterReport): string {
   const skillStatus = report.codexSkills?.status
     ?? report.claudeSkills?.status
     ?? report.opencodeSkills?.status
-    ?? report.codebuddySkills?.status;
+    ?? report.codebuddySkills?.status
+    ?? report.traeSkills?.status;
   const skills = skillStatus ? ` skills=${skillStatus}` : "";
-  const hooks = report.codebuddyHooks?.status ? ` hook-runtime=${report.codebuddyHooks.status}` : "";
+  const hookStatus = report.codebuddyHooks?.status ?? report.traeHooks?.status;
+  const hooks = hookStatus ? ` hook-runtime=${hookStatus}` : "";
   const changed = report.changed === true ? " changed" : "";
   const integration = report.integration ?? report.state?.integration ?? "hooks";
   return `${enabled ? "ok" : "not enabled"} integration=${integration}${skills}${hooks}${changed}`;
@@ -951,6 +965,8 @@ function selectedLifecycleClientNames(report: MemoraxCodeLifecycleReport): strin
     report.claudeAdapter ? "Claude Code" : undefined,
     report.dshAdapter ? "DSH" : undefined,
     report.opencodeAdapter ? "OpenCode" : undefined,
+    report.codebuddyAdapter ? "CodeBuddy/WorkBuddy" : undefined,
+    report.traeAdapter ? "Trae" : undefined,
   ].filter((name): name is string => name !== undefined);
 }
 

--- a/packages/ts/memorax-code-backend/src/lifecycle/active-clients.ts
+++ b/packages/ts/memorax-code-backend/src/lifecycle/active-clients.ts
@@ -10,6 +10,7 @@ export function readActiveManagedClients(memoraxCodeHome: string): ManagedClient
     if (typeof value.codex !== "boolean" || typeof value.claude !== "boolean") return undefined;
     if (value.opencode !== undefined && typeof value.opencode !== "boolean") return undefined;
     if (value.codebuddy !== undefined && typeof value.codebuddy !== "boolean") return undefined;
+    if (value.trae !== undefined && typeof value.trae !== "boolean") return undefined;
     if (value.dsh !== undefined && typeof value.dsh !== "boolean") return undefined;
     return {
       codex: value.codex,
@@ -19,6 +20,7 @@ export function readActiveManagedClients(memoraxCodeHome: string): ManagedClient
       dsh: value.dsh === true,
       opencode: value.opencode === true,
       ...(value.codebuddy === true ? { codebuddy: true } : {}),
+      ...(value.trae === true ? { trae: true } : {}),
     };
   } catch {
     return undefined;

--- a/packages/ts/memorax-code-backend/src/lifecycle/client-plugin-removal.ts
+++ b/packages/ts/memorax-code-backend/src/lifecycle/client-plugin-removal.ts
@@ -112,6 +112,8 @@ export async function prepareClientPluginRemovalCleanup(
   const memoraxCodeHome = resolve(options.memoraxCodeHome ?? process.env.MEMORAX_CODE_HOME ?? join(home, ".memorax-code"));
   const claudeState = await readJsonRecord(join(memoraxCodeHome, "adapters", "claude-code", "state.json"));
   const claudeHome = options.claudeHome ?? stringField(claudeState, "claudeHome");
+  const traeState = await readJsonRecord(join(memoraxCodeHome, "adapters", "trae", "state.json"));
+  const traeHome = options.traeHome ?? stringField(traeState, "traeHome");
 
   return async () => {
     try {
@@ -154,7 +156,7 @@ export async function prepareClientPluginRemovalCleanup(
             .catch((error) => removalFailure("codebuddy-plugin-remove", error)),
           traePluginInstaller.removeTraeAdapterInstallation({
             memoraxCodeHome,
-            ...(options.traeHome ? { traeHome: options.traeHome } : {}),
+            ...(traeHome ? { traeHome } : {}),
           }).catch((error) => removalFailure("trae-adapter-remove", error)),
         ]);
         return {

--- a/packages/ts/memorax-code-backend/src/lifecycle/client-plugin-removal.ts
+++ b/packages/ts/memorax-code-backend/src/lifecycle/client-plugin-removal.ts
@@ -41,6 +41,17 @@ type CodeBuddyPluginInstaller = {
   removeCodeBuddyPluginInstallation: (options: Record<string, unknown>) => CodeBuddyPluginRemovalReport;
 };
 
+type TraePluginRemovalReport = {
+  ok: boolean;
+  action: string;
+  reason?: string;
+  message?: string;
+};
+
+type TraePluginInstaller = {
+  removeTraeAdapterInstallation: (options: Record<string, unknown>) => Promise<TraePluginRemovalReport>;
+};
+
 type DshPluginRemovalReport = {
   ok: boolean;
   action: string;
@@ -65,6 +76,7 @@ export type ClientPluginRemovalOptions = {
   dshAdapterRoot?: string;
   openCodeConfigDir?: string;
   codeBuddyHome?: string;
+  traeHome?: string;
   codexCommand?: string;
   claudeCommand?: string;
   dshCommand?: string;
@@ -78,6 +90,7 @@ export type ClientPluginRemovalReport = {
   dshPlugin: DshPluginRemovalReport | ClientPluginRemovalFailure;
   opencodePlugin: OpenCodePluginRemovalReport | ClientPluginRemovalFailure;
   codebuddyPlugin: CodeBuddyPluginRemovalReport | ClientPluginRemovalFailure;
+  traePlugin: TraePluginRemovalReport | ClientPluginRemovalFailure;
 };
 
 type ClientPluginRemovalFailure = {
@@ -94,6 +107,7 @@ export async function prepareClientPluginRemovalCleanup(
   const dshProfileLifecycle = await loadDshProfileLifecycle();
   const openCodePluginInstaller = await loadOpenCodePluginInstaller();
   const codeBuddyPluginInstaller = await loadCodeBuddyPluginInstaller();
+  const traePluginInstaller = await loadTraePluginInstaller();
   const home = resolveHome(options.homeDir);
   const memoraxCodeHome = resolve(options.memoraxCodeHome ?? process.env.MEMORAX_CODE_HOME ?? join(home, ".memorax-code"));
   const claudeState = await readJsonRecord(join(memoraxCodeHome, "adapters", "claude-code", "state.json"));
@@ -102,7 +116,7 @@ export async function prepareClientPluginRemovalCleanup(
   return async () => {
     try {
       return await withBackendLifecycleLock({ home: memoraxCodeHome }, async () => {
-        const [codexPlugin, claudePlugin, dshPlugin, opencodePlugin, codebuddyPlugin] = await Promise.all([
+        const [codexPlugin, claudePlugin, dshPlugin, opencodePlugin, codebuddyPlugin, traePlugin] = await Promise.all([
           cleanupCodexAfterBackendRemoval({
             memoraxCodeHome,
             homeDir: home,
@@ -138,15 +152,20 @@ export async function prepareClientPluginRemovalCleanup(
               ...(options.codeBuddyHome ? { codeBuddyHome: options.codeBuddyHome } : {}),
             }))
             .catch((error) => removalFailure("codebuddy-plugin-remove", error)),
+          traePluginInstaller.removeTraeAdapterInstallation({
+            memoraxCodeHome,
+            ...(options.traeHome ? { traeHome: options.traeHome } : {}),
+          }).catch((error) => removalFailure("trae-adapter-remove", error)),
         ]);
         return {
-          ok: codexPlugin.ok && claudePlugin.ok && dshPlugin.ok && opencodePlugin.ok && codebuddyPlugin.ok,
+          ok: codexPlugin.ok && claudePlugin.ok && dshPlugin.ok && opencodePlugin.ok && codebuddyPlugin.ok && traePlugin.ok,
           action: "client-plugin-removal-cleanup" as const,
           codexPlugin,
           claudePlugin,
           dshPlugin,
           opencodePlugin,
           codebuddyPlugin,
+          traePlugin,
         };
       });
     } catch (error) {
@@ -159,6 +178,7 @@ export async function prepareClientPluginRemovalCleanup(
         dshPlugin: failure,
         opencodePlugin: failure,
         codebuddyPlugin: failure,
+        traePlugin: failure,
       };
     }
   };
@@ -174,6 +194,10 @@ async function loadOpenCodePluginInstaller(): Promise<OpenCodePluginInstaller> {
 
 async function loadCodeBuddyPluginInstaller(): Promise<CodeBuddyPluginInstaller> {
   return await import(new URL("../../../memorax-code-codebuddy-adapter/src/config.mjs", import.meta.url).href);
+}
+
+async function loadTraePluginInstaller(): Promise<TraePluginInstaller> {
+  return await import(new URL("../../../memorax-code-trae-adapter/src/config.mjs", import.meta.url).href);
 }
 
 async function loadDshProfileLifecycle(): Promise<DshProfileLifecycleModule> {

--- a/packages/ts/memorax-code-backend/src/lifecycle/client-selection.ts
+++ b/packages/ts/memorax-code-backend/src/lifecycle/client-selection.ts
@@ -6,9 +6,10 @@ export type ManagedClients = Readonly<{
   dsh: boolean;
   opencode: boolean;
   codebuddy?: boolean;
+  trae?: boolean;
 }>;
 
-const allClients: ManagedClients = Object.freeze({ codex: true, claude: true, dsh: true, opencode: true, codebuddy: true });
+const allClients: ManagedClients = Object.freeze({ codex: true, claude: true, dsh: true, opencode: true, codebuddy: true, trae: true });
 
 export function resolveManagedClients(argv: readonly string[], config: MemoraxCodeConfig = {}): ManagedClients {
   const explicit = argValue(argv, "--clients");
@@ -23,6 +24,7 @@ export function resolveManagedClients(argv: readonly string[], config: MemoraxCo
       dsh: config.clients.dsh !== false,
       opencode: config.clients.opencode === true,
       ...(config.clients.codebuddy === true ? { codebuddy: true } : {}),
+      ...(config.clients.trae === true ? { trae: true } : {}),
     };
   }
 
@@ -36,9 +38,9 @@ export function parseManagedClients(value: string): ManagedClients {
 
   const names = normalized.split(",").map((name) => name.trim()).filter(Boolean);
   if (names.length === 0 || names.some((name) => (
-    name !== "codex" && name !== "claude" && name !== "dsh" && name !== "opencode" && name !== "codebuddy"
+    name !== "codex" && name !== "claude" && name !== "dsh" && name !== "opencode" && name !== "codebuddy" && name !== "trae"
   ))) {
-    throw new Error(`invalid --clients value: ${value}; expected a comma-separated subset of codex, claude, dsh, opencode, codebuddy, or all or none`);
+    throw new Error(`invalid --clients value: ${value}; expected a comma-separated subset of codex, claude, dsh, opencode, codebuddy, trae, or all or none`);
   }
   return {
     codex: names.includes("codex"),
@@ -46,6 +48,7 @@ export function parseManagedClients(value: string): ManagedClients {
     dsh: names.includes("dsh"),
     opencode: names.includes("opencode"),
     ...(names.includes("codebuddy") ? { codebuddy: true } : {}),
+    ...(names.includes("trae") ? { trae: true } : {}),
   };
 }
 

--- a/packages/ts/memorax-code-backend/src/lifecycle/orchestrator.ts
+++ b/packages/ts/memorax-code-backend/src/lifecycle/orchestrator.ts
@@ -32,6 +32,7 @@ import {
 } from "../clients/dsh/lifecycle.js";
 import { openCodeAdapterLifecycle } from "../clients/opencode/lifecycle.js";
 import { codeBuddyAdapterLifecycle } from "../clients/codebuddy/lifecycle.js";
+import { traeAdapterLifecycle } from "../clients/trae/lifecycle.js";
 import type {
   AdapterReport,
 } from "./participant.js";
@@ -50,6 +51,7 @@ export type MemoraxCodeStatusReport = {
   dshAdapter?: AdapterReport;
   opencodeAdapter?: AdapterReport;
   codebuddyAdapter?: AdapterReport;
+  traeAdapter?: AdapterReport;
 };
 
 export type MemoraxCodeLifecycleReport = {
@@ -64,8 +66,10 @@ export type MemoraxCodeLifecycleReport = {
   dshAdapter?: AdapterReport;
   opencodeAdapter?: AdapterReport;
   codebuddyAdapter?: AdapterReport;
+  traeAdapter?: AdapterReport;
   codexPlugin?: Awaited<ReturnType<typeof codexAdapterLifecycle.remove>>;
   codebuddyPlugin?: Awaited<ReturnType<typeof codeBuddyAdapterLifecycle.remove>>;
+  traePlugin?: Awaited<ReturnType<typeof traeAdapterLifecycle.remove>>;
   npmPackageRemoval?: NpmPackageRemovalReport;
   removesPlugin?: boolean;
   removesUserState?: false;
@@ -152,17 +156,22 @@ export async function collectMemoraxCodeStatus(
   const codebuddyAdapter = clients.codebuddy
     ? await codeBuddyAdapterLifecycle.status({ argv, serviceOptions, backendUrl })
     : undefined;
+  const traeAdapter = clients.trae
+    ? await traeAdapterLifecycle.status({ argv, serviceOptions, backendUrl })
+    : undefined;
   const codexReady = codexAdapter ? isAdapterReady(codexAdapter) : true;
   const claudeReady = claudeAdapter ? isAdapterReady(claudeAdapter) : true;
   const dshReady = dshAdapter ? isAdapterReady(dshAdapter) : true;
   const opencodeReady = opencodeAdapter ? isAdapterReady(opencodeAdapter) : true;
   const codebuddyReady = codebuddyAdapter ? isAdapterReady(codebuddyAdapter) : true;
+  const traeReady = traeAdapter ? isAdapterReady(traeAdapter) : true;
   const optionalDshUnavailable = isOptionalUnavailableDshAdapter(dshAdapter);
   return {
     ok: backend.ok
       && codexReady
       && opencodeReady
       && codebuddyReady
+      && traeReady
       && (isOptionalUnconfiguredClaudeAdapter(claudeAdapter, codexAdapter) || claudeReady)
       && (optionalDshUnavailable || dshReady),
     action: "status",
@@ -173,6 +182,7 @@ export async function collectMemoraxCodeStatus(
     ...(dshAdapter ? { dshAdapter } : {}),
     ...(opencodeAdapter ? { opencodeAdapter } : {}),
     ...(codebuddyAdapter ? { codebuddyAdapter } : {}),
+    ...(traeAdapter ? { traeAdapter } : {}),
   };
 }
 
@@ -336,11 +346,15 @@ async function executeMemoraxCodeStart(
   const deselectedCodeBuddy = previousClients?.codebuddy && !clients.codebuddy
     ? await codeBuddyAdapterLifecycle.disable({ argv, serviceOptions })
     : undefined;
+  const deselectedTrae = previousClients?.trae && !clients.trae
+    ? await traeAdapterLifecycle.disable({ argv, serviceOptions })
+    : undefined;
   if (deselectedCodex?.ok === false
     || deselectedClaude?.ok === false
     || deselectedDsh?.ok === false
     || deselectedOpenCode?.ok === false
-    || deselectedCodeBuddy?.ok === false) {
+    || deselectedCodeBuddy?.ok === false
+    || deselectedTrae?.ok === false) {
     const recovery = await recoverPreparationFailure("adapter_disable_failed");
     return {
       ok: false,
@@ -353,6 +367,7 @@ async function executeMemoraxCodeStart(
         : {}),
       ...(deselectedOpenCode ? { opencodeAdapter: deselectedOpenCode } : {}),
       ...(deselectedCodeBuddy ? { codebuddyAdapter: deselectedCodeBuddy } : {}),
+      ...(deselectedTrae ? { traeAdapter: deselectedTrae } : {}),
     };
   }
   // The marker is a conservative cleanup scope, not a readiness signal. Persist
@@ -394,6 +409,9 @@ async function executeMemoraxCodeStart(
   const codebuddyAdapter = clients.codebuddy
     ? await codeBuddyAdapterLifecycle.prepareEnable({ argv, serviceOptions, backendUrl })
     : undefined;
+  const traeAdapter = clients.trae
+    ? await traeAdapterLifecycle.prepareEnable({ argv, serviceOptions, backendUrl })
+    : undefined;
   if (opencodeAdapter?.ok === false) {
     const recovery = await recoverPreparationFailure("opencode_adapter_enable_failed");
     return {
@@ -405,6 +423,21 @@ async function executeMemoraxCodeStart(
       ...(recovery.dshAdapter ? { dshAdapter: recovery.dshAdapter } : {}),
       opencodeAdapter,
       ...(codebuddyAdapter ? { codebuddyAdapter } : {}),
+      ...(traeAdapter ? { traeAdapter } : {}),
+    };
+  }
+  if (traeAdapter?.ok === false) {
+    const recovery = await recoverPreparationFailure("trae_adapter_enable_failed");
+    return {
+      ok: false,
+      action: "start",
+      backend: recovery.backend,
+      ...(codexAdapter ? { codexAdapter } : {}),
+      ...(claudeAdapter ? { claudeAdapter } : {}),
+      ...(recovery.dshAdapter ? { dshAdapter: recovery.dshAdapter } : {}),
+      ...(opencodeAdapter ? { opencodeAdapter } : {}),
+      ...(codebuddyAdapter ? { codebuddyAdapter } : {}),
+      traeAdapter,
     };
   }
   const preparedDshAdapter = markOptionalDshAdapter(
@@ -426,6 +459,7 @@ async function executeMemoraxCodeStart(
       dshAdapter: recovery.dshAdapter ?? preparedDshAdapter,
       ...(opencodeAdapter ? { opencodeAdapter } : {}),
       ...(codebuddyAdapter ? { codebuddyAdapter } : {}),
+      ...(traeAdapter ? { traeAdapter } : {}),
     };
   }
   const backend = await startBackendService(serviceOptions);
@@ -439,6 +473,9 @@ async function executeMemoraxCodeStart(
     const disabledCodeBuddy = codebuddyAdapter
       ? await codeBuddyAdapterLifecycle.disable({ argv, serviceOptions })
       : undefined;
+    const disabledTrae = traeAdapter
+      ? await traeAdapterLifecycle.disable({ argv, serviceOptions })
+      : undefined;
     return {
       ok: false,
       action: "start",
@@ -448,6 +485,7 @@ async function executeMemoraxCodeStart(
       ...(preparedDshAdapter ? { dshAdapter: preparedDshAdapter } : {}),
       ...(disabledOpenCode ? { opencodeAdapter: disabledOpenCode } : {}),
       ...(disabledCodeBuddy ? { codebuddyAdapter: disabledCodeBuddy } : {}),
+      ...(disabledTrae ? { traeAdapter: disabledTrae } : {}),
     };
   }
   const dshAdapter = markOptionalDshAdapter(preparedDshAdapter?.installed === true
@@ -465,6 +503,7 @@ async function executeMemoraxCodeStart(
     ...(dshAdapter ? { dshAdapter } : {}),
     ...(opencodeAdapter ? { opencodeAdapter } : {}),
     ...(codebuddyAdapter ? { codebuddyAdapter } : {}),
+    ...(traeAdapter ? { traeAdapter } : {}),
   };
 }
 
@@ -524,14 +563,16 @@ async function executeMemoraxCodeStop(
       dsh: activeClients.dsh && !clients.dsh,
       opencode: activeClients.opencode && !clients.opencode,
       codebuddy: activeClients.codebuddy && !clients.codebuddy,
+      trae: activeClients.trae && !clients.trae,
     }
     : undefined;
   const hasRemainingClients = remaining?.codex === true
     || remaining?.claude === true
     || remaining?.dsh === true
     || remaining?.opencode === true
-    || remaining?.codebuddy === true;
-  const backendOnlyStop = !clients.codex && !clients.claude && !clients.dsh && !clients.opencode && !clients.codebuddy;
+    || remaining?.codebuddy === true
+    || remaining?.trae === true;
+  const backendOnlyStop = !clients.codex && !clients.claude && !clients.dsh && !clients.opencode && !clients.codebuddy && !clients.trae;
   const packageReplacement = isPackageReplacement();
   const needsBackendStop = packageReplacement || backendOnlyStop || !hasRemainingClients;
   const quiescedDsh = clients.dsh && dshLifecycle
@@ -587,11 +628,15 @@ async function executeMemoraxCodeStop(
   const codebuddyAdapter = clients.codebuddy
     ? await codeBuddyAdapterLifecycle.disable({ argv, serviceOptions })
     : undefined;
+  const traeAdapter = clients.trae
+    ? await traeAdapterLifecycle.disable({ argv, serviceOptions })
+    : undefined;
   const adaptersOk = codexAdapter?.ok !== false
     && claudeAdapter?.ok !== false
     && dshAdapter?.ok !== false
     && opencodeAdapter?.ok !== false
-    && codebuddyAdapter?.ok !== false;
+    && codebuddyAdapter?.ok !== false
+    && traeAdapter?.ok !== false;
   const backend = stoppedBackend
     ?? (adaptersOk
       ? preservedBackendResult(serviceOptions, "active_clients_remaining")
@@ -601,7 +646,8 @@ async function executeMemoraxCodeStop(
     && claudeAdapter?.ok !== false
     && dshAdapter?.ok !== false
     && opencodeAdapter?.ok !== false
-    && codebuddyAdapter?.ok !== false;
+    && codebuddyAdapter?.ok !== false
+    && traeAdapter?.ok !== false;
   return {
     report: {
       ok,
@@ -612,6 +658,7 @@ async function executeMemoraxCodeStop(
       ...(dshAdapter ? { dshAdapter } : {}),
       ...(opencodeAdapter ? { opencodeAdapter } : {}),
       ...(codebuddyAdapter ? { codebuddyAdapter } : {}),
+      ...(traeAdapter ? { traeAdapter } : {}),
     },
     remainingClients: packageReplacement
       ? activeClients
@@ -743,11 +790,15 @@ async function executeMemoraxCodeUninstall(
   const codebuddyPlugin = clients.codebuddy
     ? await codeBuddyAdapterLifecycle.remove({ argv, serviceOptions })
     : undefined;
+  const traePlugin = clients.trae
+    ? await traeAdapterLifecycle.remove({ argv, serviceOptions })
+    : undefined;
   const pluginCleanupOk = codexPlugin?.ok !== false
     && claudePlugin?.ok !== false
     && dshPlugin?.ok !== false
     && opencodePlugin?.ok !== false
-    && codebuddyPlugin?.ok !== false;
+    && codebuddyPlugin?.ok !== false
+    && traePlugin?.ok !== false;
   const npmPackageRemoval = !pluginCleanupOk
     ? skippedNpmPackageRemoval("plugin_cleanup_failed")
     : canRemoveSharedPackage
@@ -771,12 +822,14 @@ async function executeMemoraxCodeUninstall(
     ...(dshAdapter ? { dshAdapter } : {}),
     ...(opencodeAdapter ? { opencodeAdapter } : {}),
     ...(codebuddyPlugin ? { codebuddyPlugin } : {}),
+    ...(traePlugin ? { traePlugin } : {}),
     npmPackageRemoval,
     removesPlugin: codexPlugin?.ok === true
       || claudePlugin?.ok === true
       || (dshPlugin?.ok === true && dshPlugin.skipped !== true)
       || opencodePlugin?.ok === true
-      || codebuddyPlugin?.ok === true,
+      || codebuddyPlugin?.ok === true
+      || traePlugin?.ok === true,
     removesUserState: false,
   };
 }
@@ -927,7 +980,8 @@ function includesManagedClients(selection: ManagedClients, required: ManagedClie
     && (!required.claude || selection.claude)
     && (!required.dsh || selection.dsh)
     && (!required.opencode || selection.opencode)
-    && (!required.codebuddy || selection.codebuddy === true);
+    && (!required.codebuddy || selection.codebuddy === true)
+    && (!required.trae || selection.trae === true);
 }
 
 function isPackageReplacement(): boolean {
@@ -1097,7 +1151,9 @@ export function isAdapterReady(report: AdapterReport): boolean {
     && report.claudeSkills?.ok !== false
     && report.opencodeSkills?.ok !== false
     && report.codebuddyHooks?.ok !== false
-    && report.codebuddySkills?.ok !== false;
+    && report.codebuddySkills?.ok !== false
+    && report.traeHooks?.ok !== false
+    && report.traeSkills?.ok !== false;
 }
 
 export function isOptionalUnavailableDshAdapter(report: AdapterReport | undefined): boolean {

--- a/packages/ts/memorax-code-backend/src/lifecycle/participant.ts
+++ b/packages/ts/memorax-code-backend/src/lifecycle/participant.ts
@@ -48,6 +48,7 @@ export type AdapterReport = {
   claudeSkills?: { ok?: boolean; status?: string };
   opencodeSkills?: { ok?: boolean; status?: string };
   codebuddySkills?: { ok?: boolean; status?: string };
+  traeSkills?: { ok?: boolean; status?: string };
   codebuddyHooks?: {
     ok?: boolean;
     status?: string;
@@ -55,6 +56,14 @@ export type AdapterReport = {
     runtimeObserved?: boolean;
     observationPath?: string;
   };
+  traeHooks?: {
+    ok?: boolean;
+    status?: string;
+    configured?: boolean;
+    runtimeObserved?: boolean;
+    observationPath?: string;
+  };
+  globalHooksActivationRequired?: boolean;
   pluginInstall?: AdapterPluginLifecycleReport;
   pluginRemove?: AdapterPluginLifecycleReport;
   pluginStatus?: AdapterReport;

--- a/packages/ts/memorax-code-backend/test/lifecycle/backend/backend-connection.test.mjs
+++ b/packages/ts/memorax-code-backend/test/lifecycle/backend/backend-connection.test.mjs
@@ -676,3 +676,18 @@ test("CodeBuddy adapter readiness requires a valid Hook configuration but not a 
   assert.equal(isAdapterReady(report), true);
   assert.equal(isAdapterReady({ ...report, codebuddyHooks: { ok: false, status: "invalid" } }), false);
 });
+
+test("Trae adapter readiness requires configured Global Hooks but not a prior observation", () => {
+  const report = {
+    ok: true,
+    installed: true,
+    enabled: true,
+    integration: "hooks",
+    traeSkills: { ok: true, status: "installed" },
+    traeHooks: { ok: true, status: "unverified", runtimeObserved: false },
+    globalHooksActivationRequired: true,
+  };
+  assert.equal(isAdapterReady(report), true);
+  assert.equal(isAdapterReady({ ...report, traeHooks: { ok: false, status: "invalid" } }), false);
+  assert.equal(isAdapterReady({ ...report, traeSkills: { ok: false, status: "missing" } }), false);
+});

--- a/packages/ts/memorax-code-backend/test/lifecycle/client-plugin-removal.test.mjs
+++ b/packages/ts/memorax-code-backend/test/lifecycle/client-plugin-removal.test.mjs
@@ -134,7 +134,6 @@ writeFileSync(path, JSON.stringify(manifest, null, 2) + "\\n");
       dshAdapterRoot,
       dshCommand,
       openCodeConfigDir,
-      traeHome,
     });
     await rm(dshAdapterRoot, { recursive: true, force: true });
     const report = await cleanup();

--- a/packages/ts/memorax-code-backend/test/lifecycle/client-plugin-removal.test.mjs
+++ b/packages/ts/memorax-code-backend/test/lifecycle/client-plugin-removal.test.mjs
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { test } from "node:test";
 import { prepareClientPluginRemovalCleanup } from "../../dist/lifecycle/client-plugin-removal.js";
+import { enableTraeAdapter } from "../../../memorax-code-trae-adapter/src/config.mjs";
 
 test("package-removal cleanup is prepared before shutdown and removes all client integrations", async () => {
   const root = await mkdtemp(join(tmpdir(), "memorax-code-client-plugin-removal-"));
@@ -29,6 +30,9 @@ test("package-removal cleanup is prepared before shutdown and removes all client
   const openCodePlugin = join(openCodeConfigDir, "plugins", "memorax-code.js");
   const openCodeSkill = join(openCodeConfigDir, "skills", "memorax-code");
   const openCodeState = join(memoraxCodeHome, "adapters", "opencode", "state.json");
+  const traeHome = join(home, "trae-home");
+  const traeHooks = join(traeHome, "hooks.json");
+  const traeSkill = join(traeHome, "skills", "memorax-code");
 
   try {
     await mkdir(dirname(codexPluginManifest), { recursive: true });
@@ -38,6 +42,7 @@ test("package-removal cleanup is prepared before shutdown and removes all client
     await mkdir(dirname(openCodeState), { recursive: true });
     await mkdir(dirname(openCodePlugin), { recursive: true });
     await mkdir(openCodeSkill, { recursive: true });
+    await mkdir(traeHome, { recursive: true });
     await mkdir(claudeHome, { recursive: true });
     await mkdir(dirname(dshProfilePath), { recursive: true });
     await mkdir(dshAdapterRoot, { recursive: true });
@@ -95,6 +100,13 @@ test("package-removal cleanup is prepared before shutdown and removes all client
       pluginPath: openCodePlugin,
       skillPath: openCodeSkill,
     })}\n`);
+    await writeFile(traeHooks, `${JSON.stringify({
+      hooks: {
+        UserPromptSubmit: [{ hooks: [{ type: "command", command: "user-owned-trae-hook" }] }],
+      },
+    }, null, 2)}\n`);
+    const traeInstall = await enableTraeAdapter({ memoraxCodeHome, traeHome });
+    assert.equal(traeInstall.ok, true);
     await writeFile(claudeCommand, `#!/usr/bin/env node
 import { appendFileSync } from "node:fs";
 appendFileSync(${JSON.stringify(claudeCalls)}, JSON.stringify(process.argv.slice(2)) + "\\n");
@@ -122,6 +134,7 @@ writeFileSync(path, JSON.stringify(manifest, null, 2) + "\\n");
       dshAdapterRoot,
       dshCommand,
       openCodeConfigDir,
+      traeHome,
     });
     await rm(dshAdapterRoot, { recursive: true, force: true });
     const report = await cleanup();
@@ -131,10 +144,16 @@ writeFileSync(path, JSON.stringify(manifest, null, 2) + "\\n");
     assert.equal(report.claudePlugin?.ok, true);
     assert.equal(report.dshPlugin?.ok, true);
     assert.equal(report.opencodePlugin?.ok, true);
+    assert.equal(report.traePlugin?.ok, true);
     await assert.rejects(stat(codexPluginManifest), /ENOENT/);
     await assert.rejects(stat(openCodePlugin), /ENOENT/);
     await assert.rejects(stat(openCodeSkill), /ENOENT/);
     await assert.rejects(stat(openCodeState), /ENOENT/);
+    await assert.rejects(stat(traeSkill), /ENOENT/);
+    await assert.rejects(stat(join(memoraxCodeHome, "adapters", "trae", "state.json")), /ENOENT/);
+    const remainingTraeHooks = JSON.parse(await readFile(traeHooks, "utf8"));
+    assert.equal(JSON.stringify(remainingTraeHooks).includes("user-owned-trae-hook"), true);
+    assert.equal(JSON.stringify(remainingTraeHooks).includes("--memorax-code-trae-hook-v1"), false);
     const calls = (await readFile(claudeCalls, "utf8")).trim().split("\n").map(JSON.parse);
     assert.deepEqual(calls, [
       [

--- a/packages/ts/memorax-code-backend/test/lifecycle/client-selection.test.mjs
+++ b/packages/ts/memorax-code-backend/test/lifecycle/client-selection.test.mjs
@@ -36,6 +36,13 @@ test("managed clients use persisted config", () => {
     dsh: true,
     opencode: true,
   });
+  assert.deepEqual(resolveManagedClients([], { clients: { codex: false, claude: false, trae: true } }), {
+    codex: false,
+    claude: false,
+    dsh: true,
+    opencode: false,
+    trae: true,
+  });
 });
 
 test("--clients overrides persisted config", () => {
@@ -54,9 +61,10 @@ test("--clients accepts exact client sets", () => {
   assert.deepEqual(parseManagedClients("claude"), { codex: false, claude: true, dsh: false, opencode: false });
   assert.deepEqual(parseManagedClients("dsh"), { codex: false, claude: false, dsh: true, opencode: false });
   assert.deepEqual(parseManagedClients("opencode"), { codex: false, claude: false, dsh: false, opencode: true });
+  assert.deepEqual(parseManagedClients("trae"), { codex: false, claude: false, dsh: false, opencode: false, trae: true });
   assert.deepEqual(parseManagedClients("codex,dsh,opencode"), { codex: true, claude: false, dsh: true, opencode: true });
-  assert.deepEqual(parseManagedClients("codex,claude,dsh,opencode"), { codex: true, claude: true, dsh: true, opencode: true });
-  assert.deepEqual(parseManagedClients("all"), { codex: true, claude: true, dsh: true, opencode: true, codebuddy: true });
+  assert.deepEqual(parseManagedClients("codex,claude,dsh,opencode,trae"), { codex: true, claude: true, dsh: true, opencode: true, trae: true });
+  assert.deepEqual(parseManagedClients("all"), { codex: true, claude: true, dsh: true, opencode: true, codebuddy: true, trae: true });
   assert.deepEqual(parseManagedClients("none"), { codex: false, claude: false, dsh: false, opencode: false });
 });
 
@@ -109,6 +117,17 @@ test("managed clients config rejects invalid lifecycle TOML", async () => {
       /clients\.codex must be a boolean/,
     );
 
+    await writeFile(join(home, "config.toml"), [
+      "[clients]",
+      "codex = false",
+      'trae = "true"',
+      "",
+    ].join("\n"));
+    assert.throws(
+      () => loadManagedClientsConfig(home),
+      /clients\.trae must be a boolean/,
+    );
+
     await writeFile(join(home, "config.toml"), 'model = "not-a-table"\n');
     assert.deepEqual(loadManagedClientsConfig(home), {});
 
@@ -121,11 +140,11 @@ test("active managed clients persist and clear independently of config", async (
   const home = await mkdtemp(join(tmpdir(), "memorax-code-active-client-selection-"));
   try {
     assert.equal(readActiveManagedClients(home), undefined);
-    writeActiveManagedClients(home, { codex: false, claude: true, dsh: true, opencode: true });
-    assert.deepEqual(readActiveManagedClients(home), { codex: false, claude: true, dsh: true, opencode: true });
+    writeActiveManagedClients(home, { codex: false, claude: true, dsh: true, opencode: true, trae: true });
+    assert.deepEqual(readActiveManagedClients(home), { codex: false, claude: true, dsh: true, opencode: true, trae: true });
     assert.deepEqual(
       JSON.parse(await readFile(join(home, "runtime", "backend", "managed-clients.json"), "utf8")),
-      { codex: false, claude: true, dsh: true, opencode: true },
+      { codex: false, claude: true, dsh: true, opencode: true, trae: true },
     );
     clearActiveManagedClients(home);
     assert.equal(readActiveManagedClients(home), undefined);

--- a/packages/ts/memorax-code-backend/test/lifecycle/orchestrator.test.mjs
+++ b/packages/ts/memorax-code-backend/test/lifecycle/orchestrator.test.mjs
@@ -21,6 +21,64 @@ import {
   writeManagedClientsConfig,
 } from "./support/backend-service-fixtures.mjs";
 
+test("memorax-code lifecycle installs and disables only managed Trae Hooks", async () => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-code-lifecycle-trae-"));
+  const home = join(root, "memorax-code-home");
+  const traeHome = join(root, "trae-home");
+  const hooksPath = join(traeHome, "hooks.json");
+  const port = await freePort();
+  const cliPath = fileURLToPath(new URL("../../dist/memorax-code.js", import.meta.url));
+  const userHook = { hooks: [{ type: "command", command: "user-owned-hook" }] };
+  await mkdir(traeHome, { recursive: true });
+  await writeFile(hooksPath, `${JSON.stringify({
+    customSetting: true,
+    hooks: { UserPromptSubmit: [userHook] },
+  }, null, 2)}\n`);
+  const args = [
+    "--home", home,
+    "--port", String(port),
+    "--trae-home", traeHome,
+    "--clients", "trae",
+  ];
+  try {
+    const started = await runCli(cliPath, ["start", "--json", ...args]);
+    assert.equal(started.code, 0, `${started.stdout}\n${started.stderr}`);
+    const startReport = JSON.parse(started.stdout);
+    assert.equal(startReport.ok, true);
+    assert.equal(startReport.backend.ok, true);
+    assert.equal(startReport.traeAdapter.installed, true);
+    assert.equal(startReport.traeAdapter.enabled, true);
+    assert.equal(startReport.traeAdapter.integration, "hooks");
+    assert.equal(startReport.traeAdapter.traeHooks.configured, true);
+    assert.equal(startReport.traeAdapter.traeHooks.runtimeObserved, false);
+    assert.equal(startReport.traeAdapter.globalHooksActivationRequired, true);
+    assert.equal(startReport.traeAdapter.traeSkills.ok, true);
+
+    const installedHooks = JSON.parse(await readFile(hooksPath, "utf8"));
+    assert.equal(installedHooks.customSetting, true);
+    assert.equal(JSON.stringify(installedHooks).includes("user-owned-hook"), true);
+    assert.equal((JSON.stringify(installedHooks).match(/--memorax-code-trae-hook-v1/g) ?? []).length, 3);
+    assert.equal(await pathExists(join(traeHome, "skills", "memorax-code", "SKILL.md")), true);
+
+    const status = await runCli(cliPath, ["status", "--json", ...args]);
+    assert.equal(status.code, 0, `${status.stdout}\n${status.stderr}`);
+    assert.equal(JSON.parse(status.stdout).traeAdapter.enabled, true);
+
+    const stopped = await runCli(cliPath, ["stop", "--json", ...args]);
+    assert.equal(stopped.code, 0, `${stopped.stdout}\n${stopped.stderr}`);
+    const stopReport = JSON.parse(stopped.stdout);
+    assert.equal(stopReport.ok, true);
+    assert.equal(stopReport.traeAdapter.enabled, false);
+    const stoppedHooks = JSON.parse(await readFile(hooksPath, "utf8"));
+    assert.equal(stoppedHooks.customSetting, true);
+    assert.equal(JSON.stringify(stoppedHooks).includes("user-owned-hook"), true);
+    assert.equal(JSON.stringify(stoppedHooks).includes("--memorax-code-trae-hook-v1"), false);
+  } finally {
+    await runCli(cliPath, ["stop", "--json", ...args]);
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("stop preserves setup completion while complete uninstall clears it and preserves config", async () => {
   const home = await mkdtemp(join(tmpdir(), "memorax-code-uninstall-completion-home-"));
   const port = await freePort();

--- a/packages/ts/memorax-code-trae-adapter/hooks/runtime-hook.mjs
+++ b/packages/ts/memorax-code-trae-adapter/hooks/runtime-hook.mjs
@@ -91,7 +91,8 @@ if (event === "SessionStart") {
   if (!prompt) process.exit(0);
   const cwd = stringValue(input.cwd);
   const workspaceKind = stringValue(input.workspace_kind) ?? stringValue(input.workspaceKind);
-  const activeTurn = writeActiveTurn({ sessionId, prompt, cwd, workspaceKind });
+  const activeTurnPlan = prepareActiveTurn({ sessionId, prompt, cwd, workspaceKind });
+  const activeTurn = activeTurnPlan.record;
   const response = await post("/memory/turn-start", {
     version: 1,
     client: "trae",
@@ -101,6 +102,7 @@ if (event === "SessionStart") {
     cwd,
     workspaceKind,
   });
+  if (response?.ok !== true || !commitActiveTurn(activeTurnPlan)) process.exit(0);
   const repoMemoryWorktree = stringValue(response?.repoMemoryWorktree);
   const reminderResult = await evaluateMemorySkillReminder({
     ...reminderOptions,
@@ -149,7 +151,7 @@ if (event === "SessionStart") {
   if (response?.ok === true && response?.scheduled === true) removeActiveTurn(sessionId, activeTurn.turnId);
 }
 
-function writeActiveTurn({ sessionId, prompt, cwd, workspaceKind }) {
+function prepareActiveTurn({ sessionId, prompt, cwd, workspaceKind }) {
   return withJsonFileLock(activeTurnsPath, () => {
     const state = activeTurnState();
     pruneActiveTurns(state);
@@ -170,11 +172,22 @@ function writeActiveTurn({ sessionId, prompt, cwd, workspaceKind }) {
           createdAt: now,
           updatedAt: now,
         };
-    state.sessions[sessionId] = record;
+    return { record, expectedTurnId: existing?.turnId };
+  });
+}
+
+function commitActiveTurn({ record, expectedTurnId }) {
+  return withJsonFileLock(activeTurnsPath, () => {
+    const state = activeTurnState();
+    pruneActiveTurns(state);
+    const current = validActiveTurn(state.sessions?.[record.sessionId], record.sessionId);
+    if (current?.turnId !== expectedTurnId && current?.turnId !== record.turnId) return false;
+    state.sessions[record.sessionId] = record;
+    const now = Date.now();
     state.updatedAt = new Date(now).toISOString();
     pruneActiveTurns(state);
     atomicWriteJson(activeTurnsPath, state);
-    return record;
+    return true;
   });
 }
 

--- a/packages/ts/memorax-code-trae-adapter/hooks/runtime-hook.mjs
+++ b/packages/ts/memorax-code-trae-adapter/hooks/runtime-hook.mjs
@@ -1,0 +1,327 @@
+#!/usr/bin/env node
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { writeTraeRuntimeObservation } from "../src/runtime-observation.mjs";
+
+const runtimeRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const commonRoot = join(runtimeRoot, "memorax-code-adapter-common", "src");
+const { buildRepoProcedureMemoryContext } = await import(pathToFileURL(join(commonRoot, "repo-memory", "repo-procedure-memory-context.mjs")).href);
+const { buildRepoUserProfilePreferencesContext } = await import(pathToFileURL(join(commonRoot, "repo-memory", "repo-user-profile-context.mjs")).href);
+const { resolveBackendConnection } = await import(pathToFileURL(join(commonRoot, "backend-connection.mjs")).href);
+const {
+  atomicWriteJson,
+  readJsonFile,
+  withJsonFileLock,
+} = await import(pathToFileURL(join(commonRoot, "config-utils.mjs")).href);
+const { ensureBackendAvailable, stringValue: commonStringValue } = await import(pathToFileURL(join(commonRoot, "hooks", "ensure-backend-runner.mjs")).href);
+const {
+  evaluateMemorySkillReminder,
+  markSupplementalReminderAfterCompact,
+  personalMemoryReminderContext,
+} = await import(pathToFileURL(join(commonRoot, "hooks", "memory-skill-reminder-hook.mjs")).href);
+const { isRepoMemoryJobWorker } = await import(pathToFileURL(join(commonRoot, "repo-memory", "repo-memory-job-context.mjs")).href);
+
+if (isRepoMemoryJobWorker()) process.exit(0);
+
+const MEMORY_SKILL_INVOCATION = "the `memorax-code` skill";
+const REMINDER_TRACE_TIMEOUT_MS = 1000;
+const input = await readJsonStdin();
+const event = stringValue(input?.hook_event_name) ?? stringValue(input?.hookEventName);
+const sessionId = stringValue(input?.session_id) ?? stringValue(input?.sessionId);
+if (!event || !sessionId || !["SessionStart", "UserPromptSubmit", "Stop"].includes(event)) process.exit(0);
+
+const packageMetadata = await readRecord(join(runtimeRoot, ".memorax-code-package.json"));
+const home = commonStringValue(process.env.MEMORAX_CODE_HOME)
+  ?? commonStringValue(packageMetadata.memoraxCodeHome)
+  ?? join(homedir(), ".memorax-code");
+const traeHome = commonStringValue(process.env.TRAE_CN_HOME)
+  ?? commonStringValue(process.env.TRAE_HOME)
+  ?? commonStringValue(packageMetadata.traeHome)
+  ?? join(homedir(), ".trae-cn");
+const runtimeDigest = commonStringValue(packageMetadata.runtimeDigest);
+const debugEnabled = process.env.MEMORAX_CODE_TRAE_HOOK_DEBUG === "1";
+if (runtimeDigest) {
+  try {
+    await writeTraeRuntimeObservation({ memoraxCodeHome: home, traeHome, runtimeDigest });
+  } catch (error) {
+    debug(error);
+  }
+}
+
+const reminderOptions = {
+  adapterDir: "trae",
+  debugEnv: "MEMORAX_CODE_TRAE_HOOK_DEBUG",
+  memoraxCodeHome: home,
+  runtime: "trae",
+  supplementalReminderAfterCompact: true,
+};
+const personalMemoryContextOptions = {
+  adapterDir: "trae",
+  debugEnv: "MEMORAX_CODE_TRAE_HOOK_DEBUG",
+  sessionKeyPrefix: "trae",
+};
+const activeTurnsPath = join(home, "adapters", "trae", "active-turns.json");
+
+await ensureBackendAvailable({
+  ensureBackendValue: process.env.MEMORAX_CODE_TRAE_ENSURE_BACKEND
+    ?? process.env.MEMORAX_CODE_TRAE_HOOK_ENSURE_BACKEND,
+  healthTimeoutValue: process.env.MEMORAX_CODE_TRAE_ENSURE_TIMEOUT_MS,
+  startTimeoutValue: process.env.MEMORAX_CODE_TRAE_START_TIMEOUT_MS,
+  memoraxCodeCommand: commonStringValue(process.env.MEMORAX_CODE_TRAE_LIFECYCLE_COMMAND)
+    ?? commonStringValue(process.env.MEMORAX_CODE_COMMAND),
+  pluginRoot: runtimeRoot,
+  resolveHomes: () => ({ memoraxCodeHome: home, traeHome }),
+  buildStartArgs: (homes, recoveryArguments) => [
+    "start",
+    "--home", homes.memoraxCodeHome,
+    "--clients", "trae",
+    "--trae-home", homes.traeHome,
+    ...recoveryArguments,
+  ],
+  debug,
+}, input);
+
+if (event === "SessionStart") {
+  markSupplementalReminderAfterCompact(reminderOptions, input);
+} else if (event === "UserPromptSubmit") {
+  const prompt = contentValue(input.prompt);
+  if (!prompt) process.exit(0);
+  const cwd = stringValue(input.cwd);
+  const workspaceKind = stringValue(input.workspace_kind) ?? stringValue(input.workspaceKind);
+  const activeTurn = writeActiveTurn({ sessionId, prompt, cwd, workspaceKind });
+  const response = await post("/memory/turn-start", {
+    version: 1,
+    client: "trae",
+    sessionId,
+    turnId: activeTurn.turnId,
+    prompt,
+    cwd,
+    workspaceKind,
+  });
+  const repoMemoryWorktree = stringValue(response?.repoMemoryWorktree);
+  const reminderResult = await evaluateMemorySkillReminder({
+    ...reminderOptions,
+    additionalReminderContext: personalMemoryReminderContext(MEMORY_SKILL_INVOCATION),
+    memorySkillInvocation: MEMORY_SKILL_INVOCATION,
+    remindOnFirstTurn: true,
+    requireTranscriptPath: false,
+    ...(repoMemoryWorktree ? {
+      buildCadenceReminderContext: (hookInput) => buildRepoProcedureMemoryContext({
+        ...hookInput,
+        cwd: repoMemoryWorktree,
+      }, personalMemoryContextOptions),
+      buildPersonalMemoryContext: (hookInput) => buildRepoUserProfilePreferencesContext({
+        ...hookInput,
+        cwd: repoMemoryWorktree,
+      }, personalMemoryContextOptions),
+    } : {}),
+  }, { ...input, turnId: activeTurn.turnId, workspaceKind });
+  const context = [
+    stringValue(response?.additionalContext),
+    stringValue(reminderResult?.additionalContext),
+  ].filter(Boolean).join("\n\n");
+  const systemMessage = stringValue(response?.userNotice);
+  if (context || systemMessage) {
+    process.stdout.write(`${JSON.stringify({
+      ...(systemMessage ? { systemMessage } : {}),
+      ...(context ? { hookSpecificOutput: { hookEventName: "UserPromptSubmit", additionalContext: context } } : {}),
+    })}\n`);
+  }
+  if (response !== undefined && reminderResult?.reminder) await recordReminder(reminderResult.reminder);
+} else {
+  const lastAssistantMessage = assistantMessage(input);
+  if (!lastAssistantMessage) process.exit(0);
+  const activeTurn = readActiveTurn(sessionId);
+  if (!activeTurn) process.exit(0);
+  const response = await post("/memory/writeback", {
+    version: 1,
+    client: "trae",
+    sessionId,
+    turnId: activeTurn.turnId,
+    prompt: activeTurn.prompt,
+    lastAssistantMessage,
+    cwd: activeTurn.cwd ?? stringValue(input.cwd),
+    workspaceKind: activeTurn.workspaceKind,
+  });
+  if (response?.ok === true && response?.scheduled === true) removeActiveTurn(sessionId, activeTurn.turnId);
+}
+
+function writeActiveTurn({ sessionId, prompt, cwd, workspaceKind }) {
+  return withJsonFileLock(activeTurnsPath, () => {
+    const state = activeTurnState();
+    pruneActiveTurns(state);
+    const existing = validActiveTurn(state.sessions?.[sessionId], sessionId);
+    const now = Date.now();
+    const record = existing
+      && existing.prompt === prompt
+      && existing.cwd === cwd
+      && existing.workspaceKind === workspaceKind
+      ? { ...existing, updatedAt: now }
+      : {
+          version: 1,
+          sessionId,
+          turnId: createTraeTurnId(sessionId, now, prompt),
+          prompt,
+          ...(cwd ? { cwd } : {}),
+          ...(workspaceKind ? { workspaceKind } : {}),
+          createdAt: now,
+          updatedAt: now,
+        };
+    state.sessions[sessionId] = record;
+    state.updatedAt = new Date(now).toISOString();
+    pruneActiveTurns(state);
+    atomicWriteJson(activeTurnsPath, state);
+    return record;
+  });
+}
+
+function readActiveTurn(sessionId) {
+  return withJsonFileLock(activeTurnsPath, () => {
+    const state = activeTurnState();
+    pruneActiveTurns(state);
+    atomicWriteJson(activeTurnsPath, state);
+    return validActiveTurn(state.sessions[sessionId], sessionId);
+  });
+}
+
+function removeActiveTurn(sessionId, turnId) {
+  withJsonFileLock(activeTurnsPath, () => {
+    const state = activeTurnState();
+    if (state.sessions?.[sessionId]?.turnId === turnId) delete state.sessions[sessionId];
+    state.updatedAt = new Date().toISOString();
+    atomicWriteJson(activeTurnsPath, state);
+  });
+}
+
+function activeTurnState() {
+  const value = readJsonFile(activeTurnsPath);
+  if (value?.unreadable) return { version: 1, runtime: "trae", sessions: {} };
+  const state = value?.value;
+  if (!isRecord(state) || state.version !== 1 || state.runtime !== "trae" || !isRecord(state.sessions)) {
+    return { version: 1, runtime: "trae", sessions: {} };
+  }
+  return state;
+}
+
+function pruneActiveTurns(state) {
+  const now = Date.now();
+  for (const [id, record] of Object.entries(state.sessions)) {
+    const valid = validActiveTurn(record, id);
+    if (!valid || now - valid.updatedAt > 24 * 60 * 60 * 1000) delete state.sessions[id];
+  }
+  const ordered = Object.entries(state.sessions)
+    .sort(([, left], [, right]) => Number(left.updatedAt ?? 0) - Number(right.updatedAt ?? 0));
+  while (ordered.length > 200) {
+    const [id] = ordered.shift();
+    delete state.sessions[id];
+  }
+}
+
+function validActiveTurn(value, sessionId) {
+  if (!isRecord(value)
+    || value.version !== 1
+    || value.sessionId !== sessionId
+    || !validTraeTurnId(sessionId, value.turnId, value.prompt)
+    || !contentValue(value.prompt)
+    || !Number.isSafeInteger(value.createdAt)
+    || !Number.isSafeInteger(value.updatedAt)) return undefined;
+  return value;
+}
+
+function createTraeTurnId(sessionId, createdAt, prompt) {
+  const digest = createHash("sha256").update(prompt.trim()).digest("hex");
+  return `${sessionId}:${createdAt}:${digest}`;
+}
+
+function validTraeTurnId(sessionId, turnId, prompt) {
+  if (typeof turnId !== "string" || !turnId.startsWith(`${sessionId}:`)) return false;
+  const match = /^([1-9]\d*):([a-f0-9]{64})$/.exec(turnId.slice(sessionId.length + 1));
+  return Boolean(match
+    && Number.isSafeInteger(Number(match[1]))
+    && match[2] === createHash("sha256").update(String(prompt).trim()).digest("hex"));
+}
+
+async function recordReminder(reminder) {
+  if (!reminder.turnId) return;
+  await post("/memory/skill-reminder", {
+    version: 1,
+    client: "trae",
+    sessionId: reminder.sessionId,
+    turnId: reminder.turnId,
+    cwd: reminder.cwd,
+    workspaceKind: reminder.workspaceKind,
+    content: reminder.content,
+    triggers: reminder.triggers,
+  }, REMINDER_TRACE_TIMEOUT_MS);
+}
+
+async function post(path, body, timeoutMs = 12_000) {
+  let connection;
+  try {
+    connection = resolveBackendConnection({ memoraxCodeHome: home });
+  } catch (error) {
+    debug(error);
+    return undefined;
+  }
+  const headers = { "content-type": "application/json", connection: "close" };
+  if (connection.token) headers["x-memorax-code-backend-token"] = connection.token;
+  try {
+    const response = await fetch(new URL(path, connection.url), {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    return response.ok ? await response.json().catch(() => undefined) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function assistantMessage(value) {
+  const last = contentValue(value.last_assistant_message) ?? contentValue(value.lastAssistantMessage);
+  const text = contentValue(value.text_content) ?? contentValue(value.textContent);
+  if (last && text && last !== text) {
+    debug(new Error("Trae Stop payload assistant fields do not match"));
+    return undefined;
+  }
+  return last ?? text;
+}
+
+async function readJsonStdin() {
+  try {
+    let text = "";
+    for await (const chunk of process.stdin) text += chunk;
+    return JSON.parse(text);
+  } catch {
+    return {};
+  }
+}
+
+async function readRecord(path) {
+  try {
+    const value = JSON.parse(await readFile(path, "utf8"));
+    return isRecord(value) ? value : {};
+  } catch {
+    return {};
+  }
+}
+
+function contentValue(value) {
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function stringValue(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function isRecord(value) {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function debug(error) {
+  if (debugEnabled) console.error(error instanceof Error ? error.message : String(error));
+}

--- a/packages/ts/memorax-code-trae-adapter/package.json
+++ b/packages/ts/memorax-code-trae-adapter/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@memorax-code/trae-adapter",
+  "version": "0.1.11",
+  "private": true,
+  "type": "module",
+  "description": "Trae Hook adapter for MemoraX Code memory services.",
+  "bin": { "memorax-code-trae": "src/cli.mjs" },
+  "scripts": { "test": "node --test test/*.test.mjs" }
+}

--- a/packages/ts/memorax-code-trae-adapter/src/adapter-paths.mjs
+++ b/packages/ts/memorax-code-trae-adapter/src/adapter-paths.mjs
@@ -1,0 +1,69 @@
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve, win32 } from "node:path";
+
+export function defaultTraeHome(env = process.env, home = homedir()) {
+  return resolve(stringOption(env.TRAE_CN_HOME) ?? stringOption(env.TRAE_HOME) ?? join(home, ".trae-cn"));
+}
+
+export function defaultMemoraxCodeHome(env = process.env, home = homedir()) {
+  return resolve(stringOption(env.MEMORAX_CODE_HOME) ?? join(home, ".memorax-code"));
+}
+
+export function traeHooksPath(traeHome = defaultTraeHome()) {
+  return join(traeHome, "hooks.json");
+}
+
+export function traeSkillPath(traeHome = defaultTraeHome()) {
+  return join(traeHome, "skills", "memorax-code");
+}
+
+export function traeAdapterRoot(memoraxCodeHome = defaultMemoraxCodeHome()) {
+  return join(memoraxCodeHome, "adapters", "trae");
+}
+
+export function traeAdapterStatePath(memoraxCodeHome = defaultMemoraxCodeHome()) {
+  return join(traeAdapterRoot(memoraxCodeHome), "state.json");
+}
+
+export function traeRuntimeRoot(memoraxCodeHome = defaultMemoraxCodeHome()) {
+  return join(traeAdapterRoot(memoraxCodeHome), "runtime", "generations");
+}
+
+export function traeInstallationDetected({
+  env = process.env,
+  home = homedir(),
+  platform = process.platform,
+  pathExists = existsSync,
+} = {}) {
+  if (stringOption(env.TRAE_CN_HOME) || stringOption(env.TRAE_HOME)) return true;
+  if (pathExists(defaultTraeHome(env, home))) return true;
+  return traeApplicationCandidates({ env, home, platform }).some(pathExists);
+}
+
+export function traeApplicationCandidates({ env = process.env, home = homedir(), platform = process.platform } = {}) {
+  if (platform === "darwin") {
+    return [
+      "/Applications/Trae CN.app",
+      join(home, "Applications", "Trae CN.app"),
+      "/Applications/Trae.app",
+      join(home, "Applications", "Trae.app"),
+    ];
+  }
+  if (platform === "win32") {
+    return [
+      env.LOCALAPPDATA && win32.join(env.LOCALAPPDATA, "Programs", "Trae CN"),
+      env.LOCALAPPDATA && win32.join(env.LOCALAPPDATA, "Programs", "Trae"),
+      env.ProgramFiles && win32.join(env.ProgramFiles, "Trae CN"),
+      env.ProgramFiles && win32.join(env.ProgramFiles, "Trae"),
+    ].filter(Boolean);
+  }
+  return [
+    join(home, ".local", "share", "applications", "trae.desktop"),
+    "/usr/share/applications/trae.desktop",
+  ];
+}
+
+function stringOption(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}

--- a/packages/ts/memorax-code-trae-adapter/src/cli.mjs
+++ b/packages/ts/memorax-code-trae-adapter/src/cli.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+import {
+  defaultTraeHome,
+} from "./adapter-paths.mjs";
+import {
+  disableTraeAdapter,
+  enableTraeAdapter,
+  readTraeAdapterStatus,
+  removeTraeAdapterInstallation,
+} from "./config.mjs";
+
+try {
+  const parsed = parseCli(process.argv);
+  if (parsed.help) {
+    console.log("Usage: memorax-code-trae [status|enable|disable|remove] [--trae-home DIR] [--json]");
+    process.exit(0);
+  }
+  const options = { traeHome: parsed.home };
+  const result = parsed.command === "status"
+    ? await readTraeAdapterStatus(options)
+    : parsed.command === "enable"
+      ? await enableTraeAdapter(options)
+      : parsed.command === "disable"
+        ? await disableTraeAdapter(options)
+        : parsed.command === "remove"
+          ? await removeTraeAdapterInstallation(options)
+          : undefined;
+  if (!result) throw new Error(`unknown command: ${parsed.command}`);
+  if (parsed.json) console.log(JSON.stringify(result, null, 2));
+  else console.log(`${result.action}: ${result.ok ? "ok" : "failed"}\nhome: ${result.traeHome ?? parsed.home}`);
+  const ready = result.ok === true
+    && result.installed === true
+    && result.enabled === true
+    && result.traeHooks?.ok === true
+    && result.traeSkills?.ok === true;
+  process.exit(parsed.command === "status" ? (ready ? 0 : 1) : (result.ok ? 0 : 1));
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}
+
+function parseCli(argv) {
+  const args = argv.slice(2);
+  const command = args[0] && !args[0].startsWith("-") ? args.shift() : "status";
+  let home;
+  let json = false;
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--help") return { command, help: true };
+    if (arg === "--json") { json = true; continue; }
+    if (arg === "--trae-home") {
+      home = args[++index];
+      if (!home || home.startsWith("--")) throw new Error("--trae-home requires a value");
+      continue;
+    }
+    throw new Error(`unknown option: ${arg}`);
+  }
+  return { command, home: home ?? defaultTraeHome(), json, help: false };
+}

--- a/packages/ts/memorax-code-trae-adapter/src/config.mjs
+++ b/packages/ts/memorax-code-trae-adapter/src/config.mjs
@@ -1,0 +1,593 @@
+import { createHash, randomUUID } from "node:crypto";
+import {
+  cpSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, isAbsolute, join, relative, resolve, sep, win32 } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  atomicWriteJson,
+  readAdapterState,
+  readJsonFile,
+  stringOption,
+  withJsonFileLock,
+} from "../../memorax-code-adapter-common/src/config-utils.mjs";
+import {
+  defaultMemoraxCodeHome,
+  defaultTraeHome,
+  traeAdapterRoot,
+  traeAdapterStatePath,
+  traeHooksPath,
+  traeRuntimeRoot,
+  traeSkillPath,
+} from "./adapter-paths.mjs";
+import {
+  readTraeRuntimeObservation,
+  traeRuntimeObservationPath,
+} from "./runtime-observation.mjs";
+
+const ADAPTER_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const STATE_VERSION = 1;
+const HOOK_MARKER = "--memorax-code-trae-hook-v1";
+const REQUIRED_EVENTS = ["SessionStart", "UserPromptSubmit", "Stop"];
+
+export async function enableTraeAdapter(options = {}) {
+  const paths = resolvePaths(options);
+  const previousState = readAdapterState(paths.statePath);
+  const stateProblem = validateState(previousState, paths);
+  if (stateProblem) return { ...stateProblem, action: "enable" };
+  const sourceProblem = validateSources(paths);
+  if (sourceProblem) return { ...sourceProblem, action: "enable" };
+  if (existsSync(paths.skillPath) && previousState?.skillPath !== paths.skillPath) {
+    return conflict("skill_conflict", paths, paths.skillPath);
+  }
+
+  let hookManifest;
+  try {
+    hookManifest = readHookManifest(paths.hooksPath);
+  } catch (error) {
+    return failure("hooks_invalid", paths, error);
+  }
+
+  const runtimeDigest = runtimeSourceDigest(paths);
+  const generationPath = join(paths.runtimeRoot, runtimeDigest);
+  const runtimePath = join(generationPath, "hooks", "runtime-hook.mjs");
+  const hookCommand = traeHookCommand(
+    runtimePath,
+    options.platform ?? process.platform,
+    absoluteRegularFile(options.nodePath) ?? process.execPath,
+    options.powershellPath ?? defaultWindowsPowerShellPath(),
+  );
+  const skillDigest = directoryDigest(paths.skillSourcePath);
+  const current = previousState?.runtimeDigest === runtimeDigest
+    && previousState?.skillDigest === skillDigest
+    && previousState?.enabled === true
+    && existsSync(runtimePath)
+    && directoryDigestIfPresent(paths.skillPath) === skillDigest
+    && hooksConfigured(hookManifest, hookCommand);
+
+  try {
+    materializeRuntimeGeneration(paths, generationPath, runtimeDigest, options);
+    if (directoryDigestIfPresent(paths.skillPath) !== skillDigest) {
+      materializeDirectory(paths.skillSourcePath, paths.skillPath);
+    }
+    updateManagedHooks(paths.hooksPath, hookCommand, true);
+    const now = new Date().toISOString();
+    atomicWriteJson(paths.statePath, {
+      version: STATE_VERSION,
+      runtime: "trae",
+      integration: "hooks",
+      enabled: true,
+      traeHome: paths.traeHome,
+      hooksPath: paths.hooksPath,
+      skillPath: paths.skillPath,
+      skillDigest,
+      runtimeRoot: paths.runtimeRoot,
+      runtimePath,
+      runtimeDigest,
+      hookCommand,
+      installedAt: stringOption(previousState?.installedAt) ?? now,
+      updatedAt: now,
+    });
+  } catch (error) {
+    return failure("install_failed", paths, error);
+  }
+
+  return await readTraeAdapterStatus({ ...options, ...paths, changed: !current });
+}
+
+export async function disableTraeAdapter(options = {}) {
+  const paths = resolvePaths(options);
+  const state = readAdapterState(paths.statePath);
+  const stateProblem = validateState(state, paths);
+  if (stateProblem) return { ...stateProblem, action: "disable" };
+  if (!state) {
+    return {
+      ok: true,
+      action: "disable",
+      runtime: "trae",
+      integration: "hooks",
+      installed: false,
+      enabled: false,
+      managed: false,
+      skipped: true,
+      reason: "not_managed",
+      traeHome: paths.traeHome,
+      statePath: paths.statePath,
+    };
+  }
+  try {
+    updateManagedHooks(paths.hooksPath, undefined, false);
+    atomicWriteJson(paths.statePath, {
+      ...state,
+      enabled: false,
+      disabledAt: new Date().toISOString(),
+    });
+  } catch (error) {
+    return failure("disable_failed", paths, error);
+  }
+  return {
+    ok: true,
+    action: "disable",
+    runtime: "trae",
+    integration: "hooks",
+    installed: existsSync(state.runtimePath) && existsSync(join(state.skillPath, "SKILL.md")),
+    enabled: false,
+    managed: true,
+    changed: state.enabled === true,
+    traeHome: paths.traeHome,
+    statePath: paths.statePath,
+  };
+}
+
+export async function readTraeAdapterStatus(options = {}) {
+  const paths = resolvePaths(options);
+  const state = readAdapterState(paths.statePath);
+  const stateProblem = validateState(state, paths);
+  if (stateProblem) return { ...stateProblem, action: "status" };
+  if (!state) {
+    return {
+      ok: true,
+      action: "status",
+      runtime: "trae",
+      integration: "hooks",
+      installed: false,
+      enabled: false,
+      managed: false,
+      skipped: true,
+      reason: "not_managed",
+      traeHome: paths.traeHome,
+      statePath: paths.statePath,
+      traeHooks: { ok: false, configured: false, runtimeObserved: false, status: "missing" },
+      traeSkills: skillSummary(paths.skillPath, false),
+    };
+  }
+  let manifest;
+  try {
+    manifest = readHookManifest(paths.hooksPath);
+  } catch {
+    manifest = undefined;
+  }
+  const runtimeCurrent = existsSync(state.runtimePath)
+    && state.runtimePath === join(state.runtimeRoot, state.runtimeDigest, "hooks", "runtime-hook.mjs");
+  const skillCurrent = existsSync(join(state.skillPath, "SKILL.md"))
+    && directoryDigestIfPresent(state.skillPath) === state.skillDigest;
+  const configured = Boolean(manifest && hooksConfigured(manifest, state.hookCommand));
+  const observation = await readTraeRuntimeObservation(paths.memoraxCodeHome);
+  const runtimeObserved = observation?.runtimeDigest === state.runtimeDigest
+    && comparablePath(observation.traeHome, options.platform ?? process.platform)
+      === comparablePath(paths.traeHome, options.platform ?? process.platform);
+  const installed = runtimeCurrent && skillCurrent;
+  const enabled = state.enabled === true && installed && configured;
+  return {
+    ok: true,
+    action: "status",
+    runtime: "trae",
+    integration: "hooks",
+    installed,
+    enabled,
+    managed: true,
+    current: installed && configured,
+    changed: options.changed,
+    traeHome: paths.traeHome,
+    statePath: paths.statePath,
+    installPath: dirname(state.runtimePath),
+    skillPath: state.skillPath,
+    traeHooks: {
+      ok: configured,
+      configured,
+      runtimeObserved,
+      status: configured ? (runtimeObserved ? "observed" : "unverified") : "invalid",
+      observationPath: traeRuntimeObservationPath(paths.memoraxCodeHome),
+    },
+    traeSkills: skillSummary(state.skillPath, skillCurrent),
+    globalHooksActivationRequired: configured && !runtimeObserved,
+    ...(!enabled ? { reason: !installed ? "artifacts_missing" : "hooks_not_configured" } : {}),
+  };
+}
+
+export async function removeTraeAdapterInstallation(options = {}) {
+  const paths = resolvePaths(options);
+  const state = readAdapterState(paths.statePath);
+  const stateProblem = validateState(state, paths);
+  if (stateProblem) return { ...stateProblem, action: "trae-adapter-remove" };
+  if (!state) {
+    return {
+      ok: true,
+      action: "trae-adapter-remove",
+      skipped: true,
+      reason: "not_managed",
+      removed: false,
+      statePath: paths.statePath,
+    };
+  }
+  const disabled = await disableTraeAdapter(options);
+  if (disabled.ok === false) return { ...disabled, action: "trae-adapter-remove" };
+  try {
+    rmSync(state.skillPath, { recursive: true, force: true });
+    rmSync(traeAdapterRoot(paths.memoraxCodeHome), { recursive: true, force: true });
+  } catch (error) {
+    return failure("remove_failed", paths, error, "trae-adapter-remove");
+  }
+  return {
+    ok: true,
+    action: "trae-adapter-remove",
+    runtime: "trae",
+    integration: "hooks",
+    installed: false,
+    enabled: false,
+    managed: false,
+    removed: true,
+    traeHome: paths.traeHome,
+    statePath: paths.statePath,
+  };
+}
+
+export function traeHookCommand(
+  runtimePath,
+  platform = process.platform,
+  nodePath = process.execPath,
+  powershellPath = defaultWindowsPowerShellPath(),
+) {
+  if (platform !== "win32") {
+    return `"${nodePath.replaceAll('"', '\\"')}" "${runtimePath.replaceAll('"', '\\"')}" ${HOOK_MARKER}`;
+  }
+  const script = [
+    "$ErrorActionPreference='Stop'",
+    "$utf8=[Text.UTF8Encoding]::new($false)",
+    "[Console]::InputEncoding=$utf8",
+    "[Console]::OutputEncoding=$utf8",
+    "$payload=[Console]::In.ReadToEnd()",
+    "$start=[Diagnostics.ProcessStartInfo]::new()",
+    `$start.FileName=${powershellLiteral(nodePath)}`,
+    `$start.Arguments=${powershellLiteral(`"${runtimePath}" "${HOOK_MARKER}"`)}`,
+    "$start.UseShellExecute=$false",
+    "$start.CreateNoWindow=$true",
+    "$start.RedirectStandardInput=$true",
+    "$start.RedirectStandardOutput=$true",
+    "$start.RedirectStandardError=$true",
+    "$start.StandardOutputEncoding=$utf8",
+    "$start.StandardErrorEncoding=$utf8",
+    "$process=[Diagnostics.Process]::new()",
+    "$process.StartInfo=$start",
+    "[void]$process.Start()",
+    "$stdout=$process.StandardOutput.ReadToEndAsync()",
+    "$stderr=$process.StandardError.ReadToEndAsync()",
+    "$process.StandardInput.Write($payload)",
+    "$process.StandardInput.Close()",
+    "$process.WaitForExit()",
+    "[Console]::Out.Write($stdout.GetAwaiter().GetResult())",
+    "[Console]::Error.Write($stderr.GetAwaiter().GetResult())",
+    "exit $process.ExitCode",
+  ].join(";");
+  const encoded = Buffer.from(script, "utf16le").toString("base64");
+  return `${windowsExecutableToken(powershellPath)} -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand ${encoded}`;
+}
+
+export function defaultWindowsPowerShellPath(env = process.env) {
+  const systemRoot = stringOption(env.SystemRoot)
+    ?? stringOption(env.SYSTEMROOT)
+    ?? stringOption(env.WINDIR)
+    ?? "C:\\Windows";
+  return win32.join(systemRoot, "System32", "WindowsPowerShell", "v1.0", "powershell.exe");
+}
+
+export function defaultTraeSkillSourcePath(adapterRoot = ADAPTER_ROOT) {
+  const packaged = join(adapterRoot, "skills", "memorax-code");
+  return existsSync(join(packaged, "SKILL.md"))
+    ? packaged
+    : resolve(adapterRoot, "..", "memorax-code-codex-adapter", "skills", "memorax-code");
+}
+
+export function defaultMemoraxCodeCommand(adapterRoot = ADAPTER_ROOT) {
+  const packageRoot = resolve(adapterRoot, "..", "..");
+  return [
+    join(packageRoot, "bin", "memorax-code.mjs"),
+    join(packageRoot, "npm", "memorax-code", "bin", "memorax-code.mjs"),
+  ].find((path) => existsSync(path));
+}
+
+function resolvePaths(options) {
+  const memoraxCodeHome = resolve(options.memoraxCodeHome ?? defaultMemoraxCodeHome());
+  const traeHome = resolve(options.traeHome ?? defaultTraeHome());
+  return {
+    memoraxCodeHome,
+    traeHome,
+    statePath: resolve(options.statePath ?? traeAdapterStatePath(memoraxCodeHome)),
+    hooksPath: resolve(options.hooksPath ?? traeHooksPath(traeHome)),
+    skillPath: resolve(options.skillPath ?? traeSkillPath(traeHome)),
+    runtimeRoot: resolve(options.runtimeRoot ?? traeRuntimeRoot(memoraxCodeHome)),
+    runtimeHookSourcePath: resolve(options.runtimeHookSourcePath ?? join(ADAPTER_ROOT, "hooks", "runtime-hook.mjs")),
+    runtimeObservationSourcePath: resolve(options.runtimeObservationSourcePath ?? join(ADAPTER_ROOT, "src", "runtime-observation.mjs")),
+    commonSourcePath: resolve(options.commonSourcePath ?? join(ADAPTER_ROOT, "..", "memorax-code-adapter-common", "src")),
+    skillSourcePath: resolve(options.skillSourcePath ?? defaultTraeSkillSourcePath()),
+  };
+}
+
+function validateState(state, paths) {
+  if (!state) return undefined;
+  if (state.unreadable === true) return { ok: false, reason: "state_invalid", statePath: paths.statePath };
+  if (state.version !== STATE_VERSION || state.runtime !== "trae" || state.integration !== "hooks") {
+    return { ok: false, reason: "state_invalid", statePath: paths.statePath };
+  }
+  const expected = {
+    traeHome: paths.traeHome,
+    hooksPath: paths.hooksPath,
+    skillPath: paths.skillPath,
+    runtimeRoot: paths.runtimeRoot,
+  };
+  if (Object.entries(expected).some(([key, value]) => state[key] !== value)
+    || !containedPath(paths.memoraxCodeHome, state.runtimeRoot)
+    || !containedPath(state.runtimeRoot, state.runtimePath)
+    || !/^[a-f0-9]{64}$/.test(String(state.runtimeDigest ?? ""))
+    || !/^[a-f0-9]{64}$/.test(String(state.skillDigest ?? ""))
+    || typeof state.hookCommand !== "string"
+    || !managedHookCommand(state.hookCommand)) {
+    return { ok: false, reason: "state_paths_invalid", statePath: paths.statePath };
+  }
+  return undefined;
+}
+
+function validateSources(paths) {
+  for (const [name, path] of [
+    ["runtime_hook", paths.runtimeHookSourcePath],
+    ["runtime_observation", paths.runtimeObservationSourcePath],
+  ]) {
+    if (!regularFile(path)) return { ok: false, reason: `${name}_missing`, sourcePath: path };
+  }
+  for (const [name, path] of [["common_runtime", paths.commonSourcePath], ["skill", paths.skillSourcePath]]) {
+    if (!regularDirectory(path)) return { ok: false, reason: `${name}_missing`, sourcePath: path };
+  }
+  if (!regularFile(join(paths.skillSourcePath, "SKILL.md"))) {
+    return { ok: false, reason: "skill_missing", sourcePath: paths.skillSourcePath };
+  }
+  return undefined;
+}
+
+function materializeRuntimeGeneration(paths, generationPath, runtimeDigest, options) {
+  if (existsSync(generationPath)) {
+    const record = readJsonFile(join(generationPath, "generation.json"));
+    if (record?.unreadable || record?.value?.runtimeDigest !== runtimeDigest
+      || !regularFile(join(generationPath, "hooks", "runtime-hook.mjs"))) {
+      throw new Error("Trae runtime generation is invalid");
+    }
+    return;
+  }
+  mkdirSync(paths.runtimeRoot, { recursive: true, mode: 0o700 });
+  const temporaryPath = join(paths.runtimeRoot, `.staging-${process.pid}-${randomUUID()}`);
+  try {
+    mkdirSync(join(temporaryPath, "hooks"), { recursive: true, mode: 0o700 });
+    mkdirSync(join(temporaryPath, "src"), { recursive: true, mode: 0o700 });
+    cpSync(paths.runtimeHookSourcePath, join(temporaryPath, "hooks", "runtime-hook.mjs"));
+    cpSync(paths.runtimeObservationSourcePath, join(temporaryPath, "src", "runtime-observation.mjs"));
+    cpSync(paths.commonSourcePath, join(temporaryPath, "memorax-code-adapter-common", "src"), { recursive: true });
+    atomicWriteJson(join(temporaryPath, "generation.json"), { version: 1, runtimeDigest });
+    const memoraxCodeCommand = stringOption(options.memoraxCodeCommand) ?? defaultMemoraxCodeCommand();
+    const npmExecPath = absoluteRegularFile(options.npmExecPath ?? process.env.npm_execpath);
+    atomicWriteJson(join(temporaryPath, ".memorax-code-package.json"), {
+      version: 1,
+      ...(memoraxCodeCommand ? { memoraxCodeCommand } : {}),
+      ...(npmExecPath ? { npmExecPath } : {}),
+      memoraxCodeHome: paths.memoraxCodeHome,
+      traeHome: paths.traeHome,
+      runtimeDigest,
+    });
+    renameSync(temporaryPath, generationPath);
+  } catch (error) {
+    rmSync(temporaryPath, { recursive: true, force: true });
+    if (!existsSync(generationPath)) throw error;
+  }
+}
+
+function updateManagedHooks(path, command, enabled) {
+  withJsonFileLock(path, () => {
+    const manifest = readHookManifest(path);
+    for (const event of REQUIRED_EVENTS) {
+      const existing = Array.isArray(manifest.hooks[event]) ? manifest.hooks[event] : [];
+      const filtered = existing.flatMap((group) => filterManagedGroup(group));
+      if (enabled) {
+        filtered.push({ hooks: [{ type: "command", command, timeout: event === "SessionStart" ? 35 : 15 }] });
+      }
+      if (filtered.length > 0) manifest.hooks[event] = filtered;
+      else delete manifest.hooks[event];
+    }
+    atomicWriteJson(path, manifest);
+  });
+}
+
+function filterManagedGroup(group) {
+  if (!isRecord(group) || !Array.isArray(group.hooks)) return [group];
+  const hooks = group.hooks.filter((hook) => !isManagedHook(hook));
+  return hooks.length > 0 ? [{ ...group, hooks }] : [];
+}
+
+function readHookManifest(path) {
+  if (!existsSync(path)) return { hooks: {} };
+  const parsed = JSON.parse(readFileSync(path, "utf8"));
+  if (!isRecord(parsed) || (parsed.hooks !== undefined && !isRecord(parsed.hooks))) {
+    throw new Error(`invalid Trae Hook manifest: ${path}`);
+  }
+  const manifest = { ...parsed, hooks: { ...(parsed.hooks ?? {}) } };
+  for (const event of REQUIRED_EVENTS) {
+    if (manifest.hooks[event] !== undefined && !Array.isArray(manifest.hooks[event])) {
+      throw new Error(`invalid Trae Hook event: ${event}`);
+    }
+  }
+  return manifest;
+}
+
+function hooksConfigured(manifest, expectedCommand) {
+  return REQUIRED_EVENTS.every((event) => {
+    const managed = (manifest.hooks[event] ?? [])
+      .flatMap((group) => Array.isArray(group?.hooks) ? group.hooks : [])
+      .filter(isManagedHook);
+    return managed.length === 1 && managed[0].type === "command" && managed[0].command === expectedCommand;
+  });
+}
+
+function isManagedHook(hook) {
+  return isRecord(hook) && hook.type === "command"
+    && typeof hook.command === "string" && managedHookCommand(hook.command);
+}
+
+function managedHookCommand(command) {
+  if (command.includes(HOOK_MARKER)) return true;
+  const encoded = /(?:^|\s)-EncodedCommand\s+([A-Za-z0-9+/]+={0,2})\s*$/.exec(command)?.[1];
+  if (!encoded || encoded.length % 4 !== 0) return false;
+  try {
+    return Buffer.from(encoded, "base64").toString("utf16le").includes(HOOK_MARKER);
+  } catch {
+    return false;
+  }
+}
+
+function powershellLiteral(value) {
+  return `'${String(value).replaceAll("'", "''")}'`;
+}
+
+function windowsExecutableToken(path) {
+  const normalized = String(path).replaceAll("\\", "/");
+  return /^[A-Za-z]:\/[^\s"]+$/.test(normalized) ? normalized : "powershell.exe";
+}
+
+function materializeDirectory(source, destination) {
+  mkdirSync(dirname(destination), { recursive: true });
+  const temporaryPath = `${destination}.tmp-${process.pid}-${randomUUID()}`;
+  rmSync(temporaryPath, { recursive: true, force: true });
+  try {
+    cpSync(source, temporaryPath, { recursive: true });
+    rmSync(destination, { recursive: true, force: true });
+    renameSync(temporaryPath, destination);
+  } catch (error) {
+    rmSync(temporaryPath, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+function runtimeSourceDigest(paths) {
+  const hash = createHash("sha256");
+  hashFile(hash, paths.runtimeHookSourcePath, "hooks/runtime-hook.mjs");
+  hashFile(hash, paths.runtimeObservationSourcePath, "src/runtime-observation.mjs");
+  hashDirectory(hash, paths.commonSourcePath, "memorax-code-adapter-common/src");
+  return hash.digest("hex");
+}
+
+function directoryDigest(path) {
+  const hash = createHash("sha256");
+  hashDirectory(hash, path, "");
+  return hash.digest("hex");
+}
+
+function directoryDigestIfPresent(path) {
+  try {
+    return directoryDigest(path);
+  } catch {
+    return undefined;
+  }
+}
+
+function hashDirectory(hash, root, prefix) {
+  for (const file of regularFiles(root)) {
+    hashFile(hash, file, join(prefix, relative(root, file)).replaceAll("\\", "/"));
+  }
+}
+
+function hashFile(hash, path, label) {
+  hash.update(label);
+  hash.update("\0");
+  hash.update(readFileSync(path));
+  hash.update("\0");
+}
+
+function regularFiles(root) {
+  const files = [];
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    const path = join(root, entry.name);
+    const metadata = lstatSync(path);
+    if (metadata.isSymbolicLink()) throw new Error(`managed source contains a symbolic link: ${path}`);
+    if (metadata.isDirectory()) files.push(...regularFiles(path));
+    else if (metadata.isFile()) files.push(path);
+    else throw new Error(`managed source contains a non-regular entry: ${path}`);
+  }
+  return files.sort((left, right) => left.localeCompare(right));
+}
+
+function skillSummary(path, ok) {
+  return { ok, status: ok ? "installed" : "missing", managed: ok, memoraxCode: ok, path: join(path, "SKILL.md") };
+}
+
+function failure(reason, paths, error, action = "status") {
+  return {
+    ok: false,
+    action,
+    runtime: "trae",
+    integration: "hooks",
+    installed: false,
+    enabled: false,
+    managed: existsSync(paths.statePath),
+    reason,
+    error: error instanceof Error ? error.message : String(error),
+    traeHome: paths.traeHome,
+    statePath: paths.statePath,
+  };
+}
+
+function conflict(reason, paths, conflictPath) {
+  return { ...failure(reason, paths, new Error(`unmanaged Trae artifact exists: ${conflictPath}`), "enable"), conflictPath };
+}
+
+function regularFile(path) {
+  try { return statSync(path).isFile() && !lstatSync(path).isSymbolicLink(); } catch { return false; }
+}
+
+function regularDirectory(path) {
+  try { return statSync(path).isDirectory() && !lstatSync(path).isSymbolicLink(); } catch { return false; }
+}
+
+function absoluteRegularFile(value) {
+  const path = stringOption(value);
+  return path && isAbsolute(path) && regularFile(path) ? path : undefined;
+}
+
+function containedPath(boundary, path) {
+  if (typeof path !== "string") return false;
+  const child = relative(resolve(boundary), resolve(path));
+  return child !== "" && child !== ".." && !child.startsWith(`..${sep}`) && !isAbsolute(child);
+}
+
+function comparablePath(value, platform) {
+  const normalized = String(value ?? "").replaceAll("\\", "/").replace(/\/+$/, "");
+  return platform === "win32" ? normalized.toLowerCase() : normalized;
+}
+
+function isRecord(value) {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}

--- a/packages/ts/memorax-code-trae-adapter/src/config.mjs
+++ b/packages/ts/memorax-code-trae-adapter/src/config.mjs
@@ -78,30 +78,32 @@ async function enableTraeAdapterUnlocked(paths, options) {
     && existsSync(runtimePath)
     && directoryDigestIfPresent(paths.skillPath) === skillDigest
     && hooksConfigured(hookManifest, hookCommand);
+  const now = new Date().toISOString();
+  const state = {
+    version: STATE_VERSION,
+    runtime: "trae",
+    integration: "hooks",
+    enabled: true,
+    traeHome: paths.traeHome,
+    hooksPath: paths.hooksPath,
+    skillPath: paths.skillPath,
+    skillDigest,
+    runtimeRoot: paths.runtimeRoot,
+    runtimePath,
+    runtimeDigest,
+    hookCommand,
+    installedAt: stringOption(previousState?.installedAt) ?? now,
+    updatedAt: now,
+  };
 
   try {
+    atomicWriteJson(paths.statePath, { ...state, enabled: false, installPending: true });
     materializeRuntimeGeneration(paths, generationPath, runtimeDigest, options);
     if (directoryDigestIfPresent(paths.skillPath) !== skillDigest) {
       materializeDirectory(paths.skillSourcePath, paths.skillPath);
     }
     updateManagedHooks(paths.hooksPath, hookCommand, true);
-    const now = new Date().toISOString();
-    atomicWriteJson(paths.statePath, {
-      version: STATE_VERSION,
-      runtime: "trae",
-      integration: "hooks",
-      enabled: true,
-      traeHome: paths.traeHome,
-      hooksPath: paths.hooksPath,
-      skillPath: paths.skillPath,
-      skillDigest,
-      runtimeRoot: paths.runtimeRoot,
-      runtimePath,
-      runtimeDigest,
-      hookCommand,
-      installedAt: stringOption(previousState?.installedAt) ?? now,
-      updatedAt: now,
-    });
+    atomicWriteJson(paths.statePath, state);
   } catch (error) {
     return failure("install_failed", paths, error);
   }
@@ -135,11 +137,13 @@ function disableTraeAdapterUnlocked(paths) {
   }
   try {
     updateManagedHooks(paths.hooksPath, undefined, false);
-    atomicWriteJson(paths.statePath, {
+    const disabledState = {
       ...state,
       enabled: false,
       disabledAt: new Date().toISOString(),
-    });
+    };
+    delete disabledState.installPending;
+    atomicWriteJson(paths.statePath, disabledState);
   } catch (error) {
     return failure("disable_failed", paths, error);
   }
@@ -200,6 +204,7 @@ async function readTraeAdapterStatusUnlocked(paths, options) {
       === comparablePath(paths.traeHome, options.platform ?? process.platform);
   const installed = runtimeCurrent && skillCurrent;
   const enabled = state.enabled === true && installed && configured;
+  const installPending = state.installPending === true;
   return {
     ok: true,
     action: "status",
@@ -223,7 +228,11 @@ async function readTraeAdapterStatusUnlocked(paths, options) {
     },
     traeSkills: skillSummary(state.skillPath, skillCurrent),
     globalHooksActivationRequired: configured && !runtimeObserved,
-    ...(!enabled ? { reason: !installed ? "artifacts_missing" : "hooks_not_configured" } : {}),
+    ...(!enabled ? {
+      reason: installPending
+        ? "install_incomplete"
+        : !installed ? "artifacts_missing" : "hooks_not_configured",
+    } : {}),
   };
 }
 

--- a/packages/ts/memorax-code-trae-adapter/src/config.mjs
+++ b/packages/ts/memorax-code-trae-adapter/src/config.mjs
@@ -19,6 +19,7 @@ import {
   readJsonFile,
   stringOption,
   withJsonFileLock,
+  withJsonFileLockAsync,
 } from "../../memorax-code-adapter-common/src/config-utils.mjs";
 import {
   defaultMemoraxCodeHome,
@@ -41,6 +42,10 @@ const REQUIRED_EVENTS = ["SessionStart", "UserPromptSubmit", "Stop"];
 
 export async function enableTraeAdapter(options = {}) {
   const paths = resolvePaths(options);
+  return await withTraeLifecycleLock(paths, () => enableTraeAdapterUnlocked(paths, options));
+}
+
+async function enableTraeAdapterUnlocked(paths, options) {
   const previousState = readAdapterState(paths.statePath);
   const stateProblem = validateState(previousState, paths);
   if (stateProblem) return { ...stateProblem, action: "enable" };
@@ -101,11 +106,15 @@ export async function enableTraeAdapter(options = {}) {
     return failure("install_failed", paths, error);
   }
 
-  return await readTraeAdapterStatus({ ...options, ...paths, changed: !current });
+  return await readTraeAdapterStatusUnlocked(paths, { ...options, changed: !current });
 }
 
 export async function disableTraeAdapter(options = {}) {
   const paths = resolvePaths(options);
+  return await withTraeLifecycleLock(paths, () => disableTraeAdapterUnlocked(paths));
+}
+
+function disableTraeAdapterUnlocked(paths) {
   const state = readAdapterState(paths.statePath);
   const stateProblem = validateState(state, paths);
   if (stateProblem) return { ...stateProblem, action: "disable" };
@@ -150,6 +159,10 @@ export async function disableTraeAdapter(options = {}) {
 
 export async function readTraeAdapterStatus(options = {}) {
   const paths = resolvePaths(options);
+  return await readTraeAdapterStatusUnlocked(paths, options);
+}
+
+async function readTraeAdapterStatusUnlocked(paths, options) {
   const state = readAdapterState(paths.statePath);
   const stateProblem = validateState(state, paths);
   if (stateProblem) return { ...stateProblem, action: "status" };
@@ -216,6 +229,10 @@ export async function readTraeAdapterStatus(options = {}) {
 
 export async function removeTraeAdapterInstallation(options = {}) {
   const paths = resolvePaths(options);
+  return await withTraeLifecycleLock(paths, () => removeTraeAdapterInstallationUnlocked(paths));
+}
+
+async function removeTraeAdapterInstallationUnlocked(paths) {
   const state = readAdapterState(paths.statePath);
   const stateProblem = validateState(state, paths);
   if (stateProblem) return { ...stateProblem, action: "trae-adapter-remove" };
@@ -229,7 +246,7 @@ export async function removeTraeAdapterInstallation(options = {}) {
       statePath: paths.statePath,
     };
   }
-  const disabled = await disableTraeAdapter(options);
+  const disabled = disableTraeAdapterUnlocked(paths);
   if (disabled.ok === false) return { ...disabled, action: "trae-adapter-remove" };
   try {
     rmSync(state.skillPath, { recursive: true, force: true });
@@ -258,7 +275,7 @@ export function traeHookCommand(
   powershellPath = defaultWindowsPowerShellPath(),
 ) {
   if (platform !== "win32") {
-    return `"${nodePath.replaceAll('"', '\\"')}" "${runtimePath.replaceAll('"', '\\"')}" ${HOOK_MARKER}`;
+    return `${posixShellLiteral(nodePath)} ${posixShellLiteral(runtimePath)} ${HOOK_MARKER}`;
   }
   const script = [
     "$ErrorActionPreference='Stop'",
@@ -321,6 +338,9 @@ function resolvePaths(options) {
   return {
     memoraxCodeHome,
     traeHome,
+    lifecycleLockTarget: resolve(
+      options.lifecycleLockTarget ?? join(memoraxCodeHome, "adapters", "trae-lifecycle"),
+    ),
     statePath: resolve(options.statePath ?? traeAdapterStatePath(memoraxCodeHome)),
     hooksPath: resolve(options.hooksPath ?? traeHooksPath(traeHome)),
     skillPath: resolve(options.skillPath ?? traeSkillPath(traeHome)),
@@ -330,6 +350,10 @@ function resolvePaths(options) {
     commonSourcePath: resolve(options.commonSourcePath ?? join(ADAPTER_ROOT, "..", "memorax-code-adapter-common", "src")),
     skillSourcePath: resolve(options.skillSourcePath ?? defaultTraeSkillSourcePath()),
   };
+}
+
+function withTraeLifecycleLock(paths, operation) {
+  return withJsonFileLockAsync(paths.lifecycleLockTarget, operation);
 }
 
 function validateState(state, paths) {
@@ -471,6 +495,10 @@ function managedHookCommand(command) {
 
 function powershellLiteral(value) {
   return `'${String(value).replaceAll("'", "''")}'`;
+}
+
+function posixShellLiteral(value) {
+  return `'${String(value).replaceAll("'", "'\\''")}'`;
 }
 
 function windowsExecutableToken(path) {

--- a/packages/ts/memorax-code-trae-adapter/src/runtime-observation.mjs
+++ b/packages/ts/memorax-code-trae-adapter/src/runtime-observation.mjs
@@ -1,0 +1,55 @@
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+export function traeRuntimeObservationPath(memoraxCodeHome) {
+  return join(memoraxCodeHome, "adapters", "trae", "runtime-observed.json");
+}
+
+export async function writeTraeRuntimeObservation({ memoraxCodeHome, traeHome, runtimeDigest }) {
+  const path = traeRuntimeObservationPath(memoraxCodeHome);
+  const record = {
+    version: 1,
+    runtimeDigest,
+    traeHome,
+    observedAt: new Date().toISOString(),
+  };
+  await mkdir(dirname(path), { recursive: true, mode: 0o700 });
+  const temporaryPath = `${path}.tmp-${process.pid}-${Date.now()}`;
+  await writeFile(temporaryPath, `${JSON.stringify(record, null, 2)}\n`, { mode: 0o600 });
+  await rename(temporaryPath, path);
+  return record;
+}
+
+export async function readTraeRuntimeObservation(memoraxCodeHome) {
+  try {
+    const value = JSON.parse(await readFile(traeRuntimeObservationPath(memoraxCodeHome), "utf8"));
+    if (!isRecord(value) || !hasExactKeys(value, ["observedAt", "runtimeDigest", "traeHome", "version"])) return undefined;
+    if (value.version !== 1
+      || !sha256(value.runtimeDigest)
+      || !stringValue(value.traeHome)
+      || !validTimestamp(value.observedAt)) return undefined;
+    return value;
+  } catch {
+    return undefined;
+  }
+}
+
+function isRecord(value) {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function hasExactKeys(value, expected) {
+  return Object.keys(value).sort().join("\n") === [...expected].sort().join("\n");
+}
+
+function stringValue(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function sha256(value) {
+  return typeof value === "string" && /^[a-f0-9]{64}$/.test(value);
+}
+
+function validTimestamp(value) {
+  return typeof value === "string" && Number.isFinite(Date.parse(value));
+}

--- a/packages/ts/memorax-code-trae-adapter/test/config.test.mjs
+++ b/packages/ts/memorax-code-trae-adapter/test/config.test.mjs
@@ -162,6 +162,59 @@ test("Trae install merges managed Hooks and Skill without changing user Hooks", 
   }
 });
 
+test("Trae install resumes from a persisted ownership intent", async () => {
+  const fixture = await createFixture("install-recovery");
+  try {
+    const installed = await enableTraeAdapter(fixture.options);
+    const state = JSON.parse(await readFile(installed.statePath, "utf8"));
+    await writeFile(installed.statePath, `${JSON.stringify({
+      ...state,
+      enabled: false,
+      installPending: true,
+    }, null, 2)}\n`);
+    await rm(installed.skillPath, { recursive: true, force: true });
+
+    const incomplete = await readTraeAdapterStatus(fixture.options);
+    assert.equal(incomplete.enabled, false);
+    assert.equal(incomplete.reason, "install_incomplete");
+
+    const recovered = await enableTraeAdapter(fixture.options);
+    assert.equal(recovered.ok, true);
+    assert.equal(recovered.enabled, true);
+    assert.equal(recovered.changed, true);
+    const recoveredState = JSON.parse(await readFile(recovered.statePath, "utf8"));
+    assert.equal(recoveredState.installPending, undefined);
+    assert.equal(await readFile(join(recovered.skillPath, "SKILL.md"), "utf8"), "# MemoraX Code\n");
+  } finally {
+    await rm(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("Trae install leaves shared artifacts unchanged when ownership intent cannot be persisted", async () => {
+  const fixture = await createFixture("state-write-failure");
+  try {
+    const blockedStateParent = join(fixture.root, "blocked-state");
+    const hooksPath = join(fixture.traeHome, "hooks.json");
+    const beforeHooks = await readFile(hooksPath, "utf8");
+    await writeFile(blockedStateParent, "not a directory\n");
+
+    const result = await enableTraeAdapter({
+      ...fixture.options,
+      statePath: join(blockedStateParent, "state.json"),
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "install_failed");
+    assert.equal(await readFile(hooksPath, "utf8"), beforeHooks);
+    await assert.rejects(
+      readFile(join(fixture.traeHome, "skills", "memorax-code", "SKILL.md")),
+      /ENOENT/,
+    );
+  } finally {
+    await rm(fixture.root, { recursive: true, force: true });
+  }
+});
+
 test("Trae lifecycle mutations wait for the shared cross-process lock", async () => {
   const fixture = await createFixture("lifecycle-lock");
   let releaseLock;

--- a/packages/ts/memorax-code-trae-adapter/test/config.test.mjs
+++ b/packages/ts/memorax-code-trae-adapter/test/config.test.mjs
@@ -2,7 +2,9 @@ import { strict as assert } from "node:assert";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, win32 } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
 import { test } from "node:test";
+import { withJsonFileLockAsync } from "../../memorax-code-adapter-common/src/config-utils.mjs";
 import {
   defaultTraeHome,
   traeInstallationDetected,
@@ -63,6 +65,16 @@ test("Trae Hook command hides Windows paths from the sandbox command-line wrappe
   assert.match(
     traeHookCommand("C:\\runtime.mjs", "win32", "C:\\node.exe", "C:\\Windows Directory\\powershell.exe"),
     /^powershell\.exe /,
+  );
+});
+
+test("Trae POSIX Hook command quotes shell metacharacters literally", () => {
+  const nodePath = "/opt/$node/`node`/node's";
+  const runtimePath = "/tmp/$runtime/$(touch marker)/runtime's.mjs";
+
+  assert.equal(
+    traeHookCommand(runtimePath, "linux", nodePath),
+    "'/opt/$node/`node`/node'\\''s' '/tmp/$runtime/$(touch marker)/runtime'\\''s.mjs' --memorax-code-trae-hook-v1",
   );
 });
 
@@ -150,6 +162,39 @@ test("Trae install merges managed Hooks and Skill without changing user Hooks", 
   }
 });
 
+test("Trae lifecycle mutations wait for the shared cross-process lock", async () => {
+  const fixture = await createFixture("lifecycle-lock");
+  let releaseLock;
+  let holder;
+  let pendingInstall;
+  try {
+    let markLocked;
+    const locked = new Promise((resolve) => { markLocked = resolve; });
+    const released = new Promise((resolve) => { releaseLock = resolve; });
+    holder = withJsonFileLockAsync(fixture.options.lifecycleLockTarget, async () => {
+      markLocked();
+      await released;
+    });
+    await locked;
+
+    pendingInstall = enableTraeAdapter(fixture.options);
+    await delay(50);
+    const blockedHooks = await readFile(join(fixture.traeHome, "hooks.json"), "utf8");
+    assert.equal(blockedHooks.includes("--memorax-code-trae-hook-v1"), false);
+
+    releaseLock();
+    releaseLock = undefined;
+    await holder;
+    const installed = await pendingInstall;
+    assert.equal(installed.ok, true);
+    assert.equal(installed.enabled, true);
+  } finally {
+    releaseLock?.();
+    await Promise.allSettled([holder, pendingInstall].filter(Boolean));
+    await rm(fixture.root, { recursive: true, force: true });
+  }
+});
+
 test("Trae disable and removal delete only MemoraX-managed content", async () => {
   const fixture = await createFixture("remove");
   try {
@@ -219,6 +264,7 @@ async function createFixture(name) {
   const root = await mkdtemp(join(tmpdir(), `memorax-code-trae-${name}-`));
   const traeHome = join(root, "Trae Home With Spaces");
   const memoraxCodeHome = join(root, "MemoraX Home");
+  const lifecycleLockTarget = join(root, "locks", "trae-lifecycle");
   const sourceRoot = join(root, "sources");
   const runtimeHookSourcePath = join(sourceRoot, "runtime-hook.mjs");
   const runtimeObservationSourcePath = join(sourceRoot, "runtime-observation.mjs");
@@ -253,6 +299,7 @@ async function createFixture(name) {
     options: {
       traeHome,
       memoraxCodeHome,
+      lifecycleLockTarget,
       runtimeHookSourcePath,
       runtimeObservationSourcePath,
       commonSourcePath,

--- a/packages/ts/memorax-code-trae-adapter/test/config.test.mjs
+++ b/packages/ts/memorax-code-trae-adapter/test/config.test.mjs
@@ -1,0 +1,269 @@
+import { strict as assert } from "node:assert";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, win32 } from "node:path";
+import { test } from "node:test";
+import {
+  defaultTraeHome,
+  traeInstallationDetected,
+} from "../src/adapter-paths.mjs";
+import {
+  defaultWindowsPowerShellPath,
+  disableTraeAdapter,
+  enableTraeAdapter,
+  readTraeAdapterStatus,
+  removeTraeAdapterInstallation,
+  traeHookCommand,
+} from "../src/config.mjs";
+import { writeTraeRuntimeObservation } from "../src/runtime-observation.mjs";
+
+test("Trae home and application discovery honor explicit and platform locations", () => {
+  assert.equal(defaultTraeHome({ TRAE_CN_HOME: "/custom/trae" }, "/home/user"), "/custom/trae");
+  assert.equal(defaultTraeHome({}, "/home/user"), "/home/user/.trae-cn");
+  assert.equal(traeInstallationDetected({
+    env: {},
+    home: "/home/user",
+    platform: "darwin",
+    pathExists: (path) => path === "/Applications/Trae CN.app",
+  }), true);
+  assert.equal(traeInstallationDetected({
+    env: {},
+    home: "/home/user",
+    platform: "linux",
+    pathExists: () => false,
+  }), false);
+});
+
+test("Trae Hook command hides Windows paths from the sandbox command-line wrapper", () => {
+  const command = traeHookCommand(
+    win32.join("C:\\", "Users", "Test User", ".memorax-code", "runtime-hook.mjs"),
+    "win32",
+    win32.join("C:\\", "Program Files", "nodejs", "node.exe"),
+    win32.join("C:\\", "Windows", "System32", "WindowsPowerShell", "v1.0", "powershell.exe"),
+  );
+  assert.match(command, /^C:\/Windows\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoLogo /);
+  assert.equal(command.includes('"'), false);
+  assert.equal(command.includes("Program Files"), false);
+  assert.equal(command.includes("Test User"), false);
+  assert.equal(command.includes("--memorax-code-trae-hook-v1"), false);
+  const script = decodePowerShellCommand(command);
+  assert.ok(script.includes("$start.FileName='C:\\Program Files\\nodejs\\node.exe'"));
+  assert.ok(script.includes(
+    "$start.Arguments='\"C:\\Users\\Test User\\.memorax-code\\runtime-hook.mjs\" \"--memorax-code-trae-hook-v1\"'",
+  ));
+  assert.ok(script.includes("[Console]::In.ReadToEnd()"));
+  assert.ok(script.includes("$start.RedirectStandardInput=$true"));
+  assert.ok(script.includes("$start.RedirectStandardOutput=$true"));
+  assert.ok(script.includes("$start.RedirectStandardError=$true"));
+  assert.ok(script.includes("exit $process.ExitCode"));
+  assert.equal(
+    defaultWindowsPowerShellPath({ SystemRoot: "D:\\Windows" }),
+    "D:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+  );
+  assert.match(
+    traeHookCommand("C:\\runtime.mjs", "win32", "C:\\node.exe", "C:\\Windows Directory\\powershell.exe"),
+    /^powershell\.exe /,
+  );
+});
+
+test("Trae Windows Hook lifecycle recognizes and removes the encoded ownership marker", async () => {
+  const fixture = await createFixture("windows-command");
+  try {
+    const legacy = await enableTraeAdapter({
+      ...fixture.options,
+      platform: "linux",
+      nodePath: fixture.nodePath,
+    });
+    assert.equal(legacy.ok, true);
+    assert.equal(legacy.changed, true);
+    const options = {
+      ...fixture.options,
+      platform: "win32",
+      nodePath: fixture.nodePath,
+      powershellPath: win32.join("C:\\", "Windows", "System32", "WindowsPowerShell", "v1.0", "powershell.exe"),
+    };
+    const installed = await enableTraeAdapter(options);
+    assert.equal(installed.ok, true);
+    assert.equal(installed.changed, true);
+    assert.equal(installed.traeHooks.configured, true);
+    const hooks = JSON.parse(await readFile(join(fixture.traeHome, "hooks.json"), "utf8"));
+    for (const event of ["SessionStart", "UserPromptSubmit", "Stop"]) {
+      const commands = hooks.hooks[event]
+        .flatMap((group) => group.hooks ?? [])
+        .map((hook) => hook.command)
+        .filter((command) => command?.includes("-EncodedCommand"));
+      assert.equal(commands.length, 1);
+      const [command] = commands;
+      assert.match(command, / -EncodedCommand [A-Za-z0-9+/=]+$/);
+      assert.ok(decodePowerShellCommand(command).includes("--memorax-code-trae-hook-v1"));
+    }
+    assert.equal(JSON.stringify(hooks).includes("--memorax-code-trae-hook-v1"), false);
+
+    const disabled = await disableTraeAdapter(options);
+    assert.equal(disabled.ok, true);
+    const disabledHooks = JSON.parse(await readFile(join(fixture.traeHome, "hooks.json"), "utf8"));
+    assert.equal(JSON.stringify(disabledHooks).includes("-EncodedCommand"), false);
+    assert.equal(disabledHooks.hooks.UserPromptSubmit[0].hooks[0].command, "user-command");
+  } finally {
+    await rm(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("Trae install merges managed Hooks and Skill without changing user Hooks", async () => {
+  const fixture = await createFixture("install");
+  try {
+    const installed = await enableTraeAdapter(fixture.options);
+    assert.equal(installed.ok, true);
+    assert.equal(installed.installed, true);
+    assert.equal(installed.enabled, true);
+    assert.equal(installed.changed, true);
+    assert.equal(installed.traeHooks.configured, true);
+    assert.equal(installed.traeHooks.runtimeObserved, false);
+    assert.equal(installed.globalHooksActivationRequired, true);
+    assert.equal(await readFile(join(installed.skillPath, "SKILL.md"), "utf8"), "# MemoraX Code\n");
+
+    const hooks = JSON.parse(await readFile(join(fixture.traeHome, "hooks.json"), "utf8"));
+    assert.deepEqual(hooks.custom, { preserved: true });
+    assert.equal(hooks.hooks.UserPromptSubmit[0].hooks[0].command, "user-command");
+    for (const event of ["SessionStart", "UserPromptSubmit", "Stop"]) {
+      const managed = hooks.hooks[event]
+        .flatMap((group) => group.hooks ?? [])
+        .filter((hook) => hook.command?.includes("--memorax-code-trae-hook-v1"));
+      assert.equal(managed.length, 1);
+    }
+
+    const unchanged = await enableTraeAdapter(fixture.options);
+    assert.equal(unchanged.ok, true);
+    assert.equal(unchanged.changed, false);
+
+    const state = JSON.parse(await readFile(unchanged.statePath, "utf8"));
+    await writeTraeRuntimeObservation({
+      memoraxCodeHome: fixture.memoraxCodeHome,
+      traeHome: fixture.traeHome,
+      runtimeDigest: state.runtimeDigest,
+    });
+    const observed = await readTraeAdapterStatus(fixture.options);
+    assert.equal(observed.traeHooks.runtimeObserved, true);
+    assert.equal(observed.globalHooksActivationRequired, false);
+  } finally {
+    await rm(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("Trae disable and removal delete only MemoraX-managed content", async () => {
+  const fixture = await createFixture("remove");
+  try {
+    const installed = await enableTraeAdapter(fixture.options);
+    assert.equal(installed.ok, true);
+    const unrelatedSkill = join(fixture.traeHome, "skills", "user-skill", "SKILL.md");
+    await mkdir(join(fixture.traeHome, "skills", "user-skill"), { recursive: true });
+    await writeFile(unrelatedSkill, "# User Skill\n");
+
+    const disabled = await disableTraeAdapter(fixture.options);
+    assert.equal(disabled.ok, true);
+    assert.equal(disabled.enabled, false);
+    const disabledHooks = JSON.parse(await readFile(join(fixture.traeHome, "hooks.json"), "utf8"));
+    assert.equal(JSON.stringify(disabledHooks).includes("--memorax-code-trae-hook-v1"), false);
+    assert.equal(disabledHooks.hooks.UserPromptSubmit[0].hooks[0].command, "user-command");
+    assert.equal(await readFile(join(installed.skillPath, "SKILL.md"), "utf8"), "# MemoraX Code\n");
+
+    const removed = await removeTraeAdapterInstallation(fixture.options);
+    assert.equal(removed.ok, true);
+    assert.equal(removed.removed, true);
+    await assert.rejects(readFile(join(installed.skillPath, "SKILL.md")), /ENOENT/);
+    assert.equal(await readFile(unrelatedSkill, "utf8"), "# User Skill\n");
+    const finalHooks = JSON.parse(await readFile(join(fixture.traeHome, "hooks.json"), "utf8"));
+    assert.equal(finalHooks.hooks.UserPromptSubmit[0].hooks[0].command, "user-command");
+    assert.deepEqual(finalHooks.custom, { preserved: true });
+  } finally {
+    await rm(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("Trae install refuses to overwrite an unmanaged memorax-code Skill", async () => {
+  const fixture = await createFixture("skill-conflict");
+  try {
+    const target = join(fixture.traeHome, "skills", "memorax-code");
+    await mkdir(target, { recursive: true });
+    await writeFile(join(target, "SKILL.md"), "# User-owned Skill\n");
+
+    const result = await enableTraeAdapter(fixture.options);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "skill_conflict");
+    assert.equal(await readFile(join(target, "SKILL.md"), "utf8"), "# User-owned Skill\n");
+    const hooks = JSON.parse(await readFile(join(fixture.traeHome, "hooks.json"), "utf8"));
+    assert.equal(JSON.stringify(hooks).includes("--memorax-code-trae-hook-v1"), false);
+  } finally {
+    await rm(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("Trae install fails closed for an invalid user Hook manifest", async () => {
+  const fixture = await createFixture("invalid-hooks");
+  try {
+    const hooksPath = join(fixture.traeHome, "hooks.json");
+    await writeFile(hooksPath, "{ invalid json\n");
+
+    const result = await enableTraeAdapter(fixture.options);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "hooks_invalid");
+    assert.equal(await readFile(hooksPath, "utf8"), "{ invalid json\n");
+  } finally {
+    await rm(fixture.root, { recursive: true, force: true });
+  }
+});
+
+async function createFixture(name) {
+  const root = await mkdtemp(join(tmpdir(), `memorax-code-trae-${name}-`));
+  const traeHome = join(root, "Trae Home With Spaces");
+  const memoraxCodeHome = join(root, "MemoraX Home");
+  const sourceRoot = join(root, "sources");
+  const runtimeHookSourcePath = join(sourceRoot, "runtime-hook.mjs");
+  const runtimeObservationSourcePath = join(sourceRoot, "runtime-observation.mjs");
+  const commonSourcePath = join(sourceRoot, "common");
+  const skillSourcePath = join(sourceRoot, "skill");
+  const memoraxCodeCommand = join(root, "Package With Spaces", "bin", "memorax-code.mjs");
+  const nodePath = join(root, "Program Files", "nodejs", "node.exe");
+  await mkdir(traeHome, { recursive: true });
+  await mkdir(commonSourcePath, { recursive: true });
+  await mkdir(join(skillSourcePath, "references"), { recursive: true });
+  await mkdir(join(root, "Package With Spaces", "bin"), { recursive: true });
+  await mkdir(join(root, "Program Files", "nodejs"), { recursive: true });
+  await writeFile(runtimeHookSourcePath, "console.log('runtime');\n");
+  await writeFile(runtimeObservationSourcePath, "export const observation = true;\n");
+  await writeFile(join(commonSourcePath, "shared.mjs"), "export const shared = true;\n");
+  await writeFile(join(skillSourcePath, "SKILL.md"), "# MemoraX Code\n");
+  await writeFile(join(skillSourcePath, "references", "search.md"), "search\n");
+  await writeFile(memoraxCodeCommand, "#!/usr/bin/env node\n");
+  await writeFile(nodePath, "node fixture\n");
+  await writeFile(join(traeHome, "hooks.json"), `${JSON.stringify({
+    custom: { preserved: true },
+    hooks: {
+      UserPromptSubmit: [{ matcher: "user", hooks: [{ type: "command", command: "user-command", timeout: 5 }] }],
+      Notification: [{ hooks: [{ type: "command", command: "notify-user", timeout: 5 }] }],
+    },
+  }, null, 2)}\n`);
+  return {
+    root,
+    traeHome,
+    memoraxCodeHome,
+    nodePath,
+    options: {
+      traeHome,
+      memoraxCodeHome,
+      runtimeHookSourcePath,
+      runtimeObservationSourcePath,
+      commonSourcePath,
+      skillSourcePath,
+      memoraxCodeCommand,
+    },
+  };
+}
+
+function decodePowerShellCommand(command) {
+  const encoded = / -EncodedCommand ([A-Za-z0-9+/=]+)$/.exec(command)?.[1];
+  assert.ok(encoded, command);
+  return Buffer.from(encoded, "base64").toString("utf16le");
+}

--- a/packages/ts/memorax-code-trae-adapter/test/runtime-hook.test.mjs
+++ b/packages/ts/memorax-code-trae-adapter/test/runtime-hook.test.mjs
@@ -1,0 +1,176 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { createServer } from "node:http";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { enableTraeAdapter } from "../src/config.mjs";
+
+test("Trae UserPromptSubmit records one Turn and injects memory context", async () => {
+  const fixture = await createFixture("prompt");
+  try {
+    const result = await runHook(fixture, {
+      hook_event_name: "UserPromptSubmit",
+      session_id: "trae-session-1",
+      prompt: "remember the validated Trae Hook flow",
+      cwd: fixture.root,
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.hookSpecificOutput.hookEventName, "UserPromptSubmit");
+    assert.match(output.hookSpecificOutput.additionalContext, /^memory context\n\nMemoraX Code reminder:/);
+
+    const turnStart = fixture.requests.find((request) => request.path === "/memory/turn-start");
+    assert.equal(turnStart.body.client, "trae");
+    assert.equal(turnStart.body.sessionId, "trae-session-1");
+    assert.equal(turnStart.body.prompt, "remember the validated Trae Hook flow");
+    assert.match(turnStart.body.turnId, /^trae-session-1:[1-9]\d*:[a-f0-9]{64}$/);
+
+    const reminder = fixture.requests.find((request) => request.path === "/memory/skill-reminder");
+    assert.equal(reminder.body.turnId, turnStart.body.turnId);
+    assert.deepEqual(reminder.body.triggers, ["cadence"]);
+
+    const turns = JSON.parse(await readFile(join(fixture.root, "adapters", "trae", "active-turns.json"), "utf8"));
+    assert.equal(turns.sessions["trae-session-1"].turnId, turnStart.body.turnId);
+    const observed = JSON.parse(await readFile(join(fixture.root, "adapters", "trae", "runtime-observed.json"), "utf8"));
+    assert.equal(observed.runtimeDigest, fixture.runtimeDigest);
+  } finally {
+    await fixture.close();
+  }
+});
+
+test("Trae Stop writes the matching Hook pair and clears only an accepted Turn", async () => {
+  const fixture = await createFixture("stop");
+  try {
+    await runHook(fixture, {
+      hook_event_name: "UserPromptSubmit",
+      session_id: "trae-session-2",
+      prompt: "pair this prompt with the final answer",
+      cwd: fixture.root,
+    });
+    const turnStart = fixture.requests.find((request) => request.path === "/memory/turn-start");
+
+    const stop = await runHook(fixture, {
+      hook_event_name: "Stop",
+      session_id: "trae-session-2",
+      last_assistant_message: "validated final answer",
+      text_content: "validated final answer",
+      cwd: fixture.root,
+    });
+
+    assert.equal(stop.status, 0, stop.stderr);
+    const writeback = fixture.requests.find((request) => request.path === "/memory/writeback");
+    assert.deepEqual(writeback.body, {
+      version: 1,
+      client: "trae",
+      sessionId: "trae-session-2",
+      turnId: turnStart.body.turnId,
+      prompt: "pair this prompt with the final answer",
+      lastAssistantMessage: "validated final answer",
+      cwd: fixture.root,
+    });
+    const turns = JSON.parse(await readFile(join(fixture.root, "adapters", "trae", "active-turns.json"), "utf8"));
+    assert.deepEqual(turns.sessions, {});
+  } finally {
+    await fixture.close();
+  }
+});
+
+test("Trae Stop fails closed when its assistant fields conflict", async () => {
+  const fixture = await createFixture("conflict");
+  try {
+    await runHook(fixture, {
+      hook_event_name: "UserPromptSubmit",
+      session_id: "trae-session-3",
+      prompt: "retain this turn",
+      cwd: fixture.root,
+    });
+    const before = await readFile(join(fixture.root, "adapters", "trae", "active-turns.json"), "utf8");
+
+    const stop = await runHook(fixture, {
+      hook_event_name: "Stop",
+      session_id: "trae-session-3",
+      last_assistant_message: "first answer",
+      text_content: "conflicting answer",
+      cwd: fixture.root,
+    });
+
+    assert.equal(stop.status, 0, stop.stderr);
+    assert.equal(fixture.requests.some((request) => request.path === "/memory/writeback"), false);
+    assert.equal(await readFile(join(fixture.root, "adapters", "trae", "active-turns.json"), "utf8"), before);
+  } finally {
+    await fixture.close();
+  }
+});
+
+async function createFixture(name) {
+  const root = await mkdtemp(join(tmpdir(), `memorax-code-trae-hook-${name}-`));
+  const traeHome = join(root, "trae-home");
+  const requests = [];
+  const server = createServer(async (request, response) => {
+    let text = "";
+    for await (const chunk of request) text += chunk;
+    const received = { path: request.url, body: text ? JSON.parse(text) : undefined };
+    requests.push(received);
+    const body = request.url === "/health"
+      ? { ok: true, service: "memorax-code-backend" }
+      : request.url === "/memory/turn-start"
+        ? { ok: true, additionalContext: "memory context" }
+        : request.url === "/memory/writeback"
+          ? { ok: true, scheduled: true }
+          : { ok: true };
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end(JSON.stringify(body));
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const installed = await enableTraeAdapter({
+    memoraxCodeHome: root,
+    traeHome,
+    memoraxCodeCommand: process.execPath,
+  });
+  assert.equal(installed.ok, true);
+  const state = JSON.parse(await readFile(installed.statePath, "utf8"));
+  return {
+    root,
+    traeHome,
+    requests,
+    runtimePath: state.runtimePath,
+    runtimeDigest: state.runtimeDigest,
+    server,
+    async close() {
+      await new Promise((resolve) => server.close(resolve));
+      await rm(root, { recursive: true, force: true });
+    },
+  };
+}
+
+function runHook(fixture, input) {
+  const address = fixture.server.address();
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [fixture.runtimePath], {
+      cwd: fixture.root,
+      env: {
+        ...process.env,
+        MEMORAX_CODE_BACKEND_URL: `http://127.0.0.1:${address.port}`,
+        MEMORAX_CODE_MEMORY_SKILL_REMINDER_INTERVAL_TURNS: "1",
+        TRAE_CN_HOME: fixture.traeHome,
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => { stdout += chunk; });
+    child.stderr.on("data", (chunk) => { stderr += chunk; });
+    child.on("close", (status, signal) => resolve({
+      status,
+      signal,
+      stdout: stdout.trim(),
+      stderr,
+    }));
+    child.stdin.end(JSON.stringify(input));
+  });
+}

--- a/packages/ts/memorax-code-trae-adapter/test/runtime-hook.test.mjs
+++ b/packages/ts/memorax-code-trae-adapter/test/runtime-hook.test.mjs
@@ -105,23 +105,59 @@ test("Trae Stop fails closed when its assistant fields conflict", async () => {
   }
 });
 
+test("Trae retains the previous accepted Turn when a replacement start is rejected", async () => {
+  const fixture = await createFixture("rejected-replacement");
+  try {
+    await runHook(fixture, {
+      hook_event_name: "UserPromptSubmit",
+      session_id: "trae-session-4",
+      prompt: "retain the accepted turn",
+      cwd: fixture.root,
+    });
+    const turnsPath = join(fixture.root, "adapters", "trae", "active-turns.json");
+    const before = await readFile(turnsPath, "utf8");
+    fixture.control.rejectNextTurnStart = true;
+
+    const rejected = await runHook(fixture, {
+      hook_event_name: "UserPromptSubmit",
+      session_id: "trae-session-4",
+      prompt: "do not persist this rejected replacement",
+      cwd: fixture.root,
+    });
+
+    assert.equal(rejected.status, 0, rejected.stderr);
+    assert.equal(rejected.stdout, "");
+    assert.equal(await readFile(turnsPath, "utf8"), before);
+    const starts = fixture.requests.filter((request) => request.path === "/memory/turn-start");
+    assert.equal(starts.length, 2);
+    assert.notEqual(starts[0].body.turnId, starts[1].body.turnId);
+  } finally {
+    await fixture.close();
+  }
+});
+
 async function createFixture(name) {
   const root = await mkdtemp(join(tmpdir(), `memorax-code-trae-hook-${name}-`));
   const traeHome = join(root, "trae-home");
   const requests = [];
+  const control = { rejectNextTurnStart: false };
   const server = createServer(async (request, response) => {
     let text = "";
     for await (const chunk of request) text += chunk;
     const received = { path: request.url, body: text ? JSON.parse(text) : undefined };
     requests.push(received);
-    const body = request.url === "/health"
+    const rejectedTurnStart = request.url === "/memory/turn-start" && control.rejectNextTurnStart;
+    if (rejectedTurnStart) control.rejectNextTurnStart = false;
+    const body = rejectedTurnStart
+      ? { ok: false }
+      : request.url === "/health"
       ? { ok: true, service: "memorax-code-backend" }
       : request.url === "/memory/turn-start"
         ? { ok: true, additionalContext: "memory context" }
         : request.url === "/memory/writeback"
           ? { ok: true, scheduled: true }
           : { ok: true };
-    response.writeHead(200, { "content-type": "application/json" });
+    response.writeHead(rejectedTurnStart ? 503 : 200, { "content-type": "application/json" });
     response.end(JSON.stringify(body));
   });
   await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
@@ -136,6 +172,7 @@ async function createFixture(name) {
     root,
     traeHome,
     requests,
+    control,
     runtimePath: state.runtimePath,
     runtimeDigest: state.runtimeDigest,
     server,

--- a/scripts/build-npm-packages.mjs
+++ b/scripts/build-npm-packages.mjs
@@ -74,6 +74,7 @@ async function stageMainPackage(destination) {
     "lib/memorax-code-dsh-adapter",
     "lib/memorax-code-opencode-adapter",
     "lib/memorax-code-codebuddy-adapter",
+    "lib/memorax-code-trae-adapter",
   ]) {
     await mkdir(join(destination, path), { recursive: true });
   }
@@ -119,6 +120,10 @@ async function stageMainPackage(destination) {
     "packages/ts/memorax-code-codebuddy-adapter/package.json",
     join(destination, "lib/memorax-code-codebuddy-adapter/package.json"),
   );
+  await copyFile(
+    "packages/ts/memorax-code-trae-adapter/package.json",
+    join(destination, "lib/memorax-code-trae-adapter/package.json"),
+  );
 
   await buildClaudeMarketplace({
     outputDir: join(destination, "lib/memorax-code-claude-marketplace"),
@@ -156,6 +161,7 @@ async function validateStaging(packageRoot) {
     "bin/memorax-cli.mjs",
     "bin/memorax-code-opencode.mjs",
     "bin/memorax-code-codebuddy.mjs",
+    "bin/memorax-code-trae.mjs",
     "bin/memorax-code-npm-preinstall.mjs",
     "bin/memorax-code-plugin-postinstall.mjs",
     "bin/memorax-code-setup.mjs",
@@ -268,6 +274,13 @@ async function validateStaging(packageRoot) {
     "lib/memorax-code-codebuddy-adapter/src/hook-manifest.mjs",
     "lib/memorax-code-codebuddy-adapter/src/runtime-observation.mjs",
     "lib/memorax-code-codebuddy-adapter/src/cli.mjs",
+    "lib/memorax-code-trae-adapter/package.json",
+    "lib/memorax-code-trae-adapter/hooks/runtime-hook.mjs",
+    "lib/memorax-code-trae-adapter/skills/memorax-code/SKILL.md",
+    "lib/memorax-code-trae-adapter/src/adapter-paths.mjs",
+    "lib/memorax-code-trae-adapter/src/cli.mjs",
+    "lib/memorax-code-trae-adapter/src/config.mjs",
+    "lib/memorax-code-trae-adapter/src/runtime-observation.mjs",
   ]) {
     if (!(await stat(join(packageRoot, requiredPath)).catch(() => undefined))?.isFile()) {
       throw new Error(`staged npm package is missing required runtime entrypoint: ${requiredPath}`);

--- a/scripts/npm-package-check.sh
+++ b/scripts/npm-package-check.sh
@@ -7,7 +7,9 @@ unset \
   DSH_HOME \
   CLAUDE_CONFIG_DIR \
   CLAUDE_HOME \
-  OPENCODE_CONFIG_DIR
+  OPENCODE_CONFIG_DIR \
+  TRAE_CN_HOME \
+  TRAE_HOME
 
 out_dir="${1:-dist/npm}"
 
@@ -40,6 +42,8 @@ scripts/build-npm-packages.sh "$out_dir"
   DSH_HOME="$isolated_test_home/.dsh" \
   CLAUDE_CONFIG_DIR="$isolated_test_home/.claude" \
   CLAUDE_HOME="$isolated_test_home/.claude" \
+  OPENCODE_CONFIG_DIR="$isolated_test_home/.config/opencode" \
+  TRAE_CN_HOME="$isolated_test_home/.trae-cn" \
     make test-npm-package
 )
 
@@ -75,6 +79,7 @@ expected_bins = {
     "memorax-code-codex": "bin/memorax-code-codex.mjs",
     "memorax-code-opencode": "bin/memorax-code-opencode.mjs",
     "memorax-code-codebuddy": "bin/memorax-code-codebuddy.mjs",
+    "memorax-code-trae": "bin/memorax-code-trae.mjs",
 }
 assert package_manifest.get("bin") == expected_bins, package_manifest.get("bin")
 for relative in expected_bins.values():
@@ -88,6 +93,7 @@ expected_library_dirs = {
     "memorax-code-dsh-adapter",
     "memorax-code-opencode-adapter",
     "memorax-code-codebuddy-adapter",
+    "memorax-code-trae-adapter",
 }
 actual_library_dirs = {
     path.name
@@ -225,6 +231,13 @@ for relative in [
     "lib/memorax-code-codebuddy-adapter/src/hook-manifest.mjs",
     "lib/memorax-code-codebuddy-adapter/src/runtime-observation.mjs",
     "lib/memorax-code-codebuddy-adapter/src/cli.mjs",
+    "lib/memorax-code-trae-adapter/package.json",
+    "lib/memorax-code-trae-adapter/hooks/runtime-hook.mjs",
+    "lib/memorax-code-trae-adapter/skills/memorax-code/SKILL.md",
+    "lib/memorax-code-trae-adapter/src/adapter-paths.mjs",
+    "lib/memorax-code-trae-adapter/src/cli.mjs",
+    "lib/memorax-code-trae-adapter/src/config.mjs",
+    "lib/memorax-code-trae-adapter/src/runtime-observation.mjs",
     "lib/memorax-code-backend/dist/service-entrypoint.js",
     "lib/memorax-code-backend/dist/memorax-cli.js",
     "lib/memorax-code-backend/dist/jsonl-append.js",
@@ -260,6 +273,8 @@ assert not symlinks, symlinks
 dsh_skill = package_root / "lib" / "memorax-code-dsh-adapter" / "skills" / "memorax-code" / "SKILL.md"
 codex_skill = package_root / "lib" / "memorax-code-codex-adapter" / "skills" / "memorax-code" / "SKILL.md"
 assert dsh_skill.read_bytes() == codex_skill.read_bytes()
+trae_skill = package_root / "lib" / "memorax-code-trae-adapter" / "skills" / "memorax-code" / "SKILL.md"
+assert trae_skill.read_bytes() == codex_skill.read_bytes()
 PY_STAGED_PACKAGE
 
 tarball_dir="$out_dir/tarballs"
@@ -342,6 +357,7 @@ export DSH_HOME="$home_dir/.dsh-memorax-code-package-check"
 export CLAUDE_CONFIG_DIR="$home_dir/.claude-memorax-code-package-check"
 export CLAUDE_HOME="$CLAUDE_CONFIG_DIR"
 export OPENCODE_CONFIG_DIR="$home_dir/.config/opencode-memorax-code-package-check"
+export TRAE_CN_HOME="$home_dir/.trae-cn-memorax-code-package-check"
 package_install_port="$(node -e 'const net = require("node:net"); const server = net.createServer(); server.listen(0, "127.0.0.1", () => { console.log(server.address().port); server.close(); });')"
 export MEMORAX_CODE_BACKEND_PORT="$package_install_port"
 
@@ -353,6 +369,7 @@ for unexpected in \
   "$DSH_HOME" \
   "$CLAUDE_CONFIG_DIR" \
   "$OPENCODE_CONFIG_DIR" \
+  "$TRAE_CN_HOME" \
   "$MEMORAX_CODE_HOME/config.toml" \
   "$MEMORAX_CODE_HOME/runtime/setup/setup-completion.json" \
   "$MEMORAX_CODE_HOME/runtime/install/package-transition.json" \
@@ -488,7 +505,14 @@ for relative in \
   lib/memorax-code-codebuddy-adapter/src/config.mjs \
   lib/memorax-code-codebuddy-adapter/src/hook-manifest.mjs \
   lib/memorax-code-codebuddy-adapter/src/runtime-observation.mjs \
-  lib/memorax-code-codebuddy-adapter/src/cli.mjs
+  lib/memorax-code-codebuddy-adapter/src/cli.mjs \
+  lib/memorax-code-trae-adapter/package.json \
+  lib/memorax-code-trae-adapter/hooks/runtime-hook.mjs \
+  lib/memorax-code-trae-adapter/skills/memorax-code/SKILL.md \
+  lib/memorax-code-trae-adapter/src/adapter-paths.mjs \
+  lib/memorax-code-trae-adapter/src/cli.mjs \
+  lib/memorax-code-trae-adapter/src/config.mjs \
+  lib/memorax-code-trae-adapter/src/runtime-observation.mjs
 do
   test -f "$package_install_root/$relative"
 done
@@ -506,6 +530,7 @@ printf '%s\n' 'package-check-user' 'package-check-key' | \
   MEMORAX_CODE_SKIP_CODEX_PLUGIN_INSTALL=1 \
   MEMORAX_CODE_SKIP_CLAUDE_ADAPTER_INSTALL=1 \
   MEMORAX_CODE_SKIP_OPENCODE_ADAPTER_INSTALL=1 \
+  MEMORAX_CODE_SKIP_TRAE_ADAPTER_INSTALL=1 \
   "$prefix/bin/memorax-code" setup --existing-account \
     >"$home_dir/setup.stdout" 2>"$home_dir/setup.stderr"
 node --input-type=module - "$MEMORAX_CODE_HOME/config.toml" <<'NODE_DISABLE_DSH'
@@ -549,6 +574,7 @@ assert config_sections == {
     "trace.codebuddy",
     "trace.dsh",
     "trace.opencode",
+    "trace.trae",
 }
 assert 'user_id = "package-check-user"' in config_text
 assert 'api_key = "package-check-key"' in config_text
@@ -557,6 +583,7 @@ assert "codex = false" in config_text
 assert "claude = false" in config_text
 assert "dsh = false" in config_text
 assert "opencode = false" in config_text
+assert "trae = false" in config_text
 assert memorax_code_config.stat().st_mode & 0o777 == 0o600
 completion = json.loads((home / ".memorax-code" / "runtime" / "setup" / "setup-completion.json").read_text())
 assert completion["version"] == 1
@@ -584,6 +611,7 @@ MEMORAX_CODE_SETUP_ASSUME_INTERACTIVE=1 \
 MEMORAX_CODE_SKIP_CODEX_PLUGIN_INSTALL=1 \
 MEMORAX_CODE_SKIP_CLAUDE_ADAPTER_INSTALL=1 \
 MEMORAX_CODE_SKIP_OPENCODE_ADAPTER_INSTALL=1 \
+MEMORAX_CODE_SKIP_TRAE_ADAPTER_INSTALL=1 \
 "$prefix/bin/memorax-code" >/dev/null 2>&1
 cmp "$home_dir/legacy-config-before-migration.toml" "$MEMORAX_CODE_HOME/config.toml"
 test -f "$MEMORAX_CODE_HOME/runtime/setup/setup-completion.json"

--- a/scripts/npm-package-layout.mjs
+++ b/scripts/npm-package-layout.mjs
@@ -10,6 +10,7 @@ const packagePrefixes = [
   "lib/memorax-code-dsh-adapter/",
   "lib/memorax-code-opencode-adapter/",
   "lib/memorax-code-codebuddy-adapter/",
+  "lib/memorax-code-trae-adapter/",
 ];
 const packageFiles = new Set([
   "bin",
@@ -20,6 +21,7 @@ const packageFiles = new Set([
   "bin/memorax-code-codex.mjs",
   "bin/memorax-code-opencode.mjs",
   "bin/memorax-code-codebuddy.mjs",
+  "bin/memorax-code-trae.mjs",
   "bin/memorax-code-npm-preinstall.mjs",
   "bin/memorax-code.mjs",
   "bin/memorax-cli.mjs",

--- a/scripts/npm-source-files.mjs
+++ b/scripts/npm-source-files.mjs
@@ -18,6 +18,10 @@ export const npmMainSourceTrees = Object.freeze([
     source: `packages/ts/memorax-code-codebuddy-adapter/${name}`,
     destination: `lib/memorax-code-codebuddy-adapter/${name}`,
   })),
+  ...["src", "hooks"].map((name) => ({
+    source: `packages/ts/memorax-code-trae-adapter/${name}`,
+    destination: `lib/memorax-code-trae-adapter/${name}`,
+  })),
   {
     source: "packages/ts/memorax-code-dsh-adapter/src",
     destination: "lib/memorax-code-dsh-adapter/src",
@@ -49,6 +53,10 @@ export const npmMainSourceTrees = Object.freeze([
   {
     source: "packages/ts/memorax-code-codex-adapter/skills/memorax-code",
     destination: "lib/memorax-code-codebuddy-adapter/skills/memorax-code",
+  },
+  {
+    source: "packages/ts/memorax-code-codex-adapter/skills/memorax-code",
+    destination: "lib/memorax-code-trae-adapter/skills/memorax-code",
   },
 ]);
 

--- a/scripts/sync-release-version.mjs
+++ b/scripts/sync-release-version.mjs
@@ -22,6 +22,7 @@ export const RELEASE_VERSION_TARGETS = Object.freeze([
   { file: "packages/ts/memorax-code-opencode-adapter/package.json", field: ["version"] },
   { file: "packages/ts/memorax-code-codebuddy-adapter/package.json", field: ["version"] },
   { file: "packages/ts/memorax-code-codebuddy-adapter/.codebuddy-plugin/plugin.json", field: ["version"] },
+  { file: "packages/ts/memorax-code-trae-adapter/package.json", field: ["version"] },
 ]);
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");

--- a/scripts/validate-npm-pack-json.mjs
+++ b/scripts/validate-npm-pack-json.mjs
@@ -63,6 +63,7 @@ for (const requiredPath of [
   "bin/memorax-code-setup.mjs",
   "bin/memorax-code-opencode.mjs",
   "bin/memorax-code-codebuddy.mjs",
+  "bin/memorax-code-trae.mjs",
   "lib/client-hook-runtime.mjs",
   "lib/automatic-update.mjs",
   "lib/dsh-plugin-install.mjs",
@@ -164,6 +165,13 @@ for (const requiredPath of [
   "lib/memorax-code-codebuddy-adapter/src/hook-manifest.mjs",
   "lib/memorax-code-codebuddy-adapter/src/runtime-observation.mjs",
   "lib/memorax-code-codebuddy-adapter/src/cli.mjs",
+  "lib/memorax-code-trae-adapter/package.json",
+  "lib/memorax-code-trae-adapter/hooks/runtime-hook.mjs",
+  "lib/memorax-code-trae-adapter/skills/memorax-code/SKILL.md",
+  "lib/memorax-code-trae-adapter/src/adapter-paths.mjs",
+  "lib/memorax-code-trae-adapter/src/cli.mjs",
+  "lib/memorax-code-trae-adapter/src/config.mjs",
+  "lib/memorax-code-trae-adapter/src/runtime-observation.mjs",
 ]) {
   if (!paths.has(requiredPath)) {
     throw new Error(`npm pack is missing required runtime entrypoint: ${requiredPath}`);
@@ -213,6 +221,13 @@ try {
   );
   if (packedDshSkill !== canonicalSkill) {
     throw new Error("npm pack DSH skill must remain byte-identical to the canonical skill");
+  }
+  const packedTraeSkill = await readFile(
+    join(extracted, "package", "lib/memorax-code-trae-adapter/skills/memorax-code/SKILL.md"),
+    "utf8",
+  );
+  if (packedTraeSkill !== canonicalSkill) {
+    throw new Error("npm pack Trae skill must remain byte-identical to the canonical skill");
   }
   await assertLocalTraceOnly({
     repoRoot,


### PR DESCRIPTION
## Change Summary
Add a managed Trae integration that discovers Trae, installs the shared MemoraX Code Skill, and safely registers lifecycle Hooks so Trae users receive automatic memory support without losing their existing Hook configuration.

## Implementation Highlights
- Add Trae application and data-home discovery, marker-owned `SessionStart`/`UserPromptSubmit`/`Stop` merging, content-addressed Hook runtimes, runtime observation, and Windows-safe PowerShell `EncodedCommand` launchers.
- Wire Trae through setup, start, update, status, stop, uninstall, client selection, Backend lifecycle participation, npm packaging, version checks, and public documentation.
- Materialize the canonical shared Skill, preserve unrelated Hooks, fail closed on invalid Hook files or unmanaged Skill conflicts, and clearly request the one-time manual Global Hooks activation that Trae owns.

## Validation
- `npm test --prefix packages/ts/memorax-code-trae-adapter`: 10/10 passed.
- `npm run typecheck --prefix packages/ts/memorax-code-backend` and Backend build: passed.
- `npm test --prefix packages/ts/memorax-code-backend`: 512 passed, 2 skipped.
- Codex, Claude Code, DSH, OpenCode, and CodeBuddy/WorkBuddy adapter suites: 229/229, 65/65, 28/28, 35/35, and 21/21 passed.
- `make test-npm-package`: 258 passed, 2 skipped.
- `make docs-check`: passed.
- `make npm-package-check`: passed; 447 packaged files matched the allowlist, and isolated install, setup, update, lifecycle, Trae CLI, Hook, and Skill materialization checks completed successfully.

## Full End-to-End Validation Results
- Environment: macOS, an isolated Docker Linux environment, and Windows 11 Build 26200 with Node.js 24.19.0, npm 11.17.0, and Trae CN 3.3.95.
- Scenario or matrix: Trae-only setup; one-time Global Hooks activation; real `SessionStart`, `UserPromptSubmit`, and `Stop` execution; Backend replacement during an active Turn; eight-Turn buffered automatic Add; automatic Search disabled; explicit Add/Search; Windows `Program Files` Hook launch; and Windows npm `.cmd` CLI invocation.
- Command or workflow: Installed an isolated prerelease package, selected Trae during setup, opened fresh real Trae sessions, restarted the managed Backend during a Turn, completed eight Turns, and verified adapter status, trace correlation, writeback, and explicit memory operations.
- Result: PASS on all three platforms. Windows observed all three Hooks, preserved the active Turn through Backend replacement, produced no writeback for the first seven Turns and exactly one successful writeback on Turn eight, produced no automatic retrieval, and completed explicit Add/Search without changing PowerShell execution policy.
- Evidence or artifacts: Redacted platform reports were reviewed during development. No credentials, raw transcripts, private traces, or user-specific absolute paths are committed.
- Reason not run / remaining risk: Real-client E2E was completed on the validated pre-split implementation and was not repeated after splitting this PR; the split branch retains that adapter implementation and passed the latest-main full automated and package checks above. Trae still requires users to enable Global Hooks once, exposes no stable raw Session or current-Turn CLI environment, and has no supported headless Repo Memory worker.