### PR TITLE
chore:(release) bump version to 0.1.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ behavior.
 
 ## Unreleased
 
+## [0.1.13] - 2026-09-04
+
+### Added
+
+- Supported coding agents now briefly identify when recalled Memory materially
+  shaped the final answer, while omitting the notice for unused or merely
+  confirmatory context.
+
+### Fixed
+
+- Recovered abandoned CodeBuddy/WorkBuddy plugin registry locks after
+  interrupted lifecycle operations while preserving unrelated plugin entries.
+- Fixed Repo Memory workers launched from installed packages so supported
+  clients consistently resolve their packaged runtime, including preserving
+  the triggering WorkBuddy plugin root.
+- Preserved existing Repo Memory long-option compatibility, including
+  `--option=value`, during build and update operations.
+
 ## [0.1.12] - 2026-09-02
 
 ### Added

--- a/packages/npm/memorax-code/package.json
+++ b/packages/npm/memorax-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax/memorax-code",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Persistent coding memory for Codex, Claude Code, CodeBuddy/WorkBuddy, DeepSeek Harness, OpenCode, and Trae.",
   "license": "MIT",
   "type": "module",

--- a/packages/ts/memorax-code-backend/package-lock.json
+++ b/packages/ts/memorax-code-backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@memorax-code/backend",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@memorax-code/backend",
-      "version": "0.1.12",
+      "version": "0.1.13",
       "dependencies": {
         "smol-toml": "^1.7.0"
       },

--- a/packages/ts/memorax-code-backend/package.json
+++ b/packages/ts/memorax-code-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/backend",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "private": true,
   "type": "module",
   "description": "Local memory integration, lifecycle, trace, and diagnostics for MemoraX Code.",

--- a/packages/ts/memorax-code-claude-adapter/.claude-plugin/plugin.json
+++ b/packages/ts/memorax-code-claude-adapter/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorax-code-claude-adapter",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Memory skill and local hooks for MemoraX Code in Claude Code.",
   "author": {
     "name": "MemoraX Code Maintainers"

--- a/packages/ts/memorax-code-claude-adapter/hooks/runtime-shell.json
+++ b/packages/ts/memorax-code-claude-adapter/hooks/runtime-shell.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
-  "shellVersion": "0.1.12",
+  "shellVersion": "0.1.13",
   "runtimeAbi": 1
 }

--- a/packages/ts/memorax-code-claude-adapter/package.json
+++ b/packages/ts/memorax-code-claude-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/claude-adapter",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "private": true,
   "type": "module",
   "description": "Claude Code Hook adapter for MemoraX Code memory services.",

--- a/packages/ts/memorax-code-codebuddy-adapter/.codebuddy-plugin/plugin.json
+++ b/packages/ts/memorax-code-codebuddy-adapter/.codebuddy-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorax-code-codebuddy-adapter",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "MemoraX Code memory integration for CodeBuddy and WorkBuddy.",
   "hooks": "./hooks/hooks.json",
   "skills": ["./skills/memorax-code"]

--- a/packages/ts/memorax-code-codebuddy-adapter/package.json
+++ b/packages/ts/memorax-code-codebuddy-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/codebuddy-adapter",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "private": true,
   "type": "module",
   "description": "CodeBuddy and WorkBuddy Hook adapter for MemoraX Code memory services.",

--- a/packages/ts/memorax-code-codex-adapter/.codex-plugin/plugin.json
+++ b/packages/ts/memorax-code-codex-adapter/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorax-code-codex-adapter",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Codex adapter, memory skill, and local hooks for MemoraX Code.",
   "author": {
     "name": "MemoraX AI"

--- a/packages/ts/memorax-code-codex-adapter/hooks/runtime-shell.json
+++ b/packages/ts/memorax-code-codex-adapter/hooks/runtime-shell.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
-  "shellVersion": "0.1.12",
+  "shellVersion": "0.1.13",
   "runtimeAbi": 1
 }

