### PR TITLE
refactor: share memory runtime across six coding clients

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -384,6 +384,32 @@ Important distinctions:
   authentication is required when configuration or exposure mode demands it.
 - Client-specific runtimes interpret native formats. Client-neutral memory
   coordination does not parse, mix, or guess those formats.
+- All six clients delegate their common memory lifecycle
+  to `memory/harness-runtime.ts`. Turn start resolves repository scope, records
+  Turn metadata and current-turn trace state, performs optional retrieval,
+  claims supported quota notices, and returns normalized context. Completion passes
+  validated native user/assistant content, exact identity, and a scope resolver
+  to the Turn coordinator. Their client runtimes retain native parsing,
+  correlation guards, retries, interruption recovery, and client-specific
+  materialization and Turn-end trace behavior. Codex also retains workspace
+  registry validation, exact current-turn scope recovery, and native Turn-index
+  resolution. It can provide a pre-resolved scope result, including a failure,
+  without the shared runtime resolving it again. A start observation without a
+  Turn ID can resolve scope and record trace, but cannot register a writable
+  Turn, claim quota notices, or retrieve memory. OpenCode retains SDK message
+  lineage and compaction-continuation validation, interrupted-Turn handling,
+  and the requirement for a prior session scope binding at completion. Its
+  start trace keeps the `opencode-plugin` source; Turn-start diagnostics use
+  the common metadata-registration stage before trace writes. Trae publishes
+  its active Turn snapshot through the synchronous `onTurnRegistered` callback,
+  immediately after coordinator registration and before trace or retrieval
+  can yield to a concurrent Stop. Its per-session start queue, interruption
+  records, and active-state cleanup remain client-owned. DSH supplies a
+  start-trace request containing only `start_seq`, keeps the `dsh-cordis` source,
+  and adds the native start sequence to retrieval deduplication without changing
+  Turn identity. It disables both pending and retrieval quota-notice claims.
+  Persisted event-interval validation, interruption handling, and restart scope
+  recovery remain DSH-owned.
 - OpenCode's awaited `chat.message` plugin event supplies the correlated user
   prompt and injects accepted retrieval plus shared Skill reminder, User
   Profile, and Procedure Memory context into that message's system context.
@@ -608,13 +634,14 @@ entrypoints and compatibility facades. It is not another implementation area.
 | `src/transport/http` | Shared Backend HTTP authorization, request/JSON helpers, error mapping, health, and Hook wire adaptation | Outbound provider HTTP remains with the provider capability |
 | `src/lifecycle` | Contracts, participants, client selection, locks, service orchestration, install watchdog, and client integration removal | Request-time memory flow does not depend on it |
 | `src/lifecycle/backend` | Managed process, PID/token/connection records, status probing, cleanup, and shutdown requests | Helper contracts do not depend back on the full service implementation |
-| `src/clients/codex` | Codex rollout, prompt, turn-index, and workspace interpretation; Hook memory runtime; plugin integration glue; and lifecycle participant | No Claude format fallback; request runtime remains HTTP-composition independent |
-| `src/clients/claude` | Claude transcript/turn interpretation, Hook memory runtime, and lifecycle participant | No Codex format fallback; request runtime remains HTTP-composition independent |
-| `src/clients/dsh` | DSH Session header and exact persisted event-interval interpretation, request-time memory and normalized trace runtime, and lifecycle-participant delegation | No Hook-text, rollout, transcript, SDK-message, or latest-Turn fallback; Profile mutation stays in the DSH adapter, and request runtime remains HTTP-composition independent |
-| `src/clients/opencode` | OpenCode SDK message validation and text materialization, plugin memory runtime, and lifecycle participant | No Hook-text, database, rollout, or transcript fallback; request runtime remains HTTP-composition independent |
-| `src/clients/codebuddy` | CodeBuddy/WorkBuddy native transcript interpretation, Hook memory runtime, and lifecycle participant | No Hook-payload or latest-Turn fallback; plugin mutation stays in the adapter, and request runtime remains HTTP-composition independent |
-| `src/clients/trae` | Trae Turn-ID validation, Hook-pair memory runtime, interruption handling, trace normalization, and lifecycle participant | Hook content is authoritative only for the exact validated Trae Turn; no raw-Session guess, pending queue, or cross-client fallback |
+| `src/clients/codex` | Codex rollout, prompt, turn-index, workspace interpretation and recovery; Hook memory integration through the shared harness runtime; plugin integration glue; and lifecycle participant | No Claude format fallback; request runtime remains HTTP-composition independent |
+| `src/clients/claude` | Claude transcript/turn interpretation, native correlation and interruption recovery, Hook memory integration through the shared harness runtime, and lifecycle participant | No Codex format fallback; request runtime remains HTTP-composition independent |
+| `src/clients/dsh` | DSH Session header and exact persisted event-interval interpretation, memory integration through the shared harness runtime, native interruption and normalized trace handling, and lifecycle-participant delegation | No Hook-text, rollout, transcript, SDK-message, or latest-Turn fallback; Profile mutation stays in the DSH adapter, and request runtime remains HTTP-composition independent |
+| `src/clients/opencode` | OpenCode SDK message validation and text materialization, native interruption handling, plugin memory integration through the shared harness runtime, and lifecycle participant | No Hook-text, database, rollout, or transcript fallback; completion requires a prior session scope binding; request runtime remains HTTP-composition independent |
+| `src/clients/codebuddy` | CodeBuddy/WorkBuddy native transcript interpretation, native correlation and interruption recovery, Hook memory integration through the shared harness runtime, and lifecycle participant | No Hook-payload or latest-Turn fallback; plugin mutation stays in the adapter, and request runtime remains HTTP-composition independent |
+| `src/clients/trae` | Trae Turn-ID validation, Hook-pair memory integration through the shared harness runtime, per-session start ordering and active-Turn interruption handling, trace normalization, and lifecycle participant | Hook content is authoritative only for the exact validated Trae Turn; no raw-Session guess, pending completion queue, or cross-client fallback |
 | `src/memory` | Memory commands, retrieval, writeback, turn coordination, repository session pinning, manual CLI, and buffering/chunking | Client-neutral modules do not parse native transcript formats |
+| `src/memory/harness-runtime.ts` | Common Turn-start and materialized-completion workflows for all six clients; publishes registered Turn state synchronously and owns locally created memory resources while reusing injected shared resources | No client implementation, HTTP, app/lifecycle, or direct provider-transport imports; diagnostics enter through a port and native interpretation stays with each client |
 | `src/personal-memory` | Local User Profile listing, normalization, duplicate detection, updates, deletion, and atomic storage | No Backend service, provider calls, transcript processing, or Procedure Memory mutation |
 | `src/repo-memory` | Repo Memory preparation, local and provider facet collection, delta detection, and bundle validation | Writes only deterministic raw evidence and validation output; agents author durable Markdown memory |
 | `src/repository` | Read-only repository identity | Scope derivation does not execute Git or use synchronous filesystem reads |
@@ -672,6 +699,7 @@ acyclic.
 | Contract | Owned by | Purpose |
 | --- | --- | --- |
 | `MemoryService` | `memory/service.ts` | HTTP-independent command surface for memory operations |
+| `HarnessMemoryRuntime` | `memory/harness-runtime.ts` | Coordinates common Turn-start and validated completion workflows; preserves ownership of injected repository sessions, Turn coordination, writeback, and quota-notice resources |
 | `MemoryObservabilityHook` | `memory/observability.ts` | Emits normalized operational events without importing the concrete trace Store or Backend logging |
 | `MemoryDiagnosticLogger` | `memory/observability.ts` | Injects diagnostics without binding memory kernels to Backend debug output |
 | `MemoryTurnCoordinator` | `memory/turn-coordinator.ts` | Correlates and validates client-neutral Turns and controls metadata consumption |
@@ -686,7 +714,7 @@ multiple directories does not automatically belong in `shared`.
 
 | Contract | Location | Enforces | Inspect or update when |
 | --- | --- | --- | --- |
-| Backend source boundaries | `packages/ts/memorax-code-backend/test/architecture/source-boundaries.test.mjs` | Root facade allowlist, selected direct forbidden imports, lifecycle delegation, and an acyclic relative-import graph | Adding a root surface, crossing capability boundaries, or changing a composition root |
+| Backend source boundaries | `packages/ts/memorax-code-backend/test/architecture/source-boundaries.test.mjs` | Root facade allowlist, selected direct forbidden imports including shared harness neutrality, lifecycle delegation, and an acyclic relative-import graph | Adding a root surface, crossing capability boundaries, or changing a composition root |
 | Local-only trace boundary | `scripts/check-local-trace-only.mjs` and its tests | Reviewed network-capable production modules, trace-core isolation, unreviewed trace-aware outbound bridges, and staged artifact/symlink containment | Moving or adding network code, trace-aware outbound code, or staged paths |
 | Package shape | npm package tests and package-build/check scripts | Executable wrappers, staged runtime layout, canonical source mapping, compatibility paths, and artifact allowlists | Changing entrypoints, packaging sources, materialization, or layout |
 | Documentation contract | `scripts/check-docs.mjs` and its tests | Relative links, personal absolute paths, and shipped-document consistency | Adding a root document or changing document/package layout |

--- a/packages/ts/memorax-code-backend/src/clients/claude/memory-hook-runtime.ts
+++ b/packages/ts/memorax-code-backend/src/clients/claude/memory-hook-runtime.ts
@@ -6,36 +6,21 @@ import {
   type ClaudeTranscriptTurnFailureReason,
   type ClaudeTranscriptTurnResult,
 } from "./transcript-turn.js";
-import { retrieveAutomaticMemoryContext } from "../../memory/automatic-retrieval.js";
+import type { AutomaticMemoryWritebackRejectionReason } from "../../memory/automatic-writeback.js";
 import {
-  claimQuotaNotice,
-  createPendingQuotaNoticeRuntime,
-  type PendingQuotaNoticeRuntime,
-  type QuotaNoticeClaimer,
-} from "../../memory/quota-notice.js";
-import {
-  createAutomaticMemoryWritebackRuntime,
-  type AutomaticMemoryWritebackEnqueue,
-  type AutomaticMemoryWritebackRejectionReason,
-  type AutomaticMemoryWritebackRuntime,
-} from "../../memory/automatic-writeback.js";
+  createHarnessMemoryRuntime,
+  type HarnessMemoryRuntimeOptions,
+} from "../../memory/harness-runtime.js";
 import type {
   ClaudeTurnStartCommand,
   ClaudeWritebackCommand,
   MemoryHookTurnStartResult,
 } from "../../memory/hook-command.js";
