### PR TITLE
feat: automatically enable newly supported clients on update

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -183,7 +183,7 @@ sequenceDiagram
   loop completed setup while managed Backend remains running
     Service->>Update: dispatch when persisted deadline is due
     Update->>NPM: resolve release channel and install exact target
-    Update->>Setup: reconcile retained clients non-interactively
+    Update->>Setup: reconcile client intent non-interactively
     Setup->>Completion: commit only after final verification
   end
 ```
@@ -213,12 +213,14 @@ Client startup Hooks only recover an unavailable Backend and do not own update
 cadence. The updater follows the installed release channel, serializes checks
 through the private record and lock, installs an exact published target, and
 invokes an internal non-interactive setup mode. That mode preserves the
-existing client selection and configuration. Codex Hook changes are trusted
-silently only when the marketplace identity remains the same and the exact
-incremental Hook selection survives validation before and after the config
-write. Verification failure leaves reconciliation incomplete for a later
-retry. Package replacement may retire the dispatching Backend; the restored
-Backend resumes scheduling from the same durable record.
+explicit client selection and configuration. A locally detected adapter whose
+key is absent from a legacy `[clients]` table is selected by default, while an
+explicit `false` remains disabled. Codex Hook changes are trusted silently only
+when the marketplace identity remains the same and the exact incremental Hook
+selection survives validation before and after the config write. Verification
+failure leaves reconciliation incomplete for a later retry. Package
+replacement may retire the dispatching Backend; the restored Backend resumes
+scheduling from the same durable record.
 
 The principal control-plane locations are:
 

--- a/README.md
+++ b/README.md
@@ -285,8 +285,10 @@ client session. Stable installations follow npm `latest`; prerelease
 installations follow `preview`. A successful check is reused for eight hours,
 while a failed check or reconciliation is retried after 15 minutes.
 When the published target changes, MemoraX Code installs that exact version and
-reconciles only the clients already enabled in `[clients]`; it never enables a
-newly detected client in the background.
+preserves every explicit `true` or `false` choice in `[clients]`. If the release
+adds support for a client whose key is absent from an older configuration and
+that client is detected locally, automatic reconciliation enables it by
+default. An explicit `false` remains disabled.
 
 For Codex, update reconciliation verifies the current MemoraX Code marketplace
 identity and the exact new or changed Hook hashes, then trusts those Hooks

--- a/README.zh.md
+++ b/README.zh.md
@@ -244,8 +244,9 @@ memorax-code update
 完成过 setup 后，只要托管 Backend 持续运行，它就会自行调度非阻塞更新检查，不依赖客户端
 新建会话。稳定版跟随 npm `latest`，预览版跟随 `preview`；成功检查结果复用八小时，检查或
 reconciliation 失败后 15 分钟重试。发现新版本时，MemoraX Code 会安装精确的目标版本，
-并且只 reconciliation `[clients]` 中原本已经启用的客户端，不会在后台顺便启用新检测到的
-客户端。
+并保留 `[clients]` 中所有显式的 `true` 或 `false` 选择。如果新版本新增了某个客户端支持、
+旧配置中还没有对应字段，并且本机能够检测到该客户端，自动 reconciliation 会默认启用它；
+显式设置为 `false` 的客户端仍保持关闭。
 
 在 Codex 下，更新 reconciliation 会先校验当前 MemoraX Code marketplace 身份以及新增或变化
 Hook 的精确哈希，然后静默信任这些 Hook。身份变化或 Hook 校验失败时会失败关闭，不会扩大信任

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -54,12 +54,15 @@ filesystem ACLs.
 ## Client selection
 
 If `[clients]` is absent, lifecycle commands select Codex, Claude Code, DSH,
-and OpenCode; CodeBuddy is opt-in unless detected during installation. If it is present, `codex`, `claude`, `dsh`, `opencode`, and `codebuddy` are
-boolean fields. Omitted `codex`, `claude`, or `opencode` values are disabled;
-an omitted `dsh` value remains enabled so configurations written before DSH
-support can discover an existing local Harness. Set `dsh = false` explicitly
-to disable that integration. The command-line override accepts a
-comma-separated subset:
+and OpenCode; CodeBuddy is opt-in unless detected during installation. If it
+is present, `codex`, `claude`, `dsh`, `opencode`, and `codebuddy` are boolean
+fields. Direct lifecycle commands treat omitted `codex`, `claude`, `opencode`,
+or `codebuddy` values as disabled. Setup and update reconciliation retain an
+omitted field as an undecided choice for client support added after the
+configuration was written. An omitted `dsh` value remains enabled so
+configurations written before DSH support can discover an existing local
+Harness. Set `dsh = false` explicitly to disable that integration. The
+command-line override accepts a comma-separated subset:
 
 ```text
 --clients codex|claude|dsh|opencode|codebuddy|<comma-separated subset>|all|none
