### PR TITLE
docs: clarify Trae Global Hooks activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,15 @@ registered.
 Both setup paths automatically detect supported coding agents. Restart or
 refresh every detected coding agent after setup.
 
-For Trae, setup installs the managed Skill and Global Hooks, but Trae does not
-expose a reliable programmatic switch for Global Hooks. Open Trae Settings,
-enable **Global Hooks** once, then start a new Trae session.
+> [!IMPORTANT]
+> **Trae only:** setup installs the managed Skill and Global Hooks, but Trae
+> requires its Global Hooks switch to be enabled manually. In Trae, open
+> **Settings → Hooks → Global → Configured Hooks** and enable the registered
+> hooks once. Then start a new Trae session and send one prompt. Run
+> `memorax-code status` to confirm the Trae Hook runtime changes from
+> `unverified` to `observed`. If a coding agent performs the installation, it
+> should explicitly remind the user to complete this Trae-only UI step. Other
+> supported coding agents do not require it.
 
 ### Installation Troubleshooting
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -93,8 +93,12 @@ memorax-code account --show-mark-id
 
 两种安装引导都会自动检测受支持的 Coding Agent。完成后，请重启或刷新检测到的 Coding Agent。
 
-对于 Trae，setup 会安装受管 Skill 和 Global Hooks，但 Trae 没有提供可靠的程序化开关。
-请在 Trae 设置中手动开启一次 **Global Hooks**，然后新建 Trae 会话。
+> [!IMPORTANT]
+> **仅 Trae 用户需要：** setup 会安装受管 Skill 和 Global Hooks，但 Trae 要求用户手动开启
+> Global Hooks 开关。请在 Trae 中打开 **设置 → Hooks → 全局 → 已配置的 Hooks**，开启已注册的
+> Hooks，然后新建 Trae 会话并发送一次 Prompt。运行 `memorax-code status`，确认 Trae Hook
+> runtime 从 `unverified` 变为 `observed`。如果由 Agent 代为安装，Agent 应明确提醒用户完成这项
+> Trae 专属的界面操作；其他受支持的 Coding Agent 不需要执行这一步。
 
 ### 安装故障排查
 


### PR DESCRIPTION
## Change Summary
Clarifies the Trae-only manual Global Hooks activation step so users and coding agents performing installation know which one-time UI action is still required after setup.

## Implementation Highlights
- Add a prominent Trae-only callout to the English and Chinese Quick Start guides.
- Document the exact Trae settings path, the fresh-session verification step, and the expected `unverified` to `observed` status transition.
- Tell coding agents performing installation to hand the UI step back to the user, while making clear that other supported coding agents do not require it.

## Validation
- `make docs-check`
- `git diff --check`

## Full End-to-End Validation Results
- Environment: macOS local documentation validation against current `origin/main`.
- Scenario or matrix: English and Chinese Trae onboarding guidance and README synchronization.
- Command or workflow: `make docs-check`.
- Result: PASS; all 10 documentation contract tests passed, followed by the documentation contract and bilingual README sync checks.
- Evidence or artifacts: No persistent artifacts; validation output was inspected locally.
- Reason not run / remaining risk: Runtime E2E was not rerun because this PR changes documentation only. Remaining risk is limited to Trae renaming the documented settings labels in a future release.