### PR TITLE
chore:(release) bump version to 0.1.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ behavior.
 
 ## Unreleased
 
+## [0.1.12] - 2026-09-02
+
+### Added
+
+- Added managed Trae integration with the shared MemoraX Code Skill, native
+  lifecycle Hooks, exact Turn correlation, completed-Turn writeback,
+  interrupted-Turn handling, Skill reminders, optional automatic retrieval,
+  local traces, and supported setup on macOS, Linux, and Windows. Trae users
+  enable Global Hooks once in Trae before the integration can run.
+
+### Changed
+
+- Updates now enable a newly supported coding-agent integration when its
+  runtime is detected and its client setting was previously absent. Explicit
+  enabled and disabled choices remain unchanged; automatic updates reconcile
+  silently, while manual updates prompt for unconfigured detected clients.
+- Clarified Trae activation guidance with the exact Global Hooks UI path and
+  the runtime status check used to confirm that Hooks have been observed.
+
+### Fixed
+
+- Updated Windows PowerShell Skill commands to invoke `memorax-cli.cmd`,
+  avoiding `.ps1` execution-policy failures without requiring users to change
+  PowerShell policy.
+
 ## [0.1.11] - 2026-09-01
 
 ### Fixed

--- a/packages/npm/memorax-code/package.json
+++ b/packages/npm/memorax-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax/memorax-code",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Persistent coding memory for Codex, Claude Code, CodeBuddy/WorkBuddy, DeepSeek Harness, OpenCode, and Trae.",
   "license": "MIT",
   "type": "module",

--- a/packages/ts/memorax-code-backend/package-lock.json
+++ b/packages/ts/memorax-code-backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@memorax-code/backend",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@memorax-code/backend",
-      "version": "0.1.11",
+      "version": "0.1.12",
       "dependencies": {
         "smol-toml": "^1.7.0"
       },

--- a/packages/ts/memorax-code-backend/package.json
+++ b/packages/ts/memorax-code-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/backend",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "private": true,
   "type": "module",
   "description": "Local memory integration, lifecycle, trace, and diagnostics for MemoraX Code.",

--- a/packages/ts/memorax-code-claude-adapter/.claude-plugin/plugin.json
+++ b/packages/ts/memorax-code-claude-adapter/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorax-code-claude-adapter",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Memory skill and local hooks for MemoraX Code in Claude Code.",
   "author": {
     "name": "MemoraX Code Maintainers"

--- a/packages/ts/memorax-code-claude-adapter/hooks/runtime-shell.json
+++ b/packages/ts/memorax-code-claude-adapter/hooks/runtime-shell.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
-  "shellVersion": "0.1.11",
+  "shellVersion": "0.1.12",
   "runtimeAbi": 1
 }

--- a/packages/ts/memorax-code-claude-adapter/package.json
+++ b/packages/ts/memorax-code-claude-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/claude-adapter",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "private": true,
   "type": "module",
   "description": "Claude Code Hook adapter for MemoraX Code memory services.",

--- a/packages/ts/memorax-code-codebuddy-adapter/.codebuddy-plugin/plugin.json
+++ b/packages/ts/memorax-code-codebuddy-adapter/.codebuddy-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorax-code-codebuddy-adapter",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "MemoraX Code memory integration for CodeBuddy and WorkBuddy.",
   "hooks": "./hooks/hooks.json",
   "skills": ["./skills/memorax-code"]

--- a/packages/ts/memorax-code-codebuddy-adapter/package.json
+++ b/packages/ts/memorax-code-codebuddy-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/codebuddy-adapter",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "private": true,
   "type": "module",
   "description": "CodeBuddy and WorkBuddy Hook adapter for MemoraX Code memory services.",

--- a/packages/ts/memorax-code-codex-adapter/.codex-plugin/plugin.json
+++ b/packages/ts/memorax-code-codex-adapter/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorax-code-codex-adapter",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Codex adapter, memory skill, and local hooks for MemoraX Code.",
   "author": {
     "name": "MemoraX AI"

--- a/packages/ts/memorax-code-codex-adapter/hooks/runtime-shell.json
+++ b/packages/ts/memorax-code-codex-adapter/hooks/runtime-shell.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
-  "shellVersion": "0.1.11",
+  "shellVersion": "0.1.12",
   "runtimeAbi": 1
 }

--- a/packages/ts/memorax-code-codex-adapter/package.json
+++ b/packages/ts/memorax-code-codex-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/codex-adapter",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "private": true,
   "type": "module",
   "description": "Codex Hook and memory integration for MemoraX Code.",

--- a/packages/ts/memorax-code-dsh-adapter/package.json
+++ b/packages/ts/memorax-code-dsh-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/dsh-memorax-code",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "private": true,
   "type": "module",
   "description": "DeepSeek Harness native memory adapter for MemoraX Code.",

--- a/packages/ts/memorax-code-opencode-adapter/package.json
+++ b/packages/ts/memorax-code-opencode-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/opencode-adapter",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "private": true,
   "type": "module",
   "description": "OpenCode plugin adapter for MemoraX Code memory services.",

--- a/packages/ts/memorax-code-trae-adapter/package.json
+++ b/packages/ts/memorax-code-trae-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/trae-adapter",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "private": true,
   "type": "module",
   "description": "Trae Hook adapter for MemoraX Code memory services.",


### PR DESCRIPTION
## Summary

- bump the release version from 0.1.11 to 0.1.12 across declared package and adapter manifests
- document managed Trae integration and its one-time Global Hooks activation
- document automatic enablement for newly supported detected clients
- document the Windows PowerShell memorax-cli.cmd fix

## Verification

- node scripts/sync-release-version.mjs --check
- make docs-check
- Backend suite with the repository timeout and serialized test-file concurrency: 512 passed, 0 failed, 2 skipped
- all six adapter suites: 393 passed, 0 failed
- npm package tests: 260 passed, 0 failed, 2 skipped
- make npm-package-check
- make npm-publish-dry-run (447 files, 473.2 kB package)

Note: default parallel Backend execution hit host-load-related 5-second timeouts. The same suite passed completely with test-file concurrency set to 1 and an isolated WorkBuddy home; no product or test source was changed.