@@ -72,16 +75,19 @@ DSH is available when at least one valid Profile exists under
 `$DSH_HOME/profiles`; `DSH_HOME` defaults to `~/.dsh`. An explicit
 `[clients].dsh = false` is preserved.
 
-On later setup runs, enabled client intent is preserved. Each newly available
-disabled client is offered for activation with a default of yes; declining
-keeps it disabled. A selected client that is temporarily unavailable remains
-selected instead of being permanently disabled. Direct npm installation does
-not detect clients or modify `[clients]`.
-Automatic update reconciliation also preserves the exact persisted selection;
-it does not offer or enable a newly detected client.
+On later setup runs, explicit `true` and `false` client choices are preserved.
+A detected client whose field is absent is offered for activation with a
+default of yes; declining records `false`. An absent client that is not
+detected remains absent, while a selected client that is temporarily
+unavailable remains selected. Direct npm installation does not detect clients
+or modify `[clients]`.
+Automatic update reconciliation preserves explicit choices and silently
+enables a detected client whose field is absent. This lets configurations
+written before an adapter was supported adopt it when its runtime is already
+installed, without overriding an explicit `false`.
 
 Client selection controls managed client-integration lifecycle only. It does
-not change Codex, Claude Code, DSH, or OpenCode provider settings.
+not change Codex, Claude Code, DSH, OpenCode, or CodeBuddy provider settings.
 `--clients none` runs the Backend without managing a client integration.
 
 ## Setup, automatic update, and package-transition state
@@ -127,13 +133,14 @@ Backend to disable the scheduler. Client startup Hooks only recover an
 unavailable Backend and do not schedule updates.
 
 The updater installs an exact published version and runs an internal
-non-interactive setup mode. That mode preserves `[clients]`, connection data,
-and memory preferences. For Codex, only new or changed Hooks returned by the
-incremental check are trusted silently, and the exact Hook selection is
-validated again before and after the config write. A changed marketplace
-identity or unverifiable Hook set prevents reconciliation from completing.
-The standalone `memorax-code codex-plugin trust-hooks` command still performs
-explicit review.
+non-interactive setup mode. That mode preserves explicit `[clients]` choices,
+enables detected clients missing from an older configuration, and preserves
+connection data and memory preferences. For Codex, only new or changed Hooks
+returned by the incremental check are trusted silently, and the exact Hook
+selection is validated again before and after the config write. A changed
+marketplace identity or unverifiable Hook set prevents reconciliation from
+completing. The standalone `memorax-code codex-plugin trust-hooks` command
+still performs explicit review.
 
 The installed version and next check deadline are stored in another private
 record:

--- a/packages/npm/memorax-code/bin/memorax-code-setup.mjs
+++ b/packages/npm/memorax-code/bin/memorax-code-setup.mjs
@@ -41,6 +41,7 @@ const RED = "\x1b[31m";
 const BOLD = "\x1b[1m";
 const RESET = "\x1b[0m";
 const DSH_OPTIONAL_ENV = "MEMORAX_CODE_DSH_ADAPTER_OPTIONAL";