-import type { MemoryDiagnosticLogger, MemoryObservabilityHook } from "../../memory/observability.js";
-import {
-  createMemoryTurnCoordinator,
-  type MemoryTurnCoordinator,
-  type MemoryTurnState,
+import type { MemoryDiagnosticLogger } from "../../memory/observability.js";
+import type {
+  MemoryTurnCoordinator,
+  MemoryTurnState,
 } from "../../memory/turn-coordinator.js";
-import {
-  createRepositoryMemorySessionRuntime,
-  resolvedRepoMemoryWorktree,
-  type ConfiguredRepositoryMemoryResult,
-  type RepositoryMemorySessionRuntime,
-} from "../../memory/repository-session.js";
 import type { RepositoryMemoryScopeFailureReason } from "../../repository/scope.js";
 import { traceContextFromClaudeHookBody, type TraceContext } from "../../trace/context.js";
 import {
@@ -43,7 +28,6 @@ import {
   readOpenClaudeTurn,
   recordClaudeTraceEvent,
   traceTurnEventId,
-  writeCurrentClaudeTurn,
   type TraceEventWriteResult,
 } from "../../trace/store.js";
 
@@ -70,21 +54,7 @@ export type ClaudeMemoryHookWritebackResult =
   | { ok: true; scheduled: true }
   | { ok: true; scheduled: false; reason: ClaudeMemoryHookWritebackSkipReason };
 
-export type ClaudeMemoryHookRuntimeOptions = {
-  automaticWriteback?: AutomaticMemoryWritebackEnqueue;
-  diagnosticLogger?: MemoryDiagnosticLogger;
-  env?: Record<string, string | undefined>;
-  fetchImpl?: typeof fetch;
-  claimQuotaNotice?: QuotaNoticeClaimer;
-  now?: () => number;
-  ttlMs?: number;
-  maxEntries?: number;
-  cleanupIntervalMs?: number;
-  memoryObservability?: MemoryObservabilityHook;
-  memoraxCodeHome?: string;
-  pendingQuotaNotice?: PendingQuotaNoticeRuntime;
-  repositoryMemorySession?: RepositoryMemorySessionRuntime;
-  turnCoordinator?: MemoryTurnCoordinator;
+export type ClaudeMemoryHookRuntimeOptions = HarnessMemoryRuntimeOptions & {
   transcriptReadAttempts?: number;
   transcriptRetryDelayMs?: number;
 };
@@ -104,38 +74,15 @@ export function createClaudeMemoryHookRuntime(
   options: ClaudeMemoryHookRuntimeOptions = {},
 ): ClaudeMemoryHookRuntime {
   const now = options.now ?? (() => Date.now());
-  const pendingQuotaNotice = options.pendingQuotaNotice ?? createPendingQuotaNoticeRuntime({
-    claimQuotaNotice: options.claimQuotaNotice,
-    diagnosticLogger: options.diagnosticLogger,
-    env: options.env,
-  });
-  const ownsPendingQuotaNotice = options.pendingQuotaNotice === undefined;
-  const automaticWritebackRuntime: {
-    enqueue: AutomaticMemoryWritebackEnqueue;
-    discardForScopeUpgrade?: AutomaticMemoryWritebackRuntime["discardForScopeUpgrade"];
-    close?: () => void;
-  } | undefined = options.turnCoordinator
-    ? undefined
-    : options.automaticWriteback
-      ? { enqueue: options.automaticWriteback }
-      : createAutomaticMemoryWritebackRuntime({
-        diagnosticLogger: options.diagnosticLogger,
-        queueQuotaNotice: pendingQuotaNotice.queue,
-      });
-  const turnCoordinator = options.turnCoordinator ?? createMemoryTurnCoordinator({
-    automaticWriteback: automaticWritebackRuntime!.enqueue,
-    now,
-    ttlMs: options.ttlMs,
-    maxEntries: options.maxEntries,
-    cleanupIntervalMs: options.cleanupIntervalMs,
-  });
-  const ownsTurnCoordinator = options.turnCoordinator === undefined;
-  const repositoryMemorySession = options.repositoryMemorySession ?? createRepositoryMemorySessionRuntime({
-    onScopeUpgrade: automaticWritebackRuntime?.discardForScopeUpgrade,
-  });
-  const ownsRepositoryMemorySession = options.repositoryMemorySession === undefined;
-  const automaticRetrievalPrompts = new Set<string>();
-  const automaticRetrievalPromptLimit = positiveInteger(options.maxEntries, 256);
+  const memory = createHarnessMemoryRuntime({
+    client: CLAUDE_MEMORY_TURN_CLIENT,
+    retrievalSource: "claude_hook_retrieval",
+    writebackSource: "claude_hook_writeback",
+    diagnosticPrefix: "claude_memory_hook",
+    traceFailureEvent: "claude_trace.write_failed",
+    deduplicateRetrieval: true,
+  }, options);
+  const { turnCoordinator } = memory;
 
   return {
     async recordTurnStart(command) {
@@ -154,10 +101,7 @@ export function createClaudeMemoryHookRuntime(
       }
       await reconcilePreviousInterruptedTurn(turnCoordinator, turn, options, now);
       turnCoordinator.pruneExpired();
-      const repositoryMemory = await resolveHookRepositoryMemory(turn, options, repositoryMemorySession);
-      const repoMemoryWorktree = resolvedRepoMemoryWorktree(repositoryMemory);
-      turnCoordinator.recordTurnStart({
-        client: CLAUDE_MEMORY_TURN_CLIENT,
+      return await memory.recordTurnStart({
         sessionId: turn.sessionId,
         clientTurnId: turn.promptId,
         cwd: turn.cwd,
@@ -165,72 +109,9 @@ export function createClaudeMemoryHookRuntime(
         transcriptPath: turn.transcriptPath,
         createdAt: turn.createdAt,
         traceContext: turn.traceContext,
-        repositoryMemory,
+        prompt: turn.prompt,
+        diagnosticFields: { sessionId: turn.sessionId, promptId: turn.promptId },
       });
-      options.diagnosticLogger?.("claude_memory_hook.turn_start", {
-        sessionId: turn.sessionId,
-        promptId: turn.promptId,
-        cacheSize: turnCoordinator.size(CLAUDE_MEMORY_TURN_CLIENT),
-        workspace: repositoryMemory.ok ? repositoryMemory.memory.scope?.repositorySlug : undefined,
-        workspaceScopeReason: repositoryMemory.ok ? undefined : repositoryMemory.reason,
-      });
-      await recordTraceBestEffort("claude_memory_hook.turn_start_event", recordClaudeTraceEvent({
-        eventId: traceTurnEventId(turn.traceContext, "turn_start"),
-        memoraxCodeHome: options.memoraxCodeHome,
-        env: options.env,
-        traceContext: turn.traceContext,
-        type: "turn_start",
-        source: "unknown",
-        operation: "query",
-        ok: true,
-        request: {
-          prompt: turn.prompt,
-          cwd: turn.cwd,
-          transcriptPath: turn.transcriptPath,
-        },
-      }), options.diagnosticLogger);
-      await recordTraceBestEffort("claude_memory_hook.current_turn_write", writeCurrentClaudeTurn(
-        turn.traceContext,
-        {
-          memoraxCodeHome: options.memoraxCodeHome,
-          env: options.env,
-          now: () => new Date(now()),
-        },
-      ), options.diagnosticLogger);
-      const processTurnStart = claimAutomaticRetrievalPrompt(
-        automaticRetrievalPrompts,
-        automaticRetrievalPromptLimit,
-        turn.sessionId,
-        turn.promptId,
-      );
-      if (!processTurnStart) {
-        return {
-          ok: true,
-          ...(repoMemoryWorktree ? { repoMemoryWorktree } : {}),
-        };
-      }
-      const pendingUserNotice = repositoryMemory.ok
-        ? await pendingQuotaNotice.claim(repositoryMemory.memory.config)
-        : undefined;
-      const retrieval = await retrieveAutomaticMemoryContext({
-        diagnosticLogger: options.diagnosticLogger,
-        claimQuotaNotice: options.claimQuotaNotice ?? claimQuotaNotice,
-        env: options.env ?? process.env,
-        fetchImpl: options.fetchImpl,
-        memoryObservability: options.memoryObservability,
-        memoryObservabilitySource: "claude_hook_retrieval",
-        query: turn.prompt,
-        repositoryMemory,
-        sessionKey: turn.sessionId,
-        traceContext: turn.traceContext,
-      });
-      const userNotice = [pendingUserNotice, retrieval.userNotice].filter(Boolean).join("\n");
-      return {
-        ok: true,
-        ...(repoMemoryWorktree ? { repoMemoryWorktree } : {}),
-        ...(retrieval.context ? { additionalContext: retrieval.context } : {}),
-        ...(userNotice ? { userNotice } : {}),
-      };
     },
     async writeback(command) {
       turnCoordinator.pruneExpired();
@@ -279,26 +160,18 @@ export function createClaudeMemoryHookRuntime(
         request,
         options.diagnosticLogger,
       );
-      const writeback = await turnCoordinator.completeMaterializedTurn({
-        key: claudeTurnKey(request.sessionId, request.promptId),
+      const writeback = await memory.completeTurn({
+        sessionId: request.sessionId,
+        clientTurnId: request.promptId,
         metadata: entry,
-        resolveRepositoryMemory: () => resolveCurrentHookRepositoryMemory(
-          entry,
-          request,
-          options,
-          repositoryMemorySession,
-        ),
+        resolveRepositoryMemory: () => memory.resolveRepositoryMemory({
+          sessionId: request.sessionId,
+          cwd: request.cwd ?? entry?.cwd,
+          workspaceKind: request.workspaceKind ?? entry?.workspaceKind,
+        }),
         userText: transcript.turn.userPrompt,
         assistantText: transcript.turn.assistantReply,
-        writeback: {
-          client: CLAUDE_MEMORY_TURN_CLIENT,
-          sessionKey: request.sessionId,
-          env: options.env ?? process.env,
-          fetchImpl: options.fetchImpl,
-          memoryObservability: options.memoryObservability,
-          memoryObservabilitySource: "claude_hook_writeback",
-          traceContext,
-        },
+        traceContext,
       });
       if (!writeback.scheduled) {
         options.diagnosticLogger?.("claude_memory_hook.writeback", {
@@ -322,14 +195,10 @@ export function createClaudeMemoryHookRuntime(
       return { ok: true, scheduled: true };
     },
     size() {
-      return turnCoordinator.size(CLAUDE_MEMORY_TURN_CLIENT);
+      return memory.size();
     },
     close() {
-      automaticRetrievalPrompts.clear();
-      if (ownsTurnCoordinator) turnCoordinator.close();
-      if (ownsRepositoryMemorySession) repositoryMemorySession.close();
-      automaticWritebackRuntime?.close?.();
-      if (ownsPendingQuotaNotice) pendingQuotaNotice.close();
+      memory.close();
     },
   };
 }
@@ -354,37 +223,6 @@ function transientTranscriptFailure(reason: ClaudeTranscriptTurnFailureReason): 
     || reason === "turn_not_found"
     || reason === "user_prompt_missing"
     || reason === "assistant_message_missing";
-}
-
-async function resolveHookRepositoryMemory(
-  entry: Pick<ClaudeMemoryHookTurnStart, "sessionId" | "cwd" | "workspaceKind">,
-  options: ClaudeMemoryHookRuntimeOptions,
-  repositoryMemorySession: RepositoryMemorySessionRuntime,
-): Promise<ConfiguredRepositoryMemoryResult> {
-  return await repositoryMemorySession.resolve({
-    client: CLAUDE_MEMORY_TURN_CLIENT,
-    sessionId: entry.sessionId,
-    workspaceRoot: entry.cwd,
-    workspaceKind: entry.workspaceKind,
-    memoraxCodeHome: options.memoraxCodeHome ?? options.env?.MEMORAX_CODE_HOME,
-    env: options.env,
-  });
-}
-
-async function resolveCurrentHookRepositoryMemory(
-  entry: MemoryTurnState | undefined,
-  request: ClaudeMemoryHookWritebackRequest,
-  options: ClaudeMemoryHookRuntimeOptions,
-  repositoryMemorySession: RepositoryMemorySessionRuntime,
-): Promise<ConfiguredRepositoryMemoryResult> {
-  return await repositoryMemorySession.resolve({
-    client: CLAUDE_MEMORY_TURN_CLIENT,
-    sessionId: request.sessionId,
-    workspaceRoot: request.cwd ?? entry?.cwd,
-    workspaceKind: request.workspaceKind ?? entry?.workspaceKind,
-    memoraxCodeHome: options.memoraxCodeHome ?? options.env?.MEMORAX_CODE_HOME,
-    env: options.env,
-  });
 }
 
 function turnStartFromCommand(
@@ -635,23 +473,6 @@ function claudeTurnKey(sessionId: string, promptId: string) {
     sessionId,
     clientTurnId: promptId,
   } as const;
-}
-
-function claimAutomaticRetrievalPrompt(
-  prompts: Set<string>,
-  limit: number,
-  sessionId: string,
-  promptId: string,
-): boolean {
-  const key = JSON.stringify([sessionId, promptId]);
-  if (prompts.has(key)) return false;
-  prompts.add(key);
-  while (prompts.size > limit) {
-    const oldest = prompts.values().next().value;
-    if (typeof oldest !== "string") break;
-    prompts.delete(oldest);
-  }
-  return true;
 }
 
 function traceContextForWriteback(

--- a/packages/ts/memorax-code-backend/src/clients/codebuddy/memory-hook-runtime.ts
+++ b/packages/ts/memorax-code-backend/src/clients/codebuddy/memory-hook-runtime.ts
@@ -5,18 +5,11 @@ import {
   type CodeBuddyTurn,
   type CodeBuddyTurnFailureReason,
 } from "./jsonl-history.js";
-import { retrieveAutomaticMemoryContext } from "../../memory/automatic-retrieval.js";
-import { createAutomaticMemoryWritebackRuntime, type AutomaticMemoryWritebackEnqueue, type AutomaticMemoryWritebackRejectionReason, type AutomaticMemoryWritebackRuntime } from "../../memory/automatic-writeback.js";
-import {
-  claimQuotaNotice,
-  createPendingQuotaNoticeRuntime,
-  type PendingQuotaNoticeRuntime,
-  type QuotaNoticeClaimer,
-} from "../../memory/quota-notice.js";
+import type { AutomaticMemoryWritebackRejectionReason } from "../../memory/automatic-writeback.js";
+import { createHarnessMemoryRuntime, type HarnessMemoryRuntimeOptions } from "../../memory/harness-runtime.js";
 import type { CodeBuddyTurnStartCommand, CodeBuddyWritebackCommand, MemoryHookTurnStartResult } from "../../memory/hook-command.js";
-import type { MemoryDiagnosticLogger, MemoryObservabilityHook } from "../../memory/observability.js";
-import { createMemoryTurnCoordinator, type MemoryTurnCoordinator, type MemoryTurnWritebackSkipReason } from "../../memory/turn-coordinator.js";
-import { createRepositoryMemorySessionRuntime, resolvedRepoMemoryWorktree, type ConfiguredRepositoryMemoryResult, type RepositoryMemorySessionRuntime } from "../../memory/repository-session.js";
+import type { MemoryDiagnosticLogger } from "../../memory/observability.js";
+import type { MemoryTurnCoordinator, MemoryTurnWritebackSkipReason } from "../../memory/turn-coordinator.js";
 import type { RepositoryMemoryScopeFailureReason } from "../../repository/scope.js";
 import { traceContextFromCodeBuddyHookBody, type TraceContext } from "../../trace/context.js";
 import {
@@ -24,25 +17,10 @@ import {
   readOpenTraceTurn,
   recordCodeBuddyTraceEvent,
   traceTurnEventId,
-  writeCurrentCodeBuddyTurn,
   type TraceEventWriteResult,
 } from "../../trace/store.js";
 
-type Options = {
-  automaticWriteback?: AutomaticMemoryWritebackEnqueue;
-  claimQuotaNotice?: QuotaNoticeClaimer;
-  diagnosticLogger?: MemoryDiagnosticLogger;
-  env?: Record<string, string | undefined>;
-  fetchImpl?: typeof fetch;
-  now?: () => number;
-  ttlMs?: number;
-  maxEntries?: number;
-  cleanupIntervalMs?: number;
-  memoryObservability?: MemoryObservabilityHook;
-  memoraxCodeHome?: string;
-  pendingQuotaNotice?: PendingQuotaNoticeRuntime;
-  repositoryMemorySession?: RepositoryMemorySessionRuntime;
-  turnCoordinator?: MemoryTurnCoordinator;
+type Options = HarnessMemoryRuntimeOptions & {
   transcriptReadAttempts?: number;
   transcriptRetryDelayMs?: number;
 };
@@ -52,44 +30,30 @@ export type CodeBuddyMemoryHookRuntime = { recordTurnStart(command: CodeBuddyTur
 
 export function createCodeBuddyMemoryHookRuntime(options: Options = {}): CodeBuddyMemoryHookRuntime {
   const now = options.now ?? (() => Date.now());
-  const pendingQuotaNotice = options.pendingQuotaNotice ?? createPendingQuotaNoticeRuntime({
-    claimQuotaNotice: options.claimQuotaNotice,
-    diagnosticLogger: options.diagnosticLogger,
-    env: options.env,
-  });
-  const ownsPendingQuotaNotice = options.pendingQuotaNotice === undefined;
-  const automatic = options.turnCoordinator ? undefined : options.automaticWriteback ? { enqueue: options.automaticWriteback, discardForScopeUpgrade: () => 0, drain: async () => undefined, close: () => undefined } : createAutomaticMemoryWritebackRuntime({ diagnosticLogger: options.diagnosticLogger, queueQuotaNotice: pendingQuotaNotice.queue });
-  const coordinator = options.turnCoordinator ?? createMemoryTurnCoordinator({ automaticWriteback: automatic!.enqueue, now, ttlMs: options.ttlMs, maxEntries: options.maxEntries, cleanupIntervalMs: options.cleanupIntervalMs });
-  const repository = options.repositoryMemorySession ?? createRepositoryMemorySessionRuntime({ onScopeUpgrade: automatic?.discardForScopeUpgrade });
+  const memory = createHarnessMemoryRuntime({
+    client: "codebuddy",
+    retrievalSource: "codebuddy_hook_retrieval",
+    writebackSource: "codebuddy_hook_writeback",
+    diagnosticPrefix: "codebuddy_memory_hook",
+    traceFailureEvent: "codebuddy_trace.write_failed",
+    deduplicateRetrieval: false,
+  }, options);
+  const coordinator = memory.turnCoordinator;
   return {
     async recordTurnStart(command) {
       await reconcilePreviousInterruptedTurn(coordinator, command, options, now);
-      const memory = await resolveRepository(command, options, repository);
       const traceContext = traceContextFromCodeBuddyHookBody(command, new Date(now()).toISOString());
-      coordinator.recordTurnStart({ client: "codebuddy", sessionId: command.sessionId, clientTurnId: command.turnId, cwd: command.cwd, workspaceKind: command.workspaceKind, transcriptPath: command.transcriptPath, createdAt: now(), traceContext, repositoryMemory: memory });
-      await recordTraceBestEffort("codebuddy_memory_hook.turn_start_event", recordCodeBuddyTraceEvent({
-        eventId: traceTurnEventId(traceContext, "turn_start"),
-        memoraxCodeHome: options.memoraxCodeHome,
-        env: options.env,
+      return memory.recordTurnStart({
+        sessionId: command.sessionId,
+        clientTurnId: command.turnId,
+        cwd: command.cwd,
+        workspaceKind: command.workspaceKind,
+        transcriptPath: command.transcriptPath,
+        createdAt: now(),
         traceContext,
-        type: "turn_start",
-        source: "unknown",
-        operation: "query",
-        ok: true,
-        request: { prompt: command.prompt, cwd: command.cwd, transcriptPath: command.transcriptPath },
-      }), options.diagnosticLogger);
-      await recordTraceBestEffort("codebuddy_memory_hook.current_turn_write", writeCurrentCodeBuddyTurn(traceContext, {
-        memoraxCodeHome: options.memoraxCodeHome,
-        env: options.env,
-        now: () => new Date(now()),
-      }), options.diagnosticLogger);
-      const repoMemoryWorktree = resolvedRepoMemoryWorktree(memory);
-      const pendingUserNotice = memory.ok
-        ? await pendingQuotaNotice.claim(memory.memory.config)
-        : undefined;
-      const retrieval = await retrieveAutomaticMemoryContext({ diagnosticLogger: options.diagnosticLogger, claimQuotaNotice: options.claimQuotaNotice ?? claimQuotaNotice, env: options.env ?? process.env, fetchImpl: options.fetchImpl, memoryObservability: options.memoryObservability, memoryObservabilitySource: "codebuddy_hook_retrieval", query: command.prompt, repositoryMemory: memory, sessionKey: command.sessionId, traceContext: traceContextFromCodeBuddyHookBody(command) });
-      const userNotice = [pendingUserNotice, retrieval.userNotice].filter(Boolean).join("\n");
-      return { ok: true, ...(repoMemoryWorktree ? { repoMemoryWorktree } : {}), ...(retrieval.context ? { additionalContext: retrieval.context } : {}), ...(userNotice ? { userNotice } : {}) };
+        prompt: command.prompt,
+        retrievalTraceContext: traceContextFromCodeBuddyHookBody(command),
+      });
     },
     async writeback(command) {
       const entry = coordinator.getTurn({ client: "codebuddy", sessionId: command.sessionId, clientTurnId: command.turnId });
@@ -106,19 +70,24 @@ export function createCodeBuddyMemoryHookRuntime(options: Options = {}): CodeBud
         return { ok: true, scheduled: false, reason: transcript.reason };
       }
       await recordCodeBuddyTurnEnd(options, traceContext, transcript.turn);
-      const memory = await resolveRepository({ ...command, cwd: command.cwd ?? entry?.cwd, workspaceKind: command.workspaceKind ?? entry?.workspaceKind }, options, repository);
-      const completed = await coordinator.completeMaterializedTurn({ key: { client: "codebuddy", sessionId: command.sessionId, clientTurnId: command.turnId }, metadata: entry, resolveRepositoryMemory: async () => memory, userText: transcript.turn.userPrompt, assistantText: transcript.turn.assistantReply, writeback: { client: "codebuddy", sessionKey: command.sessionId, env: options.env ?? process.env, fetchImpl: options.fetchImpl, memoryObservability: options.memoryObservability, memoryObservabilitySource: "codebuddy_hook_writeback", traceContext: traceContextFromCodeBuddyHookBody(command) } });
+      const repositoryMemory = await memory.resolveRepositoryMemory({ sessionId: command.sessionId, cwd: command.cwd ?? entry?.cwd, workspaceKind: command.workspaceKind ?? entry?.workspaceKind });
+      const completed = await memory.completeTurn({
+        sessionId: command.sessionId,
+        clientTurnId: command.turnId,
+        metadata: entry,
+        resolveRepositoryMemory: async () => repositoryMemory,
+        userText: transcript.turn.userPrompt,
+        assistantText: transcript.turn.assistantReply,
+        traceContext: traceContextFromCodeBuddyHookBody(command),
+      });
       await recordCodeBuddyTurnMaterialization(options, traceContext, transcript.turn);
       return completed.scheduled ? { ok: true, scheduled: true } : { ok: true, scheduled: false, reason: completed.reason };
     },
-    size() { return coordinator.size("codebuddy"); },
-    close() { if (!options.turnCoordinator) coordinator.close(); if (!options.repositoryMemorySession) repository.close(); automatic?.close?.(); if (ownsPendingQuotaNotice) pendingQuotaNotice.close(); },
+    size() { return memory.size(); },
+    close() { memory.close(); },
   };
 }
 
-async function resolveRepository(command: { sessionId: string; cwd?: string; workspaceKind?: string }, options: Options, repository: RepositoryMemorySessionRuntime): Promise<ConfiguredRepositoryMemoryResult> {
-  return repository.resolve({ client: "codebuddy", sessionId: command.sessionId, workspaceRoot: command.cwd, workspaceKind: command.workspaceKind, memoraxCodeHome: options.memoraxCodeHome ?? options.env?.MEMORAX_CODE_HOME, env: options.env });
-}
 async function readWithRetry(input: { transcriptPath: string; sessionId: string; turnId: string }, options: Options) {
   const attempts = options.transcriptReadAttempts ?? 6;
   let result = await readCodeBuddyTranscriptTurn(input);

--- a/packages/ts/memorax-code-backend/src/clients/codex/memory-hook-runtime.ts
+++ b/packages/ts/memorax-code-backend/src/clients/codex/memory-hook-runtime.ts
@@ -4,19 +4,12 @@ import {
   type CodexRolloutTurn,
   type CodexRolloutTurnFailureReason,
 } from "./rollout-turn.js";
+import type { AutomaticMemoryWritebackRejectionReason } from "../../memory/automatic-writeback.js";
 import {
-  createAutomaticMemoryWritebackRuntime,
-  type AutomaticMemoryWritebackEnqueue,
-  type AutomaticMemoryWritebackRejectionReason,
-  type AutomaticMemoryWritebackRuntime,
-} from "../../memory/automatic-writeback.js";
-import { retrieveAutomaticMemoryContext } from "../../memory/automatic-retrieval.js";
-import {
-  claimQuotaNotice,
-  createPendingQuotaNoticeRuntime,
-  type PendingQuotaNoticeRuntime,
-  type QuotaNoticeClaimer,
-} from "../../memory/quota-notice.js";
+  createHarnessMemoryRuntime,
+  type HarnessMemoryRuntime,
+  type HarnessMemoryRuntimeOptions,
+} from "../../memory/harness-runtime.js";
 import { readCodexSessionTurnIndex } from "./session-turn-index.js";
 import { resolveCodexWorkspaceRoot } from "./workspace-links.js";
 import type {
@@ -24,18 +17,12 @@ import type {
   CodexTurnStartCommand,
   CodexWritebackCommand,
 } from "../../memory/hook-command.js";
-import type { MemoryDiagnosticLogger, MemoryObservabilityHook } from "../../memory/observability.js";
-import {
-  createMemoryTurnCoordinator,
-  type MemoryTurnCoordinator,
-  type MemoryTurnState,
+import type { MemoryDiagnosticLogger } from "../../memory/observability.js";
+import type {
+  MemoryTurnCoordinator,
+  MemoryTurnState,
 } from "../../memory/turn-coordinator.js";
-import {
-  createRepositoryMemorySessionRuntime,
-  resolvedRepoMemoryWorktree,
-  type ConfiguredRepositoryMemoryResult,
-  type RepositoryMemorySessionRuntime,
-} from "../../memory/repository-session.js";
+import type { ConfiguredRepositoryMemoryResult } from "../../memory/repository-session.js";
 import type {
   RepositoryMemoryScope,
   RepositoryMemoryScopeFailureReason,
@@ -47,7 +34,6 @@ import {
   readOpenCodexTurn,
   recordCodexTraceEvent,
   traceTurnEventId,
-  writeCurrentCodexTurn,
   type CodexTurnOutcome,
 } from "../../trace/store.js";
 
@@ -88,22 +74,7 @@ type CodexMemoryHookWritebackRequest = Omit<CodexWritebackCommand, "version" | "
   traceContext?: TraceContext;
 };
 
-export type CodexMemoryHookRuntimeOptions = {
-  automaticWriteback?: AutomaticMemoryWritebackEnqueue;
-  diagnosticLogger?: MemoryDiagnosticLogger;
-  env?: Record<string, string | undefined>;
-  fetchImpl?: typeof fetch;
-  claimQuotaNotice?: QuotaNoticeClaimer;
-  now?: () => number;
-  ttlMs?: number;
-  maxEntries?: number;
-  cleanupIntervalMs?: number;
-  memoryObservability?: MemoryObservabilityHook;
-  memoraxCodeHome?: string;
-  pendingQuotaNotice?: PendingQuotaNoticeRuntime;
-  repositoryMemorySession?: RepositoryMemorySessionRuntime;
-  turnCoordinator?: MemoryTurnCoordinator;
-};
+export type CodexMemoryHookRuntimeOptions = HarnessMemoryRuntimeOptions;
 
 export type CodexMemoryHookRuntime = {
   recordTurnStart(command: CodexTurnStartCommand): Promise<MemoryHookTurnStartResult>;
@@ -116,38 +87,15 @@ const CODEX_MEMORY_TURN_CLIENT = "codex" as const;
 
 export function createCodexMemoryHookRuntime(options: CodexMemoryHookRuntimeOptions = {}): CodexMemoryHookRuntime {
   const now = options.now ?? (() => Date.now());
-  const pendingQuotaNotice = options.pendingQuotaNotice ?? createPendingQuotaNoticeRuntime({
-    claimQuotaNotice: options.claimQuotaNotice,
-    diagnosticLogger: options.diagnosticLogger,
-    env: options.env,
-  });
-  const ownsPendingQuotaNotice = options.pendingQuotaNotice === undefined;
-  const automaticWritebackRuntime: {
-    enqueue: AutomaticMemoryWritebackEnqueue;
-    discardForScopeUpgrade?: AutomaticMemoryWritebackRuntime["discardForScopeUpgrade"];
-    close?: () => void;
-  } | undefined = options.turnCoordinator
-    ? undefined
-    : options.automaticWriteback
-      ? { enqueue: options.automaticWriteback }
-      : createAutomaticMemoryWritebackRuntime({
-        diagnosticLogger: options.diagnosticLogger,
-        queueQuotaNotice: pendingQuotaNotice.queue,
-      });
-  const turnCoordinator = options.turnCoordinator ?? createMemoryTurnCoordinator({
-    automaticWriteback: automaticWritebackRuntime!.enqueue,
-    now,
-    ttlMs: options.ttlMs,
-    maxEntries: options.maxEntries,
-    cleanupIntervalMs: options.cleanupIntervalMs,
-  });
-  const ownsTurnCoordinator = options.turnCoordinator === undefined;
-  const repositoryMemorySession = options.repositoryMemorySession ?? createRepositoryMemorySessionRuntime({
-    onScopeUpgrade: automaticWritebackRuntime?.discardForScopeUpgrade,
-  });
-  const ownsRepositoryMemorySession = options.repositoryMemorySession === undefined;
-  const automaticRetrievalTurns = new Set<string>();
-  const automaticRetrievalTurnLimit = positiveInteger(options.maxEntries, 256);
+  const memory = createHarnessMemoryRuntime({
+    client: CODEX_MEMORY_TURN_CLIENT,
+    retrievalSource: "codex_hook_retrieval",
+    writebackSource: "codex_hook_writeback",
+    diagnosticPrefix: "memory_hook",
+    traceFailureEvent: "codex_trace.write_failed",
+    deduplicateRetrieval: true,
+  }, options);
+  const { turnCoordinator } = memory;
 
   return {
     async recordTurnStart(command) {
@@ -163,90 +111,27 @@ export function createCodexMemoryHookRuntime(options: CodexMemoryHookRuntimeOpti
       await reconcilePreviousInterruptedTurn(turnCoordinator, turn, options, now);
       turnCoordinator.pruneExpired();
       const [repositoryMemory, sessionTurnIndex] = await Promise.all([
-        resolveHookRepositoryMemory(turn, options, repositoryMemorySession),
+        resolveHookRepositoryMemory(turn, options, memory),
         resolveSessionTurnIndex(turn, options.diagnosticLogger),
       ]);
-      const repoMemoryWorktree = resolvedRepoMemoryWorktree(repositoryMemory);
-      if (turn.turnId) {
-        turnCoordinator.recordTurnStart({
-          client: CODEX_MEMORY_TURN_CLIENT,
-          sessionId: turn.sessionId,
-          clientTurnId: turn.turnId,
-          cwd: turn.cwd,
-          workspaceKind: turn.workspaceKind,
-          transcriptPath: turn.transcriptPath,
-          createdAt: turn.createdAt,
-          sessionTurnIndex,
-          traceContext: turn.traceContext,
-          repositoryMemory,
-        });
-      }
-      options.diagnosticLogger?.("memory_hook.turn_start", {
+      return await memory.recordTurnStart({
         sessionId: turn.sessionId,
-        turnId: turn.turnId,
-        promptChars: turn.prompt.length,
-        cacheSize: turnCoordinator.size(CODEX_MEMORY_TURN_CLIENT),
-        workspace: repositoryMemory.ok ? repositoryMemory.memory.scope?.repositorySlug : undefined,
-        workspaceScopeReason: repositoryMemory.ok ? undefined : repositoryMemory.reason,
+        clientTurnId: turn.turnId,
+        cwd: turn.cwd,
+        workspaceKind: turn.workspaceKind,
+        transcriptPath: turn.transcriptPath,
+        createdAt: turn.createdAt,
         sessionTurnIndex,
-      });
-      await recordTraceBestEffort("memory_hook.turn_start_event", recordCodexTraceEvent({
-        eventId: traceTurnEventId(turn.traceContext, "turn_start"),
-        memoraxCodeHome: options.memoraxCodeHome,
-        env: options.env,
         traceContext: turn.traceContext,
-        type: "turn_start",
-        source: "unknown",
-        operation: "query",
-        ok: true,
-        sessionTurnIndex,
-        request: {
-          prompt: turn.prompt,
-          cwd: turn.cwd,
-          transcriptPath: turn.transcriptPath,
-        },
-      }), options.diagnosticLogger);
-      await recordTraceBestEffort("memory_hook.current_turn_write", writeCurrentCodexTurn(turn.traceContext, {
-        memoraxCodeHome: options.memoraxCodeHome,
-        env: options.env,
-        now: () => new Date(now()),
-      }), options.diagnosticLogger);
-      const processTurnStart = turn.turnId
-        ? claimAutomaticRetrievalTurn(
-          automaticRetrievalTurns,
-          automaticRetrievalTurnLimit,
-          turn.sessionId,
-          turn.turnId,
-        )
-        : false;
-      if (!processTurnStart) {
-        return {
-          ok: true,
-          ...(repoMemoryWorktree ? { repoMemoryWorktree } : {}),
-        };
-      }
-      const pendingUserNotice = repositoryMemory.ok
-        ? await pendingQuotaNotice.claim(repositoryMemory.memory.config)
-        : undefined;
-      const retrieval = await retrieveAutomaticMemoryContext({
-        diagnosticLogger: options.diagnosticLogger,
-        claimQuotaNotice: options.claimQuotaNotice ?? claimQuotaNotice,
-        env: options.env ?? process.env,
-        fetchImpl: options.fetchImpl,
-        memoryObservability: options.memoryObservability,
-        memoryObservabilitySource: "codex_hook_retrieval",
-        query: turn.prompt,
+        prompt: turn.prompt,
         repositoryMemory,
-        sessionKey: turn.sessionId,
-        traceContext: turn.traceContext,
+        diagnosticFields: {
+          sessionId: turn.sessionId,
+          turnId: turn.turnId,
+          promptChars: turn.prompt.length,
+          sessionTurnIndex,
+        },
       });
-      const userNotice = [pendingUserNotice, retrieval.userNotice].filter(Boolean).join("\n");
-      return {
-        ok: true,
-        ...(repoMemoryWorktree ? { repoMemoryWorktree } : {}),
-        ...(retrieval.context ? { additionalContext: retrieval.context } : {}),
-        ...(userNotice ? { userNotice } : {}),
-      };
     },
     async writeback(command) {
       turnCoordinator.pruneExpired();
@@ -311,27 +196,20 @@ export function createCodexMemoryHookRuntime(options: CodexMemoryHookRuntimeOpti
         });
         return { ok: true, scheduled: false, reason: rollout.reason };
       }
-      const writeback = await turnCoordinator.completeMaterializedTurn({
-        key: codexTurnKey(request.sessionId, request.turnId),
+      const writeback = await memory.completeTurn({
+        sessionId: request.sessionId,
+        clientTurnId: request.turnId,
         metadata: entry,
         resolveRepositoryMemory: () => resolveCurrentHookRepositoryMemory(
           entry,
           request,
           options,
-          repositoryMemorySession,
+          memory,
           recoveredTraceContext,
         ),
         userText: rollout.turn.userPrompt,
         assistantText: rollout.turn.assistantReply,
-        writeback: {
-          client: CODEX_MEMORY_TURN_CLIENT,
-          sessionKey: request.sessionId,
-          env: options.env ?? process.env,
-          fetchImpl: options.fetchImpl,
-          memoryObservability: options.memoryObservability,
-          memoryObservabilitySource: "codex_hook_writeback",
-          traceContext,
-        },
+        traceContext,
       });
       if (!writeback.scheduled) {
         options.diagnosticLogger?.("memory_hook.writeback", {
@@ -355,14 +233,10 @@ export function createCodexMemoryHookRuntime(options: CodexMemoryHookRuntimeOpti
       return { ok: true, scheduled: true };
     },
     size() {
-      return turnCoordinator.size(CODEX_MEMORY_TURN_CLIENT);
+      return memory.size();
     },
     close() {
-      automaticRetrievalTurns.clear();
-      if (ownsTurnCoordinator) turnCoordinator.close();
-      if (ownsRepositoryMemorySession) repositoryMemorySession.close();
-      automaticWritebackRuntime?.close?.();
-      if (ownsPendingQuotaNotice) pendingQuotaNotice.close();
+      memory.close();
     },
   };
 }
@@ -393,7 +267,7 @@ async function resolveSessionTurnIndex(input: {
 async function resolveHookRepositoryMemory(
   entry: Pick<CodexMemoryHookTurnStart, "sessionId" | "cwd" | "workspaceKind">,
   options: CodexMemoryHookRuntimeOptions,
-  repositoryMemorySession: RepositoryMemorySessionRuntime,
+  memory: HarnessMemoryRuntime,
   requireBoundScope = false,
 ): Promise<ConfiguredRepositoryMemoryResult> {
   const memoraxCodeHome = options.memoraxCodeHome ?? options.env?.MEMORAX_CODE_HOME;
@@ -403,24 +277,18 @@ async function resolveHookRepositoryMemory(
       sessionKey: entry.sessionId,
     })
     : undefined;
-  const primary = await repositoryMemorySession.resolve({
-    client: CODEX_MEMORY_TURN_CLIENT,
+  const primary = await memory.resolveRepositoryMemory({
     sessionId: entry.sessionId,
-    workspaceRoot: registeredWorkspace ?? entry.cwd,
+    cwd: registeredWorkspace ?? entry.cwd,
     workspaceKind: entry.workspaceKind,
     requireBoundScope,
-    memoraxCodeHome,
-    env: options.env,
   });
   if (!primary.ok || !registeredWorkspace || !entry.cwd) return primary;
-  return await repositoryMemorySession.resolve({
-    client: CODEX_MEMORY_TURN_CLIENT,
+  return await memory.resolveRepositoryMemory({
     sessionId: entry.sessionId,
-    workspaceRoot: entry.cwd,
+    cwd: entry.cwd,
     workspaceKind: entry.workspaceKind,
     requireBoundScope,
-    memoraxCodeHome,
-    env: options.env,
   });
 }
 
@@ -428,7 +296,7 @@ async function resolveCurrentHookRepositoryMemory(
   entry: MemoryTurnState | undefined,
   request: CodexMemoryHookWritebackRequest,
   options: CodexMemoryHookRuntimeOptions,
-  repositoryMemorySession: RepositoryMemorySessionRuntime,
+  memory: HarnessMemoryRuntime,
   recoveredTraceContext?: TraceContext,
 ): Promise<ConfiguredRepositoryMemoryResult> {
   if (!entry) {
@@ -437,35 +305,29 @@ async function resolveCurrentHookRepositoryMemory(
         sessionId: request.sessionId!,
         cwd: request.cwd,
         workspaceKind: request.workspaceKind,
-      }, options, repositoryMemorySession, true);
+      }, options, memory, true);
     }
     const recovered = await resolveHookRepositoryMemory({
       sessionId: request.sessionId!,
       cwd: recoveredTraceContext.cwd,
       workspaceKind: recoveredTraceContext.workspaceKind,
-    }, options, repositoryMemorySession);
+    }, options, memory);
     if (!recovered.ok || (!request.cwd && !request.workspaceKind)) return recovered;
     return await resolveHookRepositoryMemory({
       sessionId: request.sessionId!,
       cwd: request.cwd ?? recoveredTraceContext.cwd,
       workspaceKind: request.workspaceKind ?? recoveredTraceContext.workspaceKind,
-    }, options, repositoryMemorySession);
+    }, options, memory);
   }
   return !request.cwd
-    ? await repositoryMemorySession.resolve({
-      client: CODEX_MEMORY_TURN_CLIENT,
+    ? await memory.resolveRepositoryMemory({
       sessionId: entry.sessionId,
       workspaceKind: request.workspaceKind ?? entry.workspaceKind,
-      memoraxCodeHome: options.memoraxCodeHome ?? options.env?.MEMORAX_CODE_HOME,
-      env: options.env,
     })
-    : await repositoryMemorySession.resolve({
-      client: CODEX_MEMORY_TURN_CLIENT,
+    : await memory.resolveRepositoryMemory({
       sessionId: entry.sessionId,
-      workspaceRoot: request.cwd,
+      cwd: request.cwd,
       workspaceKind: request.workspaceKind ?? entry.workspaceKind,
-      memoraxCodeHome: options.memoraxCodeHome ?? options.env?.MEMORAX_CODE_HOME,
-      env: options.env,
     });
 }
 
@@ -720,28 +582,6 @@ function codexTurnKey(sessionId: string, turnId: string) {
     sessionId,
     clientTurnId: turnId,
   };
-}
-
-function claimAutomaticRetrievalTurn(
-  turns: Set<string>,
-  limit: number,
-  sessionId: string,
-  turnId: string,
-): boolean {
-  const key = JSON.stringify([sessionId, turnId]);
-  if (turns.has(key)) return false;
-  turns.add(key);
-  while (turns.size > limit) {
-    const oldest = turns.values().next().value;
-    if (typeof oldest !== "string") break;
-    turns.delete(oldest);
-  }
-  return true;
-}
-
-function positiveInteger(value: unknown, fallback: number): number {
-  const parsed = Number(value);
-  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
 }
 
 async function recordTraceBestEffort<T>(

--- a/packages/ts/memorax-code-backend/src/clients/dsh/memory-hook-runtime.ts
+++ b/packages/ts/memorax-code-backend/src/clients/dsh/memory-hook-runtime.ts
@@ -1,7 +1,7 @@
 import {
   type AutomaticMemoryWritebackRejectionReason,
 } from "../../memory/automatic-writeback.js";
-import { retrieveAutomaticMemoryContext } from "../../memory/automatic-retrieval.js";
+import { createHarnessMemoryRuntime } from "../../memory/harness-runtime.js";
 import type {
   DshTurnStartCommand,
   DshWritebackCommand,
@@ -11,15 +11,8 @@ import type {
   MemoryDiagnosticLogger,
   MemoryObservabilityHook,
 } from "../../memory/observability.js";
-import {
-  resolvedRepoMemoryWorktree,
-  type ConfiguredRepositoryMemoryResult,
-  type RepositoryMemorySessionRuntime,
-} from "../../memory/repository-session.js";
-import {
-  type MemoryTurnCoordinator,
-  type MemoryTurnState,
-} from "../../memory/turn-coordinator.js";
+import type { RepositoryMemorySessionRuntime } from "../../memory/repository-session.js";
+import type { MemoryTurnCoordinator } from "../../memory/turn-coordinator.js";
 import type { RepositoryMemoryScopeFailureReason } from "../../repository/scope.js";
 import {
   dshSessionEventTurn,
@@ -35,7 +28,6 @@ import {
   markCurrentTraceTurnOutcome,
   recordTraceEvent,
   traceTurnEventId,
-  writeCurrentTraceTurn,
   type TraceTurnOutcome,
 } from "../../trace/store.js";
 
@@ -74,9 +66,17 @@ export function createDshMemoryHookRuntime(
   options: DshMemoryHookRuntimeOptions,
 ): DshMemoryHookRuntime {
   const now = options.now ?? (() => Date.now());
-  const { repositoryMemorySession, turnCoordinator } = options;
-  const retrievalTurns = new Set<string>();
-  const retrievalTurnLimit = positiveInteger(options.maxEntries, 256);
+  const harness = createHarnessMemoryRuntime({
+    client: DSH_MEMORY_TURN_CLIENT,
+    retrievalSource: "dsh_native_retrieval",
+    writebackSource: "dsh_native_writeback",
+    diagnosticPrefix: "dsh_memory",
+    traceFailureEvent: "dsh_trace.write_failed",
+    turnStartTraceSource: "dsh-cordis",
+    deduplicateRetrieval: true,
+    quotaNotices: false,
+  }, options);
+  const { turnCoordinator } = harness;
 
   return {
     async recordTurnStart(command) {
@@ -86,78 +86,22 @@ export function createDshMemoryHookRuntime(
         command,
         new Date(createdAt).toISOString(),
       );
-      const repositoryMemory = await resolveHookRepositoryMemory(command, options, repositoryMemorySession);
-      turnCoordinator.recordTurnStart({
-        client: DSH_MEMORY_TURN_CLIENT,
+      return harness.recordTurnStart({
         sessionId: command.sessionId,
         clientTurnId: String(command.turn),
         cwd: command.cwd,
         eventStartSeq: command.startSeq,
         createdAt,
+        prompt: command.prompt,
         traceContext,
-        repositoryMemory,
-      });
-      options.diagnosticLogger?.("dsh_memory.turn_start", {
-        sessionId: command.sessionId,
-        turn: command.turn,
-        startSeq: command.startSeq,
-        cacheSize: turnCoordinator.size(DSH_MEMORY_TURN_CLIENT),
-        workspace: repositoryMemory.ok ? repositoryMemory.memory.scope?.repositorySlug : undefined,
-        workspaceScopeReason: repositoryMemory.ok ? undefined : repositoryMemory.reason,
-      });
-      await recordDshTraceBestEffort("dsh_memory.turn_start_event", recordTraceEvent({
-        eventId: traceTurnEventId(traceContext, "turn_start"),
-        memoraxCodeHome: options.memoraxCodeHome,
-        env: options.env,
-        traceContext,
-        type: "turn_start",
-        source: "dsh-cordis",
-        operation: "query",
-        ok: true,
-        request: {
-          start_seq: command.startSeq,
+        traceRequest: { start_seq: command.startSeq },
+        retrievalKeySuffix: String(command.startSeq),
+        diagnosticFields: {
+          sessionId: command.sessionId,
+          turn: command.turn,
+          startSeq: command.startSeq,
         },
-      }), options.diagnosticLogger);
-      await recordDshTraceBestEffort("dsh_memory.current_turn_write", writeCurrentTraceTurn(
-        traceContext,
-        {
-          client: "dsh",
-          memoraxCodeHome: options.memoraxCodeHome,
-          env: options.env,
-          now: () => new Date(now()),
-        },
-      ), options.diagnosticLogger);
-
-      const repoMemoryWorktree = resolvedRepoMemoryWorktree(repositoryMemory);
-      const retrievalKey = JSON.stringify([command.sessionId, command.turn, command.startSeq]);
-      if (retrievalTurns.has(retrievalKey)) {
-        return {
-          ok: true,
-          ...(repoMemoryWorktree ? { repoMemoryWorktree } : {}),
-        };
-      }
-      retrievalTurns.add(retrievalKey);
-      while (retrievalTurns.size > retrievalTurnLimit) {
-        const oldest = retrievalTurns.values().next().value;
-        if (typeof oldest !== "string") break;
-        retrievalTurns.delete(oldest);
-      }
-      const retrieval = await retrieveAutomaticMemoryContext({
-        diagnosticLogger: options.diagnosticLogger,
-        env: options.env ?? process.env,
-        fetchImpl: options.fetchImpl,
-        memoryObservability: options.memoryObservability,
-        memoryObservabilitySource: "dsh_native_retrieval",
-        query: command.prompt,
-        repositoryMemory,
-        sessionKey: command.sessionId,
-        traceContext,
       });
-      return {
-        ok: true,
-        ...(repoMemoryWorktree ? { repoMemoryWorktree } : {}),
-        ...(retrieval.context ? { additionalContext: retrieval.context } : {}),
-      };
     },
     async writeback(command) {
       turnCoordinator.pruneExpired();
@@ -197,26 +141,20 @@ export function createDshMemoryHookRuntime(
         turn: materialized.turn,
       });
 
-      const writeback = await turnCoordinator.completeMaterializedTurn({
-        key,
+      const writeback = await harness.completeTurn({
+        sessionId: command.sessionId,
+        clientTurnId: String(command.turn),
         metadata: entry,
-        resolveRepositoryMemory: () => resolveCurrentHookRepositoryMemory(
-          entry,
-          command,
-          options,
-          repositoryMemorySession,
-        ),
+        resolveRepositoryMemory: () => harness.resolveRepositoryMemory({
+          sessionId: command.sessionId,
+          cwd: command.cwd,
+          // DSH's persisted session header and exact event interval remain native
+          // authority after a Backend restart, when the in-memory binding is gone.
+          requireBoundScope: entry !== undefined,
+        }),
         userText: materialized.turn.userPrompt,
         assistantText: materialized.turn.assistantReply,
-        writeback: {
-          client: DSH_MEMORY_TURN_CLIENT,
-          sessionKey: command.sessionId,
-          env: options.env ?? process.env,
-          fetchImpl: options.fetchImpl,
-          memoryObservability: options.memoryObservability,
-          memoryObservabilitySource: "dsh_native_writeback",
-          traceContext,
-        },
+        traceContext,
       });
       if (!writeback.scheduled) {
         return skippedWriteback(command, writeback.reason, options, writeback.metadataDisposition);
@@ -236,7 +174,7 @@ export function createDshMemoryHookRuntime(
       return { ok: true, scheduled: true };
     },
     close() {
-      retrievalTurns.clear();
+      harness.close();
     },
   };
 }
@@ -327,38 +265,6 @@ function dshTurnKey(sessionId: string, turn: number) {
   } as const;
 }
 
-async function resolveHookRepositoryMemory(
-  command: DshTurnStartCommand,
-  options: DshMemoryHookRuntimeOptions,
-  repositoryMemorySession: RepositoryMemorySessionRuntime,
-): Promise<ConfiguredRepositoryMemoryResult> {
-  return await repositoryMemorySession.resolve({
-    client: DSH_MEMORY_TURN_CLIENT,
-    sessionId: command.sessionId,
-    workspaceRoot: command.cwd,
-    memoraxCodeHome: options.memoraxCodeHome ?? options.env?.MEMORAX_CODE_HOME,
-    env: options.env,
-  });
-}
-
-async function resolveCurrentHookRepositoryMemory(
-  entry: MemoryTurnState | undefined,
-  command: DshWritebackCommand,
-  options: DshMemoryHookRuntimeOptions,
-  repositoryMemorySession: RepositoryMemorySessionRuntime,
-): Promise<ConfiguredRepositoryMemoryResult> {
-  return await repositoryMemorySession.resolve({
-    client: DSH_MEMORY_TURN_CLIENT,
-    sessionId: command.sessionId,
-    workspaceRoot: command.cwd,
-    // DSH's persisted session header and exact event interval remain native
-    // authority after a Backend restart, when the in-memory binding is gone.
-    requireBoundScope: entry !== undefined,
-    memoraxCodeHome: options.memoraxCodeHome ?? options.env?.MEMORAX_CODE_HOME,
-    env: options.env,
-  });
-}
-
 function skippedWriteback(
   command: DshWritebackCommand,
   reason: DshMemoryHookWritebackSkipReason,
@@ -375,9 +281,4 @@ function skippedWriteback(
     endSeq: command.endSeq,
   });
   return { ok: true, scheduled: false, reason };
-}
-
-function positiveInteger(value: unknown, fallback: number): number {
-  const parsed = Number(value);
-  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
 }

--- a/packages/ts/memorax-code-backend/src/clients/opencode/memory-hook-runtime.ts
+++ b/packages/ts/memorax-code-backend/src/clients/opencode/memory-hook-runtime.ts
@@ -1,40 +1,20 @@
+import type { AutomaticMemoryWritebackRejectionReason } from "../../memory/automatic-writeback.js";
 import {
-  createAutomaticMemoryWritebackRuntime,
-  type AutomaticMemoryWritebackEnqueue,
-  type AutomaticMemoryWritebackRejectionReason,
-  type AutomaticMemoryWritebackRuntime,
-} from "../../memory/automatic-writeback.js";
-import { retrieveAutomaticMemoryContext } from "../../memory/automatic-retrieval.js";
-import {
-  claimQuotaNotice,
-  createPendingQuotaNoticeRuntime,
-  type PendingQuotaNoticeRuntime,
-  type QuotaNoticeClaimer,
-} from "../../memory/quota-notice.js";
+  createHarnessMemoryRuntime,
+  type HarnessMemoryRuntimeOptions,
+} from "../../memory/harness-runtime.js";
 import type {
   MemoryHookTurnStartResult,
   OpenCodeTurnStartCommand,
   OpenCodeWritebackCommand,
 } from "../../memory/hook-command.js";
-import type { MemoryDiagnosticLogger, MemoryObservabilityHook } from "../../memory/observability.js";
-import {
-  createMemoryTurnCoordinator,
-  type MemoryTurnCoordinator,
-  type MemoryTurnState,
-} from "../../memory/turn-coordinator.js";
-import {
-  createRepositoryMemorySessionRuntime,
-  resolvedRepoMemoryWorktree,
-  type ConfiguredRepositoryMemoryResult,
-  type RepositoryMemorySessionRuntime,
-} from "../../memory/repository-session.js";
+import type { MemoryDiagnosticLogger } from "../../memory/observability.js";
 import type { RepositoryMemoryScopeFailureReason } from "../../repository/scope.js";
 import { traceContextFromOpenCodeHookBody, type TraceContext } from "../../trace/context.js";
 import {
   markCurrentTraceTurnOutcome,
   recordTraceEvent,
   traceTurnEventId,
-  writeCurrentTraceTurn,
 } from "../../trace/store.js";
 import {
   openCodeMessageTurn,
@@ -53,22 +33,7 @@ export type OpenCodeMemoryHookWritebackResult =
   | { ok: true; scheduled: true }
   | { ok: true; scheduled: false; reason: OpenCodeMemoryHookWritebackSkipReason };
 
-export type OpenCodeMemoryHookRuntimeOptions = {
-  automaticWriteback?: AutomaticMemoryWritebackEnqueue;
-  diagnosticLogger?: MemoryDiagnosticLogger;
-  env?: Record<string, string | undefined>;
-  fetchImpl?: typeof fetch;
-  claimQuotaNotice?: QuotaNoticeClaimer;
-  now?: () => number;
-  ttlMs?: number;
-  maxEntries?: number;
-  cleanupIntervalMs?: number;
-  memoryObservability?: MemoryObservabilityHook;
-  memoraxCodeHome?: string;
-  pendingQuotaNotice?: PendingQuotaNoticeRuntime;
-  repositoryMemorySession?: RepositoryMemorySessionRuntime;
-  turnCoordinator?: MemoryTurnCoordinator;
-};
+export type OpenCodeMemoryHookRuntimeOptions = HarnessMemoryRuntimeOptions;
 
 export type OpenCodeMemoryHookRuntime = {
   recordTurnStart(command: OpenCodeTurnStartCommand): Promise<MemoryHookTurnStartResult>;
@@ -83,126 +48,32 @@ export function createOpenCodeMemoryHookRuntime(
   options: OpenCodeMemoryHookRuntimeOptions = {},
 ): OpenCodeMemoryHookRuntime {
   const now = options.now ?? (() => Date.now());
-  const pendingQuotaNotice = options.pendingQuotaNotice ?? createPendingQuotaNoticeRuntime({
-    claimQuotaNotice: options.claimQuotaNotice,
-    diagnosticLogger: options.diagnosticLogger,
-    env: options.env,
-  });
-  const ownsPendingQuotaNotice = options.pendingQuotaNotice === undefined;
-  const automaticWritebackRuntime: {
-    enqueue: AutomaticMemoryWritebackEnqueue;
-    discardForScopeUpgrade?: AutomaticMemoryWritebackRuntime["discardForScopeUpgrade"];
-    close?: () => void;
-  } | undefined = options.turnCoordinator
-    ? undefined
-    : options.automaticWriteback
-      ? { enqueue: options.automaticWriteback }
-      : createAutomaticMemoryWritebackRuntime({
-        diagnosticLogger: options.diagnosticLogger,
-        queueQuotaNotice: pendingQuotaNotice.queue,
-      });
-  const turnCoordinator = options.turnCoordinator ?? createMemoryTurnCoordinator({
-    automaticWriteback: automaticWritebackRuntime!.enqueue,
-    now,
-    ttlMs: options.ttlMs,
-    maxEntries: options.maxEntries,
-    cleanupIntervalMs: options.cleanupIntervalMs,
-  });
-  const ownsTurnCoordinator = options.turnCoordinator === undefined;
-  const repositoryMemorySession = options.repositoryMemorySession ?? createRepositoryMemorySessionRuntime({
-    onScopeUpgrade: automaticWritebackRuntime?.discardForScopeUpgrade,
-  });
-  const ownsRepositoryMemorySession = options.repositoryMemorySession === undefined;
-  const retrievalTurns = new Set<string>();
-  const retrievalTurnLimit = positiveInteger(options.maxEntries, 256);
+  const memory = createHarnessMemoryRuntime({
+    client: OPENCODE_MEMORY_TURN_CLIENT,
+    retrievalSource: "opencode_plugin_retrieval",
+    writebackSource: "opencode_plugin_writeback",
+    diagnosticPrefix: "opencode_memory",
+    traceFailureEvent: "opencode_trace.write_failed",
+    turnStartTraceSource: "opencode-plugin",
+    deduplicateRetrieval: true,
+  }, options);
+  const { turnCoordinator } = memory;
 
   return {
     async recordTurnStart(command) {
       turnCoordinator.pruneExpired();
       const createdAt = now();
       const traceContext = traceContextFromOpenCodeHookBody(command, new Date(createdAt).toISOString());
-      const repositoryMemory = await resolveHookRepositoryMemory(
-        command,
-        options,
-        repositoryMemorySession,
-      );
-      const repoMemoryWorktree = resolvedRepoMemoryWorktree(repositoryMemory);
-      turnCoordinator.recordTurnStart({
-        client: OPENCODE_MEMORY_TURN_CLIENT,
+      return await memory.recordTurnStart({
         sessionId: command.sessionId,
         clientTurnId: command.userMessageId,
         cwd: command.cwd,
         workspaceKind: command.workspaceKind,
         createdAt,
         traceContext,
-        repositoryMemory,
+        prompt: command.prompt,
+        diagnosticFields: { sessionId: command.sessionId, userMessageId: command.userMessageId },
       });
-      await recordTraceBestEffort("opencode_memory.turn_start_event", recordTraceEvent({
-        eventId: traceTurnEventId(traceContext, "turn_start"),
-        memoraxCodeHome: options.memoraxCodeHome,
-        env: options.env,
-        traceContext,
-        type: "turn_start",
-        source: "opencode-plugin",
-        operation: "query",
-        ok: true,
-        request: {
-          prompt: command.prompt,
-          cwd: command.cwd,
-        },
-      }), options.diagnosticLogger);
-      await recordTraceBestEffort("opencode_memory.current_turn_write", writeCurrentTraceTurn(
-        traceContext,
-        {
-          client: "opencode",
-          memoraxCodeHome: options.memoraxCodeHome,
-          env: options.env,
-          now: () => new Date(now()),
-        },
-      ), options.diagnosticLogger);
-      options.diagnosticLogger?.("opencode_memory.turn_start", {
-        sessionId: command.sessionId,
-        userMessageId: command.userMessageId,
-        cacheSize: turnCoordinator.size(OPENCODE_MEMORY_TURN_CLIENT),
-        workspace: repositoryMemory.ok ? repositoryMemory.memory.scope?.repositorySlug : undefined,
-        workspaceScopeReason: repositoryMemory.ok ? undefined : repositoryMemory.reason,
-      });
-
-      const retrievalKey = JSON.stringify([command.sessionId, command.userMessageId]);
-      if (retrievalTurns.has(retrievalKey)) {
-        return {
-          ok: true,
-          ...(repoMemoryWorktree ? { repoMemoryWorktree } : {}),
-        };
-      }
-      retrievalTurns.add(retrievalKey);
-      while (retrievalTurns.size > retrievalTurnLimit) {
-        const oldest = retrievalTurns.values().next().value;
-        if (typeof oldest !== "string") break;
-        retrievalTurns.delete(oldest);
-      }
-      const pendingUserNotice = repositoryMemory.ok
-        ? await pendingQuotaNotice.claim(repositoryMemory.memory.config)
-        : undefined;
-      const retrieval = await retrieveAutomaticMemoryContext({
-        diagnosticLogger: options.diagnosticLogger,
-        claimQuotaNotice: options.claimQuotaNotice ?? claimQuotaNotice,
-        env: options.env ?? process.env,
-        fetchImpl: options.fetchImpl,
-        memoryObservability: options.memoryObservability,
-        memoryObservabilitySource: "opencode_plugin_retrieval",
-        query: command.prompt,
-        repositoryMemory,
-        sessionKey: command.sessionId,
-        traceContext,
-      });
-      const userNotice = [pendingUserNotice, retrieval.userNotice].filter(Boolean).join("\n");
-      return {
-        ok: true,
-        ...(repoMemoryWorktree ? { repoMemoryWorktree } : {}),
-        ...(retrieval.context ? { additionalContext: retrieval.context } : {}),
-        ...(userNotice ? { userNotice } : {}),
-      };
     },
     async writeback(command) {
       turnCoordinator.pruneExpired();
@@ -290,26 +161,19 @@ export function createOpenCodeMemoryHookRuntime(
           env: options.env,
         },
       ), options.diagnosticLogger);
-      const writeback = await turnCoordinator.completeMaterializedTurn({
-        key,
+      const writeback = await memory.completeTurn({
+        sessionId: command.sessionId,
+        clientTurnId: command.userMessageId,
         metadata: entry,
-        resolveRepositoryMemory: () => resolveCurrentHookRepositoryMemory(
-          entry,
-          command,
-          options,
-          repositoryMemorySession,
-        ),
+        resolveRepositoryMemory: () => memory.resolveRepositoryMemory({
+          sessionId: command.sessionId,
+          cwd: command.cwd ?? entry?.cwd,
+          workspaceKind: command.workspaceKind ?? entry?.workspaceKind,
+          requireBoundScope: true,
+        }),
         userText: materialized.turn.userPrompt,
         assistantText: materialized.turn.assistantReply,
-        writeback: {
-          client: OPENCODE_MEMORY_TURN_CLIENT,
-          sessionKey: command.sessionId,
-          env: options.env ?? process.env,
-          fetchImpl: options.fetchImpl,
-          memoryObservability: options.memoryObservability,
-          memoryObservabilitySource: "opencode_plugin_writeback",
-          traceContext,
-        },
+        traceContext,
       });
       if (!writeback.scheduled) {
         options.diagnosticLogger?.("opencode_memory.writeback", {
@@ -335,14 +199,10 @@ export function createOpenCodeMemoryHookRuntime(
       return { ok: true, scheduled: true };
     },
     size() {
-      return turnCoordinator.size(OPENCODE_MEMORY_TURN_CLIENT);
+      return memory.size();
     },
     close() {
-      retrievalTurns.clear();
-      if (ownsTurnCoordinator) turnCoordinator.close();
-      if (ownsRepositoryMemorySession) repositoryMemorySession.close();
-      automaticWritebackRuntime?.close?.();
-      if (ownsPendingQuotaNotice) pendingQuotaNotice.close();
+      memory.close();
     },
   };
 }
@@ -353,38 +213,6 @@ function openCodeTurnKey(sessionId: string, userMessageId: string) {
     sessionId,
     clientTurnId: userMessageId,
   } as const;
-}
-
-async function resolveHookRepositoryMemory(
-  command: OpenCodeTurnStartCommand,
-  options: OpenCodeMemoryHookRuntimeOptions,
-  repositoryMemorySession: RepositoryMemorySessionRuntime,
-): Promise<ConfiguredRepositoryMemoryResult> {
-  return await repositoryMemorySession.resolve({
-    client: OPENCODE_MEMORY_TURN_CLIENT,
-    sessionId: command.sessionId,
-    workspaceRoot: command.cwd,
-    workspaceKind: command.workspaceKind,
-    memoraxCodeHome: options.memoraxCodeHome ?? options.env?.MEMORAX_CODE_HOME,
-    env: options.env,
-  });
-}
-
-async function resolveCurrentHookRepositoryMemory(
-  entry: MemoryTurnState | undefined,
-  command: OpenCodeWritebackCommand,
-  options: OpenCodeMemoryHookRuntimeOptions,
-  repositoryMemorySession: RepositoryMemorySessionRuntime,
-): Promise<ConfiguredRepositoryMemoryResult> {
-  return await repositoryMemorySession.resolve({
-    client: OPENCODE_MEMORY_TURN_CLIENT,
-    sessionId: command.sessionId,
-    workspaceRoot: command.cwd ?? entry?.cwd,
-    workspaceKind: command.workspaceKind ?? entry?.workspaceKind,
-    requireBoundScope: true,
-    memoraxCodeHome: options.memoraxCodeHome ?? options.env?.MEMORAX_CODE_HOME,
-    env: options.env,
-  });
 }
 
 async function recordTraceBestEffort(
@@ -400,9 +228,4 @@ async function recordTraceBestEffort(
       error: error instanceof Error ? error.message : String(error),
     });
   }
-}
-
-function positiveInteger(value: unknown, fallback: number): number {
-  const parsed = Number(value);
-  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
 }

--- a/packages/ts/memorax-code-backend/src/clients/trae/memory-hook-runtime.ts
+++ b/packages/ts/memorax-code-backend/src/clients/trae/memory-hook-runtime.ts
@@ -1,41 +1,25 @@
+import type { AutomaticMemoryWritebackRejectionReason } from "../../memory/automatic-writeback.js";
 import {
-  createAutomaticMemoryWritebackRuntime,
-  type AutomaticMemoryWritebackEnqueue,
-  type AutomaticMemoryWritebackRejectionReason,
-  type AutomaticMemoryWritebackRuntime,
-} from "../../memory/automatic-writeback.js";
-import { retrieveAutomaticMemoryContext } from "../../memory/automatic-retrieval.js";
-import {
-  claimQuotaNotice,
-  createPendingQuotaNoticeRuntime,
-  type PendingQuotaNoticeRuntime,
-  type QuotaNoticeClaimer,
-} from "../../memory/quota-notice.js";
+  createHarnessMemoryRuntime,
+  type HarnessMemoryRuntimeOptions,
+} from "../../memory/harness-runtime.js";
 import type {
   MemoryHookTurnStartResult,
   TraeTurnStartCommand,
   TraeWritebackCommand,
 } from "../../memory/hook-command.js";
-import type { MemoryDiagnosticLogger, MemoryObservabilityHook } from "../../memory/observability.js";
-import {
-  createMemoryTurnCoordinator,
-  type MemoryTurnCoordinator,
-  type MemoryTurnState,
-  type MemoryTurnWritebackSkipReason,
+import type { MemoryDiagnosticLogger } from "../../memory/observability.js";
+import type {
+  MemoryTurnCoordinator,
+  MemoryTurnState,
+  MemoryTurnWritebackSkipReason,
 } from "../../memory/turn-coordinator.js";
-import {
-  createRepositoryMemorySessionRuntime,
-  resolvedRepoMemoryWorktree,
-  type ConfiguredRepositoryMemoryResult,
-  type RepositoryMemorySessionRuntime,
-} from "../../memory/repository-session.js";
 import type { RepositoryMemoryScopeFailureReason } from "../../repository/scope.js";
 import { traceContextFromTraeHookBody, type TraceContext } from "../../trace/context.js";
 import {
   markCurrentTraceTurnOutcome,
   recordTraceEvent,
   traceTurnEventId,
-  writeCurrentTraceTurn,
 } from "../../trace/store.js";
 
 export type TraeMemoryHookWritebackSkipReason =
@@ -50,22 +34,7 @@ export type TraeMemoryHookWritebackResult =
   | { ok: true; scheduled: true }
   | { ok: true; scheduled: false; reason: TraeMemoryHookWritebackSkipReason };
 
-export type TraeMemoryHookRuntimeOptions = {
-  automaticWriteback?: AutomaticMemoryWritebackEnqueue;
-  diagnosticLogger?: MemoryDiagnosticLogger;
-  env?: Record<string, string | undefined>;
-  fetchImpl?: typeof fetch;
-  claimQuotaNotice?: QuotaNoticeClaimer;
-  now?: () => number;
-  ttlMs?: number;
-  maxEntries?: number;
-  cleanupIntervalMs?: number;
-  memoryObservability?: MemoryObservabilityHook;
-  memoraxCodeHome?: string;
-  pendingQuotaNotice?: PendingQuotaNoticeRuntime;
-  repositoryMemorySession?: RepositoryMemorySessionRuntime;
-  turnCoordinator?: MemoryTurnCoordinator;
-};
+export type TraeMemoryHookRuntimeOptions = HarnessMemoryRuntimeOptions;
 
 export type TraeMemoryHookRuntime = {
   recordTurnStart(command: TraeTurnStartCommand): Promise<MemoryHookTurnStartResult>;
@@ -80,37 +49,16 @@ export function createTraeMemoryHookRuntime(
   options: TraeMemoryHookRuntimeOptions = {},
 ): TraeMemoryHookRuntime {
   const now = options.now ?? (() => Date.now());
-  const pendingQuotaNotice = options.pendingQuotaNotice ?? createPendingQuotaNoticeRuntime({
-    claimQuotaNotice: options.claimQuotaNotice,
-    diagnosticLogger: options.diagnosticLogger,
-    env: options.env,
-  });
-  const ownsPendingQuotaNotice = options.pendingQuotaNotice === undefined;
-  const automaticWritebackRuntime: {
-    enqueue: AutomaticMemoryWritebackEnqueue;
-    discardForScopeUpgrade?: AutomaticMemoryWritebackRuntime["discardForScopeUpgrade"];
-    close?: () => void;
-  } | undefined = options.turnCoordinator
-    ? undefined
-    : options.automaticWriteback
-      ? { enqueue: options.automaticWriteback }
-      : createAutomaticMemoryWritebackRuntime({
-        diagnosticLogger: options.diagnosticLogger,
-        queueQuotaNotice: pendingQuotaNotice.queue,
-      });
-  const turnCoordinator = options.turnCoordinator ?? createMemoryTurnCoordinator({
-    automaticWriteback: automaticWritebackRuntime!.enqueue,
-    now,
-    ttlMs: options.ttlMs,
-    maxEntries: options.maxEntries,
-    cleanupIntervalMs: options.cleanupIntervalMs,
-  });
-  const ownsTurnCoordinator = options.turnCoordinator === undefined;
-  const repositoryMemorySession = options.repositoryMemorySession ?? createRepositoryMemorySessionRuntime({
-    onScopeUpgrade: automaticWritebackRuntime?.discardForScopeUpgrade,
-  });
-  const ownsRepositoryMemorySession = options.repositoryMemorySession === undefined;
-  const retrievalTurns = new Set<string>();
+  const memory = createHarnessMemoryRuntime({
+    client: TRAE_MEMORY_TURN_CLIENT,
+    retrievalSource: "trae_hook_retrieval",
+    writebackSource: "trae_hook_writeback",
+    diagnosticPrefix: "trae_memory",
+    traceFailureEvent: "trae_trace.write_failed",
+    turnStartTraceSource: "trae-hook",
+    deduplicateRetrieval: true,
+  }, options);
+  const { turnCoordinator } = memory;
   const interruptedTurns = new Set<string>();
   const activeTurns = new Map<string, MemoryTurnState>();
   const turnStartOperations = new Map<string, Promise<MemoryHookTurnStartResult>>();
@@ -136,74 +84,24 @@ export function createTraeMemoryHookRuntime(
       }
       const createdAt = now();
       const traceContext = traceContextFromTraeHookBody(command, new Date(createdAt).toISOString());
-      const repositoryMemory = await resolveHookRepositoryMemory(command, options, repositoryMemorySession);
-      const repoMemoryWorktree = resolvedRepoMemoryWorktree(repositoryMemory);
-      const turn = turnCoordinator.recordTurnStart({
-        client: TRAE_MEMORY_TURN_CLIENT,
+      return await memory.recordTurnStart({
         sessionId: command.sessionId,
         clientTurnId: command.turnId,
         cwd: command.cwd,
         workspaceKind: command.workspaceKind,
         createdAt,
         traceContext,
-        repositoryMemory,
-      });
-      activeTurns.delete(command.sessionId);
-      activeTurns.set(command.sessionId, turn);
-      while (activeTurns.size > runtimeTurnLimit) {
-        const oldestSessionId = activeTurns.keys().next().value;
-        if (typeof oldestSessionId !== "string") break;
-        activeTurns.delete(oldestSessionId);
-      }
-      await recordTraceBestEffort("trae_memory.turn_start_event", recordTraceEvent({
-        eventId: traceTurnEventId(traceContext, "turn_start"),
-        memoraxCodeHome: options.memoraxCodeHome,
-        env: options.env,
-        traceContext,
-        type: "turn_start",
-        source: "trae-hook",
-        operation: "query",
-        ok: true,
-        request: { prompt: command.prompt, cwd: command.cwd },
-      }), options.diagnosticLogger);
-      await recordTraceBestEffort("trae_memory.current_turn_write", writeCurrentTraceTurn(
-        traceContext,
-        {
-          client: "trae",
-          memoraxCodeHome: options.memoraxCodeHome,
-          env: options.env,
-          now: () => new Date(now()),
+        prompt: command.prompt,
+        onTurnRegistered(turn) {
+          activeTurns.delete(command.sessionId);
+          activeTurns.set(command.sessionId, turn);
+          while (activeTurns.size > runtimeTurnLimit) {
+            const oldestSessionId = activeTurns.keys().next().value;
+            if (typeof oldestSessionId !== "string") break;
+            activeTurns.delete(oldestSessionId);
+          }
         },
-      ), options.diagnosticLogger);
-
-      const retrievalKey = JSON.stringify([command.sessionId, command.turnId]);
-      if (retrievalTurns.has(retrievalKey)) {
-        return { ok: true, ...(repoMemoryWorktree ? { repoMemoryWorktree } : {}) };
-      }
-      retrievalTurns.add(retrievalKey);
-      trimBounded(retrievalTurns, runtimeTurnLimit);
-      const pendingUserNotice = repositoryMemory.ok
-        ? await pendingQuotaNotice.claim(repositoryMemory.memory.config)
-        : undefined;
-      const retrieval = await retrieveAutomaticMemoryContext({
-        diagnosticLogger: options.diagnosticLogger,
-        claimQuotaNotice: options.claimQuotaNotice ?? claimQuotaNotice,
-        env: options.env ?? process.env,
-        fetchImpl: options.fetchImpl,
-        memoryObservability: options.memoryObservability,
-        memoryObservabilitySource: "trae_hook_retrieval",
-        query: command.prompt,
-        repositoryMemory,
-        sessionKey: command.sessionId,
-        traceContext,
       });
-      const userNotice = [pendingUserNotice, retrieval.userNotice].filter(Boolean).join("\n");
-      return {
-        ok: true,
-        ...(repoMemoryWorktree ? { repoMemoryWorktree } : {}),
-        ...(retrieval.context ? { additionalContext: retrieval.context } : {}),
-        ...(userNotice ? { userNotice } : {}),
-      };
     },
 
     async writeback(command) {
@@ -220,23 +118,16 @@ export function createTraeMemoryHookRuntime(
       const key = traeTurnKey(command.sessionId, command.turnId);
       const entry = turnCoordinator.getTurn(key) ?? activeTurn;
       const traceContext = entry?.traceContext ?? traceContextFromTraeHookBody(command);
-      const repositoryMemory = await resolveHookRepositoryMemory(command, options, repositoryMemorySession);
+      const repositoryMemory = await memory.resolveRepositoryMemory(command);
       await recordCompletedTurn(traceContext, command, options, now);
-      const completed = await turnCoordinator.completeMaterializedTurn({
-        key,
+      const completed = await memory.completeTurn({
+        sessionId: command.sessionId,
+        clientTurnId: command.turnId,
         metadata: entry,
         resolveRepositoryMemory: async () => repositoryMemory,
         userText: command.prompt,
         assistantText: command.lastAssistantMessage,
-        writeback: {
-          client: "trae",
-          sessionKey: command.sessionId,
-          env: options.env ?? process.env,
-          fetchImpl: options.fetchImpl,
-          memoryObservability: options.memoryObservability,
-          memoryObservabilitySource: "trae_hook_writeback",
-          traceContext,
-        },
+        traceContext,
       });
       await recordMaterializedTurn(traceContext, command, options);
       if (activeTurn?.clientTurnId === command.turnId) activeTurns.delete(command.sessionId);
@@ -253,18 +144,14 @@ export function createTraeMemoryHookRuntime(
     },
 
     size() {
-      return turnCoordinator.size(TRAE_MEMORY_TURN_CLIENT);
+      return memory.size();
     },
 
     close() {
-      retrievalTurns.clear();
       interruptedTurns.clear();
       activeTurns.clear();
       turnStartOperations.clear();
-      if (ownsTurnCoordinator) turnCoordinator.close();
-      if (ownsRepositoryMemorySession) repositoryMemorySession.close();
-      automaticWritebackRuntime?.close?.();
-      if (ownsPendingQuotaNotice) pendingQuotaNotice.close();
+      memory.close();
     },
   };
 
@@ -357,21 +244,6 @@ async function recordMaterializedTurn(
     request: { prompt: command.prompt },
     response: { assistant: command.lastAssistantMessage },
   }), options.diagnosticLogger);
-}
-
-async function resolveHookRepositoryMemory(
-  command: TraeTurnStartCommand | TraeWritebackCommand,
-  options: TraeMemoryHookRuntimeOptions,
-  repository: RepositoryMemorySessionRuntime,
-): Promise<ConfiguredRepositoryMemoryResult> {
-  return await repository.resolve({
-    client: "trae",
-    sessionId: command.sessionId,
-    workspaceRoot: command.cwd,
-    workspaceKind: command.workspaceKind,
-    memoraxCodeHome: options.memoraxCodeHome ?? options.env?.MEMORAX_CODE_HOME,
-    env: options.env,
-  });
 }
 
 function traeTurnKey(sessionId: string, turnId: string): {

--- a/packages/ts/memorax-code-backend/src/memory/harness-runtime.ts
+++ b/packages/ts/memorax-code-backend/src/memory/harness-runtime.ts
@@ -1,0 +1,289 @@
+import { retrieveAutomaticMemoryContext } from "./automatic-retrieval.js";
+import {
+  createAutomaticMemoryWritebackRuntime,
+  type AutomaticMemoryWritebackEnqueue,
+  type AutomaticMemoryWritebackRuntime,
+} from "./automatic-writeback.js";
+import type { MemoryHookTurnStartResult } from "./hook-command.js";
+import type {
+  MemoryDiagnosticLogger,
+  MemoryObservabilityHook,
+  MemoryObservabilitySource,
+} from "./observability.js";
+import {
+  claimQuotaNotice,
+  createPendingQuotaNoticeRuntime,
+  type PendingQuotaNoticeRuntime,
+  type QuotaNoticeClaimer,
+} from "./quota-notice.js";
+import {
+  createRepositoryMemorySessionRuntime,
+  resolvedRepoMemoryWorktree,
+  type ConfiguredRepositoryMemoryResult,
+  type RepositoryMemorySessionRuntime,
+} from "./repository-session.js";
+import {
+  createMemoryTurnCoordinator,
+  type MemoryTurnClient,
+  type MemoryTurnCoordinator,
+  type MemoryTurnStart,
+  type MemoryTurnState,
+  type MemoryTurnWritebackResult,
+} from "./turn-coordinator.js";
+import type { TraceContext } from "../trace/context.js";
+import { recordTraceEvent, traceTurnEventId, writeCurrentTraceTurn } from "../trace/store.js";
+
+export type HarnessMemoryRuntimeOptions = {
+  automaticWriteback?: AutomaticMemoryWritebackEnqueue;
+  diagnosticLogger?: MemoryDiagnosticLogger;
+  env?: Record<string, string | undefined>;
+  fetchImpl?: typeof fetch;
+  claimQuotaNotice?: QuotaNoticeClaimer;
+  now?: () => number;
+  ttlMs?: number;
+  maxEntries?: number;
+  cleanupIntervalMs?: number;
+  memoryObservability?: MemoryObservabilityHook;
+  memoraxCodeHome?: string;
+  pendingQuotaNotice?: PendingQuotaNoticeRuntime;
+  repositoryMemorySession?: RepositoryMemorySessionRuntime;
+  turnCoordinator?: MemoryTurnCoordinator;
+};
+
+export type HarnessMemoryDefinition = Readonly<{
+  client: MemoryTurnClient;
+  retrievalSource: MemoryObservabilitySource;
+  writebackSource: MemoryObservabilitySource;
+  diagnosticPrefix: string;
+  traceFailureEvent: string;
+  turnStartTraceSource?: string;
+  deduplicateRetrieval: boolean;
+  quotaNotices?: boolean;
+}>;
+
+export type HarnessTurnStart = Omit<MemoryTurnStart, "client" | "clientTurnId" | "repositoryMemory"> & Readonly<{
+  // Uncorrelated start observations may update trace, but cannot register a
+  // writable Turn or trigger retrieval.
+  clientTurnId?: string;
+  prompt: string;
+  repositoryMemory?: ConfiguredRepositoryMemoryResult;
+  retrievalTraceContext?: TraceContext;
+  // Native event boundaries may distinguish retrieval attempts within one Turn.
+  retrievalKeySuffix?: string;
+  // Replaces the default request when live prompt text is not trace authority.
+  traceRequest?: Record<string, unknown>;
+  diagnosticFields?: Record<string, unknown>;
+  // Publish the registered state synchronously, before trace or retrieval can
+  // yield to a concurrent completion.
+  onTurnRegistered?: (turn: MemoryTurnState) => void;
+}>;
+
+// Only client-specific materializers may supply completion content. A terminal
+// Hook signal or a trace record alone does not establish this input.
+export type HarnessTurnCompletion = Readonly<{
+  sessionId: string;
+  clientTurnId: string;
+  metadata?: MemoryTurnState;
+  userText: string;
+  assistantText: string;
+  traceContext?: TraceContext;
+  resolveRepositoryMemory: () => Promise<ConfiguredRepositoryMemoryResult>;
+}>;
+
+export type HarnessMemoryRuntime = ReturnType<typeof createHarnessMemoryRuntime>;
+
+export function createHarnessMemoryRuntime(
+  definition: HarnessMemoryDefinition,
+  options: HarnessMemoryRuntimeOptions = {},
+) {
+  const now = options.now ?? (() => Date.now());
+  const pendingQuotaNotice = definition.quotaNotices === false ? undefined : options.pendingQuotaNotice ?? createPendingQuotaNoticeRuntime({
+    claimQuotaNotice: options.claimQuotaNotice,
+    diagnosticLogger: options.diagnosticLogger,
+    env: options.env,
+  });
+  const automaticWriteback: {
+    enqueue: AutomaticMemoryWritebackEnqueue;
+    discardForScopeUpgrade?: AutomaticMemoryWritebackRuntime["discardForScopeUpgrade"];
+    close?: () => void;
+  } | undefined = options.turnCoordinator
+    ? undefined
+    : options.automaticWriteback
+      ? { enqueue: options.automaticWriteback }
+      : createAutomaticMemoryWritebackRuntime({
+        diagnosticLogger: options.diagnosticLogger,
+        queueQuotaNotice: pendingQuotaNotice?.queue,
+      });
+  const turnCoordinator = options.turnCoordinator ?? createMemoryTurnCoordinator({
+    automaticWriteback: automaticWriteback!.enqueue,
+    now,
+    ttlMs: options.ttlMs,
+    maxEntries: options.maxEntries,
+    cleanupIntervalMs: options.cleanupIntervalMs,
+  });
+  const repositoryMemorySession = options.repositoryMemorySession ?? createRepositoryMemorySessionRuntime({
+    onScopeUpgrade: automaticWriteback?.discardForScopeUpgrade,
+  });
+  const retrievalTurns = new Set<string>();
+  const retrievalTurnLimit = positiveInteger(options.maxEntries, 256);
+
+  function resolveRepositoryMemory(input: { sessionId: string; cwd?: string; workspaceKind?: string; requireBoundScope?: boolean }) {
+    return repositoryMemorySession.resolve({
+      client: definition.client,
+      sessionId: input.sessionId,
+      workspaceRoot: input.cwd,
+      workspaceKind: input.workspaceKind,
+      requireBoundScope: input.requireBoundScope,
+      memoraxCodeHome: options.memoraxCodeHome ?? options.env?.MEMORAX_CODE_HOME,
+      env: options.env,
+    });
+  }
+
+  async function recordTraceBestEffort(label: string, operation: Promise<unknown>) {
+    try {
+      await operation;
+    } catch (error) {
+      options.diagnosticLogger?.(definition.traceFailureEvent, {
+        label: `${definition.diagnosticPrefix}.${label}`,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  return {
+    turnCoordinator,
+    resolveRepositoryMemory,
+    async recordTurnStart(input: HarnessTurnStart): Promise<MemoryHookTurnStartResult> {
+      validateTraceIdentity(definition.client, input, input.traceContext);
+      validateTraceIdentity(definition.client, input, input.retrievalTraceContext);
+      const {
+        prompt, retrievalTraceContext, retrievalKeySuffix, traceRequest,
+        diagnosticFields, onTurnRegistered, repositoryMemory: resolvedMemory, ...turn
+      } = input;
+      const repositoryMemory = resolvedMemory ?? await resolveRepositoryMemory(input);
+      if (turn.clientTurnId) {
+        const state = turnCoordinator.recordTurnStart({ ...turn, client: definition.client, clientTurnId: turn.clientTurnId, repositoryMemory });
+        onTurnRegistered?.(state);
+      }
+      if (diagnosticFields) {
+        options.diagnosticLogger?.(`${definition.diagnosticPrefix}.turn_start`, {
+          ...diagnosticFields,
+          cacheSize: turnCoordinator.size(definition.client),
+          workspace: repositoryMemory.ok ? repositoryMemory.memory.scope?.repositorySlug : undefined,
+          workspaceScopeReason: repositoryMemory.ok ? undefined : repositoryMemory.reason,
+        });
+      }
+      await recordTraceBestEffort("turn_start_event", recordTraceEvent({
+        eventId: traceTurnEventId(turn.traceContext, "turn_start"),
+        memoraxCodeHome: options.memoraxCodeHome,
+        env: options.env,
+        traceContext: turn.traceContext,
+        type: "turn_start",
+        source: definition.turnStartTraceSource ?? "unknown",
+        operation: "query",
+        ok: true,
+        sessionTurnIndex: turn.sessionTurnIndex,
+        request: traceRequest ?? { prompt, cwd: turn.cwd, transcriptPath: turn.transcriptPath },
+      }));
+      await recordTraceBestEffort("current_turn_write", writeCurrentTraceTurn(turn.traceContext, {
+        memoraxCodeHome: options.memoraxCodeHome,
+        env: options.env,
+        now: () => new Date(now()),
+      }));
+      const repoMemoryWorktree = resolvedRepoMemoryWorktree(repositoryMemory);
+      if (!turn.clientTurnId || (definition.deduplicateRetrieval && !claimRetrievalTurn(retrievalTurns, retrievalTurnLimit, {
+        sessionId: turn.sessionId,
+        clientTurnId: turn.clientTurnId,
+      }, retrievalKeySuffix))) {
+        return { ok: true, ...(repoMemoryWorktree ? { repoMemoryWorktree } : {}) };
+      }
+      const pendingUserNotice = repositoryMemory.ok
+        ? await pendingQuotaNotice?.claim(repositoryMemory.memory.config)
+        : undefined;
+      const retrieval = await retrieveAutomaticMemoryContext({
+        diagnosticLogger: options.diagnosticLogger,
+        claimQuotaNotice: definition.quotaNotices === false ? undefined : options.claimQuotaNotice ?? claimQuotaNotice,
+        env: options.env ?? process.env,
+        fetchImpl: options.fetchImpl,
+        memoryObservability: options.memoryObservability,
+        memoryObservabilitySource: definition.retrievalSource,
+        query: prompt,
+        repositoryMemory,
+        sessionKey: turn.sessionId,
+        traceContext: retrievalTraceContext ?? turn.traceContext,
+      });
+      const userNotice = [pendingUserNotice, retrieval.userNotice].filter(Boolean).join("\n");
+      return {
+        ok: true,
+        ...(repoMemoryWorktree ? { repoMemoryWorktree } : {}),
+        ...(retrieval.context ? { additionalContext: retrieval.context } : {}),
+        ...(userNotice ? { userNotice } : {}),
+      };
+    },
+    async completeTurn(input: HarnessTurnCompletion): Promise<MemoryTurnWritebackResult> {
+      validateTraceIdentity(definition.client, input, input.traceContext);
+      return turnCoordinator.completeMaterializedTurn({
+        key: { client: definition.client, sessionId: input.sessionId, clientTurnId: input.clientTurnId },
+        metadata: input.metadata,
+        resolveRepositoryMemory: input.resolveRepositoryMemory,
+        userText: input.userText,
+        assistantText: input.assistantText,
+        writeback: {
+          client: definition.client,
+          sessionKey: input.sessionId,
+          env: options.env ?? process.env,
+          fetchImpl: options.fetchImpl,
+          memoryObservability: options.memoryObservability,
+          memoryObservabilitySource: definition.writebackSource,
+          traceContext: input.traceContext,
+        },
+      });
+    },
+    size() {
+      return turnCoordinator.size(definition.client);
+    },
+    close() {
+      retrievalTurns.clear();
+      if (!options.turnCoordinator) turnCoordinator.close();
+      if (!options.repositoryMemorySession) repositoryMemorySession.close();
+      automaticWriteback?.close?.();
+      if (!options.pendingQuotaNotice) pendingQuotaNotice?.close();
+    },
+  };
+}
+
+function validateTraceIdentity(
+  client: MemoryTurnClient,
+  turn: Pick<HarnessTurnStart, "sessionId" | "clientTurnId">,
+  context: TraceContext | undefined,
+): void {
+  if (!context) return;
+  const traceClient = client === "claude-code" ? "claude" : client;
+  if (
+    context.client !== traceClient
+    || context.sessionId !== turn.sessionId
+    || (context.turnId !== undefined && context.turnId !== turn.clientTurnId)
+  ) throw new Error("harness trace identity mismatch");
+}
+
+function claimRetrievalTurn(
+  turns: Set<string>,
+  limit: number,
+  turn: Pick<MemoryTurnStart, "sessionId" | "clientTurnId">,
+  suffix?: string,
+): boolean {
+  const key = JSON.stringify([turn.sessionId, turn.clientTurnId, suffix]);
+  if (turns.has(key)) return false;
+  turns.add(key);
+  while (turns.size > limit) {
+    const oldest = turns.values().next().value;
+    if (typeof oldest !== "string") break;
+    turns.delete(oldest);
+  }
+  return true;
+}
+
+function positiveInteger(value: unknown, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}

--- a/packages/ts/memorax-code-backend/test/architecture/source-boundaries.test.mjs
+++ b/packages/ts/memorax-code-backend/test/architecture/source-boundaries.test.mjs
@@ -44,6 +44,7 @@ const rules = [
     importers: [
       "memory/automatic-retrieval.ts",
       "memory/automatic-writeback.ts",
+      "memory/harness-runtime.ts",
       "clients/claude/memory-hook-runtime.ts",
       "clients/claude/transcript-turn.ts",
       "clients/codex/memory-hook-runtime.ts",
@@ -66,10 +67,27 @@ const rules = [
     forbidden: ["node:http", "server-", "entrypoints/", "transport/http/", "app/state"],
   },
   {
+    name: "shared harness memory runtime stays independent from native clients, HTTP, composition, and provider transport",
+    importers: ["memory/harness-runtime.ts"],
+    forbidden: [
+      "clients/",
+      "node:http",
+      "node:https",
+      "server-",
+      "entrypoints/",
+      "transport/http/",
+      "app/",
+      "lifecycle/",
+      "provider/memorax/adapter",
+      "provider/memorax/http",
+    ],
+  },
+  {
     name: "memory service kernel receives Backend diagnostics through a port",
     importers: [
       "memory/automatic-retrieval.ts",
       "memory/automatic-writeback.ts",
+      "memory/harness-runtime.ts",
       "clients/claude/memory-hook-runtime.ts",
       "clients/codex/memory-hook-runtime.ts",
       "clients/dsh/memory-hook-runtime.ts",

--- a/packages/ts/memorax-code-backend/test/clients/codex/codex-memory-hook-runtime.test.mjs
+++ b/packages/ts/memorax-code-backend/test/clients/codex/codex-memory-hook-runtime.test.mjs
@@ -106,6 +106,47 @@ test("Codex Hook retrieves automatic memory once per exact turn", async () => {
   }
 });
 
+test("memory hook preserves registered workspace failures instead of rebinding to Hook cwd", async () => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-code-hook-registered-scope-"));
+  const registered = join(root, "registered");
+  const registryDir = join(root, "adapters", "codex");
+  const sessionId = "session-registered-scope";
+  await mkdir(registered);
+  await mkdir(registryDir, { recursive: true });
+  await writeFile(join(registered, ".git"), "invalid Git pointer\n");
+  await writeFile(join(registryDir, "workspaces.json"), JSON.stringify({ sessions: { [sessionId]: { cwd: registered } } }));
+  const transcriptPath = await writeRollout(root, sessionId, [
+    { turnId: "invalid-registry", prompt: "Keep the registered scope failure.", reply: "No fallback to Hook cwd." },
+    { turnId: "conflicting-registry", prompt: "Check both workspace authorities.", reply: "No cross-workspace binding." },
+  ]);
+  const requests = [];
+  const controller = createCodexMemoryHookRuntime({
+    memoraxCodeHome: root,
+    env: { ...WRITEBACK_ENV, MEMORAX_CODE_HOME: root, MEMORAX_CODE_MEMORY_RETRIEVAL_ENABLED: "true" },
+    automaticWriteback: (input) => { requests.push(input); return { accepted: true }; },
+    fetchImpl: async (input) => { requests.push(input); throw new Error("unexpected retrieval"); },
+  });
+  try {
+    for (const [turnId, reason] of [
+      ["invalid-registry", "workspace_scope_unavailable"],
+      ["conflicting-registry", "workspace_scope_mismatch"],
+    ]) {
+      assert.deepEqual(await controller.recordTurnStart({
+        sessionId, turnId, prompt: "Preserve native workspace authority.", cwd: TEST_WORKSPACE, transcriptPath,
+      }), { ok: true });
+      assert.deepEqual(await controller.writeback({
+        sessionId, turnId, lastAssistantMessage: "Completed.", cwd: TEST_WORKSPACE, transcriptPath,
+      }), { ok: true, scheduled: false, reason });
+      if (turnId === "invalid-registry") await rm(join(registered, ".git"));
+    }
+    assert.equal(controller.size(), 2);
+    assert.deepEqual(requests, []);
+  } finally {
+    controller.close();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("memory hook writeback accepts repeated authority metadata in the exact Codex rollout turn", async () => {
   const root = await mkdtemp(join(tmpdir(), "memorax-code-hook-rollout-source-"));
   const workspace = join(root, "memorax-code");

--- a/packages/ts/memorax-code-backend/test/clients/codex/codex-memory-hook-trace.test.mjs
+++ b/packages/ts/memorax-code-backend/test/clients/codex/codex-memory-hook-trace.test.mjs
@@ -27,6 +27,39 @@ const WRITEBACK_ENV = {
   MEMORAX_CODE_MEMORAX_USER_ID: "user-1",
 };
 
+test("memory hook observes a Codex start without turn identity without consuming quota or retrieving", async () => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-code-hook-uncorrelated-start-"));
+  const calls = [];
+  const controller = createCodexMemoryHookRuntime({
+    memoraxCodeHome: root,
+    env: { ...WRITEBACK_ENV, MEMORAX_CODE_HOME: root, MEMORAX_CODE_MEMORY_RETRIEVAL_ENABLED: "true" },
+    automaticWriteback: () => { calls.push("writeback"); return { accepted: true }; },
+    pendingQuotaNotice: { claim: async () => { calls.push("quota"); }, queue() {}, close() {} },
+    fetchImpl: async () => { calls.push("search"); throw new Error("unexpected retrieval"); },
+  });
+  const sessionId = "session-without-turn-id";
+  try {
+    assert.deepEqual(await controller.recordTurnStart({
+      sessionId,
+      prompt: "Observe this start without guessing its turn.",
+      cwd: TEST_WORKSPACE,
+      transcriptPath: join(root, "rollout.jsonl"),
+    }), GIT_TURN_START_RESULT);
+    assert.equal(controller.size(), 0);
+    assert.deepEqual(calls, []);
+    const events = (await readFile(tracePaths(root).eventsJsonl(sessionId), "utf8"))
+      .trim().split("\n").map((line) => JSON.parse(line));
+    assert.equal(events.length, 1);
+    assert.equal(events[0].type, "turn_start");
+    assert.equal(events[0].trace.session_id, sessionId);
+    assert.equal(events[0].trace.turn_id, undefined);
+    assert.equal(events[0].request.prompt, "Observe this start without guessing its turn.");
+  } finally {
+    controller.close();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("memory hook turn-start trace failures do not create unhandled rejections", async () => {
   const root = await mkdtemp(join(tmpdir(), "memorax-code-hook-trace-unhandled-"));
   const blocker = join(root, "debug");

--- a/packages/ts/memorax-code-backend/test/clients/dsh/dsh-memory-hook.test.mjs
+++ b/packages/ts/memorax-code-backend/test/clients/dsh/dsh-memory-hook.test.mjs
@@ -5,6 +5,10 @@ import { join, resolve } from "node:path";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
 import { createBackendState } from "../../../dist/app/state.js";
+import { createDshMemoryHookRuntime } from "../../../dist/clients/dsh/memory-hook-runtime.js";
+import { createRepositoryMemorySessionRuntime } from "../../../dist/memory/repository-session.js";
+import { createMemoryService } from "../../../dist/memory/service.js";
+import { createMemoryTurnCoordinator } from "../../../dist/memory/turn-coordinator.js";
 import { createBackendServer } from "../../../dist/server.js";
 import { listen } from "../../support/helpers.mjs";
 import { createHttpBackendClient } from "../../../../memorax-code-dsh-adapter/src/http-client.mjs";
@@ -18,6 +22,161 @@ import { dshTurnInterval } from "./support/dsh-session-fixtures.mjs";
 
 const TEST_WORKSPACE = fileURLToPath(new URL("../../..", import.meta.url));
 const TEST_REPO_ROOT = resolve(TEST_WORKSPACE, "../../..");
+
+test("DSH retrieval deduplicates exact event starts without changing the native Turn identity", async () => {
+  const sessionHome = await mkdtemp(join(tmpdir(), "memorax-code-dsh-retrieval-identity-"));
+  const repositoryMemorySession = createRepositoryMemorySessionRuntime();
+  const turnCoordinator = createMemoryTurnCoordinator({
+    automaticWriteback: () => ({ accepted: true }),
+  });
+  const pendingQuotaCalls = [];
+  let searchCalls = 0;
+  const runtime = createDshMemoryHookRuntime({
+    memoraxCodeHome: sessionHome,
+    repositoryMemorySession,
+    turnCoordinator,
+    pendingQuotaNotice: {
+      queue() {},
+      async claim() {
+        pendingQuotaCalls.push("claim");
+        return "Pending write quota notice.";
+      },
+      close() { pendingQuotaCalls.push("close"); },
+    },
+    env: {
+      MEMORAX_CODE_HOME: sessionHome,
+      MEMORAX_CODE_DSH_TRACE_ENABLED: "false",
+      MEMORAX_CODE_MEMORY_RETRIEVAL_ENABLED: "true",
+      MEMORAX_CODE_MEMORAX_ENDPOINT: "http://memorax.test",
+      MEMORAX_CODE_MEMORAX_API_KEY: "secret",
+      MEMORAX_CODE_MEMORAX_USER_ID: "user-1",
+    },
+    fetchImpl: async () => {
+      searchCalls += 1;
+      return new Response(JSON.stringify({
+        success: true,
+        data: {
+          task_id: "dsh-search",
+          status: "completed",
+          data: [{ id: "memory-1", memory: "Use exact DSH event starts.", score: 0.95 }],
+        },
+      }), { headers: { "content-type": "application/json" } });
+    },
+  });
+  const command = {
+    version: 1,
+    client: "dsh",
+    sessionId: "dsh-retrieval-session",
+    turn: 3,
+    startSeq: 40,
+    cwd: TEST_WORKSPACE,
+    prompt: "Implement the DSH adapter.",
+  };
+  const key = { client: "dsh", sessionId: command.sessionId, clientTurnId: String(command.turn) };
+  try {
+    assert.match((await runtime.recordTurnStart(command)).additionalContext, /exact DSH event starts/);
+    assert.equal(searchCalls, 1);
+    assert.equal(turnCoordinator.getTurn(key).eventStartSeq, 40);
+    assert.deepEqual(await runtime.recordTurnStart(command), { ok: true, repoMemoryWorktree: TEST_REPO_ROOT });
+    assert.equal(searchCalls, 1);
+
+    assert.match((await runtime.recordTurnStart({ ...command, startSeq: 41 })).additionalContext, /exact DSH event starts/);
+    assert.equal(searchCalls, 2);
+    assert.equal(turnCoordinator.size("dsh"), 1);
+    assert.equal(turnCoordinator.getTurn(key).clientTurnId, "3");
+    assert.equal(turnCoordinator.getTurn(key).eventStartSeq, 41);
+    assert.deepEqual(pendingQuotaCalls, []);
+  } finally {
+    runtime.close();
+    turnCoordinator.close();
+    repositoryMemorySession.close();
+    await rm(sessionHome, { recursive: true, force: true });
+    assert.deepEqual(pendingQuotaCalls, []);
+  }
+});
+
+test("DSH leaves pending write and retrieval quota notices unclaimed for other clients", async () => {
+  const sessionHome = await mkdtemp(join(tmpdir(), "memorax-code-dsh-quota-"));
+  const claimed = [];
+  const interval = dshTurnInterval({ sessionId: "dsh-quota-session", cwd: TEST_WORKSPACE });
+  const service = createMemoryService({
+    memoraxCodeHome: sessionHome,
+    env: {
+      MEMORAX_CODE_HOME: sessionHome,
+      MEMORAX_CODE_DSH_TRACE_ENABLED: "false",
+      MEMORAX_CODE_CLAUDE_TRACE_ENABLED: "false",
+      MEMORAX_CODE_MEMORY_RETRIEVAL_ENABLED: "true",
+      MEMORAX_CODE_MEMORY_WRITEBACK_ENABLED: "true",
+      MEMORAX_CODE_MEMORY_WRITEBACK_BUFFER_ENABLED: "false",
+      MEMORAX_CODE_MEMORAX_ENDPOINT: "http://memorax.test",
+      MEMORAX_CODE_MEMORAX_API_KEY: "secret",
+      MEMORAX_CODE_MEMORAX_USER_ID: "user-1",
+    },
+    claimQuotaNotice: async (_config, quota) => {
+      claimed.push(quota.featureCode);
+      return `${quota.featureCode}: ${quota.remaining}`;
+    },
+    fetchImpl: async (url) => {
+      const searching = String(url).endsWith("/v1/memories/search");
+      return new Response(JSON.stringify({
+        success: true,
+        data: {
+          task_id: searching ? "dsh-search" : "dsh-add",
+          status: searching ? "completed" : "queued",
+          ...(searching ? {
+            data: [{ id: "memory-1", memory: "Use the shared memory runtime.", score: 0.95 }],
+          } : {}),
+          balances: [{
+            product_code: "memory_api",
+            feature_code: searching ? "memory_search" : "memory_write",
+            spec_key: "calls",
+            quota_unit: "times",
+            remaining: searching ? 10 : 9,
+            quota_limit: 100,
+          }],
+        },
+      }), { headers: { "content-type": "application/json" } });
+    },
+  });
+  const command = {
+    version: 1,
+    client: "dsh",
+    sessionId: interval.sessionId,
+    turn: interval.turn,
+    startSeq: interval.startSeq,
+    cwd: TEST_WORKSPACE,
+    prompt: "Implement the DSH adapter.",
+  };
+  try {
+    const first = await service.recordTurnStart(command);
+    assert.match(first.additionalContext, /shared memory runtime/);
+    assert.equal(first.userNotice, undefined);
+    assert.deepEqual(claimed, []);
+    assert.deepEqual(await service.writebackTurn({ version: 1, client: "dsh", ...interval }), { ok: true, scheduled: true });
+    await service.drain();
+
+    const next = await service.recordTurnStart({ ...command, turn: 2, startSeq: interval.endSeq + 1 });
+    assert.match(next.additionalContext, /shared memory runtime/);
+    assert.equal(next.userNotice, undefined);
+    assert.deepEqual(claimed, []);
+
+    const otherClient = await service.recordTurnStart({
+      version: 1,
+      client: "claude-code",
+      sessionId: "claude-quota-session",
+      promptId: "claude-quota-prompt",
+      transcriptPath: join(sessionHome, "claude-transcript.jsonl"),
+      cwd: TEST_WORKSPACE,
+      prompt: "Check the shared memory runtime.",
+    });
+    assert.equal(otherClient.userNotice, "memory_write: 9\nmemory_search: 10");
+    assert.deepEqual(claimed, ["memory_write", "memory_search"]);
+  } finally {
+    await service.drain();
+    service.close();
+    await rm(sessionHome, { recursive: true, force: true });
+  }
+});
 
 test("Backend runs DSH Search, normalized Trace, and Add from one native Turn interval", async () => {
   const sessionHome = await mkdtemp(join(tmpdir(), "memorax-code-dsh-hook-"));
@@ -167,6 +326,8 @@ test("Backend runs DSH Search, normalized Trace, and Add from one native Turn in
     assert.equal(traceEvents.every((event) => event.trace.client === "dsh"), true);
     assert.equal(traceEvents.every((event) => event.trace.turn_id === String(interval.turn)), true);
     assert.equal(traceEvents[0].trace.context_origin, "dsh-cordis-turn-start");
+    assert.equal(traceEvents[0].source, "dsh-cordis");
+    assert.deepEqual(traceEvents[0].request, { start_seq: interval.startSeq });
     assert.equal(traceEvents[1].source, "dsh_native_retrieval");
     assert.equal(traceEvents[1].trace.context_origin, "dsh-cordis-turn-start");
     assert.equal(traceEvents[3].trace.context_origin, "dsh-session-event-log");
@@ -370,6 +531,8 @@ test("Backend closes an interrupted DSH Trace without requiring Turn content or 
     const traceText = await readFile(traceEventsPath, "utf8");
     const traceEvents = traceText.trim().split("\n").map((line) => JSON.parse(line));
     assert.deepEqual(traceEvents.map((event) => event.type), ["turn_start", "turn_end"]);
+    assert.equal(traceEvents[0].source, "dsh-cordis");
+    assert.deepEqual(traceEvents[0].request, { start_seq: interval.startSeq });
     assert.equal(traceEvents[1].outcome, "interrupted");
     assert.equal(traceEvents[1].request.native_outcome, "interrupted");
     assert.equal(traceEvents[1].trace.context_origin, "dsh-session-event-log");

--- a/packages/ts/memorax-code-backend/test/clients/opencode/opencode-memory-hook.test.mjs
+++ b/packages/ts/memorax-code-backend/test/clients/opencode/opencode-memory-hook.test.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 import { createOpenCodeMemoryHookRuntime } from "../../../dist/clients/opencode/memory-hook-runtime.js";
 import { openCodeMessageTurn } from "../../../dist/clients/opencode/message-turn.js";
 import { openCodeTracePaths } from "../../../dist/trace/config.js";
+import { createMemoryTurnCoordinator } from "../../../dist/memory/turn-coordinator.js";
 import {
   parseTurnStartCommand,
   parseWritebackCommand,
@@ -244,6 +245,8 @@ test("OpenCode finalizes an explicit MessageAbortedError without writeback", asy
       { type: "turn_start", outcome: undefined },
       { type: "turn_end", outcome: "interrupted" },
     ]);
+    assert.deepEqual(events.map(({ source }) => source), ["opencode-plugin", "opencode-plugin"]);
+    assert.deepEqual(events.map(({ trace }) => trace.client), ["opencode", "opencode"]);
     assert.equal(JSON.parse(await readFile(paths.currentTurnPath, "utf8")).turn_state, "interrupted");
   } finally {
     runtime.close();
@@ -333,6 +336,17 @@ test("OpenCode runtime reuses retrieval, scope, writeback, and quota notices", a
       { role: "assistant", content: "OpenCode assistant reply." },
     ]);
 
+    assert.deepEqual(await runtime.recordTurnStart({
+      version: 1,
+      client: "opencode",
+      sessionId: "session-1",
+      userMessageId: "user-1",
+      prompt: "OpenCode user prompt.",
+      cwd: TEST_WORKSPACE,
+      workspaceKind: "project",
+    }), { ok: true, repoMemoryWorktree: start.repoMemoryWorktree });
+    assert.equal(searchCalls, 1);
+
     const next = await runtime.recordTurnStart({
       version: 1,
       client: "opencode",
@@ -346,6 +360,71 @@ test("OpenCode runtime reuses retrieval, scope, writeback, and quota notices", a
     assert.doesNotMatch(next.additionalContext, /memory_write/);
   } finally {
     runtime.close();
+    await rm(memoraxCodeHome, { recursive: true, force: true });
+  }
+});
+
+test("OpenCode SDK completion requires a prior scope binding but not unexpired turn metadata", async () => {
+  const memoraxCodeHome = await mkdtemp(join(tmpdir(), "memorax-code-opencode-bound-scope-"));
+  const writebacks = [];
+  let now = Date.now();
+  const turnCoordinator = createMemoryTurnCoordinator({
+    now: () => now,
+    ttlMs: 1,
+    automaticWriteback: (input) => { writebacks.push(input); return { accepted: true }; },
+  });
+  const runtime = createOpenCodeMemoryHookRuntime({
+    memoraxCodeHome,
+    now: () => now,
+    turnCoordinator,
+    env: {
+      MEMORAX_CODE_HOME: memoraxCodeHome,
+      MEMORAX_CODE_OPENCODE_TRACE_ENABLED: "false",
+      MEMORAX_CODE_MEMORY_RETRIEVAL_ENABLED: "false",
+      MEMORAX_CODE_MEMORAX_ENDPOINT: "http://memorax.test",
+      MEMORAX_CODE_MEMORAX_API_KEY: "secret",
+      MEMORAX_CODE_MEMORAX_USER_ID: "user-1",
+    },
+  });
+  const command = {
+    version: 1,
+    client: "opencode",
+    sessionId: "session-1",
+    userMessageId: "user-1",
+    assistantMessageId: "assistant-final",
+    messages: compactedOpenCodeMessages(),
+    cwd: TEST_WORKSPACE,
+    workspaceKind: "project",
+  };
+  try {
+    assert.deepEqual(await runtime.writeback(command), {
+      ok: true, scheduled: false, reason: "workspace_scope_unavailable",
+    });
+    assert.deepEqual(writebacks, []);
+    await runtime.recordTurnStart({
+      version: 1,
+      client: "opencode",
+      sessionId: command.sessionId,
+      userMessageId: command.userMessageId,
+      prompt: "The Hook prompt is not writeback content authority.",
+      cwd: TEST_WORKSPACE,
+      workspaceKind: "project",
+    });
+    assert.equal(runtime.size(), 1);
+    now += 10;
+    turnCoordinator.pruneExpired();
+    assert.equal(runtime.size(), 0);
+    assert.deepEqual(await runtime.writeback(command), { ok: true, scheduled: true });
+    assert.equal(runtime.size(), 0);
+    assert.equal(writebacks.length, 1);
+    assert.equal(writebacks[0].client, "opencode");
+    assert.equal(writebacks[0].userText, "OpenCode user prompt.");
+    assert.equal(writebacks[0].assistantText, "OpenCode final reply.");
+    assert.equal(writebacks[0].traceContext.turnId, "user-1");
+    assert.equal(writebacks[0].memoryObservabilitySource, "opencode_plugin_writeback");
+  } finally {
+    runtime.close();
+    turnCoordinator.close();
     await rm(memoraxCodeHome, { recursive: true, force: true });
   }
 });

--- a/packages/ts/memorax-code-backend/test/clients/trae/trae-memory-hook.test.mjs
+++ b/packages/ts/memorax-code-backend/test/clients/trae/trae-memory-hook.test.mjs
@@ -232,6 +232,69 @@ test("Trae runtime preserves interruption authority after coordinator metadata e
   }
 });
 
+test("Trae accepts the replacement Turn Stop while its start retrieval is pending", async () => {
+  const fixture = await createFixture("pending-retrieval-stop");
+  const writes = [];
+  let now = 1_700_000_000_000;
+  let searchCalls = 0;
+  let markSecondSearchStarted;
+  let releaseSecondSearch;
+  const secondSearchStarted = new Promise((resolve) => { markSecondSearchStarted = resolve; });
+  const secondSearchGate = new Promise((resolve) => { releaseSecondSearch = resolve; });
+  const runtime = createTraeMemoryHookRuntime({
+    env: configuredEnv(fixture.home, {
+      MEMORAX_CODE_TRAE_TRACE_ENABLED: "false",
+      MEMORAX_CODE_MEMORY_RETRIEVAL_ENABLED: "true",
+    }),
+    now: () => now,
+    ttlMs: 5,
+    cleanupIntervalMs: 60_000,
+    automaticWriteback: (request) => { writes.push(request); return { accepted: true }; },
+    fetchImpl: async (url) => {
+      assert.match(String(url), /\/v1\/memories\/search$/);
+      searchCalls += 1;
+      if (searchCalls === 2) {
+        markSecondSearchStarted();
+        await secondSearchGate;
+      }
+      return new Response(JSON.stringify({
+        success: true,
+        data: { task_id: `search-${searchCalls}`, status: "completed", data: [] },
+      }), { status: 200, headers: { "content-type": "application/json" } });
+    },
+  });
+  const first = turnStart("trae-pending-session", "Start the first Turn.", fixture.workspace, now);
+  const second = turnStart("trae-pending-session", "Replace it with the second Turn.", fixture.workspace, now + 1);
+  let pendingStart;
+  try {
+    await runtime.recordTurnStart(first);
+    now += 1;
+    pendingStart = runtime.recordTurnStart(second);
+    await secondSearchStarted;
+    // Stop prunes coordinator metadata at this time. The active snapshot must
+    // already refer to the replacement even though its start has not returned.
+    now += 10;
+    assert.deepEqual(await runtime.writeback({
+      ...second,
+      lastAssistantMessage: "The replacement completed before Search returned.",
+    }), { ok: true, scheduled: true });
+    assert.deepEqual(await runtime.writeback({
+      ...first,
+      lastAssistantMessage: "The original completion arrived late.",
+    }), { ok: true, scheduled: false, reason: "interrupted" });
+    assert.deepEqual(writes.map(({ userText }) => userText), [second.prompt]);
+    assert.equal(runtime.size(), 0);
+    assert.equal(searchCalls, 2);
+    releaseSecondSearch();
+    assert.deepEqual(await pendingStart, { ok: true });
+  } finally {
+    releaseSecondSearch();
+    if (pendingStart) await Promise.allSettled([pendingStart]);
+    runtime.close();
+    await fixture.cleanup();
+  }
+});
+
 test("Trae complete Hook payload restores writeback after Backend runtime restart", async () => {
   const fixture = await createFixture("restart");
   const env = configuredEnv(fixture.home, { MEMORAX_CODE_TRAE_TRACE_ENABLED: "false" });
@@ -332,6 +395,7 @@ test("Trae trace records interrupted and completed Turn lifecycles", async () =>
       second.turnId,
     ]);
     assert.equal(events.every((event) => event.trace.client === "trae"), true);
+    assert.equal(events.every((event) => event.source === "trae-hook"), true);
     assert.equal(events.every((event) => event.trace.context_origin === "trae-hook-body"), true);
     assert.equal(writes.length, 1);
     const current = JSON.parse(await readFile(

--- a/packages/ts/memorax-code-backend/test/lifecycle/backend/service-lifecycle.test.mjs
+++ b/packages/ts/memorax-code-backend/test/lifecycle/backend/service-lifecycle.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
 import { EventEmitter } from "node:events";
 import { readFileSync } from "node:fs";
 import { chmod, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
@@ -769,15 +770,30 @@ test("failed startup retains PID state when cleanup fails or the PID remains ali
         response.end('{"ok":true,"service":"not-memorax-code"}');
       });
       const port = await listen(occupied);
+      let child;
+      let childClosed;
       try {
         const result = await startBackendService(
           { home, port, timeoutMs: 100 },
-          { terminateProcessTree, isProcessAlive: () => true },
+          {
+            terminateProcessTree,
+            isProcessAlive: () => true,
+            spawnProcess: (...args) => {
+              child = spawn(...args);
+              childClosed = new Promise((resolve) => child.once("close", resolve));
+              return child;
+            },
+          },
         );
         assert.equal(result.ok, false);
         assert.match(result.error, /cleanup failed and PID state was retained/);
         assert.equal(readBackendServiceState({ home })?.pid, result.state?.pid);
       } finally {
+        // The injected termination functions do not stop the real fixture process.
+        if (child && child.exitCode === null && child.signalCode === null) {
+          child.kill("SIGKILL");
+        }
+        await childClosed;
         await new Promise((resolve) => occupied.close(resolve));
         await rm(home, { recursive: true, force: true });
       }

--- a/packages/ts/memorax-code-backend/test/memory/harness-runtime.test.mjs
+++ b/packages/ts/memorax-code-backend/test/memory/harness-runtime.test.mjs
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { createHarnessMemoryRuntime } from "../../dist/memory/harness-runtime.js";
+import { createRepositoryMemorySessionRuntime } from "../../dist/memory/repository-session.js";
+import { createMemoryTurnCoordinator } from "../../dist/memory/turn-coordinator.js";
+
+test("harness runtime rejects conflicting trace identity before recording or dispatching", async () => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-harness-identity-"));
+  const writebacks = [];
+  const runtime = createHarnessMemoryRuntime(definition("claude-code"), {
+    memoraxCodeHome: root,
+    env: {},
+    automaticWriteback: (input) => { writebacks.push(input); return { accepted: true }; },
+  });
+  const foreignContext = {
+    schemaVersion: "1",
+    client: "codebuddy",
+    sessionId: "session",
+    turnId: "turn",
+    contextOrigin: "codebuddy-hook-body",
+    capturedAt: new Date().toISOString(),
+  };
+  const turn = { sessionId: "session", clientTurnId: "turn", createdAt: Date.now(), prompt: "Read the exact turn." };
+  try {
+    await assert.rejects(runtime.recordTurnStart({ ...turn, traceContext: foreignContext }), /trace identity mismatch/);
+    await assert.rejects(runtime.recordTurnStart({ ...turn, retrievalTraceContext: foreignContext }), /trace identity mismatch/);
+    await assert.rejects(runtime.completeTurn({
+      ...turn,
+      userText: "Read the exact turn.",
+      assistantText: "The native turn is complete.",
+      traceContext: foreignContext,
+      resolveRepositoryMemory: () => { throw new Error("must reject before scope resolution"); },
+    }), /trace identity mismatch/);
+    assert.equal(runtime.size(), 0);
+    assert.deepEqual(writebacks, []);
+    assert.deepEqual(await readdir(root), []);
+  } finally {
+    runtime.close();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("harness runtimes isolate identical turns and preserve injected resources when one closes", async () => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-harness-shared-"));
+  const workspace = join(root, "workspace");
+  await mkdir(workspace);
+  const writebacks = [];
+  const coordinator = createMemoryTurnCoordinator({
+    automaticWriteback: (input) => { writebacks.push(input); return { accepted: true }; },
+  });
+  const repository = createRepositoryMemorySessionRuntime();
+  const closed = [];
+  const options = {
+    memoraxCodeHome: join(root, "home"),
+    env: {
+      MEMORAX_CODE_MEMORAX_ENDPOINT: "http://memorax.test",
+      MEMORAX_CODE_MEMORAX_API_KEY: "test-key",
+      MEMORAX_CODE_MEMORAX_USER_ID: "test-user",
+      MEMORAX_CODE_MEMORY_RETRIEVAL_ENABLED: "false",
+    },
+    turnCoordinator: { ...coordinator, close: () => closed.push("coordinator") },
+    repositoryMemorySession: { ...repository, close: () => closed.push("repository") },
+    pendingQuotaNotice: { claim: async () => undefined, queue() {}, close: () => closed.push("quota") },
+    fetchImpl: async () => { throw new Error("automatic retrieval is disabled"); },
+  };
+  const claude = createHarnessMemoryRuntime(definition("claude-code"), options);
+  const codebuddy = createHarnessMemoryRuntime(definition("codebuddy"), options);
+  // Normalized input can come from SDK or Hook evidence without a transcript
+  // path. Client-specific materializers supply the native evidence.
+  const turn = { sessionId: "same-session", clientTurnId: "same-turn", cwd: workspace, createdAt: Date.now(), prompt: "Original prompt." };
+  try {
+    await claude.recordTurnStart(turn);
+    await codebuddy.recordTurnStart(turn);
+    assert.equal(claude.size(), 1);
+    assert.equal(codebuddy.size(), 1);
+    claude.close();
+    assert.deepEqual(closed, []);
+    const metadata = coordinator.getTurn({ client: "codebuddy", sessionId: turn.sessionId, clientTurnId: turn.clientTurnId });
+    const result = await codebuddy.completeTurn({
+      ...turn,
+      metadata,
+      userText: "Verified native prompt.",
+      assistantText: "Verified native reply.",
+      resolveRepositoryMemory: () => codebuddy.resolveRepositoryMemory(turn),
+    });
+    assert.deepEqual(result, { scheduled: true, metadataDisposition: "consumed" });
+    assert.equal(claude.size(), 1);
+    assert.equal(codebuddy.size(), 0);
+    assert.equal(writebacks[0].client, "codebuddy");
+    assert.equal(writebacks[0].userText, "Verified native prompt.");
+    assert.equal(writebacks[0].assistantText, "Verified native reply.");
+    assert.equal(writebacks[0].memoryObservabilitySource, "codebuddy_hook_writeback");
+  } finally {
+    claude.close();
+    codebuddy.close();
+    coordinator.close();
+    repository.close();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+function definition(client) {
+  const prefix = client === "claude-code" ? "claude" : client;
+  return {
+    client,
+    retrievalSource: `${prefix}_hook_retrieval`,
+    writebackSource: `${prefix}_hook_writeback`,
+    diagnosticPrefix: `${prefix}_memory_hook`,
+    traceFailureEvent: `${prefix}_trace.write_failed`,
+    deduplicateRetrieval: client === "claude-code",
+  };
+}

--- a/packages/ts/memorax-code-trae-adapter/test/runtime-hook.test.mjs
+++ b/packages/ts/memorax-code-trae-adapter/test/runtime-hook.test.mjs
@@ -209,6 +209,7 @@ function runHook(fixture, input) {
       cwd: fixture.root,
       env: {
         ...process.env,
+        MEMORAX_CODE_HOME: fixture.root,
         MEMORAX_CODE_BACKEND_URL: `http://127.0.0.1:${address.port}`,
         MEMORAX_CODE_MEMORY_SKILL_REMINDER_INTERVAL_TURNS: "1",
         TRAE_CN_HOME: fixture.traeHome,

--- a/scripts/check-local-trace-only.mjs
+++ b/scripts/check-local-trace-only.mjs
@@ -39,6 +39,7 @@ const reviewedNetworkSources = new Set([
   "packages/ts/memorax-code-backend/src/memory/automatic-retrieval.ts",
   "packages/ts/memorax-code-backend/src/memory/automatic-writeback.ts",
   "packages/ts/memorax-code-backend/src/memory/cli.ts",
+  "packages/ts/memorax-code-backend/src/memory/harness-runtime.ts",
   "packages/ts/memorax-code-backend/src/memory/writeback-buffer.ts",
   "packages/ts/memorax-code-backend/src/repo-memory/detect-updates.ts",
   "packages/ts/memorax-code-backend/src/provider/memorax/adapter.ts",


### PR DESCRIPTION
## Change Summary

Consolidate duplicated memory Hook orchestration across Codex, Claude Code, OpenCode, DSH, WorkBuddy, and Trae into a shared Backend runtime, so future harness integrations reuse the same repository, Turn, retrieval, and writeback flow.

## Implementation Highlights

- Introduce `memory/harness-runtime.ts` for repository/session binding, Turn registration and completion, retrieval deduplication, quota notices, trace recording, and owned-resource cleanup.
- Keep native event parsing, authoritative content loading, correlation, and recovery in each client runtime. Preserve DSH's retrieval sequencing and quota behavior, Trae's synchronous active-Turn publication, and ownership of injected shared resources.
- Add runtime and client regressions, update architecture and local-trace contracts, and isolate two existing lifecycle test fixtures. Automatic Search remains disabled by default.

This is PR 1 of the harness refactoring series. Shared adapter transport/locking, lifecycle summaries, and integration coverage checks follow separately.

## Validation

All checks ran directly in a fresh checkout based on `main` (`ab85768`), with isolated test homes and the original test assertions, timeouts, and concurrency.

- `make docs-check`: passed, 10 tests.
- `make test`: passed, 1,207 tests passed and 4 skipped.
- `make npm-package-check`: passed, including 274 package tests, 2 skipped tests, the 420-file tarball allowlist, and packaged installation/lifecycle smoke checks.
- `git diff --cached --check`: passed before commit.

| Suite in `make test` | Passed | Skipped |
| --- | ---: | ---: |
| Backend, including typecheck and architecture contracts | 533 | 2 |
| Codex | 235 | 0 |
| Claude Code | 65 | 0 |
| DSH | 28 | 0 |
| OpenCode | 35 | 0 |
| WorkBuddy | 22 | 0 |
| Trae | 15 | 0 |
| npm package and local-only trace contracts | 274 | 2 |

The skips cover filesystem-dependent Unicode/case-distinct paths and the opt-in real macOS Keychain/Linux Secret Service tests.

## Full End-to-End Validation Results

- Environment: macOS 26.5.1 arm64, Node.js 24.15.0, npm 11.12.1; isolated HOME, client configuration, and temporary directories.
- Scenario or matrix: synthetic native-format memory Hook tests for all six clients; fresh packaged installation, reinstall while stopped and active, Codex/Claude Hook lifecycle checks, provider-configuration preservation, and tarball content validation.
- Command or workflow: `make test` followed by `make npm-package-check`.
- Result: both commands exited successfully; no executable-format errors or leftover test Backend processes.
- Evidence or artifacts: the test totals above, successful local-only trace and 420-file allowlist checks, and the final `npm-package-check: completed` marker. Local logs and a verification receipt were retained outside Git.
- Reason not run / remaining risk: live coding-client/model sessions and MemoraX-backed end-to-end checks were not run; these require separate opt-in configuration. This validation uses synthetic client fixtures and local package smoke tests.

