### PR TITLE
fix: recover stale CodeBuddy plugin registry locks

### DIFF
--- a/packages/ts/memorax-code-adapter-common/src/config-utils.d.mts
+++ b/packages/ts/memorax-code-adapter-common/src/config-utils.d.mts
@@ -2,6 +2,7 @@ export type JsonFileLockOptions = Readonly<{
   timeoutMs?: number;
   staleMs?: number;
   retryMs?: number;
+  ensurePrivateDirectory?: boolean;
 }>;
 
 export type AsyncJsonFileLockOptions = JsonFileLockOptions & Readonly<{

--- a/packages/ts/memorax-code-adapter-common/src/config-utils.mjs
+++ b/packages/ts/memorax-code-adapter-common/src/config-utils.mjs
@@ -108,7 +108,9 @@ export function withJsonFileLock(path, operation, options = {}) {
   const deadline = Date.now() + timeoutMs;
   const observedProcessStarts = new Map();
   const directory = dirname(path);
-  ensurePrivateDirectory(directory, { durableBoundary: directory });
+  if (options.ensurePrivateDirectory !== false) {
+    ensurePrivateDirectory(directory, { durableBoundary: directory });
+  }
 
   while (!tryAcquireJsonFileLock(lockPath, ownerId)) {
     if (removeStaleJsonFileLock(lockPath, staleMs, observedProcessStarts)) continue;
@@ -145,7 +147,9 @@ export async function withJsonFileLockAsync(path, operation, options = {}) {
   const observedProcessStarts = new Map();
   const directory = dirname(path);
   throwIfJsonFileLockAborted(signal, path, lockPath);
-  ensurePrivateDirectory(directory, { durableBoundary: directory });
+  if (options.ensurePrivateDirectory !== false) {
+    ensurePrivateDirectory(directory, { durableBoundary: directory });
+  }
 
   while (!tryAcquireJsonFileLock(lockPath, ownerId)) {
     throwIfJsonFileLockAborted(signal, path, lockPath);

--- a/packages/ts/memorax-code-backend/src/clients/codebuddy/lifecycle.ts
+++ b/packages/ts/memorax-code-backend/src/clients/codebuddy/lifecycle.ts
@@ -8,19 +8,19 @@ type CodeBuddyConfig = {
 };
 export const codeBuddyAdapterLifecycle = {
   async status({ argv, serviceOptions }) {
-    try { return (await load()).readCodeBuddyAdapterStatus(options(argv, serviceOptions)); }
+    try { return await (await load()).readCodeBuddyAdapterStatus(options(argv, serviceOptions)); }
     catch (error) { return failure("status", error); }
   },
   async prepareEnable({ argv, serviceOptions }) {
-    try { return (await load()).enableCodeBuddyAdapter(options(argv, serviceOptions)); }
+    try { return await (await load()).enableCodeBuddyAdapter(options(argv, serviceOptions)); }
     catch (error) { return failure("enable", error); }
   },
   async disable({ argv, serviceOptions }) {
-    try { return (await load()).disableCodeBuddyAdapter(options(argv, serviceOptions)); }
+    try { return await (await load()).disableCodeBuddyAdapter(options(argv, serviceOptions)); }
     catch (error) { return failure("disable", error); }
   },
   async remove({ argv, serviceOptions }) {
-    try { return (await load()).removeCodeBuddyPluginInstallation(options(argv, serviceOptions)); }
+    try { return await (await load()).removeCodeBuddyPluginInstallation(options(argv, serviceOptions)); }
     catch (error) {
       return {
         ok: false,

--- a/packages/ts/memorax-code-backend/src/lifecycle/orchestrator.ts
+++ b/packages/ts/memorax-code-backend/src/lifecycle/orchestrator.ts
@@ -426,6 +426,20 @@ async function executeMemoraxCodeStart(
       ...(traeAdapter ? { traeAdapter } : {}),
     };
   }
+  if (codebuddyAdapter?.ok === false) {
+    const recovery = await recoverPreparationFailure("codebuddy_adapter_enable_failed");
+    return {
+      ok: false,
+      action: "start",
+      backend: recovery.backend,
+      ...(codexAdapter ? { codexAdapter } : {}),
+      ...(claudeAdapter ? { claudeAdapter } : {}),
+      ...(recovery.dshAdapter ? { dshAdapter: recovery.dshAdapter } : {}),
+      ...(opencodeAdapter ? { opencodeAdapter } : {}),
+      codebuddyAdapter,
+      ...(traeAdapter ? { traeAdapter } : {}),
+    };
+  }
   if (traeAdapter?.ok === false) {
     const recovery = await recoverPreparationFailure("trae_adapter_enable_failed");
     return {
@@ -494,6 +508,7 @@ async function executeMemoraxCodeStart(
   const optionalDshUnavailable = isOptionalUnavailableDshAdapter(dshAdapter);
   return {
     ok: claudeAdapter?.ok !== false
+      && (!codebuddyAdapter || isAdapterReady(codebuddyAdapter))
       && (!dshAdapter || isAdapterReady(dshAdapter) || optionalDshUnavailable),
     action: "start",
     ...(optionalDshUnavailable ? { degraded: true } : {}),

--- a/packages/ts/memorax-code-backend/test/clients/codebuddy/codebuddy-lifecycle.test.mjs
+++ b/packages/ts/memorax-code-backend/test/clients/codebuddy/codebuddy-lifecycle.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
@@ -7,8 +7,9 @@ import { codeBuddyAdapterLifecycle } from "../../../dist/clients/codebuddy/lifec
 
 test("CodeBuddy lifecycle converts asynchronous adapter failures into its own report", async () => {
   const root = await mkdtemp(join(tmpdir(), "memorax-codebuddy-lifecycle-failure-"));
-  const codeBuddyHome = join(root, "blocked-home");
-  await writeFile(codeBuddyHome, "not a directory\n");
+  const codeBuddyHome = join(root, "codebuddy-home");
+  await mkdir(codeBuddyHome);
+  await writeFile(join(codeBuddyHome, "settings.json"), "{invalid-json\n");
   try {
     const context = {
       argv: ["--codebuddy-home", codeBuddyHome],
@@ -24,7 +25,7 @@ test("CodeBuddy lifecycle converts asynchronous adapter failures into its own re
       const report = await codeBuddyAdapterLifecycle[method](context);
       assert.equal(report.ok, false, method);
       assert.equal(report.action, action, method);
-      assert.match(report[errorField], /ENOTDIR|not a directory/i, method);
+      assert.match(report[errorField], /JSON|Unexpected|Expected/i, method);
     }
   } finally {
     await rm(root, { recursive: true, force: true });

--- a/packages/ts/memorax-code-backend/test/clients/codebuddy/codebuddy-lifecycle.test.mjs
+++ b/packages/ts/memorax-code-backend/test/clients/codebuddy/codebuddy-lifecycle.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { codeBuddyAdapterLifecycle } from "../../../dist/clients/codebuddy/lifecycle.js";
+
+test("CodeBuddy lifecycle converts asynchronous adapter failures into its own report", async () => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-codebuddy-lifecycle-failure-"));
+  const codeBuddyHome = join(root, "blocked-home");
+  await writeFile(codeBuddyHome, "not a directory\n");
+  try {
+    const context = {
+      argv: ["--codebuddy-home", codeBuddyHome],
+      serviceOptions: { home: join(root, "memorax-code-home") },
+      backendUrl: "http://127.0.0.1:8787",
+    };
+    for (const [method, action, errorField] of [
+      ["status", "status", "error"],
+      ["prepareEnable", "enable", "error"],
+      ["disable", "disable", "error"],
+      ["remove", "codebuddy-plugin-remove", "message"],
+    ]) {
+      const report = await codeBuddyAdapterLifecycle[method](context);
+      assert.equal(report.ok, false, method);
+      assert.equal(report.action, action, method);
+      assert.match(report[errorField], /ENOTDIR|not a directory/i, method);
+    }
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/packages/ts/memorax-code-backend/test/lifecycle/orchestrator.test.mjs
+++ b/packages/ts/memorax-code-backend/test/lifecycle/orchestrator.test.mjs
@@ -309,6 +309,57 @@ test("start recovers the Backend when Codex preparation fails after shutdown", a
   }
 });
 
+test("start recovers the Backend when CodeBuddy preparation fails after shutdown", async () => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-code-start-codebuddy-recovery-"));
+  const home = join(root, "memorax-code-home");
+  const codeBuddyHome = join(root, "blocked-codebuddy-home");
+  const port = await freePort();
+  const cliPath = fileURLToPath(new URL("../../dist/memorax-code.js", import.meta.url));
+  const observedPids = new Set();
+  const commonArgs = ["--home", home, "--port", String(port)];
+  await writeFile(codeBuddyHome, "not a directory\n");
+  try {
+    const initial = await runCli(cliPath, [
+      "start", "--json", ...commonArgs, "--clients", "none",
+    ]);
+    assert.equal(initial.code, 0, `${initial.stdout}\n${initial.stderr}`);
+    observedPids.add(JSON.parse(initial.stdout).backend.state.pid);
+
+    const failed = await runCli(cliPath, [
+      "start", "--json", ...commonArgs,
+      "--codebuddy-home", codeBuddyHome,
+      "--clients", "codebuddy",
+    ]);
+
+    assert.equal(failed.code, 1, `${failed.stdout}\n${failed.stderr}`);
+    assert.equal(failed.stderr, "");
+    const report = JSON.parse(failed.stdout);
+    assert.equal(report.ok, false);
+    assert.equal(report.codebuddyAdapter.ok, false);
+    assert.match(report.codebuddyAdapter.error, /ENOTDIR|not a directory/i);
+    assert.equal(report.dshAdapter, undefined);
+    assert.equal(report.backend.ok, true, report.backend.error);
+    assert.equal(
+      report.backend.reason,
+      "codebuddy_adapter_enable_failed_backend_recovered",
+    );
+    observedPids.add(report.backend.state.pid);
+    const health = await fetch(`http://127.0.0.1:${port}/health`).then(
+      (response) => response.json(),
+    );
+    assert.equal(health.ok, true);
+    assert.equal(health.instanceId, report.backend.state.instanceId);
+  } finally {
+    await runCli(cliPath, ["stop", "--json", ...commonArgs, "--clients", "none"]);
+    for (const pid of observedPids) {
+      if (!Number.isSafeInteger(pid) || !isProcessAlive(pid)) continue;
+      terminateProcessTree(pid);
+      await waitForProcessExit(pid);
+    }
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("memorax-code start preserves custom Claude provider settings while enabling Hooks", async () => {
   const home = await mkdtemp(join(tmpdir(), "memorax-code-lifecycle-claude-home-"));
   const claudeHome = await mkdtemp(join(tmpdir(), "memorax-code-lifecycle-claude-config-"));

--- a/packages/ts/memorax-code-codebuddy-adapter/src/config.mjs
+++ b/packages/ts/memorax-code-codebuddy-adapter/src/config.mjs
@@ -4,6 +4,7 @@ import { homedir } from "node:os";
 import { basename, dirname, join, relative, sep, win32 } from "node:path";
 import { fileURLToPath } from "node:url";
 import { resolveHookCodeBuddyCommand } from "../../memorax-code-adapter-common/src/clients/codebuddy-command.mjs";
+import { withJsonFileLockAsync } from "../../memorax-code-adapter-common/src/config-utils.mjs";
 import {
   codeBuddyHookManifestConfigured,
   materializeCodeBuddyHookManifest,
@@ -230,27 +231,16 @@ async function updateRegistry(home, mutate) {
 }
 
 async function updateJsonRecord(path, mutate) {
-  const lockPath = `${path}.lock`;
   await mkdir(dirname(path), { recursive: true });
-  let handle;
-  for (let attempt = 0; attempt < 100; attempt += 1) {
-    try {
-      handle = await import("node:fs/promises").then(({ open }) => open(lockPath, "wx", 0o600));
-      break;
-    } catch (error) {
-      if (error?.code !== "EEXIST") throw error;
-      await new Promise((resolve) => setTimeout(resolve, Math.min(50, 5 + attempt)));
-    }
-  }
-  if (!handle) throw new Error(`timed out acquiring lock: ${lockPath}`);
-  try {
+  await withJsonFileLockAsync(path, async () => {
     const value = await readJsonRecord(path);
     mutate(value);
     await writeJsonFile(path, value);
-  } finally {
-    await handle.close();
-    await rm(lockPath, { force: true });
-  }
+  }, {
+    timeoutMs: 5000,
+    // WorkBuddy owns this directory; preserve its permission policy.
+    ensurePrivateDirectory: false,
+  });
 }
 
 async function updateJsonRecordIfPresent(path, mutate) {

--- a/packages/ts/memorax-code-codebuddy-adapter/test/config.test.mjs
+++ b/packages/ts/memorax-code-codebuddy-adapter/test/config.test.mjs
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { cp, mkdir, mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
+import { cp, mkdir, mkdtemp, readFile, stat, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -78,6 +78,14 @@ test("derives the install cache version from the CodeBuddy plugin manifest", asy
   await cp(new URL("../src/hook-manifest.mjs", import.meta.url), hookManifestPath);
   await cp(new URL("../src/runtime-observation.mjs", import.meta.url), runtimeObservationPath);
   await cp(new URL("../../memorax-code-adapter-common/src/clients/codebuddy-command.mjs", import.meta.url), commandPath);
+  await cp(
+    new URL("../../memorax-code-adapter-common/src/config-utils.mjs", import.meta.url),
+    join(root, "memorax-code-adapter-common", "src", "config-utils.mjs"),
+  );
+  await cp(
+    new URL("../../memorax-code-adapter-common/src/runtime-record.mjs", import.meta.url),
+    join(root, "memorax-code-adapter-common", "src", "runtime-record.mjs"),
+  );
   await writeFile(join(adapterRoot, ".codebuddy-plugin", "plugin.json"), '{"version":"9.8.7"}\n');
   const isolated = await import(pathToFileURL(configPath).href);
   assert.equal(isolated.codeBuddyInstallPath(join(root, "home")), join(
@@ -306,6 +314,35 @@ test("malformed CodeBuddy registry fails closed", async () => {
   await mkdir(join(home, "plugins"), { recursive: true });
   await writeFile(join(home, "plugins", "installed_plugins.json"), "not-json\n");
   await assert.rejects(() => enableCodeBuddyAdapter({ codeBuddyHome: home }), /JSON|Unexpected token/);
+});
+
+test("recovers an abandoned legacy registry lock without losing user plugins", async () => {
+  const home = await mkdtemp(join(tmpdir(), "memorax-codebuddy-stale-lock-"));
+  const pluginId = "memorax-code-codebuddy-adapter@memorax-code-local";
+  const registryPath = join(home, "plugins", "installed_plugins.json");
+  const lockPath = `${registryPath}.lock`;
+  await mkdir(marketplaceRoot(home), { recursive: true });
+  await writeFile(codeBuddySettingsPath(home), JSON.stringify({
+    enabledPlugins: { [pluginId]: true },
+  }));
+  await writeFile(registryPath, JSON.stringify({
+    version: 2,
+    plugins: {
+      "user-plugin@user-marketplace": [{ scope: "user", enabled: true }],
+      [pluginId]: [{ scope: "user", enabled: true }],
+    },
+  }));
+  await writeFile(lockPath, "");
+  const staleTime = new Date(Date.now() - 60_000);
+  await utimes(lockPath, staleTime, staleTime);
+
+  const disabled = await disableCodeBuddyAdapter({ codeBuddyHome: home });
+
+  assert.equal(disabled.ok, true);
+  const registry = JSON.parse(await readFile(registryPath, "utf8"));
+  assert.ok(registry.plugins["user-plugin@user-marketplace"]);
+  assert.equal(registry.plugins[pluginId][0].enabled, false);
+  assert.equal(await exists(lockPath), false);
 });
 
 async function exists(path) {

--- a/packages/ts/memorax-code-codex-adapter/test/config-utils-lock.test.mjs
+++ b/packages/ts/memorax-code-codex-adapter/test/config-utils-lock.test.mjs
@@ -84,6 +84,26 @@ test("JSON state lock tightens an existing private state directory", {
   }
 });
 
+test("JSON state lock can preserve an externally owned directory mode", {
+  skip: process.platform === "win32",
+}, async () => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-code-json-lock-external-mode-"));
+  const directory = join(root, "external-state");
+  const path = join(directory, "state.json");
+  try {
+    await mkdir(directory, { recursive: true });
+    await chmod(directory, 0o755);
+
+    await withJsonFileLockAsync(path, async () => undefined, {
+      ensurePrivateDirectory: false,
+    });
+
+    assert.equal((await stat(directory)).mode & 0o777, 0o755);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("async JSON state lock serializes the complete awaited operation", async () => {
   const root = await mkdtemp(join(tmpdir(), "memorax-code-json-lock-async-"));
   const path = join(root, "state.json");


### PR DESCRIPTION
## Change Summary
Recover abandoned CodeBuddy/WorkBuddy plugin-registry locks and report adapter failures accurately without leaving Backend startup in a false-success or stopped state.

## Implementation Highlights
- Reuse the shared owner-aware JSON lock for WorkBuddy registry updates, reclaim stale legacy empty locks, bound acquisition to five seconds, and preserve WorkBuddy-owned directory permissions and unrelated plugin entries.
- Await CodeBuddy lifecycle operations inside their error boundary so asynchronous status, enable, disable, and remove failures remain CodeBuddy reports instead of escaping into the DSH lifecycle wrapper.
- Add explicit CodeBuddy preparation-failure recovery and readiness validation to Backend startup, with portable regression fixtures for macOS, Linux, and Windows.

## Validation
- `npm run typecheck --prefix packages/ts/memorax-code-backend`
- Backend focused lifecycle tests for CodeBuddy asynchronous failures and start recovery.
- Shared JSON lock tests: 10/10 passed.
- CodeBuddy adapter suite: 22/22 passed.
- DSH adapter: 28/28; OpenCode adapter: 35/35; Trae adapter: 15/15.
- `git diff --check` and Backend architecture/source-boundary checks passed.

## Full End-to-End Validation Results
- Environment: macOS arm64 with Node.js v24.15.0; Docker `node:24-bookworm` Linux arm64 with Node.js v24.20.0; real Windows environment using an isolated npm prefix and WorkBuddy Home.
- Scenario or matrix: stale empty registry lock recovery; fresh-lock preservation and bounded failure; stale lock with a live owner; CodeBuddy error attribution; Backend recovery and PID replacement; registry preservation; normal status and uninstall cleanup.
- Command or workflow: built `@memorax/memorax-code@0.1.12` from this branch, installed the tgz into isolated homes, exercised repeated `start`, `status`, and `uninstall --no-npm-uninstall` lifecycle flows, and validated `/health`, lock state, adapter reports, and registry contents.
- Result: PASS on macOS, Docker/Linux, and Windows. Windows returned `ENOENT` rather than `ENOTDIR` for a file used as a fake home, so the cross-platform asynchronous-error fixture now uses malformed JSON; the corresponding Windows supplemental test confirmed all four lifecycle operations resolve to CodeBuddy-owned failure reports.
- Evidence or artifacts: automated lock and lifecycle regression tests in this PR plus redacted local E2E reports; no credentials, transcripts, or user configuration are included.
- Reason not run / remaining risk: full Codex, Claude, Backend, and package aggregate gates encounter an existing macOS `spawn ENOEXEC` executable-fixture failure that reproduces on pristine `main`; affected CodeBuddy/shared-lock suites, package build and staging, and all three platform E2E flows passed.