+const SETUP_CLIENTS = ["codex", "claude", "opencode", "codebuddy"];
 
 const skipCodexPluginInstall = truthyEnv(process.env.MEMORAX_CODE_SKIP_CODEX_PLUGIN_INSTALL);
 const skipClaudeAdapterInstall = truthyEnv(process.env.MEMORAX_CODE_SKIP_CLAUDE_ADAPTER_INSTALL);
@@ -68,8 +69,10 @@ const claudeRuntime = ensureClaudeCommandEnv();
 const claudeCommand = claudeRuntime.command;
 const codeBuddyRuntime = ensureCodeBuddyCommandEnv();
 const codeBuddyCommand = codeBuddyRuntime.command;
-const previousClients = readPersistedClientSelection();
-const existingSetup = previousClients !== undefined;
+const persistedClientSelection = readPersistedClientSelection();
+const existingSetup = persistedClientSelection !== undefined;
+const previousClients = persistedClientSelection?.selected ?? [];
+const explicitClientChoices = persistedClientSelection?.explicit ?? [];
 const persistedDshSelection = readPersistedDshSelection();
 const dshEnabledByConfig = persistedDshSelection !== false;
 let dshProfiles = [];
@@ -114,7 +117,7 @@ try {
   process.exit(1);
 }
 runCommonPreflight();
