### PR TITLE
refactor: unify lifecycle reporting across six coding clients

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -162,6 +162,14 @@ implementations are loaded by their Backend lifecycle participants. Preserve
 the participant contract and each client's actual authority instead of forcing
 matching directory shapes.
 
+Lifecycle report interpretation is shared in `lifecycle/client-reports.ts`.
+Its static client catalog maps lifecycle IDs and display names to existing
+report keys. The report projection supplies readiness and presentation data
+to the orchestrator and CLI while preserving the raw client-specific JSON.
+It does not discover clients, select defaults, read installation state, or
+perform lifecycle mutations. Native participants continue to own those
+operations, including DSH Profile ordering and locks.
+
 ## 3. Runtime Flows
 
 The system has two related but distinct planes. The control plane installs and
@@ -639,6 +647,7 @@ entrypoints and compatibility facades. It is not another implementation area.
 | `src/app` | Backend state/security, runtime resource assembly, observability fan-out, active requests, and graceful shutdown | Does not install plugins or own the lifecycle control plane |
 | `src/transport/http` | Shared Backend HTTP authorization, request/JSON helpers, error mapping, health, and Hook wire adaptation | Outbound provider HTTP remains with the provider capability |
 | `src/lifecycle` | Contracts, participants, client selection, locks, service orchestration, install watchdog, and client integration removal | Request-time memory flow does not depend on it |
+| `src/lifecycle/client-reports.ts` | Static lifecycle client identity and pure projections of adapter readiness and diagnostic summaries | No native discovery, filesystem or process access, lifecycle mutations, or replacement of raw client reports |
 | `src/lifecycle/backend` | Managed process, PID/token/connection records, status probing, cleanup, and shutdown requests | Helper contracts do not depend back on the full service implementation |
 | `src/clients/codex` | Codex rollout, prompt, turn-index, workspace interpretation and recovery; Hook memory integration through the shared harness runtime; plugin integration glue; and lifecycle participant | No Claude format fallback; request runtime remains HTTP-composition independent |
 | `src/clients/claude` | Claude transcript/turn interpretation, native correlation and interruption recovery, Hook memory integration through the shared harness runtime, and lifecycle participant | No Codex format fallback; request runtime remains HTTP-composition independent |
@@ -711,6 +720,7 @@ acyclic.
 | `MemoryTurnCoordinator` | `memory/turn-coordinator.ts` | Correlates and validates client-neutral Turns and controls metadata consumption |
 | `RepositoryMemorySessionRuntime` | `memory/repository-session.ts` | Pins and validates repository scope, including the bounded degraded-direct-`.git` to verified-Git upgrade |
 | `AdapterLifecycleParticipant` | `lifecycle/participant.ts` | Lets lifecycle orchestration use client adapters without embedding their implementation details |
+| Lifecycle client reports | `lifecycle/client-reports.ts` | Maps existing client report keys to common readiness and presentation data without changing native report authority |
 | Backend lifecycle contracts | `lifecycle/contracts.ts` | Separate `BackendServiceOptions`, injectable runtime, resolved endpoint, and `BackendServiceResult` from managed-service implementation |
 
 Ports stay with the capability that owns their semantics. A contract used by
@@ -720,7 +730,7 @@ multiple directories does not automatically belong in `shared`.
 
 | Contract | Location | Enforces | Inspect or update when |
 | --- | --- | --- | --- |
-| Backend source boundaries | `packages/ts/memorax-code-backend/test/architecture/source-boundaries.test.mjs` | Root facade allowlist, selected direct forbidden imports including shared harness neutrality, lifecycle delegation, and an acyclic relative-import graph | Adding a root surface, crossing capability boundaries, or changing a composition root |
+| Backend source boundaries | `packages/ts/memorax-code-backend/test/architecture/source-boundaries.test.mjs` | Root facade allowlist, discovered client-runtime coverage, selected direct forbidden imports including shared harness and lifecycle-report neutrality, lifecycle delegation, and an acyclic relative-import graph | Adding a client or root surface, crossing capability boundaries, or changing a composition root |
 | Local-only trace boundary | `scripts/check-local-trace-only.mjs` and its tests | Reviewed network-capable production modules, trace-core isolation, unreviewed trace-aware outbound bridges, and staged artifact/symlink containment | Moving or adding network code, trace-aware outbound code, or staged paths |
 | Package shape | npm package tests and package-build/check scripts | Executable wrappers, staged runtime layout, canonical source mapping, compatibility paths, and artifact allowlists | Changing entrypoints, packaging sources, materialization, or layout |
 | Documentation contract | `scripts/check-docs.mjs` and its tests | Relative links, personal absolute paths, and shipped-document consistency | Adding a root document or changing document/package layout |
@@ -730,6 +740,14 @@ The forbidden-import rules are targeted direct-import checks for named
 modules; they are not a universal directory-level or transitive dependency
 checker. The acyclic check separately covers all Backend TypeScript relative
 imports.
+
+Client runtime rules discover modules that import `memory/harness-runtime`
+and require every native client source directory to have a covered runtime.
+New runtimes therefore join the shared checks without depending on a fixed
+filename or a duplicated client list. Native-reader rules remain explicit;
+add newly introduced readers to the applicable rules and their client-owned
+behavior tests. Lifecycle report projections are separately checked against
+native-client, filesystem, process, HTTP, and lifecycle-implementation imports.
 
 Do not weaken an executable boundary merely to make a new import or path pass.
 If the intended architecture has not changed, move composition outward or