--- a/packages/ts/memorax-code-codex-adapter/package.json
+++ b/packages/ts/memorax-code-codex-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/codex-adapter",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "private": true,
   "type": "module",
   "description": "Codex Hook and memory integration for MemoraX Code.",

--- a/packages/ts/memorax-code-dsh-adapter/package.json
+++ b/packages/ts/memorax-code-dsh-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/dsh-memorax-code",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "private": true,
   "type": "module",
   "description": "DeepSeek Harness native memory adapter for MemoraX Code.",

--- a/packages/ts/memorax-code-opencode-adapter/package.json
+++ b/packages/ts/memorax-code-opencode-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/opencode-adapter",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "private": true,
   "type": "module",
   "description": "OpenCode plugin adapter for MemoraX Code memory services.",

--- a/packages/ts/memorax-code-trae-adapter/package.json
+++ b/packages/ts/memorax-code-trae-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/trae-adapter",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "private": true,
   "type": "module",
   "description": "Trae Hook adapter for MemoraX Code memory services.",


### PR DESCRIPTION
## Change Summary
Prepare `@memorax/memorax-code` 0.1.13 by synchronizing release metadata and documenting the user-visible Memory, Repo Memory, and CodeBuddy/WorkBuddy improvements merged since 0.1.12.

## Implementation Highlights
- Bump the public package, Backend, adapter, plugin, and Hook shell versions from 0.1.12 to 0.1.13 through the declared release-version contract.
- Add the 0.1.13 changelog entry for meaningful Memory-use disclosures, packaged Repo Memory worker compatibility, and stale CodeBuddy/WorkBuddy registry-lock recovery without exposing implementation-only dependency changes.

## Validation
- `node scripts/sync-release-version.mjs --check`: passed.
- `node --test packages/npm/memorax-code/test/release-version.test.mjs`: 1 passed, 0 failed.
- `npm run typecheck --prefix packages/ts/memorax-code-backend`: passed.
- `make docs-check`: 10 passed, 0 failed; documentation contract and README language synchronization passed.
- OpenCode adapter: 35 passed, 0 failed.
- CodeBuddy/WorkBuddy adapter: 22 passed, 0 failed.
- DeepSeek Harness adapter: 28 passed, 0 failed.
- Trae adapter: 15 passed, 0 failed.
- `make npm-publish-dry-run`: passed; 416 files, 427.8 kB package, stable `latest` tag.

## Full End-to-End Validation Results
- Environment: release-candidate packaging on macOS arm64 with Node.js 24.15.0 and npm 11.12.1; merged Repo Memory and Memory-impact changes were also validated before merge on macOS, Debian 12 arm64 Docker, and Windows 11 x64.
- Scenario or matrix: version synchronization and final npm artifact for this release commit; packaged Repo Memory generation in Codex, Claude Code, OpenCode, and WorkBuddy; Memory-impact behavior across supported native clients; CodeBuddy/WorkBuddy stale-lock lifecycle recovery.
- Command or workflow: built the 0.1.13 staged package and ran `npm publish --dry-run`; the merged feature PRs installed local tarballs into isolated client homes, triggered native Repo Memory or Memory Search flows, validated generated bundles, and checked Git cleanliness and packaged-file allowlists.
- Result: the 0.1.13 package builds and passes npm publish dry-run. Repo Memory completed on macOS and Linux for Codex, Claude Code, OpenCode, and WorkBuddy. Windows completed for Codex, Claude Code, and OpenCode; WorkBuddy discovery, Hooks, scheduling, and plugin pinning passed, and its fixed-model control completed. Memory-impact behavior passed on macOS, Linux Codex, and Windows. Stale-lock recovery passed on macOS, Linux, and Windows.
- Evidence or artifacts: release metadata is the single commit in this PR. Detailed redacted validation evidence is recorded in merged PRs #139, #141, and #143; no credentials, transcripts, or local diagnostic artifacts are included.
- Reason not run / remaining risk: no second full real-client E2E matrix was repeated for this version-only commit. Windows WorkBuddy with its default `auto` model remains completion-time sensitive to the model selected by WorkBuddy, while the fixed-model control passes.