-const requestedClients = ["codex", "claude", "opencode", "codebuddy"];
+const requestedClients = SETUP_CLIENTS;
 const codexPreflight = requestedClients.includes("codex") && !skipCodexPluginInstall
   ? runCodexPreflight({
       integrationSelected: !existingSetup || previousClients.includes("codex"),
@@ -141,11 +144,21 @@ const detectedClients = requestedClients.filter((client) => {
   if (client === "opencode") return !skipOpenCodeAdapterInstall && opencodePreflight.ok;
   return !skipCodeBuddyAdapterInstall && codebuddyPreflight.ok;
 });
+const newlyDetectedClients = existingSetup
+  ? detectedClients.filter((client) => !explicitClientChoices.includes(client))
+  : [];
 const selectedClients = automaticUpdateMode
-  ? previousClients
+  ? requestedClients.filter((client) => (
+      previousClients.includes(client) || newlyDetectedClients.includes(client)
+    ))
   : existingSetup
-    ? await chooseUpdateClients(previousClients, detectedClients, scriptedAnswers)
+    ? await chooseUpdateClients(previousClients, newlyDetectedClients, scriptedAnswers)
     : detectedClients;
+const clientsWithPersistedIntent = existingSetup
+  ? requestedClients.filter((client) => (
+      explicitClientChoices.includes(client) || newlyDetectedClients.includes(client)
+    ))
+  : requestedClients;
 const installClients = detectedClients.filter((client) => selectedClients.includes(client));
 if (existingSetup) {
   log(clientSelectionMessage(selectedClients, { dshSelected }));
@@ -169,7 +182,7 @@ if (requestedClients.includes("opencode") && !skipOpenCodeAdapterInstall && !ope
 if (requestedClients.includes("codebuddy") && !skipCodeBuddyAdapterInstall && !codebuddyPreflight.ok) {
   log("CodeBuddy/WorkBuddy runtime was not detected; skipping its adapter setup.");
 }
-if (writeClientSelectionConfig(selectedClients) === "failed") {
+if (writeClientSelectionConfig(selectedClients, clientsWithPersistedIntent) === "failed") {
   printPostinstallSummary("not-verified");
   process.exit(1);
 }
@@ -371,16 +384,15 @@ async function maybeConfigureMemoraxMemory(scriptedAnswers, {
   }
 }
 
-async function chooseUpdateClients(previousClients, detectedClients, scriptedAnswers) {
+async function chooseUpdateClients(previousClients, newlyDetectedClients, scriptedAnswers) {
   const selected = new Set(previousClients);
-  const availableDisabledClients = detectedClients.filter((client) => !selected.has(client));
-  if (availableDisabledClients.length === 0) return [...previousClients];
+  if (newlyDetectedClients.length === 0) return [...previousClients];
 
   let rl;
   try {
-    for (const client of availableDisabledClients) {
+    for (const client of newlyDetectedClients) {
       const label = clientLabel(client);
-      const question = `${label} runtime is available, but its integration is disabled in [clients]. Enable it now? [Y/n]`;
+      const question = `${label} runtime is not configured in [clients]. Enable it now? [Y/n]`;
       let answer;
       if (scriptedAnswers) {
         log(question);
@@ -399,7 +411,7 @@ async function chooseUpdateClients(previousClients, detectedClients, scriptedAns
   } finally {
     rl?.close();
   }
-  return ["codex", "claude", "opencode", "codebuddy"].filter((client) => selected.has(client));
+  return SETUP_CLIENTS.filter((client) => selected.has(client));
 }
 
 async function configureMemoraxMemoryFromAnswers(answers, detectedPreferences, {
@@ -753,12 +765,10 @@ function readPersistedClientSelection() {
   try {
     const clients = parse(readFileSync(path, "utf8"))?.clients;
     if (!clients || typeof clients !== "object" || typeof clients.codex !== "boolean" || typeof clients.claude !== "boolean") return undefined;
-    return [
-      clients.codex ? "codex" : undefined,
-      clients.claude ? "claude" : undefined,
-      clients.opencode === true ? "opencode" : undefined,
-      clients.codebuddy === true ? "codebuddy" : undefined,
-    ].filter(Boolean);
+    return {
+      selected: SETUP_CLIENTS.filter((client) => clients[client] === true),
+      explicit: SETUP_CLIENTS.filter((client) => typeof clients[client] === "boolean"),
+    };
   } catch {
     return undefined;
   }
@@ -775,22 +785,24 @@ function readPersistedDshSelection() {
   }
 }
 
-function writeClientSelectionConfig(clients) {
+function writeClientSelectionConfig(clients, configuredClients = SETUP_CLIENTS) {
   const path = memoraxCodeConfigPath();
   return updateConfigFileAtomically({
     path,
-    defaultText: setManagedClientSelection(defaultMemoraxCodeConfig(), clients),
-    transform: (text) => setManagedClientSelection(text, clients),
+    defaultText: setManagedClientSelection(defaultMemoraxCodeConfig(), clients, configuredClients),
+    transform: (text) => setManagedClientSelection(text, clients, configuredClients),
     parseToml: parse,
     warn: (message) => log(message),
   });
 }
 
-function setManagedClientSelection(text, clients) {
-  const withOpenCode = setTomlField(text, "clients", "opencode", String(clients.includes("opencode")));
-  const withClaude = setTomlField(withOpenCode, "clients", "claude", String(clients.includes("claude")));
-  const withCodeBuddy = setTomlField(withClaude, "clients", "codebuddy", String(clients.includes("codebuddy")));
-  return setTomlField(withCodeBuddy, "clients", "codex", String(clients.includes("codex")));
+function setManagedClientSelection(text, clients, configuredClients = SETUP_CLIENTS) {
+  let updated = text;
+  for (const client of ["opencode", "claude", "codebuddy", "codex"]) {
+    if (!configuredClients.includes(client)) continue;
+    updated = setTomlField(updated, "clients", client, String(clients.includes(client)));
+  }
+  return updated;
 }
 
 function writeMemoraxConfig({ userId, endpoint, outputLanguage, apiKey }) {

--- a/packages/npm/memorax-code/test/setup.test.mjs
+++ b/packages/npm/memorax-code/test/setup.test.mjs
@@ -715,18 +715,20 @@ test("setup update mode skips MemoraX credentials and silently trusts verified H
     "",
   ].join("\n");
   const run = await runSetup({
+    codebuddyAvailable: true,
     existingCache: true,
     updateMode: true,
     memoraxCodeConfig: existingConfig,
     interactive: true,
-    input: "n\n",
+    input: "\n",
     hookSnapshot: [],
     hookUpdatePlan: [added],
   });
   try {
     assert.equal(run.result.code, 0, run.result.stderr);
-    assert.match(run.result.stderr, /Claude Code runtime is available, but its integration is disabled in \[clients\]\. Enable it now\? \[Y\/n\]/);
-    assert.match(run.result.stderr, /Keeping the Claude Code integration disabled/);
+    assert.doesNotMatch(run.result.stderr, /Claude Code runtime .* Enable it now\?/);
+    assert.match(run.result.stderr, /CodeBuddy\/WorkBuddy runtime is not configured in \[clients\]\. Enable it now\? \[Y\/n\]/);
+    assert.match(run.result.stderr, /Enabling the CodeBuddy\/WorkBuddy integration/);
     assert.doesNotMatch(run.result.stderr, /Trust these new or changed Codex Hooks/);
     assert.match(run.result.stderr, /Trusted 1 new or changed MemoraX Code Codex Hook/);
     assert.doesNotMatch(run.result.stderr, /Existing MemoraX configuration detected/);
@@ -741,6 +743,8 @@ test("setup update mode skips MemoraX credentials and silently trusts verified H
     assert.match(config, /api_key = "existing-api-key"/);
     assert.match(config, /user_id = "existing-user-id"/);
     assert.match(config, /output_language = "en"/);
+    assert.match(config, /claude = false/);
+    assert.match(config, /codebuddy = true/);
   } finally {
     await rm(run.root, { recursive: true, force: true });
   }
@@ -1071,7 +1075,7 @@ test("interactive setup after reinstall automatically reuses a complete MemoraX 
     assert.match(run.result.stderr, /Automatic writeback: Disabled by effective configuration/);
     assert.equal(
       await readFile(join(run.memoraxCodeHome, "config.toml"), "utf8"),
-      existingConfig.replace("[clients]\n", "[clients]\ncodebuddy = false\nopencode = false\n"),
+      existingConfig,
     );
     await assertSetupComplete(run);
   } finally {
@@ -1282,6 +1286,66 @@ test("automatic update setup is non-interactive and preserves disabled clients",
     assert.match(config, /dsh = false/);
     assert.match(config, /opencode = false/);
     assert.match(config, /codebuddy = false/);
+    await assertSetupComplete(run);
+  } finally {
+    await rm(run.root, { recursive: true, force: true });
+  }
+});
+
+test("automatic update setup enables a detected client missing from legacy config", async () => {
+  const existingConfig = [
+    "[clients]",
+    "codex = true",
+    "claude = false",
+    "dsh = false",
+    "opencode = false",
+    "",
+  ].join("\n");
+  const run = await runSetup({
+    codebuddyAvailable: true,
+    existingCache: true,
+    interactive: false,
+    memoraxCodeConfig: existingConfig,
+    memoraxEnv: { MEMORAX_CODE_SETUP_AUTOMATIC_UPDATE: "1" },
+    updateMode: true,
+  });
+  try {
+    assert.equal(run.result.code, 0, run.result.stderr);
+    assert.doesNotMatch(run.result.stderr, /Enable it now\?/);
+    assert.match(run.log, /^memorax-code start --clients codex,codebuddy$/m);
+    const config = await readFile(join(run.memoraxCodeHome, "config.toml"), "utf8");
+    assert.match(config, /codex = true/);
+    assert.match(config, /claude = false/);
+    assert.match(config, /opencode = false/);
+    assert.match(config, /codebuddy = true/);
+    await assertSetupComplete(run);
+  } finally {
+    await rm(run.root, { recursive: true, force: true });
+  }
+});
+
+test("automatic update setup leaves an unavailable unconfigured client undecided", async () => {
+  const existingConfig = [
+    "[clients]",
+    "codex = true",
+    "claude = false",
+    "dsh = false",
+    "opencode = false",
+    "",
+  ].join("\n");
+  const run = await runSetup({
+    existingCache: true,
+    interactive: false,
+    memoraxCodeConfig: existingConfig,
+    memoraxEnv: { MEMORAX_CODE_SETUP_AUTOMATIC_UPDATE: "1" },
+    updateMode: true,
+  });
+  try {
+    assert.equal(run.result.code, 0, run.result.stderr);
+    assert.match(run.log, /^memorax-code start --clients codex$/m);
+    const config = await readFile(join(run.memoraxCodeHome, "config.toml"), "utf8");
+    assert.equal(tomlSectionText(config, "clients"), tomlSectionText(existingConfig, "clients"));
+    assert.doesNotMatch(tomlSectionText(config, "clients"), /codebuddy\s*=/);
     await assertSetupComplete(run);
   } finally {
     await rm(run.root, { recursive: true, force: true });


### PR DESCRIPTION
## Change Summary
Automatically enable a newly supported coding-agent integration during update when its runtime is detected and the existing `[clients]` config has no explicit choice, while preserving every explicit enabled or disabled choice.

## Implementation Highlights
- Track explicit client choices separately from currently enabled clients so missing legacy fields remain distinguishable from deliberate `false` values.
- Reconcile newly detected clients silently during automatic updates and prompt only for genuinely unconfigured clients during manual updates.
- Preserve missing fields when the corresponding runtime is unavailable, and document the migration semantics in both READMEs, configuration docs, and the architecture contract.

## Validation
- `make npm-package-check`: 257 passed, 2 skipped, 0 failed; local-only trace gate passed; npm pack allowlist passed for 419 files.
- Targeted setup coverage verifies explicit opt-out preservation, detected missing-client activation, and unavailable missing-client preservation.

## Full End-to-End Validation Results
- Environment: macOS with real WorkBuddy CLI 2.132.0; isolated MemoraX Code, coding-agent Homes, npm prefix, and Backend port.
- Scenario or matrix: legacy `[clients]` config without `codebuddy`, with WorkBuddy installed.
- Command or workflow: package-level non-interactive automatic-update reconciliation.
- Result: `codebuddy = true`; WorkBuddy plugin installed, enabled, managed, marketplace-ready; Skill installed; setup completion and Backend health valid. Hook status was the expected `unverified` before first real Hook execution.
- Evidence or artifacts: local 0.1.11 package built from commit `2ec066e`; isolated test directory cleaned and Backend port released.

- Environment: Linux Docker on Node.js 20 and Node.js 24.
- Scenario or matrix: explicit `false`, detected missing client, and unavailable missing client.
- Command or workflow: targeted Node 20 tests plus the complete Node 24 package gate.
- Result: all feature scenarios passed; Node 24 reported 257 passed, 2 skipped, 0 failed; trace and 419-file package checks passed.
- Evidence or artifacts: containers removed after validation. An existing Node 20 concurrent trial-provision timeout passed when rerun alone and was unrelated to this change.

- Environment: Windows build 26200, Node.js 24.19.0, npm 11.17.0, WorkBuddy 5.4.7, bundled CodeBuddy runtime 2.132.0.
- Scenario or matrix: newly supported WorkBuddy absent from legacy config, explicit WorkBuddy opt-out, and isolated lifecycle verification.
- Command or workflow: isolated npm prefix, client Homes, Backend port, and automatic-update reconciliation using the packaged runtime.
- Result: Windows E2E passed; missing detected client was enabled silently, explicit choices were preserved, and no confirmed defect was found.
- Evidence or artifacts: tgz SHA-256 `55141e0320e06ba7f3acc7734790ce39888e73911f933071d3a5c608e629e01a`; temporary directories moved to Recycle Bin; no residual processes or source changes.

- Reason not run / remaining risk: no known feature-specific validation gap remains.