@@ -935,6 +953,9 @@ Placement rules:
 Contributor-facing verification profiles are centralized in
 [AGENTS.md Section 5](AGENTS.md#5-verification). Architecture change routing
 uses those named profiles rather than copying commands here.
+The [harness onboarding checklist](CONTRIBUTING.md#adding-a-harness)
+connects native authority, lifecycle reporting, packaging, and existing test
+contracts without introducing a separate adapter test framework.
 
 | Change surface | Primary evidence | Contracts to inspect | Verification profile |
 | --- | --- | --- | --- |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,8 +22,9 @@ npm ci --prefix packages/ts/memorax-code-backend
 
 Do not commit credentials, `.env.local`, local client transcripts, MemoraX
 content, generated trace data, package staging, or machine-specific paths.
-Use isolated `MEMORAX_CODE_HOME`, `CODEX_HOME`, and `CLAUDE_CONFIG_DIR`
-locations for lifecycle, install, or destructive tests.
+Use isolated `MEMORAX_CODE_HOME` and client homes (`CODEX_HOME`,
+`CLAUDE_CONFIG_DIR`, `DSH_HOME`, `OPENCODE_CONFIG_DIR`, `CODEBUDDY_HOME`, and
+`TRAE_CN_HOME`) for lifecycle, install, or destructive tests.
 
 ## Repository Ownership
 
@@ -33,12 +34,17 @@ locations for lifecycle, install, or destructive tests.
 | `memorax-code-adapter-common` | Durable runtime records, cross-process configuration primitives, shared Hook and Repo Memory helpers | Client transcript formats or plugin policy |
 | `memorax-code-codex-adapter` | Codex plugin, Hooks, native session/workspace observation, diagnostics, bundled skill | Codex provider configuration or login |
 | `memorax-code-claude-adapter` | Claude Code plugin, Hooks, native observation, diagnostics | Anthropic provider configuration or login |
+| `memorax-code-dsh-adapter` | Cordis Turn bridge, Profile lifecycle, runtime bundles, and shared-skill integration | DSH provider or Session ownership |
+| `memorax-code-opencode-adapter` | Plugin, managed loader, shared-skill installation, and diagnostics | OpenCode provider configuration or native message interpretation |
+| `memorax-code-codebuddy-adapter` | CodeBuddy/WorkBuddy plugin, Hooks, transcript bridge, and shared-skill installation | CodeBuddy provider configuration or native transcript interpretation |
+| `memorax-code-trae-adapter` | Global Hook merging, runtime generations, shared-skill installation, and diagnostics | Trae provider settings or application-level Hook activation |
 | `packages/npm/memorax-code` | Public CLI, installation, update, uninstall, postinstall, and package layout | Product runtime authority |
 | `scripts` and `.github` | Repeatable repository checks, packaging, and CI | Runtime behavior |
 
 The Backend is a local memory and lifecycle service, not a model-provider
-proxy. Codex and Claude Code continue to own models, provider credentials,
-tool execution, and native transcripts.
+proxy. All six clients continue to own models, provider credentials, tool
+execution, and native conversation data. See [Architecture](ARCHITECTURE.md)
+for the authoritative package boundaries and runtime flows.
 
 ## Making a Change
 
@@ -53,6 +59,54 @@ tool execution, and native transcripts.
 6. Run focused checks first, then broaden validation when the change crosses
    package or lifecycle boundaries.
 
+## Adding a Harness
+
+Use the existing contracts below as the integration checklist. Extend the
+closest suite with synthetic native fixtures; keep client-specific authority
+and recovery cases in that client's tests.
+
+1. **Establish native authority.** Identify start/completion events, exact
+   Session and Turn correlation, workspace evidence, content storage or SDK
+   records, interruption, and restart recovery. Implement native interpretation
+   under `src/clients/<client>` and use
+   [HarnessMemoryRuntime](packages/ts/memorax-code-backend/src/memory/harness-runtime.ts)
+   for common memory orchestration. Preserve client-qualified identity and
+   fail closed when the required authority is unavailable.
+2. **Connect the command boundary.** Extend the versioned client command
+   schema and [HTTP contract cases](packages/ts/memorax-code-backend/test/transport/http/memory-hook.test.mjs).
+   Verify exact content, missing or conflicting identity, repeated completion,
+   interruption, and scope pinning in `test/clients/<client>`. Shared
+   [Turn coordinator](packages/ts/memorax-code-backend/test/memory/memory-turn-coordinator.test.mjs)
+   and [harness runtime](packages/ts/memorax-code-backend/test/memory/harness-runtime.test.mjs)
+   tests already cover their common invariants; retain native fixtures for
+   each client's parser and bridge.
+3. **Implement lifecycle and reports.** Add an
+   [AdapterLifecycleParticipant](packages/ts/memorax-code-backend/src/lifecycle/participant.ts),
+   register report identity in
+   [client-reports](packages/ts/memorax-code-backend/src/lifecycle/client-reports.ts),
+   and verify readiness and summaries in the
+   [report contract tests](packages/ts/memorax-code-backend/test/lifecycle/client-reports.test.mjs)
+   alongside the existing lifecycle tests.
+   Explicitly handle client discovery, persisted selection, activation,
+   disablement, and removal in their owning layers; catalog registration alone
+   does not enable a client. Preserve user-owned configuration, native locks,
+   and public report compatibility.
+4. **Ship the actual runtime.** Declare adapter sources and canonical Skill
+   materialization in [npm source mapping](scripts/npm-source-files.mjs).
+   Check artifact requirements in [package building](scripts/build-npm-packages.mjs),
+   [packed-file validation](scripts/validate-npm-pack-json.mjs), and
+   [installed-package checks](scripts/npm-package-check.sh). Run the adapter's
+   tests against its deployed layout as appropriate; do not maintain a new
+   independent Skill copy.
+5. **Complete the existing gates.** Update
+   [source boundaries](packages/ts/memorax-code-backend/test/architecture/source-boundaries.test.mjs)
+   for new native readers and intentional dependencies. Runtime discovery
+   requires each native client directory to use the shared harness runtime.
+   Register new network-capable modules with the
+   [local-only trace gate](scripts/check-local-trace-only.mjs). Add the adapter
+   suite to the repository and platform checks, update architecture and public
+   client documentation, and run the relevant validation profiles below.
+
 ## Validation
 
 Choose checks by impact:
@@ -62,7 +116,12 @@ Choose checks by impact:
 | Backend TypeScript | `npm run typecheck --prefix packages/ts/memorax-code-backend` and `npm test --prefix packages/ts/memorax-code-backend` |
 | Codex integration or bundled skill | `npm test --prefix packages/ts/memorax-code-codex-adapter` |
 | Claude Code integration or shared skill | `npm test --prefix packages/ts/memorax-code-claude-adapter` |
-| Shared adapter or Hook runtime | Both adapter suites and the affected Backend tests |
+| DeepSeek Harness integration | `npm test --prefix packages/ts/memorax-code-dsh-adapter` |
+| OpenCode integration | `npm test --prefix packages/ts/memorax-code-opencode-adapter` |
+| CodeBuddy/WorkBuddy integration | `npm test --prefix packages/ts/memorax-code-codebuddy-adapter` |
+| Trae integration | `npm test --prefix packages/ts/memorax-code-trae-adapter` |
+| Shared adapter or Hook runtime | All six adapter suites and the affected Backend tests; add `make npm-package-check` for staged runtime or package layout changes |
+| Lifecycle report interpretation | Backend tests and `make npm-package-check` for CLI or lifecycle changes |
 | Public documentation | `make docs-check` |
 | Install, update, uninstall, CLI, or artifact layout | `make npm-package-check` |
 | Broad cross-layer change | `make test` |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -27,6 +27,12 @@ Codex, Claude Code, and OpenCode provide client-specific `doctor` commands;
 CodeBuddy/WorkBuddy and Trae provide adapter status commands, and DSH uses the
 shared lifecycle status.
 
+Lifecycle summaries include every selected client. A configured integration
+does not prove that its Hook has run: `hook-runtime=unverified` and
+`hook-runtime=observed` distinguish those states. Trae may report a configured
+integration while still requiring its one-time Global Hooks activation; follow
+the activation guidance printed by `start`, `restart`, or `status`.
+
 ## Package installed, but setup did not start
 
 This is expected after:

--- a/packages/ts/memorax-code-backend/src/entrypoints/backend-cli.ts
+++ b/packages/ts/memorax-code-backend/src/entrypoints/backend-cli.ts
@@ -41,7 +41,6 @@ import {
 import { inspectCodexPluginHooks, trustCodexPluginHooks, type CodexHook } from "../clients/codex/plugin-hooks.js";
 import {
   collectMemoraxCodeStatus,
-  isAdapterReady,
   isOptionalUnavailableDshAdapter,
   isOptionalUnconfiguredClaudeAdapter,
   restartMemoraxCodeService,
@@ -53,6 +52,12 @@ import {
   type MemoraxCodeStatusReport,
   type NpmPackageRemovalReport,
 } from "../lifecycle/orchestrator.js";
+import {
+  LIFECYCLE_CLIENTS,
+  isAdapterReady,
+  lifecycleAdapterReports,
+  summarizeAdapterReport,
+} from "../lifecycle/client-reports.js";
 import { backendEnv } from "../config/backend-env.js";
 import {
   backendServiceHome,
@@ -81,7 +86,7 @@ export function runBackendCli(argv = process.argv): void {
       "[--codex-command CMD]",
       "[--codex-home DIR] [--claude-home DIR] [--dsh-home DIR] [--opencode-config-dir DIR] [--codebuddy-home DIR] [--trae-home DIR]",
       "[--dsh-command CMD] [--dsh-adapter-root DIR] [--memorax-code-command CMD]",
-      "[--clients codex|claude|dsh|opencode|codebuddy|trae|CLIENT,...|all|none]",
+      `[--clients ${LIFECYCLE_CLIENTS.map(({ id }) => id).join("|")}|CLIENT,...|all|none]`,
       "[--json]",
       "[--marketplace-path FILE] [--plugin-source-path DIR] [--claude-command CMD] [--help]",
       "[--yes]",
@@ -552,7 +557,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function printMemoraxCodeStatus(report: MemoraxCodeStatusReport): void {
+export function printMemoraxCodeStatus(report: MemoraxCodeStatusReport): void {
   const backend = report.backend;
   const degraded = report.degraded === true;
   backendLog(`MemoraX Code Backend status: ${report.ok ? blueBold(degraded ? "Enabled (degraded)" : "Enabled") : redBold("Unavailable")}`);
@@ -562,14 +567,7 @@ function printMemoraxCodeStatus(report: MemoraxCodeStatusReport): void {
   backendLog(`Backend status: ${backend.ok ? blueBold("Enabled") : redBold("Unavailable")} ${backend.url}${backend.status ? ` status=${backend.status}` : ""}${backendIdentityDetail(backend.identity)}${backend.error ? ` error=${backend.error}` : ""}`);
   if (backend.service) backendLog(`Backend service: ${backend.service}`);
   if (typeof backend.authRequired === "boolean") backendLog(`Client auth: ${backend.authRequired ? "required" : "not required"}`);
-  if (report.codexAdapter) {
-    backendLog(`Codex adapter: ${adapterStatusLine(report.codexAdapter)}`);
-  }
-  if (report.claudeAdapter) backendLog(`Claude adapter: ${claudeAdapterStatusLine(report.claudeAdapter, report.codexAdapter)}`);
-  if (report.dshAdapter) backendLog(`DSH adapter: ${dshAdapterStatusLine(report.dshAdapter)}`);
-  if (report.opencodeAdapter) backendLog(`OpenCode adapter: ${adapterStatusLine(report.opencodeAdapter)}`);
-  if (report.codebuddyAdapter) backendLog(`CodeBuddy adapter: ${adapterStatusLine(report.codebuddyAdapter)}`);
-  if (report.traeAdapter) backendLog(`Trae adapter: ${adapterStatusLine(report.traeAdapter)}`);
+  printAdapterReports(report, true);
   if (!suppressBackendGuidance()) {
     for (const line of statusGuidance(report)) backendLog(line);
   }
@@ -659,7 +657,7 @@ export async function runBackendTokenCommand(
   }
 }
 
-function printLifecycleResult(report: MemoraxCodeLifecycleReport): void {
+export function printLifecycleResult(report: MemoraxCodeLifecycleReport): void {
   const degraded = report.degraded === true || report.backend?.degraded === true;
   backendLog(`${lifecycleActionLabel(report.action)}: ${report.ok ? green(degraded ? "ok (degraded)" : "ok") : red("needs attention")}`);
   if (report.message) backendLog(report.message);
@@ -674,12 +672,7 @@ function printLifecycleResult(report: MemoraxCodeLifecycleReport): void {
       backendLog(`Warning: ${warning.message}${warning.errorCode ? ` code=${warning.errorCode}` : ""}`);
     }
   }
-  if (report.codexAdapter) backendLog(`Codex adapter: ${adapterStatusLine(report.codexAdapter)}`);
-  if (report.claudeAdapter) backendLog(`Claude adapter: ${adapterStatusLine(report.claudeAdapter)}`);
-  if (report.dshAdapter) backendLog(`DSH adapter: ${dshAdapterStatusLine(report.dshAdapter)}`);
-  if (report.opencodeAdapter) backendLog(`OpenCode adapter: ${adapterStatusLine(report.opencodeAdapter)}`);
-  if (report.codebuddyAdapter) backendLog(`CodeBuddy adapter: ${adapterStatusLine(report.codebuddyAdapter)}`);
-  if (report.traeAdapter) backendLog(`Trae adapter: ${adapterStatusLine(report.traeAdapter)}`);
+  printAdapterReports(report);
   if (report.codexPlugin) {
     const removed = report.codexPlugin.removedPaths.length;
     const marketplace = report.codexPlugin.marketplaceChanged ? " marketplace=updated" : " marketplace=unchanged";
@@ -689,6 +682,26 @@ function printLifecycleResult(report: MemoraxCodeLifecycleReport): void {
   if (!suppressBackendGuidance()) {
     for (const line of lifecycleGuidance(report)) backendLog(line);
   }
+}
+
+function printAdapterReports(
+  report: MemoraxCodeLifecycleReport | MemoraxCodeStatusReport,
+  status = false,
+): void {
+  for (const { client, report: adapter } of lifecycleAdapterReports(report)) {
+    const detail = client.id === "dsh"
+      ? dshAdapterStatusLine(adapter)
+      : client.id === "claude" && status
+        ? claudeAdapterStatusLine(adapter, report.codexAdapter)
+        : adapterStatusLine(adapter);
+    backendLog(`${adapterDisplayName(client)} adapter: ${detail}`);
+  }
+}
+
+function adapterDisplayName(client: typeof LIFECYCLE_CLIENTS[number]): string {
+  if (client.id === "claude") return "Claude";
+  if (client.id === "codebuddy") return "CodeBuddy";
+  return client.name;
 }
 
 const BACKEND_PREFIX = "[MemoraX Code Backend]:";
@@ -731,6 +744,7 @@ function lifecycleActionLabel(action: MemoraxCodeLifecycleReport["action"]): str
 }
 
 function lifecycleGuidance(report: MemoraxCodeLifecycleReport): string[] {
+  const adapters = lifecycleAdapterReports(report);
   if (report.action === "start") {
     if (report.backend?.ok === false) {
       return [
@@ -738,24 +752,18 @@ function lifecycleGuidance(report: MemoraxCodeLifecycleReport): string[] {
         "Run `memorax-code logs` for details, then retry `memorax-code start`.",
       ];
     }
-    if (!report.codexAdapter && !report.claudeAdapter && !report.dshAdapter && !report.opencodeAdapter) {
+    if (adapters.length === 0) {
       return [
         green("Backend is running."),
         "Adapters were not changed for this command.",
       ];
     }
     const optionalDshUnavailable = isOptionalUnavailableDshAdapter(report.dshAdapter);
-    if ((!report.codexAdapter || isAdapterReady(report.codexAdapter))
-      && (!report.claudeAdapter || isAdapterReady(report.claudeAdapter))
-      && (!report.dshAdapter
-        || isAdapterReady(report.dshAdapter)
-        || optionalDshUnavailable)
-      && (!report.opencodeAdapter || isAdapterReady(report.opencodeAdapter))) {
+    if (adapters.every(({ client, report: adapter }) => (
+      isAdapterReady(adapter) || (client.id === "dsh" && optionalDshUnavailable)
+    ))) {
       return [
-        green(optionalDshUnavailable
-          && !report.codexAdapter
-          && !report.claudeAdapter
-          && !report.opencodeAdapter
+        green(optionalDshUnavailable && adapters.length === 1
           ? "Backend is running; the optional DSH integration is unavailable."
           : "Backend is running and available client integrations are enabled."),
         ...(optionalDshUnavailable
@@ -766,9 +774,12 @@ function lifecycleGuidance(report: MemoraxCodeLifecycleReport): string[] {
               green("Existing sessions with the stable plugin shell select the active runtime on their next user prompt."),
               "Restart or refresh a client only if its plugin shell changed or MemoraX Code is not active on the next prompt.",
             ]
-          : optionalDshUnavailable
-            ? []
-            : [green("New DSH sessions can use MemoraX Code through the active Profile integration.")]),
+          : adapters.some(({ client }) => client.id !== "dsh")
+            ? ["Restart or refresh a client if MemoraX Code is not active on the next prompt."]
+            : optionalDshUnavailable
+              ? []
+              : [green("New DSH sessions can use MemoraX Code through the active Profile integration.")]),
+        ...activationGuidance(report),
       ];
     }
     return [
@@ -784,10 +795,9 @@ function lifecycleGuidance(report: MemoraxCodeLifecycleReport): string[] {
         green(backendKeptRunning
           ? "Backend remains running for the other active client integrations."
           : "Backend is stopped."),
-        ...(report.codexAdapter ? [green("Codex Hook integration is stopped; provider config was not changed.")] : []),
-        ...(report.claudeAdapter ? [green("Claude Code Hook integration is stopped; provider config was not changed.")] : []),
-        ...(report.dshAdapter ? [green("DSH Profile integration is stopped.")] : []),
-        ...(report.opencodeAdapter ? [green("OpenCode plugin integration is stopped; provider config was not changed.")] : []),
+        ...adapters.map(({ client }) => green(client.id === "dsh"
+          ? "DSH Profile integration is stopped."
+          : `${client.name} ${client.id === "opencode" ? "plugin" : "Hook"} integration is stopped; provider config was not changed.`)),
       ]
       : [
         red("Backend did not stop cleanly."),
@@ -799,6 +809,7 @@ function lifecycleGuidance(report: MemoraxCodeLifecycleReport): string[] {
       ? [
         green("Backend restarted."),
         green("Available client integrations were reconciled with the restarted Backend."),
+        ...activationGuidance(report),
         "Restart or refresh a client only if MemoraX Code is not active on the next prompt.",
       ]
       : [
@@ -834,12 +845,10 @@ function lifecycleGuidance(report: MemoraxCodeLifecycleReport): string[] {
 }
 
 function statusGuidance(report: MemoraxCodeStatusReport): string[] {
+  const adapters = lifecycleAdapterReports(report);
   if (report.ok) {
     const optionalDshUnavailable = isOptionalUnavailableDshAdapter(report.dshAdapter);
-    if (report.dshAdapter
-      && !report.codexAdapter
-      && !report.claudeAdapter
-      && !report.opencodeAdapter) {
+    if (report.dshAdapter && adapters.length === 1) {
       if (optionalDshUnavailable) {
         return [
           green("Backend is running; the optional DSH integration is unavailable."),
@@ -852,10 +861,10 @@ function statusGuidance(report: MemoraxCodeStatusReport): string[] {
       ];
     }
     return [
-      green("MemoraX Code is ready; sessions with the stable plugin shell use the active Hook runtime on their next user prompt."),
-      ...(report.traeAdapter?.globalHooksActivationRequired
-        ? ["Trae requires one manual step: open Trae Settings and enable Global Hooks, then start a new Trae session."]
-        : []),
+      green(adapters.length === 0 || report.codexAdapter || report.claudeAdapter || report.opencodeAdapter
+        ? "MemoraX Code is ready; sessions with the stable plugin shell use the active Hook runtime on their next user prompt."
+        : "MemoraX Code is ready for new client sessions."),
+      ...activationGuidance(report),
       ...(optionalDshUnavailable
         ? [`DSH integration is unavailable: ${report.dshAdapter?.reason ?? "not available"}.`]
         : []),
@@ -878,42 +887,35 @@ function statusGuidance(report: MemoraxCodeStatusReport): string[] {
       "Run `memorax-code start`, then `memorax-code status`.",
     ];
   }
-  if (report.codexAdapter && !isAdapterReady(report.codexAdapter)) {
+  const unavailable = adapters.find(({ client, report: adapter }) => (
+    !isAdapterReady(adapter)
+      && !(client.id === "claude" && isOptionalUnconfiguredClaudeAdapter(adapter, report.codexAdapter))
+      && !(client.id === "dsh" && isOptionalUnavailableDshAdapter(adapter))
+  ));
+  if (unavailable) {
+    const { client } = unavailable;
+    const guidance = client.id === "codex"
+      ? "Run `memorax-code start`, restart or refresh Codex, then enable the MemoraX Code Codex Adapter plugin."
+      : client.id === "dsh"
+        ? "Run `memorax-code start`, then retry `memorax-code status`."
+        : client.id === "trae"
+          ? "Run `memorax-code start --clients trae`, then enable Global Hooks in Trae Settings if this is the first setup."
+          : `Run \`memorax-code start\`, then restart or refresh ${client.name}.`;
     return [
-      red("Codex adapter is not enabled."),
-      "Run `memorax-code start`, restart or refresh Codex, then enable the MemoraX Code Codex Adapter plugin.",
-    ];
-  }
-  if (report.claudeAdapter && !isAdapterReady(report.claudeAdapter) && !isOptionalUnconfiguredClaudeAdapter(report.claudeAdapter, report.codexAdapter)) {
-    return [
-      red("Claude adapter is not enabled."),
-      "Run `memorax-code start`, then restart or refresh Claude Code.",
-    ];
-  }
-  if (report.dshAdapter
-    && !isAdapterReady(report.dshAdapter)
-    && !isOptionalUnavailableDshAdapter(report.dshAdapter)) {
-    return [
-      red("DSH adapter is not enabled."),
-      "Run `memorax-code start`, then retry `memorax-code status`.",
-    ];
-  }
-  if (report.opencodeAdapter && !isAdapterReady(report.opencodeAdapter)) {
-    return [
-      red("OpenCode adapter is not enabled."),
-      "Run `memorax-code start`, then restart or refresh OpenCode.",
-    ];
-  }
-  if (report.traeAdapter && !isAdapterReady(report.traeAdapter)) {
-    return [
-      red("Trae adapter is not enabled."),
-      "Run `memorax-code start --clients trae`, then enable Global Hooks in Trae Settings if this is the first setup.",
+      red(`${adapterDisplayName(client)} adapter is not enabled.`),
+      guidance,
     ];
   }
   return [
     red("MemoraX Code needs attention."),
     "Run `memorax-code status` and `memorax-code logs` for details.",
   ];
+}
+
+function activationGuidance(report: MemoraxCodeLifecycleReport | MemoraxCodeStatusReport): string[] {
+  return report.traeAdapter && summarizeAdapterReport(report.traeAdapter).activationRequired
+    ? ["Trae requires one manual step: open Trae Settings and enable Global Hooks, then start a new Trae session."]
+    : [];
 }
 
 function backendIdentityDetail(identity: MemoraxCodeStatusReport["backend"]["identity"]): string {
@@ -945,29 +947,15 @@ function adapterStatusLine(report: AdapterReport): string {
   if (report.backendUrlMatches === false) {
     return `not ok endpoint_mismatch configured=${report.configuredBackendUrl ?? "missing"} expected=${report.expectedBackendUrl ?? "unknown"}`;
   }
-  const enabled = isAdapterReady(report);
-  const skillStatus = report.codexSkills?.status
-    ?? report.claudeSkills?.status
-    ?? report.opencodeSkills?.status
-    ?? report.codebuddySkills?.status
-    ?? report.traeSkills?.status;
+  const { ready, integration, skillStatus, hookStatus } = summarizeAdapterReport(report);
   const skills = skillStatus ? ` skills=${skillStatus}` : "";
-  const hookStatus = report.codebuddyHooks?.status ?? report.traeHooks?.status;
   const hooks = hookStatus ? ` hook-runtime=${hookStatus}` : "";
   const changed = report.changed === true ? " changed" : "";
-  const integration = report.integration ?? report.state?.integration ?? "hooks";
-  return `${enabled ? "ok" : "not enabled"} integration=${integration}${skills}${hooks}${changed}`;
+  return `${ready ? "ok" : "not enabled"} integration=${integration ?? "hooks"}${skills}${hooks}${changed}`;
 }
 
 function selectedLifecycleClientNames(report: MemoraxCodeLifecycleReport): string[] {
-  return [
-    report.codexAdapter ? "Codex" : undefined,
-    report.claudeAdapter ? "Claude Code" : undefined,
-    report.dshAdapter ? "DSH" : undefined,
-    report.opencodeAdapter ? "OpenCode" : undefined,
-    report.codebuddyAdapter ? "CodeBuddy/WorkBuddy" : undefined,
-    report.traeAdapter ? "Trae" : undefined,
-  ].filter((name): name is string => name !== undefined);
+  return lifecycleAdapterReports(report).map(({ client }) => client.name);
 }
 
 function lifecycleClientName(report: MemoraxCodeLifecycleReport): string | undefined {

--- a/packages/ts/memorax-code-backend/src/lifecycle/active-clients.ts
+++ b/packages/ts/memorax-code-backend/src/lifecycle/active-clients.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import type { ManagedClients } from "./client-selection.js";
+import { LIFECYCLE_CLIENTS } from "./client-reports.js";
 
 export function readActiveManagedClients(memoraxCodeHome: string): ManagedClients | undefined {
   const path = activeManagedClientsPath(memoraxCodeHome);
@@ -8,10 +9,7 @@ export function readActiveManagedClients(memoraxCodeHome: string): ManagedClient
   try {
     const value = JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>;
     if (typeof value.codex !== "boolean" || typeof value.claude !== "boolean") return undefined;
-    if (value.opencode !== undefined && typeof value.opencode !== "boolean") return undefined;
-    if (value.codebuddy !== undefined && typeof value.codebuddy !== "boolean") return undefined;
-    if (value.trae !== undefined && typeof value.trae !== "boolean") return undefined;
-    if (value.dsh !== undefined && typeof value.dsh !== "boolean") return undefined;
+    if (LIFECYCLE_CLIENTS.some(({ id }) => value[id] !== undefined && typeof value[id] !== "boolean")) return undefined;
     return {
       codex: value.codex,
       claude: value.claude,

--- a/packages/ts/memorax-code-backend/src/lifecycle/client-reports.ts
+++ b/packages/ts/memorax-code-backend/src/lifecycle/client-reports.ts
@@ -1,0 +1,73 @@
+import type { AdapterReport } from "./participant.js";
+
+// Lifecycle names and legacy report fields are independent of Hook wire IDs.
+export const LIFECYCLE_CLIENTS = [
+  { id: "codex", name: "Codex", reportKey: "codexAdapter", skillKey: "codexSkills", hookKey: undefined },
+  { id: "claude", name: "Claude Code", reportKey: "claudeAdapter", skillKey: "claudeSkills", hookKey: undefined },
+  { id: "dsh", name: "DSH", reportKey: "dshAdapter", skillKey: undefined, hookKey: undefined },
+  { id: "opencode", name: "OpenCode", reportKey: "opencodeAdapter", skillKey: "opencodeSkills", hookKey: undefined },
+  { id: "codebuddy", name: "CodeBuddy/WorkBuddy", reportKey: "codebuddyAdapter", skillKey: "codebuddySkills", hookKey: "codebuddyHooks" },
+  { id: "trae", name: "Trae", reportKey: "traeAdapter", skillKey: "traeSkills", hookKey: "traeHooks" },
+] as const;
+
+export type LifecycleClient = typeof LIFECYCLE_CLIENTS[number];
+export type LifecycleClientId = LifecycleClient["id"];
+export type ClientAdapterReports = Partial<Record<LifecycleClient["reportKey"], AdapterReport>>;
+
+export function lifecycleAdapterReports(reports: ClientAdapterReports): {
+  client: LifecycleClient;
+  report: AdapterReport;
+}[] {
+  return LIFECYCLE_CLIENTS.flatMap((client) => {
+    const report = reports[client.reportKey];
+    return report ? [{ client, report }] : [];
+  });
+}
+
+export type AdapterReportSummary = Readonly<{
+  ready: boolean;
+  installed: boolean;
+  enabled: boolean;
+  integration?: string;
+  skillStatus?: string;
+  hookStatus?: string;
+  configured?: boolean;
+  runtimeObserved?: boolean;
+  activationRequired: boolean;
+}>;
+
+// Project legacy reports without changing their public JSON or native authority.
+export function summarizeAdapterReport(report: AdapterReport): AdapterReportSummary {
+  const skills = LIFECYCLE_CLIENTS.flatMap(({ skillKey }) => {
+    const value = skillKey ? report[skillKey] : undefined;
+    return value ? [value] : [];
+  });
+  const hooks = LIFECYCLE_CLIENTS.flatMap(({ hookKey }) => {
+    const value = hookKey ? report[hookKey] : undefined;
+    return value ? [value] : [];
+  });
+  const integration = report.integration ?? report.state?.integration;
+  const installed = report.installed === true;
+  const enabled = report.enabled === true;
+  return {
+    ready: (integration === "hooks" || integration === "plugin")
+      && report.ok !== false
+      && installed
+      && enabled
+      && report.backendUrlMatches !== false
+      && skills.every((skill) => skill.ok !== false)
+      && hooks.every((hook) => hook.ok !== false),
+    installed,
+    enabled,
+    integration,
+    skillStatus: skills.find((skill) => skill.status !== undefined)?.status,
+    hookStatus: hooks.find((hook) => hook.status !== undefined)?.status,
+    configured: hooks.find((hook) => hook.configured !== undefined)?.configured,
+    runtimeObserved: hooks.find((hook) => hook.runtimeObserved !== undefined)?.runtimeObserved,
+    activationRequired: report.globalHooksActivationRequired === true,
+  };
+}
+
+export function isAdapterReady(report: AdapterReport): boolean {
+  return summarizeAdapterReport(report).ready;
+}

--- a/packages/ts/memorax-code-backend/src/lifecycle/client-selection.ts
+++ b/packages/ts/memorax-code-backend/src/lifecycle/client-selection.ts
@@ -1,15 +1,16 @@
 import { loadLifecycleMemoraxCodeConfig, type MemoraxCodeConfig } from "../config/memorax-code.js";
+import { LIFECYCLE_CLIENTS, type LifecycleClientId } from "./client-reports.js";
 
-export type ManagedClients = Readonly<{
-  codex: boolean;
-  claude: boolean;
-  dsh: boolean;
-  opencode: boolean;
-  codebuddy?: boolean;
-  trae?: boolean;
-}>;
+// Preserve explicit false fields in legacy selection records. Later clients
+// remain absent unless selected; this is distinct from discovery defaults.
+const LEGACY_SELECTION_CLIENTS = ["codex", "claude", "dsh", "opencode"] as const;
+type LegacySelectionClient = typeof LEGACY_SELECTION_CLIENTS[number];
+export type ManagedClients = Readonly<Record<LegacySelectionClient, boolean>
+  & Partial<Record<Exclude<LifecycleClientId, LegacySelectionClient>, boolean>>>;
 
-const allClients: ManagedClients = Object.freeze({ codex: true, claude: true, dsh: true, opencode: true, codebuddy: true, trae: true });
+const allClients: ManagedClients = Object.freeze(Object.fromEntries(
+  LIFECYCLE_CLIENTS.map(({ id }) => [id, true]),
+) as ManagedClients);
 
 export function resolveManagedClients(argv: readonly string[], config: MemoraxCodeConfig = {}): ManagedClients {
   const explicit = argValue(argv, "--clients");
@@ -37,19 +38,12 @@ export function parseManagedClients(value: string): ManagedClients {
   if (normalized === "none") return { codex: false, claude: false, dsh: false, opencode: false };
 
   const names = normalized.split(",").map((name) => name.trim()).filter(Boolean);
-  if (names.length === 0 || names.some((name) => (
-    name !== "codex" && name !== "claude" && name !== "dsh" && name !== "opencode" && name !== "codebuddy" && name !== "trae"
-  ))) {
-    throw new Error(`invalid --clients value: ${value}; expected a comma-separated subset of codex, claude, dsh, opencode, codebuddy, trae, or all or none`);
+  if (names.length === 0 || names.some((name) => !LIFECYCLE_CLIENTS.some(({ id }) => id === name))) {
+    throw new Error(`invalid --clients value: ${value}; expected a comma-separated subset of ${LIFECYCLE_CLIENTS.map(({ id }) => id).join(", ")}, or all or none`);
   }
-  return {
-    codex: names.includes("codex"),
-    claude: names.includes("claude"),
-    dsh: names.includes("dsh"),
-    opencode: names.includes("opencode"),
-    ...(names.includes("codebuddy") ? { codebuddy: true } : {}),
-    ...(names.includes("trae") ? { trae: true } : {}),
-  };
+  return Object.fromEntries(LIFECYCLE_CLIENTS
+    .filter(({ id }) => LEGACY_SELECTION_CLIENTS.some((legacy) => legacy === id) || names.includes(id))
+    .map(({ id }) => [id, names.includes(id)])) as ManagedClients;
 }
 
 export function loadManagedClientsConfig(memoraxCodeHome: string): MemoraxCodeConfig {

--- a/packages/ts/memorax-code-backend/src/lifecycle/orchestrator.ts
+++ b/packages/ts/memorax-code-backend/src/lifecycle/orchestrator.ts
@@ -23,6 +23,8 @@ import { seedMissingMemoraxCodeConfig } from "../provider/memorax/config.js";
 import { runProcessWithWindowsNpm } from "../shared/windows-cli-invocation.js";
 import { loadManagedClientsConfig, resolveManagedClients, type ManagedClients } from "./client-selection.js";
 import { clearActiveManagedClients, readActiveManagedClients, writeActiveManagedClients } from "./active-clients.js";
+import { LIFECYCLE_CLIENTS, lifecycleAdapterReports, isAdapterReady, type ClientAdapterReports } from "./client-reports.js";
+export { isAdapterReady } from "./client-reports.js";
 import { codexAdapterLifecycle } from "../clients/codex/lifecycle.js";
 import { claudeAdapterLifecycle } from "../clients/claude/lifecycle.js";
 import {
@@ -41,32 +43,20 @@ export type {
   AdapterReport,
 } from "./participant.js";
 
-export type MemoraxCodeStatusReport = {
+export type MemoraxCodeStatusReport = ClientAdapterReports & {
   ok: boolean;
   action: "status";
   degraded?: true;
   backend: Awaited<ReturnType<typeof runBackendStatus>>;
-  codexAdapter?: AdapterReport;
-  claudeAdapter?: AdapterReport;
-  dshAdapter?: AdapterReport;
-  opencodeAdapter?: AdapterReport;
-  codebuddyAdapter?: AdapterReport;
-  traeAdapter?: AdapterReport;
 };
 
-export type MemoraxCodeLifecycleReport = {
+export type MemoraxCodeLifecycleReport = ClientAdapterReports & {
   ok: boolean;
   action: "start" | "stop" | "restart" | "uninstall";
   degraded?: true;
   reason?: string;
   message?: string;
   backend?: Awaited<ReturnType<typeof startBackendService | typeof stopBackendService>>;
-  codexAdapter?: AdapterReport;
-  claudeAdapter?: AdapterReport;
-  dshAdapter?: AdapterReport;
-  opencodeAdapter?: AdapterReport;
-  codebuddyAdapter?: AdapterReport;
-  traeAdapter?: AdapterReport;
   codexPlugin?: Awaited<ReturnType<typeof codexAdapterLifecycle.remove>>;
   codebuddyPlugin?: Awaited<ReturnType<typeof codeBuddyAdapterLifecycle.remove>>;
   traePlugin?: Awaited<ReturnType<typeof traeAdapterLifecycle.remove>>;
@@ -159,21 +149,13 @@ export async function collectMemoraxCodeStatus(
   const traeAdapter = clients.trae
     ? await traeAdapterLifecycle.status({ argv, serviceOptions, backendUrl })
     : undefined;
-  const codexReady = codexAdapter ? isAdapterReady(codexAdapter) : true;
-  const claudeReady = claudeAdapter ? isAdapterReady(claudeAdapter) : true;
-  const dshReady = dshAdapter ? isAdapterReady(dshAdapter) : true;
-  const opencodeReady = opencodeAdapter ? isAdapterReady(opencodeAdapter) : true;
-  const codebuddyReady = codebuddyAdapter ? isAdapterReady(codebuddyAdapter) : true;
-  const traeReady = traeAdapter ? isAdapterReady(traeAdapter) : true;
+  const adapters = lifecycleAdapterReports({ codexAdapter, claudeAdapter, dshAdapter, opencodeAdapter, codebuddyAdapter, traeAdapter });
   const optionalDshUnavailable = isOptionalUnavailableDshAdapter(dshAdapter);
   return {
     ok: backend.ok
-      && codexReady
-      && opencodeReady
-      && codebuddyReady
-      && traeReady
-      && (isOptionalUnconfiguredClaudeAdapter(claudeAdapter, codexAdapter) || claudeReady)
-      && (optionalDshUnavailable || dshReady),
+      && adapters.every(({ client, report }) => isAdapterReady(report)
+        || (client.id === "claude" && isOptionalUnconfiguredClaudeAdapter(report, codexAdapter))
+        || (client.id === "dsh" && optionalDshUnavailable)),
     action: "status",
     ...(optionalDshUnavailable ? { degraded: true } : {}),
     backend,
@@ -581,13 +563,8 @@ async function executeMemoraxCodeStop(
       trae: activeClients.trae && !clients.trae,
     }
     : undefined;
-  const hasRemainingClients = remaining?.codex === true
-    || remaining?.claude === true
-    || remaining?.dsh === true
-    || remaining?.opencode === true
-    || remaining?.codebuddy === true
-    || remaining?.trae === true;
-  const backendOnlyStop = !clients.codex && !clients.claude && !clients.dsh && !clients.opencode && !clients.codebuddy && !clients.trae;
+  const hasRemainingClients = LIFECYCLE_CLIENTS.some(({ id }) => remaining?.[id] === true);
+  const backendOnlyStop = LIFECYCLE_CLIENTS.every(({ id }) => !clients[id]);
   const packageReplacement = isPackageReplacement();
   const needsBackendStop = packageReplacement || backendOnlyStop || !hasRemainingClients;
   const quiescedDsh = clients.dsh && dshLifecycle
@@ -646,23 +623,13 @@ async function executeMemoraxCodeStop(
   const traeAdapter = clients.trae
     ? await traeAdapterLifecycle.disable({ argv, serviceOptions })
     : undefined;
-  const adaptersOk = codexAdapter?.ok !== false
-    && claudeAdapter?.ok !== false
-    && dshAdapter?.ok !== false
-    && opencodeAdapter?.ok !== false
-    && codebuddyAdapter?.ok !== false
-    && traeAdapter?.ok !== false;
+  const adaptersOk = lifecycleAdapterReports({ codexAdapter, claudeAdapter, dshAdapter, opencodeAdapter, codebuddyAdapter, traeAdapter })
+    .every(({ report }) => report.ok !== false);
   const backend = stoppedBackend
     ?? (adaptersOk
       ? preservedBackendResult(serviceOptions, "active_clients_remaining")
       : preservedBackendResult(serviceOptions, "adapter_disable_failed"));
-  const ok = backend.ok
-    && codexAdapter?.ok !== false
-    && claudeAdapter?.ok !== false
-    && dshAdapter?.ok !== false
-    && opencodeAdapter?.ok !== false
-    && codebuddyAdapter?.ok !== false
-    && traeAdapter?.ok !== false;
+  const ok = backend.ok && adaptersOk;
   return {
     report: {
       ok,
@@ -1153,22 +1120,6 @@ async function withMemoraxCodeLifecycleLock(
       },
     };
   }
-}
-
-export function isAdapterReady(report: AdapterReport): boolean {
-  const integration = report.integration ?? report.state?.integration;
-  return (integration === "hooks" || integration === "plugin")
-    && report.ok !== false
-    && report.installed === true
-    && report.enabled === true
-    && report.backendUrlMatches !== false
-    && report.codexSkills?.ok !== false
-    && report.claudeSkills?.ok !== false
-    && report.opencodeSkills?.ok !== false
-    && report.codebuddyHooks?.ok !== false
-    && report.codebuddySkills?.ok !== false
-    && report.traeHooks?.ok !== false
-    && report.traeSkills?.ok !== false;
 }
 
 export function isOptionalUnavailableDshAdapter(report: AdapterReport | undefined): boolean {

--- a/packages/ts/memorax-code-backend/test/architecture/source-boundaries.test.mjs
+++ b/packages/ts/memorax-code-backend/test/architecture/source-boundaries.test.mjs
@@ -17,6 +17,19 @@ const backendRootFacades = [
   "user-profile.ts",
   "windows-cli-invocation.ts",
 ];
+const importPatterns = [
+  /\bimport\s+(?:type\s+)?[\s\S]*?\s+from\s+["']([^"']+)["']/g,
+  /\bimport\s+["']([^"']+)["']/g,
+  /\bexport\s+(?:type\s+)?[\s\S]*?\s+from\s+["']([^"']+)["']/g,
+  /\bimport\s*\(\s*["']([^"']+)["']\s*\)/g,
+];
+const clientModules = await sourceModules(join(backendSrc, "clients"));
+const clientMemoryRuntimes = [];
+for (const module of clientModules) {
+  if ((await directRelativeImports(module)).includes("memory/harness-runtime")) {
+    clientMemoryRuntimes.push(module);
+  }
+}
 
 const rules = [
   {
@@ -45,14 +58,10 @@ const rules = [
       "memory/automatic-retrieval.ts",
       "memory/automatic-writeback.ts",
       "memory/harness-runtime.ts",
-      "clients/claude/memory-hook-runtime.ts",
+      ...clientMemoryRuntimes,
       "clients/claude/transcript-turn.ts",
-      "clients/codex/memory-hook-runtime.ts",
-      "clients/dsh/memory-hook-runtime.ts",
       "clients/dsh/session-turn.ts",
-      "clients/opencode/memory-hook-runtime.ts",
       "clients/opencode/message-turn.ts",
-      "clients/codebuddy/memory-hook-runtime.ts",
       "clients/codebuddy/jsonl-history.ts",
       "memory/turn-coordinator.ts",
       "memory/service.ts",
@@ -88,11 +97,7 @@ const rules = [
       "memory/automatic-retrieval.ts",
       "memory/automatic-writeback.ts",
       "memory/harness-runtime.ts",
-      "clients/claude/memory-hook-runtime.ts",
-      "clients/codex/memory-hook-runtime.ts",
-      "clients/dsh/memory-hook-runtime.ts",
-      "clients/opencode/memory-hook-runtime.ts",
-      "clients/codebuddy/memory-hook-runtime.ts",
+      ...clientMemoryRuntimes,
       "provider/memorax/adapter.ts",
       "memory/turn-coordinator.ts",
       "memory/service.ts",
@@ -112,43 +117,26 @@ const rules = [
   {
     name: "Hook memory runtimes use normalized automatic writeback",
     importers: [
-      "clients/claude/memory-hook-runtime.ts",
-      "clients/codex/memory-hook-runtime.ts",
-      "clients/dsh/memory-hook-runtime.ts",
-      "clients/opencode/memory-hook-runtime.ts",
+      ...clientMemoryRuntimes,
       "memory/turn-coordinator.ts",
     ],
     forbidden: ["memory/writeback"],
   },
   {
-    name: "Codex memory hook runtime stays independent from HTTP and Backend composition",
-    importers: ["clients/codex/memory-hook-runtime.ts"],
-    forbidden: ["node:http", "server-", "entrypoints/", "transport/http/", "app/state"],
-  },
-  {
-    name: "Claude memory hook runtime stays independent from HTTP and Backend composition",
-    importers: ["clients/claude/memory-hook-runtime.ts", "clients/claude/transcript-turn.ts"],
-    forbidden: ["node:http", "server-", "entrypoints/", "transport/http/", "app/state"],
-  },
-  {
-    name: "OpenCode memory hook runtime stays independent from HTTP and Backend composition",
-    importers: ["clients/opencode/memory-hook-runtime.ts", "clients/opencode/message-turn.ts"],
-    forbidden: ["node:http", "server-", "entrypoints/", "transport/http/", "app/state"],
-  },
-  {
-    name: "CodeBuddy memory hook runtime stays independent from HTTP and Backend composition",
-    importers: ["clients/codebuddy/memory-hook-runtime.ts", "clients/codebuddy/jsonl-history.ts"],
-    forbidden: ["node:http", "server-", "entrypoints/", "transport/http/", "app/state"],
-  },
-  {
-    name: "DSH memory hook runtime stays independent from HTTP and Backend composition",
-    importers: ["clients/dsh/memory-hook-runtime.ts", "clients/dsh/session-turn.ts"],
+    name: "client memory runtimes and native readers stay independent from HTTP and Backend composition",
+    importers: [
+      ...clientMemoryRuntimes,
+      "clients/claude/transcript-turn.ts",
+      "clients/opencode/message-turn.ts",
+      "clients/codebuddy/jsonl-history.ts",
+      "clients/dsh/session-turn.ts",
+    ],
     forbidden: ["node:http", "server-", "entrypoints/", "transport/http/", "app/state"],
   },
   {
     name: "memory turn coordinator stays independent from HTTP, Backend composition, and client transcripts",
     importers: ["memory/turn-coordinator.ts"],
-    forbidden: ["node:http", "server-", "entrypoints/", "transport/http/", "app/state", "clients/codex/rollout", "clients/claude/", "clients/dsh/", "clients/opencode/"],
+    forbidden: ["node:http", "server-", "entrypoints/", "transport/http/", "app/state", "clients/"],
   },
   {
     name: "HTTP server stays independent from install watchdog and client plugin lifecycle",
@@ -173,6 +161,23 @@ const rules = [
     ],
   },
   {
+    name: "lifecycle report projections stay independent from client discovery and mutation",
+    importers: ["lifecycle/client-reports.ts"],
+    forbidden: [
+      "clients/",
+      "node:fs",
+      "node:fs/promises",
+      "node:child_process",
+      "node:http",
+      "node:https",
+      "app/",
+      "entrypoints/",
+      "transport/",
+      "lifecycle/orchestrator",
+      "lifecycle/backend/service",
+    ],
+  },
+  {
     name: "lifecycle helpers consume contracts instead of the service implementation",
     importers: [
       "lifecycle/participant.ts",
@@ -189,6 +194,12 @@ const rules = [
     forbidden: ["memory/", "server-", "entrypoints/", "transport/http/"],
   },
 ];
+
+test("every native client has a memory runtime covered by shared source boundaries", () => {
+  const clients = (modules) => [...new Set(modules.map((module) => module.split("/")[1]))].sort();
+  assert.notEqual(clientModules.length, 0);
+  assert.deepEqual(clients(clientMemoryRuntimes), clients(clientModules));
+});
 
 test("backend source boundaries keep production, observability, and lifecycle imports separated", async () => {
   const violations = [];
@@ -286,13 +297,6 @@ function importSpecifiers(text) {
   }
   return specs;
 }
-
-const importPatterns = [
-  /\bimport\s+(?:type\s+)?[\s\S]*?\s+from\s+["']([^"']+)["']/g,
-  /\bimport\s+["']([^"']+)["']/g,
-  /\bexport\s+(?:type\s+)?[\s\S]*?\s+from\s+["']([^"']+)["']/g,
-  /\bimport\s*\(\s*["']([^"']+)["']\s*\)/g,
-];
 
 function matchesForbiddenTarget(target, forbidden) {
   if (forbidden.endsWith("-") || forbidden.endsWith("/")) return target.startsWith(forbidden);

--- a/packages/ts/memorax-code-backend/test/entrypoints/backend-cli-reports.test.mjs
+++ b/packages/ts/memorax-code-backend/test/entrypoints/backend-cli-reports.test.mjs
@@ -1,0 +1,163 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { stripVTControlCharacters } from "node:util";
+import {
+  printLifecycleResult,
+  printMemoraxCodeStatus,
+} from "../../dist/entrypoints/backend-cli.js";
+
+const readyAdapter = { ok: true, installed: true, enabled: true, integration: "hooks" };
+const backend = { ok: true, action: "start", url: "http://127.0.0.1:8787" };
+
+function captureReport(t, print, report) {
+  const lines = [];
+  const logger = t.mock.method(console, "log", (line) => lines.push(line));
+  const suppression = process.env.MEMORAX_CODE_BACKEND_SUPPRESS_GUIDANCE;
+  delete process.env.MEMORAX_CODE_BACKEND_SUPPRESS_GUIDANCE;
+  try {
+    print(report);
+    return stripVTControlCharacters(lines.join("\n"));
+  } finally {
+    logger.mock.restore();
+    if (suppression === undefined) delete process.env.MEMORAX_CODE_BACKEND_SUPPRESS_GUIDANCE;
+    else process.env.MEMORAX_CODE_BACKEND_SUPPRESS_GUIDANCE = suppression;
+  }
+}
+
+for (const { key, name, label } of [
+  { key: "codebuddyAdapter", name: "CodeBuddy/WorkBuddy", label: "CodeBuddy" },
+  { key: "traeAdapter", name: "Trae", label: "Trae" },
+]) {
+  test(`${name}-only lifecycle guidance describes the changed integration`, (t) => {
+    const started = captureReport(t, printLifecycleResult, {
+      ok: true,
+      action: "start",
+      backend,
+      [key]: readyAdapter,
+    });
+    assert.ok(started.includes(`${label} adapter: ok integration=hooks`));
+    assert.match(started, /available client integrations are enabled/);
+    assert.doesNotMatch(started, /Adapters were not changed|New DSH sessions|stable plugin shell/);
+
+    const stopped = captureReport(t, printLifecycleResult, {
+      ok: true,
+      action: "stop",
+      backend: { ok: true, action: "stop", skipped: true, reason: "active_clients_remaining" },
+      [key]: { ...readyAdapter, enabled: false },
+    });
+    assert.match(stopped, /Backend remains running for the other active client integrations/);
+    assert.ok(stopped.includes(`${name} Hook integration is stopped; provider config was not changed.`));
+
+    const removed = captureReport(t, printLifecycleResult, {
+      ok: true,
+      action: "uninstall",
+      [key]: { ok: true, removed: true },
+    });
+    assert.ok(removed.includes(`MemoraX Code has been uninstalled from ${name}.`));
+  });
+
+  test(`${name} failure is included in mixed-client start and status guidance`, (t) => {
+    const report = {
+      ok: false,
+      backend,
+      codexAdapter: readyAdapter,
+      [key]: { ...readyAdapter, enabled: false },
+    };
+    const started = captureReport(t, printLifecycleResult, { ...report, action: "start" });
+    assert.match(started, /one or more adapters are not enabled/);
+    assert.doesNotMatch(started, /available client integrations are enabled|Adapters were not changed/);
+
+    const status = captureReport(t, printMemoraxCodeStatus, { ...report, action: "status" });
+    assert.ok(status.includes(`${label} adapter is not enabled.`));
+    assert.doesNotMatch(status, /MemoraX Code needs attention/);
+  });
+}
+
+test("Trae activation remains explicit before a Hook has been observed", (t) => {
+  const traeAdapter = {
+    ...readyAdapter,
+    traeSkills: { ok: true, status: "installed" },
+    traeHooks: { ok: true, status: "unverified", configured: true, runtimeObserved: false },
+    globalHooksActivationRequired: true,
+  };
+  for (const action of ["start", "restart", "status"]) {
+    const output = captureReport(t, action === "status" ? printMemoraxCodeStatus : printLifecycleResult, {
+      ok: true,
+      action,
+      backend,
+      traeAdapter,
+    });
+    assert.match(output, /Trae adapter: ok integration=hooks skills=installed hook-runtime=unverified/);
+    assert.match(output, /open Trae Settings and enable Global Hooks, then start a new Trae session/);
+  }
+  const observed = captureReport(t, printMemoraxCodeStatus, {
+    ok: true,
+    action: "status",
+    backend,
+    traeAdapter: {
+      ...traeAdapter,
+      traeHooks: { ok: true, status: "observed", configured: true, runtimeObserved: true },
+      globalHooksActivationRequired: false,
+    },
+  });
+  assert.match(observed, /hook-runtime=observed/);
+  assert.doesNotMatch(observed, /requires one manual step/);
+});
+
+test("optional DSH with Trae retains both unavailable and activation guidance", (t) => {
+  const report = {
+    ok: true,
+    degraded: true,
+    backend,
+    dshAdapter: { ok: false, optional: true, reason: "not-detected" },
+    traeAdapter: { ...readyAdapter, globalHooksActivationRequired: true },
+  };
+  for (const action of ["start", "status"]) {
+    const output = captureReport(t, action === "status" ? printMemoraxCodeStatus : printLifecycleResult, {
+      ...report,
+      action,
+    });
+    assert.match(output, /DSH adapter: unavailable not-detected/);
+    assert.match(output, /DSH integration is unavailable: not-detected/);
+    assert.match(output, /open Trae Settings and enable Global Hooks/);
+    assert.doesNotMatch(output, /ready for new DSH sessions|New DSH sessions/);
+  }
+});
+
+test("adapter report output preserves all six client labels and summary fields", (t) => {
+  const output = captureReport(t, printMemoraxCodeStatus, {
+    ok: true,
+    action: "status",
+    backend,
+    codexAdapter: { ...readyAdapter, codexSkills: { status: "ok" } },
+    claudeAdapter: { ...readyAdapter, claudeSkills: { status: "ok" } },
+    dshAdapter: { ...readyAdapter, integration: "plugin", version: "1.0.0", dshVersionTested: false },
+    opencodeAdapter: { ...readyAdapter, integration: "plugin", opencodeSkills: { status: "ok" } },
+    codebuddyAdapter: { ...readyAdapter, codebuddySkills: { status: "ok" }, codebuddyHooks: { status: "observed" } },
+    traeAdapter: { ...readyAdapter, traeSkills: { status: "installed" }, traeHooks: { status: "unverified" } },
+  });
+  assert.deepEqual(output.split("\n").filter((line) => line.includes(" adapter:")), [
+    "[MemoraX Code Backend]: Codex adapter: ok integration=hooks skills=ok",
+    "[MemoraX Code Backend]: Claude adapter: ok integration=hooks skills=ok",
+    "[MemoraX Code Backend]: DSH adapter: ok integration=plugin version=1.0.0 tested=false",
+    "[MemoraX Code Backend]: OpenCode adapter: ok integration=plugin skills=ok",
+    "[MemoraX Code Backend]: CodeBuddy adapter: ok integration=hooks skills=ok hook-runtime=observed",
+    "[MemoraX Code Backend]: Trae adapter: ok integration=hooks skills=installed hook-runtime=unverified",
+  ]);
+});
+
+test("optional Claude and DSH reports retain their status exceptions", (t) => {
+  const output = captureReport(t, printMemoraxCodeStatus, {
+    ok: false,
+    action: "status",
+    backend,
+    codexAdapter: readyAdapter,
+    claudeAdapter: { ok: true, installed: false, reason: "not-configured" },
+    dshAdapter: { ok: false, optional: true, reason: "not-detected" },
+    codebuddyAdapter: { ...readyAdapter, enabled: false },
+  });
+  assert.match(output, /Claude adapter: skipped not-configured/);
+  assert.match(output, /DSH adapter: unavailable not-detected/);
+  assert.match(output, /CodeBuddy adapter is not enabled/);
+  assert.doesNotMatch(output, /Claude adapter is not enabled|DSH adapter is not enabled/);
+});

--- a/packages/ts/memorax-code-backend/test/lifecycle/client-reports.test.mjs
+++ b/packages/ts/memorax-code-backend/test/lifecycle/client-reports.test.mjs
@@ -1,0 +1,144 @@
+import assert from "node:assert/strict";
+import { readdir } from "node:fs/promises";
+import { test } from "node:test";
+import {
+  LIFECYCLE_CLIENTS,
+  isAdapterReady,
+  lifecycleAdapterReports,
+  summarizeAdapterReport,
+} from "../../dist/lifecycle/client-reports.js";
+
+const clients = [
+  { id: "codex", name: "Codex", reportKey: "codexAdapter", skillKey: "codexSkills" },
+  { id: "claude", name: "Claude Code", reportKey: "claudeAdapter", skillKey: "claudeSkills" },
+  { id: "dsh", name: "DSH", reportKey: "dshAdapter" },
+  { id: "opencode", name: "OpenCode", reportKey: "opencodeAdapter", skillKey: "opencodeSkills" },
+  { id: "codebuddy", name: "CodeBuddy/WorkBuddy", reportKey: "codebuddyAdapter", skillKey: "codebuddySkills", hookKey: "codebuddyHooks" },
+  { id: "trae", name: "Trae", reportKey: "traeAdapter", skillKey: "traeSkills", hookKey: "traeHooks" },
+];
+
+function installedAdapter(client) {
+  return {
+    ok: true,
+    installed: true,
+    enabled: true,
+    integration: "plugin",
+    backendUrlMatches: true,
+    ...(client.skillKey ? { [client.skillKey]: { ok: true, status: "installed" } } : {}),
+    ...(client.hookKey ? { [client.hookKey]: { ok: true, status: "unverified", configured: true, runtimeObserved: false } } : {}),
+  };
+}
+
+test("lifecycle client catalog covers every Backend client without duplicate report keys", async () => {
+  assert.equal(new Set(LIFECYCLE_CLIENTS.map(({ reportKey }) => reportKey)).size, LIFECYCLE_CLIENTS.length);
+  assert.equal(LIFECYCLE_CLIENTS.every(({ name }) => typeof name === "string" && name.length > 0), true);
+  const entries = await readdir(new URL("../../src/clients/", import.meta.url), { withFileTypes: true });
+  assert.deepEqual(
+    LIFECYCLE_CLIENTS.map(({ id }) => id).sort(),
+    entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name).sort(),
+  );
+});
+
+test("lifecycle reports include only present clients in catalog order and retain raw reports", () => {
+  const trae = Object.freeze({ ok: false, reason: "not-installed", globalHooksActivationRequired: true });
+  const codex = Object.freeze({ ok: true, installed: true });
+  const dsh = Object.freeze({ optional: true, skipped: true, reason: "not-detected" });
+  const raw = Object.freeze({ traeAdapter: trae, unknownAdapter: {}, codexAdapter: codex, claudeAdapter: undefined, dshAdapter: dsh });
+  const before = JSON.stringify(raw);
+  const selected = lifecycleAdapterReports(raw);
+  assert.deepEqual(selected.map(({ client }) => client.id), ["codex", "dsh", "trae"]);
+  assert.equal(selected[0].report, codex);
+  assert.equal(selected[1].report, dsh);
+  assert.equal(selected[2].report, trae);
+  assert.equal(JSON.stringify(raw), before);
+  assert.deepEqual(lifecycleAdapterReports({}), []);
+});
+
+for (const client of clients) {
+  test(`${client.name} report summary preserves readiness and native status fields`, () => {
+    const raw = installedAdapter(client);
+    const before = structuredClone(raw);
+    const summary = summarizeAdapterReport(raw);
+    assert.equal(summary.ready, true);
+    assert.equal(summary.installed, true);
+    assert.equal(summary.enabled, true);
+    assert.equal(isAdapterReady(raw), true);
+    assert.equal(summary.integration, "plugin");
+    assert.equal(summary.skillStatus, client.skillKey ? "installed" : undefined);
+    assert.equal(summary.hookStatus, client.hookKey ? "unverified" : undefined);
+    assert.equal(summary.configured, client.hookKey ? true : undefined);
+    assert.equal(summary.runtimeObserved, client.hookKey ? false : undefined);
+    assert.equal(summary.activationRequired, false);
+    assert.deepEqual(raw, before);
+
+    for (const patch of [
+      { ok: false },
+      { installed: false },
+      { enabled: false },
+      { backendUrlMatches: false },
+      { integration: "unsupported" },
+    ]) {
+      const failed = { ...raw, ...patch };
+      assert.equal(isAdapterReady(failed), false, JSON.stringify(patch));
+      assert.equal(summarizeAdapterReport(failed).ready, false, JSON.stringify(patch));
+    }
+
+    for (const key of [client.skillKey, client.hookKey].filter(Boolean)) {
+      for (const status of ["missing", "invalid"]) {
+        const failed = { ...raw, [key]: { ok: false, status } };
+        assert.equal(isAdapterReady(failed), false, `${key} ${status}`);
+        const failedSummary = summarizeAdapterReport(failed);
+        assert.equal(failedSummary.ready, false, `${key} ${status}`);
+        assert.equal(key === client.skillKey ? failedSummary.skillStatus : failedSummary.hookStatus, status);
+      }
+    }
+  });
+}
+
+test("readiness preserves optional report fields and nested integration without inferring installation", () => {
+  const legacy = { installed: true, enabled: true, state: { integration: "hooks" } };
+  assert.equal(isAdapterReady(legacy), true);
+  assert.equal(summarizeAdapterReport(legacy).integration, "hooks");
+  assert.equal(isAdapterReady({ ...legacy, integration: "unsupported" }), false);
+  assert.equal(isAdapterReady({ installed: true, enabled: true }), false);
+  assert.equal(summarizeAdapterReport({ installed: true, enabled: true }).integration, undefined);
+  assert.equal(summarizeAdapterReport({}).installed, false);
+  assert.equal(summarizeAdapterReport({}).enabled, false);
+  assert.equal(isAdapterReady({ integration: "hooks", enabled: true }), false);
+  assert.equal(isAdapterReady({ integration: "hooks", installed: true }), false);
+  assert.equal(isAdapterReady({ state: { integration: "hooks", enabled: true }, installed: true }), false);
+});
+
+test("configured Hooks and observed runtime remain separate from installation readiness", () => {
+  for (const client of clients.filter(({ hookKey }) => hookKey)) {
+    const raw = installedAdapter(client);
+    const configured = summarizeAdapterReport(raw);
+    assert.equal(configured.ready, true);
+    assert.equal(configured.configured, true);
+    assert.equal(configured.runtimeObserved, false);
+
+    const observed = summarizeAdapterReport({
+      ...raw,
+      [client.hookKey]: { ok: true, status: "observed", configured: true, runtimeObserved: true },
+    });
+    assert.equal(observed.ready, true);
+    assert.equal(observed.configured, true);
+    assert.equal(observed.runtimeObserved, true);
+    assert.equal(observed.hookStatus, "observed");
+  }
+});
+
+test("Trae Global Hooks activation requirement is retained without becoming a readiness blocker", () => {
+  const raw = Object.freeze({
+    ...installedAdapter(clients.find(({ id }) => id === "trae")),
+    traeHooks: Object.freeze({ ok: true, status: "unverified", configured: true, runtimeObserved: false }),
+    globalHooksActivationRequired: true,
+  });
+  const summary = summarizeAdapterReport(raw);
+  assert.equal(summary.ready, true);
+  assert.equal(summary.activationRequired, true);
+  assert.equal(summary.configured, true);
+  assert.equal(summary.runtimeObserved, false);
+  assert.equal(raw.globalHooksActivationRequired, true);
+  assert.equal(Object.hasOwn(raw, "activationRequired"), false);
+});

--- a/packages/ts/memorax-code-backend/test/lifecycle/client-selection.test.mjs
+++ b/packages/ts/memorax-code-backend/test/lifecycle/client-selection.test.mjs
@@ -57,15 +57,34 @@ test("--clients overrides persisted config", () => {
 });
 
 test("--clients accepts exact client sets", () => {
-  assert.deepEqual(parseManagedClients("codex"), { codex: true, claude: false, dsh: false, opencode: false });
-  assert.deepEqual(parseManagedClients("claude"), { codex: false, claude: true, dsh: false, opencode: false });
-  assert.deepEqual(parseManagedClients("dsh"), { codex: false, claude: false, dsh: true, opencode: false });
-  assert.deepEqual(parseManagedClients("opencode"), { codex: false, claude: false, dsh: false, opencode: true });
-  assert.deepEqual(parseManagedClients("trae"), { codex: false, claude: false, dsh: false, opencode: false, trae: true });
+  for (const client of ["codex", "claude", "dsh", "opencode", "codebuddy", "trae"]) {
+    const expected = { codex: false, claude: false, dsh: false, opencode: false, [client]: true };
+    assert.deepEqual(parseManagedClients(client), expected);
+    assert.deepEqual(parseManagedClients(` ${client.toUpperCase()}, ${client} `), expected);
+    assert.deepEqual(resolveManagedClients(["--clients", client], { clients: { codex: true, claude: true, dsh: true, opencode: true, codebuddy: true, trae: true } }), expected);
+  }
   assert.deepEqual(parseManagedClients("codex,dsh,opencode"), { codex: true, claude: false, dsh: true, opencode: true });
   assert.deepEqual(parseManagedClients("codex,claude,dsh,opencode,trae"), { codex: true, claude: true, dsh: true, opencode: true, trae: true });
   assert.deepEqual(parseManagedClients("all"), { codex: true, claude: true, dsh: true, opencode: true, codebuddy: true, trae: true });
   assert.deepEqual(parseManagedClients("none"), { codex: false, claude: false, dsh: false, opencode: false });
+});
+
+test("optional managed clients are omitted unless explicitly enabled", () => {
+  assert.deepEqual(resolveManagedClients([], { clients: { codebuddy: false, trae: false } }), {
+    codex: false,
+    claude: false,
+    dsh: true,
+    opencode: false,
+  });
+  for (const client of ["codebuddy", "trae"]) {
+    assert.deepEqual(resolveManagedClients([], { clients: { [client]: true, dsh: false } }), {
+      codex: false,
+      claude: false,
+      dsh: false,
+      opencode: false,
+      [client]: true,
+    });
+  }
 });
 
 test("--clients rejects missing and unknown values", () => {


### PR DESCRIPTION
## Change Summary
Unify lifecycle readiness and CLI summaries across all six coding clients while preserving existing client selection defaults and JSON report fields. WorkBuddy-only and Trae-only commands now describe their integration correctly, and their failures participate in mixed-client guidance.

## Implementation Highlights
- Add a static lifecycle client catalog and pure report projections shared by selection validation, the orchestrator, and CLI rendering. Native discovery, installation, and lifecycle mutations remain with each participant.
- Preserve existing report keys, display labels, readiness rules, optional Claude/DSH behavior, and active-client selection compatibility.
- Include all selected clients in start, stop, status, and uninstall guidance; retain Trae Global Hooks activation guidance for start, restart, and status, separately from observed Hook execution.
- Add report and CLI regression coverage, extend source-boundary discovery, and document the lifecycle reporting boundary and harness onboarding checklist.

## Validation
- Focused lifecycle reports, client selection, CLI reports, and architecture checks: 35 passed.
- `make docs-check`: 10 passed; documentation contracts and README synchronization passed.
- `make test`: 1,246 passed, 4 skipped, 0 failed, including Backend TypeScript typecheck and all six adapter suites.
- `make npm-package-check`: completed successfully, including npm tests, local-only trace checks, a 426-file package allowlist, and isolated installed-package checks.
- The four skips cover filesystem Unicode/case aliasing and opt-in macOS Keychain/Linux Secret Service tests.
- Independent scope and compatibility review found no blocking issues; `git diff --check` passed.

## Full End-to-End Validation Results
- Environment: macOS arm64, Node.js 24.15.0, npm 11.12.1; fresh isolated application/client homes, XDG directories, and temporary storage.
- Scenario or matrix: synthetic lifecycle/report scenarios for Codex, Claude Code, DSH, OpenCode, CodeBuddy/WorkBuddy, and Trae, plus packaged CLI/install/update checks. Real coding-client sessions and MemoraX-backed memory operations were not exercised.
- Command or workflow: focused Node tests, `make docs-check`, `make test`, and `make npm-package-check`, run sequentially with inherited application overrides cleared.
- Result: all required local checks completed successfully with unchanged source throughout validation.
- Evidence or artifacts: test logs and a source-tree verification receipt retained locally; no private fixtures or logs included in this PR.
- Reason not run / remaining risk: real-client and MemoraX-backed end-to-end tests require explicit opt-in and were not requested. Native application activation, Hook execution in real sessions, and remote memory behavior remain unverified in this run.
