### PR TITLE
docs: remove Python runtime note from user guides

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -16,7 +16,6 @@ installation. For a source checkout and contributor setup, see
   because DSH's native Profile plugin manager delegates package changes to it.
   The tested DSH baseline is `0.1.0-rc.6`; other valid semantic versions are
   reported as untested rather than rejected automatically.
-- Python 3 only for local User Profile Memory operations.
 - On Linux, `/usr/bin/secret-tool` from libsecret and an available Secret
   Service in the current user session for setup-managed credentials.
 

--- a/README.md
+++ b/README.md
@@ -53,11 +53,10 @@ and validation sooner.
 ## Quick Start
 
 Prepare Node.js 20+ (Node.js 24 LTS recommended) and at least one of Codex,
-Claude Code, WorkBuddy, DeepSeek Harness, OpenCode, or Trae. Python 3 is
-currently needed only for local User Profile Memory operations. Each
-coding-agent harness retains its own runtime requirements; current DeepSeek
-Harness releases require Node.js `^22.19.0 || >=24.0.0`. DSH may be installed
-globally or initialized beforehand through its official `npx` workflow.
+Claude Code, WorkBuddy, DeepSeek Harness, OpenCode, or Trae. Each coding-agent
+harness retains its own runtime requirements; current DeepSeek Harness releases
+require Node.js `^22.19.0 || >=24.0.0`. DSH may be installed globally or
+initialized beforehand through its official `npx` workflow.
 
 ### Install and Connect
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -49,9 +49,9 @@ MemoraX Code 让 Codex、Claude Code、WorkBuddy、DeepSeek Harness、OpenCode �
 ## 快速开始
 
 开始前，请确保已安装 Node.js 20 或更高版本（推荐 Node.js 24 LTS），以及 Codex、Claude Code、
-WorkBuddy、DeepSeek Harness、OpenCode 或 Trae 中的至少一个。目前只有本地 User Profile Memory
-操作需要 Python 3。各 Coding Agent Harness 仍需满足自身的运行时要求；当前 DeepSeek Harness
-版本要求 Node.js `^22.19.0 || >=24.0.0`。DSH 可全局安装，也可事先通过其官方 `npx` 流程完成初始化。
+WorkBuddy、DeepSeek Harness、OpenCode 或 Trae 中的至少一个。各 Coding Agent Harness 仍需满足
+自身的运行时要求；当前 DeepSeek Harness 版本要求 Node.js `^22.19.0 || >=24.0.0`。DSH 可全局安装，
+也可事先通过其官方 `npx` 流程完成初始化。
 
 ### 安装与接入
 

--- a/packages/npm/memorax-code/README.md
+++ b/packages/npm/memorax-code/README.md
@@ -8,7 +8,6 @@ CodeBuddy/WorkBuddy, DeepSeek Harness, OpenCode, and Trae.
 - Node.js 20 or newer (Node.js 24 LTS recommended) and npm.
 - At least one of Codex, Claude Code, CodeBuddy/WorkBuddy, DeepSeek Harness,
   OpenCode Desktop or CLI, or Trae.
-- Python 3 only for local User Profile Memory operations.
 
 ## Install
 


### PR DESCRIPTION
## Change Summary

Remove the Python runtime note from user-facing installation documentation so the prerequisites stay focused on the normal setup flow.

## Implementation Highlights

- Removed the note from the English and Chinese quick starts, the installation guide, and the npm package README.
- Kept the existing Node.js and coding-agent harness requirements unchanged.

## Validation

`make docs-check` and `git diff --check`.

## Full End-to-End Validation Results

- Environment: macOS
- Scenario or matrix: User-facing documentation remains valid and the English and Chinese README sections stay synchronized.
- Command or workflow: `make docs-check`
- Result: PASS; 10 documentation tests passed, followed by the documentation contract and README language-sync checks.
- Evidence or artifacts: Local command output only; no artifact was generated.
- Reason not run / remaining risk: Runtime E2E was not run because this change only removes documentation text and does not modify runtime or package behavior.
