### PR TITLE
fix: correct client lifecycle, turn handling, and repository scope

### DIFF
--- a/packages/ts/memorax-code-adapter-common/src/backend-connection.mjs
+++ b/packages/ts/memorax-code-adapter-common/src/backend-connection.mjs
@@ -174,6 +174,8 @@ export function resolveBackendConnection(options = {}) {
   const selected = selectedBackendUrl(options.backendUrl, env, authorityState, authorityPath);
   const tokenFromEnvironment = stringValue(options.backendToken)
     ?? stringValue(env.MEMORAX_CODE_BACKEND_TOKEN);
+  // A persisted token belongs to its recorded URL. An address override must
+  // not silently carry that token to a different Backend.
   const authorityMatches = authority?.url === selected.url;
   const persistedToken = !tokenFromEnvironment && authorityMatches && authority?.tokenPath
     ? readToken(authority.tokenPath, memoraxCodeHome)

--- a/packages/ts/memorax-code-adapter-common/src/config-utils.mjs
+++ b/packages/ts/memorax-code-adapter-common/src/config-utils.mjs
@@ -99,6 +99,8 @@ export function atomicWriteText(path, value) {
   }
 }
 
+// timeoutMs limits acquisition waits; staleMs governs stale-owner checks.
+// Neither is a lease on a live owner's lock. The callback must finish synchronously.
 export function withJsonFileLock(path, operation, options = {}) {
   const timeoutMs = positiveInteger(options.timeoutMs, JSON_FILE_LOCK_TIMEOUT_MS);
   const staleMs = positiveInteger(options.staleMs, JSON_FILE_LOCK_STALE_MS);
@@ -136,6 +138,8 @@ export function withJsonFileLock(path, operation, options = {}) {
   }
 }
 
+// signal can prevent the callback from starting, but cannot interrupt it.
+// Once started, operation holds the lock until its returned promise settles.
 export async function withJsonFileLockAsync(path, operation, options = {}) {
   const timeoutMs = positiveInteger(options.timeoutMs, JSON_FILE_LOCK_TIMEOUT_MS);
   const staleMs = positiveInteger(options.staleMs, JSON_FILE_LOCK_STALE_MS);

--- a/packages/ts/memorax-code-adapter-common/src/hooks/client-hook-launcher.mjs
+++ b/packages/ts/memorax-code-adapter-common/src/hooks/client-hook-launcher.mjs
@@ -198,6 +198,8 @@ function currentSelection({ client, component, fallback, memoraxCodeHome }) {
     : fallback;
 }
 
+// A Turn must finish with the runtime selected at its start. If that pin
+// cannot be resolved, do not substitute current or another bundled version.
 function selectionFromPin({ client, component, fallback, memoraxCodeHome, pin }) {
   if (pin.generationSource === "bundled") {
     return fallback?.generationId === pin.generationId ? fallback : undefined;

--- a/packages/ts/memorax-code-adapter-common/src/hooks/hook-runtime-generation.mjs
+++ b/packages/ts/memorax-code-adapter-common/src/hooks/hook-runtime-generation.mjs
@@ -66,6 +66,8 @@ export function clientHookRuntimePaths(memoraxCodeHome) {
   };
 }
 
+// Staging leaves current authority unchanged so failed lifecycle readiness
+// checks cannot replace the active generation. Activation is a separate step.
 export function stageClientHookRuntimeGeneration({
   packageRoot,
   memoraxCodeHome,
@@ -186,6 +188,8 @@ export function prepareClientHookRuntimeGeneration(options = {}) {
   return { generation, current };
 }
 
+// Full-tree digests are checked at stage/activation, not on each Hook lookup.
+// Reads validate metadata and rely on published generations staying unchanged.
 export function readCurrentClientHookRuntime(memoraxCodeHome) {
   const paths = clientHookRuntimePaths(memoraxCodeHome);
   const state = readJsonRuntimeRecord(paths.currentPath);

--- a/packages/ts/memorax-code-adapter-common/src/runtime-record.mjs
+++ b/packages/ts/memorax-code-adapter-common/src/runtime-record.mjs
@@ -47,6 +47,8 @@ export function readJsonRuntimeRecord(path) {
   return { status: "present", value };
 }
 
+// Atomic replacement gives readers a complete snapshot. Read-modify-write
+// callers must hold their own lock across the read and this write.
 export function writePrivateJsonRecord(path, value, options) {
   const directoryPath = dirname(path);
   ensurePrivateDirectory(directoryPath, {
@@ -76,6 +78,8 @@ export function writePrivateJsonRecord(path, value, options) {
     }
     throw error;
   }
+  // rename has already published the new record. A directory-sync failure
+  // means crash durability is uncertain; it does not mean the write was undone.
   try {
     (options?.syncDirectory ?? syncDirectory)(directoryPath);
     return { path, record: value, durability: "confirmed" };

--- a/packages/ts/memorax-code-backend/src/clients/claude/memory-hook-runtime.ts
+++ b/packages/ts/memorax-code-backend/src/clients/claude/memory-hook-runtime.ts
@@ -154,6 +154,8 @@ export function createClaudeMemoryHookRuntime(
       if (turnEndRecord && !turnEndRecord.written && turnEndRecord.reason === "duplicate_event") {
         await recordClaudeTurnMaterialization(options, traceContext, transcript.turn);
       }
+      // The Hook reply is diagnostic evidence only; persisted transcript content
+      // remains authoritative even when the two texts differ.
       recordAssistantConsistencyDiagnostic(
         transcript.turn.assistantReply,
         request.lastAssistantMessage,
@@ -207,6 +209,8 @@ async function readExactTranscriptTurnWithRetry(
   input: { transcriptPath: string; sessionId: string; promptId: string },
   options: ClaudeMemoryHookRuntimeOptions,
 ): Promise<ClaudeTranscriptTurnResult> {
+  // Stop may arrive before transcript writes finish. Retry read/content
+  // availability failures, but reject identity mismatches and branch ambiguity.
   const attempts = positiveInteger(options.transcriptReadAttempts, DEFAULT_TRANSCRIPT_READ_ATTEMPTS);
   const retryDelayMs = nonNegativeInteger(options.transcriptRetryDelayMs, DEFAULT_TRANSCRIPT_RETRY_DELAY_MS);
   let result: ClaudeTranscriptTurnResult = { ok: false, reason: "turn_not_found" };

--- a/packages/ts/memorax-code-backend/src/clients/claude/transcript-turn.ts
+++ b/packages/ts/memorax-code-backend/src/clients/claude/transcript-turn.ts
@@ -264,6 +264,8 @@ function requestedSessionRecords(
   records: JsonRecord[],
   requestedSessionId: string,
 ): JsonRecord[] | undefined {
+  // Imported history may precede this Session, but must not reappear inside it.
+  // Exclude that prefix so parent traversal cannot import another Session's content.
   let requestedSessionStart: number | undefined;
   for (const [index, record] of records.entries()) {
     const sessionId = sessionIdFromRecord(record);
@@ -310,6 +312,8 @@ type ClaudePromptBranch = Readonly<{
 function maximalTerminalLineages<T extends Readonly<{ branch: ClaudePromptBranch }>>(
   candidates: readonly T[],
 ): T[] {
+  // Ancestor and descendant end_turn records can be snapshots of one completion.
+  // Keep terminal descendants; sibling branches remain ambiguous regardless of file order.
   const indexesByRecord = new Map<JsonRecord, number[]>();
   const indexesByUuid = new Map<string, number[]>();
   for (const [index, candidate] of candidates.entries()) {
@@ -430,6 +434,8 @@ function interactivePromptIndex(
 }
 
 function interruptionMarker(record: JsonRecord): boolean {
+  // interruptedMessageId signals interruption but need not be a transcript record UUID.
+  // Associate content through the marker's parentUuid chain instead.
   return record.type === "user"
     && record.isSidechain !== true
     && Boolean(stringValue(record.interruptedMessageId ?? record.interrupted_message_id));

--- a/packages/ts/memorax-code-backend/src/clients/codebuddy/jsonl-history.ts
+++ b/packages/ts/memorax-code-backend/src/clients/codebuddy/jsonl-history.ts
@@ -118,6 +118,8 @@ function selectCodeBuddyTurnBranch(
   if (!records) return { ok: false, reason: "malformed_transcript" };
   const session = records.filter((record) => stringField(record, "sessionId") === input.sessionId);
   const users = session.filter((record) => record.role === "user" && visibleUserPrompt(record));
+  // The pre-submit byte boundary excludes earlier identical prompts; the digest
+  // locates the native user record. Writeback content still comes from the transcript.
   const candidates = users.filter((record) => {
     const prompt = visibleUserPrompt(record);
     return Boolean(
@@ -210,7 +212,8 @@ function contentText(value: unknown): string | undefined {
 function belongsTo(record: CodeBuddyHistoryRecord, userId: string, records: readonly CodeBuddyHistoryRecord[]): boolean {
   let current: CodeBuddyHistoryRecord | undefined = record;
   const seen = new Set<string>();
-  for (let depth = 0; current && depth < 100; depth += 1) {
+  // Detect cycles without truncating valid long tool chains.
+  while (current) {
     const id = stringField(current, "id");
     if (id && seen.has(id)) return false;
     if (id) seen.add(id);

--- a/packages/ts/memorax-code-backend/src/clients/codebuddy/jsonl-history.ts
+++ b/packages/ts/memorax-code-backend/src/clients/codebuddy/jsonl-history.ts
@@ -51,7 +51,7 @@ export function codeBuddyTranscriptTurnFromJsonLines(
 ): CodeBuddyTurnResult {
   const selected = selectCodeBuddyTurnBranch(text, input);
   if (!selected.ok) return selected;
-  const branch = selected.records.filter((record) => record.role === "assistant" && record.status === "completed" && belongsTo(record, selected.userId, selected.records));
+  const branch = selected.records.filter((record) => record.role === "assistant" && record.status === "completed");
   if (branch.length !== 1) return { ok: false, reason: branch.length > 1 ? "turn_ambiguous" : "assistant_message_missing" };
   const assistant = branch[0];
   const reply = assistantText(assistant);
@@ -63,7 +63,7 @@ export function codeBuddyTranscriptTurnFromJsonLines(
       turnId: input.turnId,
       userPrompt: selected.userPrompt,
       assistantReply: reply,
-      activities: activitiesBetween(selected.records, selected.userId, assistant),
+      activities: turnActivities(selected.records),
       sessionTurnIndex: selected.sessionTurnIndex,
     },
   };
@@ -78,7 +78,6 @@ export function codeBuddyInterruptedTranscriptTurnFromJsonLines(
   const assistants = selected.records.filter((record) => (
     record.role === "assistant"
     && (record.type === "message" || stringField(record, "status") !== undefined)
-    && belongsTo(record, selected.userId, selected.records)
   ));
   if (assistants.length > 1) return { ok: false, reason: "turn_ambiguous" };
   const assistant = assistants[0];
@@ -92,7 +91,7 @@ export function codeBuddyInterruptedTranscriptTurnFromJsonLines(
       turnId: input.turnId,
       userPrompt: selected.userPrompt,
       assistantReply: assistant ? assistantText(assistant) ?? "" : "",
-      activities: assistant ? activitiesBetween(selected.records, selected.userId, assistant) : [],
+      activities: assistant ? turnActivities(selected.records) : [],
       sessionTurnIndex: selected.sessionTurnIndex,
     },
   };
@@ -100,7 +99,6 @@ export function codeBuddyInterruptedTranscriptTurnFromJsonLines(
 
 type SelectedCodeBuddyTurnBranch = Readonly<{
   records: ParsedHistoryRecord[];
-  userId: string;
   userPrompt: string;
   sessionTurnIndex: number;
 }>;
@@ -136,8 +134,7 @@ function selectCodeBuddyTurnBranch(
   if (!userId || !userPrompt) return { ok: false, reason: "turn_not_found" };
   return {
     ok: true,
-    records,
-    userId,
+    records: recordsInBranch(records, userId),
     userPrompt,
     sessionTurnIndex: users.indexOf(user) + 1,
   };
@@ -209,28 +206,38 @@ function contentText(value: unknown): string | undefined {
   return parts.join("\n") || undefined;
 }
 
-function belongsTo(record: CodeBuddyHistoryRecord, userId: string, records: readonly CodeBuddyHistoryRecord[]): boolean {
-  let current: CodeBuddyHistoryRecord | undefined = record;
-  const seen = new Set<string>();
-  // Detect cycles without truncating valid long tool chains.
-  while (current) {
-    const id = stringField(current, "id");
-    if (id && seen.has(id)) return false;
-    if (id) seen.add(id);
-    const parent = stringField(current, "parentId");
-    if (!parent) return false;
-    if (parent === userId) return true;
-    current = records.find((candidate) => stringField(candidate, "id") === parent);
+function recordsInBranch(records: ParsedHistoryRecord[], userId: string): ParsedHistoryRecord[] {
+  // Resolve descendants once; repeated ancestor scans become cubic on long tool chains.
+  const childrenByParent = new Map<string, CodeBuddyHistoryRecord[]>();
+  for (const record of records) {
+    const parentId = stringField(record, "parentId");
+    if (!parentId) continue;
+    const children = childrenByParent.get(parentId);
+    if (children) children.push(record);
+    else childrenByParent.set(parentId, [record]);
   }
-  return false;
+  const branch = new Set<CodeBuddyHistoryRecord>();
+  const pending = [userId];
+  const seen = new Set<string>();
+  for (let index = 0; index < pending.length; index += 1) {
+    const parentId = pending[index];
+    if (seen.has(parentId)) continue;
+    seen.add(parentId);
+    for (const child of childrenByParent.get(parentId) ?? []) {
+      branch.add(child);
+      const id = stringField(child, "id");
+      if (id) pending.push(id);
+    }
+  }
+  // Keep parsed order, including ID-less records and tools on sibling branches.
+  return records.filter((record) => branch.has(record));
 }
 
-function activitiesBetween(records: readonly CodeBuddyHistoryRecord[], userId: string, assistant: CodeBuddyHistoryRecord): CodeBuddyActivity[] {
+function turnActivities(records: readonly CodeBuddyHistoryRecord[]): CodeBuddyActivity[] {
   const result: CodeBuddyActivity[] = [];
   for (const record of records) {
     const type = stringField(record, "type");
     if (type !== "function_call" && type !== "function_call_result") continue;
-    if (!belongsTo(record, userId, records) || !belongsTo(assistant, userId, records)) continue;
     const name = stringField(record, "name") ?? stringField(record, "function") ?? "tool";
     result.push({ kind: "tool", name, ...(contentText(record.arguments) ? { input: contentText(record.arguments) } : {}), ...(contentText(record.output) ? { output: contentText(record.output) } : {}) });
   }

--- a/packages/ts/memorax-code-backend/src/clients/codebuddy/memory-hook-runtime.ts
+++ b/packages/ts/memorax-code-backend/src/clients/codebuddy/memory-hook-runtime.ts
@@ -41,6 +41,8 @@ export function createCodeBuddyMemoryHookRuntime(options: Options = {}): CodeBud
   const coordinator = memory.turnCoordinator;
   return {
     async recordTurnStart(command) {
+      // Interrupted turns may never emit Stop. Reconcile before the new turn
+      // replaces the session's current trace identity.
       await reconcilePreviousInterruptedTurn(coordinator, command, options, now);
       const traceContext = traceContextFromCodeBuddyHookBody(command, new Date(now()).toISOString());
       return memory.recordTurnStart({
@@ -177,6 +179,8 @@ async function reconcilePreviousInterruptedTurn(
 ): Promise<void> {
   const candidate = await previousInterruptedTurnCandidate(coordinator, currentTurn, options, now);
   if (!candidate) return;
+  // Trace and cached metadata only locate the candidate; the native transcript
+  // must confirm interruption before we close it and discard pending metadata.
   const transcript = await readCodeBuddyInterruptedTranscriptTurn({
     transcriptPath: candidate.transcriptPath,
     sessionId: candidate.sessionId,

--- a/packages/ts/memorax-code-backend/src/clients/codex/memory-hook-runtime.ts
+++ b/packages/ts/memorax-code-backend/src/clients/codex/memory-hook-runtime.ts
@@ -284,6 +284,8 @@ async function resolveHookRepositoryMemory(
     requireBoundScope,
   });
   if (!primary.ok || !registeredWorkspace || !entry.cwd) return primary;
+  // Validate both sources against the session binding; preferring the registry
+  // must not hide a conflicting Hook cwd.
   return await memory.resolveRepositoryMemory({
     sessionId: entry.sessionId,
     cwd: entry.cwd,
@@ -300,6 +302,8 @@ async function resolveCurrentHookRepositoryMemory(
   recoveredTraceContext?: TraceContext,
 ): Promise<ConfiguredRepositoryMemoryResult> {
   if (!entry) {
+    // Without Turn metadata, only the exact persisted current Turn can restore
+    // a missing scope binding; Stop fields alone cannot authorize a new binding.
     if (!recoveredTraceContext) {
       return await resolveHookRepositoryMemory({
         sessionId: request.sessionId!,

--- a/packages/ts/memorax-code-backend/src/clients/codex/plugin-hooks.ts
+++ b/packages/ts/memorax-code-backend/src/clients/codex/plugin-hooks.ts
@@ -180,6 +180,8 @@ async function trustHookSelectionWithContext(
   selectedHooks: CodexHook[],
 ): Promise<void> {
   await withCodexAppServer(context.codexCommand, context.workspace, context.env, async (client) => {
+    // Recheck the reviewed hashes, condition the write on the config version,
+    // then verify trust took effect. Conflicts must not broaden the selection.
     const currentHooks = await listMemoraxCodeHooksFromClient(client, context.workspace);
     const reviewedHooks = exactCurrentHookSelection(currentHooks, selectedHooks);
     const userLayer = await readCodexUserConfigLayer(client, context.workspace);

--- a/packages/ts/memorax-code-backend/src/clients/codex/plugin-install.ts
+++ b/packages/ts/memorax-code-backend/src/clients/codex/plugin-install.ts
@@ -182,6 +182,8 @@ async function updateVersionedCodexPlugin(
   const marketplaceRoot = codexCliMarketplaceRoot(codexHome);
   const marketplacePath = join(marketplaceRoot, ".agents", "plugins", "marketplace.json");
   const pluginSourcePath = join(marketplaceRoot, "versions", version, "plugins", PLUGIN_NAME);
+  // Existing sessions may still reference an older directory. Publish or reuse
+  // immutable versioned artifacts before switching the marketplace pointer.
   await publishImmutableDirectory(pluginSourcePath, dirname(pluginSourcePath), version, async (temporaryRoot) => {
     await stagePluginSource(sourceRoot, temporaryRoot);
     await writePluginMetadata(temporaryRoot, codexCommand);
@@ -367,12 +369,17 @@ export async function removeCodexPlugin(options: CodexPluginRemoveOptions = {}):
   const removedPaths: string[] = [];
 
   const pluginRemove = await removeActivatedCodexPlugin(options, home, codexHome);
-  const marketplaceChanged = await removePersonalMarketplaceEntry(marketplacePath);
-  await removeStagedPluginSource(pluginSourcePath, removedPaths);
-  await removeCachedPluginRoots(codexHome, removedPaths);
+  let marketplaceChanged = false;
+  // A failed native removal may leave registration pointing at these files.
+  // Retain them for retry and let the outer lifecycle stop npm removal.
+  if (pluginRemove.ok) {
+    marketplaceChanged = await removePersonalMarketplaceEntry(marketplacePath);
+    await removeStagedPluginSource(pluginSourcePath, removedPaths);
+    await removeCachedPluginRoots(codexHome, removedPaths);
+  }
 
   return {
-    ok: true,
+    ok: pluginRemove.ok,
     action: "codex-plugin-remove",
     codexHome,
     marketplacePath,

--- a/packages/ts/memorax-code-backend/src/clients/codex/rollout-turn.ts
+++ b/packages/ts/memorax-code-backend/src/clients/codex/rollout-turn.ts
@@ -211,6 +211,9 @@ function scanCodexRolloutTurn(transcript: string, targetTurnId: string): CodexRo
     }
 
     const payload = isRecord(record.payload) ? record.payload : {};
+    // Only session_meta on the first nonblank line owns this file's identity.
+    // Imported history may contain the exact Turn, but makes cumulative usage
+    // and session-relative Turn indexes unsafe to infer.
     if (record.type === "session_meta") {
       if (authorityHeaderCandidate) {
         authoritySessionId = nonBlankString(payload.id);
@@ -300,6 +303,8 @@ function scanCodexRolloutTurn(transcript: string, targetTurnId: string): CodexRo
       continue;
     }
     if (eventType === "token_count") {
+      // Cumulative counters make duplicate snapshots contribute nothing; a
+      // counter rollback establishes a new baseline instead of a negative delta.
       const snapshot = tokenUsageSnapshot(payload);
       if (!snapshot) continue;
       if (activeTurnId === targetTurnId) {
@@ -336,6 +341,8 @@ function scanCodexRolloutTurn(transcript: string, targetTurnId: string): CodexRo
     composite,
     targetSeen,
     turnMetadataMismatch,
+    // Current-format response items take precedence over legacy event mirrors;
+    // missing response-item text may use the matching Turn's legacy text.
     userPrompt: responseItemUserPrompt ?? userPrompt,
     assistantReply: responseItemAssistantReply ?? assistantReply,
     visibleAssistantMessages,

--- a/packages/ts/memorax-code-backend/src/clients/dsh/session-turn.ts
+++ b/packages/ts/memorax-code-backend/src/clients/dsh/session-turn.ts
@@ -172,6 +172,8 @@ export function dshSessionEventTurn(input: DshSessionTurnInput): DshSessionTurnR
         if (!message || !validSurfaceOp(value.surfaceOp)) {
           return { ok: false, reason: "event_invalid" };
         }
+        // Native user/message events also carry plugin recall and compaction content;
+        // only directly appended user input belongs in the writeback prompt.
         if (message.source.kind === "user") {
           if (value.surfaceOp !== "append") {
             return { ok: false, reason: "event_invalid" };
@@ -202,6 +204,8 @@ export function dshSessionEventTurn(input: DshSessionTurnInput): DshSessionTurnR
   }
 
   if (!outcome) return { ok: false, reason: "turn_boundary_mismatch" };
+  // A validated non-completed interval can close the trace without text.
+  // Nonempty prompt and reply are required only for completed-Turn writeback.
   if (outcome !== "completed") {
     return { ok: false, reason: "turn_not_completed", outcome };
   }
@@ -233,6 +237,8 @@ function validateSessionHeader(
   ) return "session_header_invalid";
   if (stringField(header, "id") !== input.sessionId) return "session_identity_mismatch";
   if (stringField(header, "cwd") !== input.cwd) return "workspace_identity_mismatch";
+  // Ordinary user forks also have a parentSession; use origin/delegationDepth
+  // to identify delegated sessions rather than excluding every fork.
   if (Object.prototype.hasOwnProperty.call(header, "parentSession")) {
     if (!stringField(header, "parentSession")) return "session_header_invalid";
   }

--- a/packages/ts/memorax-code-backend/src/clients/opencode/memory-hook-runtime.ts
+++ b/packages/ts/memorax-code-backend/src/clients/opencode/memory-hook-runtime.ts
@@ -169,6 +169,8 @@ export function createOpenCodeMemoryHookRuntime(
           sessionId: command.sessionId,
           cwd: command.cwd ?? entry?.cwd,
           workspaceKind: command.workspaceKind ?? entry?.workspaceKind,
+          // SDK messages establish content identity, not the session's workspace scope.
+          // Require the binding established by a prior turn-start.
           requireBoundScope: true,
         }),
         userText: materialized.turn.userPrompt,

--- a/packages/ts/memorax-code-backend/src/clients/opencode/message-turn.ts
+++ b/packages/ts/memorax-code-backend/src/clients/opencode/message-turn.ts
@@ -100,6 +100,8 @@ function terminalUserMessageFor(
     message.info.role === "user" && messageId(message) === input.userMessageId
   ));
   if (startIndex < 0) return undefined;
+  // A matching tail assistant and marked continuation prove that compaction
+  // changed the final assistant's parent without starting a new user turn.
   const lineageAssistantIds = new Set<string>();
   let terminalUserMessageId = input.userMessageId;
   let awaitingContinuation = false;

--- a/packages/ts/memorax-code-backend/src/clients/trae/memory-hook-runtime.ts
+++ b/packages/ts/memorax-code-backend/src/clients/trae/memory-hook-runtime.ts
@@ -130,7 +130,10 @@ export function createTraeMemoryHookRuntime(
         traceContext,
       });
       await recordMaterializedTurn(traceContext, command, options);
-      if (activeTurn?.clientTurnId === command.turnId) activeTurns.delete(command.sessionId);
+      if (
+        activeTurn?.clientTurnId === command.turnId
+        && activeTurns.get(command.sessionId) === activeTurn
+      ) activeTurns.delete(command.sessionId);
       options.diagnosticLogger?.("trae_memory.writeback", {
         scheduled: completed.scheduled,
         ...(!completed.scheduled ? { reason: completed.reason } : {}),

--- a/packages/ts/memorax-code-backend/src/clients/trae/memory-hook-runtime.ts
+++ b/packages/ts/memorax-code-backend/src/clients/trae/memory-hook-runtime.ts
@@ -60,6 +60,7 @@ export function createTraeMemoryHookRuntime(
   }, options);
   const { turnCoordinator } = memory;
   const interruptedTurns = new Set<string>();
+  // Active snapshots outlive coordinator TTL to preserve long turns' interruption authority.
   const activeTurns = new Map<string, MemoryTurnState>();
   const turnStartOperations = new Map<string, Promise<MemoryHookTurnStartResult>>();
   const runtimeTurnLimit = positiveInteger(options.maxEntries, 256);
@@ -92,6 +93,7 @@ export function createTraeMemoryHookRuntime(
         createdAt,
         traceContext,
         prompt: command.prompt,
+        // Publish before trace or retrieval can yield to a concurrent Stop.
         onTurnRegistered(turn) {
           activeTurns.delete(command.sessionId);
           activeTurns.set(command.sessionId, turn);
@@ -130,6 +132,8 @@ export function createTraeMemoryHookRuntime(
         traceContext,
       });
       await recordMaterializedTurn(traceContext, command, options);
+      // Clear only the captured snapshot; a newer turn may have registered
+      // while this Stop was awaiting completion.
       if (
         activeTurn?.clientTurnId === command.turnId
         && activeTurns.get(command.sessionId) === activeTurn

--- a/packages/ts/memorax-code-backend/src/memory/automatic-writeback.ts
+++ b/packages/ts/memorax-code-backend/src/memory/automatic-writeback.ts
@@ -75,6 +75,8 @@ export type AutomaticMemoryWritebackRejectionReason =
   | "config_missing"
   | RepositoryMemoryScopeFailureReason;
 
+// Acceptance confirms local handling, including duplicates already accepted.
+// Callers may consume matching metadata; remote writeback can still fail.
 export type AutomaticMemoryWritebackEnqueueResult =
   | { accepted: true }
   | { accepted: false; reason: AutomaticMemoryWritebackRejectionReason };
@@ -98,6 +100,8 @@ export type AutomaticMemoryWritebackRuntimeOptions = {
 type AutomaticMemoryWritebackState = {
   diagnosticLogger: MemoryDiagnosticLogger;
   queueQuotaNotice?: (config: MemoraxAdapterConfig, quota: MemoraxQuotaSnapshot) => void;
+  // Tracks in-flight and recently successful writes in a bounded TTL cache.
+  // Success keeps keys to suppress replay; terminal failure releases them.
   pendingWritebacks: Map<string, number>;
   writebackBuffer: MemoryWritebackBufferRuntime;
   accepting: boolean;
@@ -272,6 +276,8 @@ function automaticMemoryWritebackDecision(
     role: "assistant",
     sessionKey,
   }, state.diagnosticLogger);
+  // Hashes and buffers must use the redacted text, before chunking can split
+  // sensitive patterns. Dispatch rechecks this invariant on full messages.
   const userRedaction = redactMemoryPayloadText(boundedUserText);
   const assistantRedaction = redactMemoryPayloadText(boundedAssistantText);
   logAutomaticMemoryPayloadRedaction(state, sessionKey, "user", rawUserText, userRedaction);

--- a/packages/ts/memorax-code-backend/src/memory/repository-session.ts
+++ b/packages/ts/memorax-code-backend/src/memory/repository-session.ts
@@ -133,6 +133,9 @@ export async function resolveConfiguredRepositoryMemoryForSession(
       sessionScopes.set(input.owner, scopes);
     }
     const cached = scopes.get(bindingKey);
+    // A mismatch stays rejected for this base user even if later hooks return
+    // to the original workspace, preventing reuse of a conflicted binding.
+    // Changing the base user requires a new binding.
     if (cached?.scope.baseUserId === configResult.config.userId && cached.mismatch) {
       return repositoryScopeMismatch();
     }
@@ -146,6 +149,8 @@ export async function resolveConfiguredRepositoryMemoryForSession(
     }
     const workspaceKind = input.workspaceKind?.trim().toLowerCase();
     let workspaceRoot = input.workspaceRoot?.trim() ? input.workspaceRoot : undefined;
+    // Preserve the folder namespace when hooks run from nested directories.
+    // Reuse the bound root only after ruling out another workspace or repository.
     if (
       cachedScope
       && repositoryMemoryScopeKind(cachedScope) === "local-directory"
@@ -176,6 +181,8 @@ export async function resolveConfiguredRepositoryMemoryForSession(
     if (cached?.scope.baseUserId === configResult.config.userId) {
       if (!repositoryMemoryScopesMatch(cached.scope, scopeResult.scope)) {
         if (repositoryMemoryScopeCanUpgradeFromDegradedGit(cached.scope, scopeResult.scope)) {
+          // The writeback owner uses this synchronous callback to discard pending
+          // folder-scoped turns before the Git binding becomes visible.
           input.onScopeUpgrade?.({
             client: input.client,
             sessionId,

--- a/packages/ts/memorax-code-backend/src/memory/turn-coordinator.ts
+++ b/packages/ts/memorax-code-backend/src/memory/turn-coordinator.ts
@@ -229,6 +229,8 @@ function turnMetadataDisposition(
   const key = turnKey(completion.key);
   const current = turns.get(key);
   if (!current) return "absent";
+  // Scope resolution can yield while the same Turn key is re-registered.
+  // Consume only the completion's original snapshot, preserving replacement state.
   if (!consume || !completion.metadata || current !== completion.metadata) return "retained";
   turns.delete(key);
   return "consumed";

--- a/packages/ts/memorax-code-backend/src/memory/writeback-buffer.ts
+++ b/packages/ts/memorax-code-backend/src/memory/writeback-buffer.ts
@@ -296,6 +296,7 @@ function resetMemoryWritebackIdleTimer(
   const delayMs = Math.max(0, buffer.idleDeadlineAt - clock.now());
   buffer.timer = clock.setTimeout(() => {
     const current = writebackBuffers.get(buffer.bufferKey);
+    // Ignore callbacks from an older batch or a superseded idle deadline.
     if (current !== buffer || current.timerGeneration !== generation) return;
     flushMemoryWritebackBuffer(writebackBuffers, buffer.bufferKey, "idle_limit", deps);
   }, delayMs);

--- a/packages/ts/memorax-code-backend/src/memory/writeback-chunk.ts
+++ b/packages/ts/memorax-code-backend/src/memory/writeback-chunk.ts
@@ -79,6 +79,9 @@ function chunkWritebackMessages(
     current.push(...payload);
   };
 
+  // Keep each turn together when possible; split long messages without
+  // repeating user context on every assistant fragment. maxChars bounds each
+  // message fragment, while paired payloads may exceed it in total.
   for (const turn of turns) {
     const userChunks = turn.user ? chunkWritebackMessage(turn.user, config) : [];
     const assistantChunks = turn.assistants.flatMap((message) => chunkWritebackMessage(message, config));

--- a/packages/ts/memorax-code-backend/src/repository/scope.ts
+++ b/packages/ts/memorax-code-backend/src/repository/scope.ts
@@ -18,6 +18,8 @@ export type RepositoryMemoryScopeFallbackReason = "git_metadata_invalid";
 export type RepositoryMemoryScope = Readonly<{
   schemaVersion: "workspace-memory-scope.v1";
   baseUserId: string;
+  // Same-named repositories may share the remote namespace in effectiveUserId.
+  // repositoryKey separately identifies the local scope used for session binding.
   effectiveUserId: string;
   repositoryKey: string;
   repositorySlug: string;
@@ -248,6 +250,9 @@ async function resolveGitRepository(workspace: string): Promise<GitRepositoryRes
       workspaceRoot: marker.workspaceRoot,
     };
   } catch (error) {
+    // Only a direct .git directory can anchor folder fallback for malformed or
+    // incomplete metadata. An invalid .git file pointer or a permission error
+    // leaves scope authority unverified, so resolution must fail closed.
     if (directDirectoryMarker && canFallbackFromDirectGitDirectory(error)) {
       return {
         kind: "degraded",

--- a/packages/ts/memorax-code-backend/src/repository/scope.ts
+++ b/packages/ts/memorax-code-backend/src/repository/scope.ts
@@ -532,20 +532,25 @@ function repositoryNameFromRemoteUrl(value: string): string | undefined {
     || raw.startsWith("./")
     || raw.startsWith("../")
     || raw.startsWith("\\\\")
-    || /^[a-zA-Z]:[\\/]/.test(raw)
+    || /^[a-zA-Z]:/.test(raw)
+    || /^file:/i.test(raw)
   ) return undefined;
 
-  try {
-    const parsed = new URL(raw);
-    if (!["http:", "https:", "ssh:", "git:", "git+ssh:", "git+https:"].includes(parsed.protocol)) {
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(raw)) {
+    try {
+      const parsed = new URL(raw);
+      if (!["http:", "https:", "ssh:", "git:", "git+ssh:", "git+https:"].includes(parsed.protocol)) {
+        return undefined;
+      }
+      if (!parsed.hostname.trim()) return undefined;
+      return repositoryNameFromRemotePath(parsed.pathname);
+    } catch {
       return undefined;
     }
-    if (!parsed.hostname.trim()) return undefined;
-    return repositoryNameFromRemotePath(parsed.pathname);
-  } catch {
-    const scp = /^(?:[^@/:\s]+@)?[^/:\s]+:(.+)$/.exec(raw);
-    return scp?.[1] ? repositoryNameFromRemotePath(scp[1]) : undefined;
   }
+  // A double colon denotes Git's remote-helper syntax, not an SCP address.
+  const scp = /^(?:[^@/:\s]+@)?[^/:\s]+:(?!:)(.+)$/.exec(raw);
+  return scp?.[1] ? repositoryNameFromRemotePath(scp[1]) : undefined;
 }
 
 function repositoryNameFromRemotePath(value: string): string | undefined {

--- a/packages/ts/memorax-code-backend/test/clients/codebuddy/codebuddy-transcript.test.mjs
+++ b/packages/ts/memorax-code-backend/test/clients/codebuddy/codebuddy-transcript.test.mjs
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
+import { performance } from "node:perf_hooks";
 import {
   codeBuddyInterruptedTranscriptTurnFromJsonLines,
   codeBuddyTranscriptTurnFromJsonLines,
@@ -30,7 +31,8 @@ test("preserves completed and interrupted replies through a long tool chain", ()
   const records = [
     { id: "u1", type: "message", role: "user", sessionId, content: [{ type: "input_text", text: "long task" }] },
   ];
-  const callCount = 60;
+  // Stay within the normal test budget even when a turn has thousands of records.
+  const callCount = 1000;
   for (let index = 0; index < callCount; index += 1) {
     records.push(
       { id: `c${index}`, type: "function_call", role: "assistant", parentId: records.at(-1).id, name: "Bash", arguments: "{}" },
@@ -43,7 +45,11 @@ test("preserves completed and interrupted replies through a long tool chain", ()
   };
   records.push(assistant);
   const input = { sessionId, turnId: provisionalTurnId("long task") };
-  const completed = codeBuddyTranscriptTurnFromJsonLines(records.map(JSON.stringify).join("\n"), input);
+  const transcript = records.map(JSON.stringify).join("\n");
+  const startedAt = performance.now();
+  const completed = codeBuddyTranscriptTurnFromJsonLines(transcript, input);
+  // Synchronous parsing can block the runner's timeout, so check elapsed time too.
+  assert.ok(performance.now() - startedAt < 5000, "Long-chain extraction must avoid repeated transcript scans");
   assert.equal(completed.ok, true);
   assert.equal(completed.turn.userPrompt, "long task");
   assert.equal(completed.turn.assistantReply, "done");
@@ -55,6 +61,29 @@ test("preserves completed and interrupted replies through a long tool chain", ()
   assert.equal(interrupted.ok, true);
   assert.equal(interrupted.turn.assistantReply, "partial answer");
   assert.equal(interrupted.turn.activities.length, callCount * 2);
+});
+
+test("preserves descendant activities and parsed order after duplicate replacement", () => {
+  const records = [
+    { id: "u1", type: "message", role: "user", sessionId, content: [{ type: "input_text", text: "branch task" }] },
+    { id: "c1", type: "function_call", parentId: "u1", name: "Bash", arguments: "main" },
+    { id: "r1", type: "function_call_result", parentId: "c1", output: "main result" },
+    { id: "sibling", type: "function_call", parentId: "u1", name: "Read", arguments: "sibling" },
+    { type: "function_call_result", parentId: "sibling", output: "sibling result" },
+    { id: "replaced", type: "function_call", parentId: "u1", name: "stale" },
+    { id: "a1", type: "message", role: "assistant", parentId: "r1", status: "completed", content: [{ type: "output_text", text: "done" }] },
+    { id: "replaced", type: "function_call", parentId: "missing", name: "unrelated" },
+  ];
+  const result = codeBuddyTranscriptTurnFromJsonLines(records.map(JSON.stringify).join("\n"), {
+    sessionId, turnId: provisionalTurnId("branch task"),
+  });
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.turn.activities, [
+    { kind: "tool", name: "tool", output: "sibling result" },
+    { kind: "tool", name: "Bash", input: "main" },
+    { kind: "tool", name: "tool", output: "main result" },
+    { kind: "tool", name: "Read", input: "sibling" },
+  ]);
 });
 
 test("rejects a completed reply whose parent chain cycles without reaching the user", () => {
@@ -80,6 +109,7 @@ test("fails closed on cancelled incomplete assistant", () => {
 test("recovers an interrupted turn without assistant material", () => {
   const lines = [
     { id: "u1", type: "message", role: "user", sessionId, content: [{ type: "input_text", text: "<user_query>cancel before reply</user_query>" }] },
+    { id: "c1", type: "function_call", parentId: "u1", name: "Bash", arguments: "{}" },
   ].map(JSON.stringify).join("\n");
   assert.deepEqual(
     codeBuddyInterruptedTranscriptTurnFromJsonLines(lines, {

--- a/packages/ts/memorax-code-backend/test/clients/codebuddy/codebuddy-transcript.test.mjs
+++ b/packages/ts/memorax-code-backend/test/clients/codebuddy/codebuddy-transcript.test.mjs
@@ -26,6 +26,49 @@ test("extracts hidden user query and completed assistant branch", () => {
   assert.equal(result.turn.assistantReply, "done");
 });
 
+test("preserves completed and interrupted replies through a long tool chain", () => {
+  const records = [
+    { id: "u1", type: "message", role: "user", sessionId, content: [{ type: "input_text", text: "long task" }] },
+  ];
+  const callCount = 60;
+  for (let index = 0; index < callCount; index += 1) {
+    records.push(
+      { id: `c${index}`, type: "function_call", role: "assistant", parentId: records.at(-1).id, name: "Bash", arguments: "{}" },
+      { id: `r${index}`, type: "function_call_result", parentId: `c${index}`, output: `result ${index}` },
+    );
+  }
+  const assistant = {
+    id: "a1", type: "message", role: "assistant", parentId: records.at(-1).id,
+    status: "completed", content: [{ type: "output_text", text: "done" }],
+  };
+  records.push(assistant);
+  const input = { sessionId, turnId: provisionalTurnId("long task") };
+  const completed = codeBuddyTranscriptTurnFromJsonLines(records.map(JSON.stringify).join("\n"), input);
+  assert.equal(completed.ok, true);
+  assert.equal(completed.turn.userPrompt, "long task");
+  assert.equal(completed.turn.assistantReply, "done");
+  assert.equal(completed.turn.activities.length, callCount * 2);
+
+  assistant.status = "incomplete";
+  assistant.content[0].text = "partial answer";
+  const interrupted = codeBuddyInterruptedTranscriptTurnFromJsonLines(records.map(JSON.stringify).join("\n"), input);
+  assert.equal(interrupted.ok, true);
+  assert.equal(interrupted.turn.assistantReply, "partial answer");
+  assert.equal(interrupted.turn.activities.length, callCount * 2);
+});
+
+test("rejects a completed reply whose parent chain cycles without reaching the user", () => {
+  const lines = [
+    { id: "u1", type: "message", role: "user", sessionId, content: [{ type: "input_text", text: "cyclic chain" }] },
+    { id: "c1", type: "function_call", role: "assistant", parentId: "r1", name: "Bash", arguments: "{}" },
+    { id: "r1", type: "function_call_result", parentId: "c1", output: "unrelated result" },
+    { id: "a1", type: "message", role: "assistant", parentId: "r1", status: "completed", content: [{ type: "output_text", text: "must not persist" }] },
+  ].map(JSON.stringify).join("\n");
+  assert.deepEqual(codeBuddyTranscriptTurnFromJsonLines(lines, {
+    sessionId, turnId: provisionalTurnId("cyclic chain"),
+  }), { ok: false, reason: "assistant_message_missing" });
+});
+
 test("fails closed on cancelled incomplete assistant", () => {
   const lines = [
     { id: "u1", type: "message", role: "user", sessionId, content: [{ type: "input_text", text: "<user_query>cancel me</user_query>" }] },

--- a/packages/ts/memorax-code-backend/test/clients/codex/codex-plugin-install.test.mjs
+++ b/packages/ts/memorax-code-backend/test/clients/codex/codex-plugin-install.test.mjs
@@ -387,6 +387,8 @@ test("memorax-code uninstall leaves Codex config unchanged and removes the plugi
       memoraxCodeHome,
       "--codex-home",
       codexHome,
+      "--codex-command",
+      join(root, "missing-codex"),
       "--port",
       String(port),
       "--clients",
@@ -604,6 +606,79 @@ test("memorax-code uninstall retains the plugin when the Codex Hook adapter cann
     assert.equal(report.npmPackageRemoval.reason, "lifecycle_stop_failed");
     await stat(join(pluginRoot, ".codex-plugin", "plugin.json"));
     await stat(activeClientsPath);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("memorax-code uninstall preserves Codex artifacts and npm installation after native removal fails", async () => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-code-uninstall-native-failure-"));
+  const home = join(root, "home");
+  const codexHome = join(home, "codex-home");
+  const memoraxCodeHome = join(home, "memorax-code-home");
+  const fakeCodex = join(root, "fake-codex.mjs");
+  const fakeNpm = join(root, "fake-npm.mjs");
+  const npmLog = join(root, "npm.log");
+  const packageRoot = join(root, "node_modules", "@memorax", "memorax-code");
+  const cacheRoot = join(codexHome, "plugins", "cache", "memorax-code", "memorax-code-codex-adapter", "test-version");
+  try {
+    await mkdir(memoraxCodeHome, { recursive: true });
+    await writeFile(join(memoraxCodeHome, "config.toml"), "[clients]\ncodex = true\nclaude = false\ndsh = false\nopencode = false\ncodebuddy = false\ntrae = false\n");
+    await mkdir(join(packageRoot, "bin"), { recursive: true });
+    await writeFile(join(packageRoot, "package.json"), JSON.stringify({ name: "@memorax/memorax-code", version: "0.1.2" }));
+    await writeFile(join(packageRoot, "bin", "memorax-code.mjs"), "#!/usr/bin/env node\n");
+    await writeFile(fakeNpm, `import { appendFileSync } from "node:fs";
+appendFileSync(${JSON.stringify(npmLog)}, JSON.stringify(process.argv.slice(2)) + "\\n");
+`);
+    await writeFile(fakeCodex, `#!/usr/bin/env node
+const args = process.argv.slice(2);
+const expected = process.env.TEST_CODEX_REMOVE_FAILURE === "plugin"
+  ? ["plugin", "remove"] : ["plugin", "marketplace", "remove"];
+if (process.env.TEST_CODEX_REMOVE_FAILURE && expected.every((part, index) => args[index] === part)) {
+  console.error("fixture: native registry permission denied");
+  process.exit(1);
+}
+`);
+    await chmod(fakeCodex, 0o755);
+    const env = {
+      HOME: home,
+      CODEX_HOME: codexHome,
+      MEMORAX_CODE_NPM_PACKAGE_ROOT: packageRoot,
+      MEMORAX_CODE_NPM_COMMAND: process.execPath,
+      MEMORAX_CODE_NPM_EXEC_PATH: fakeNpm,
+    };
+    const install = await runMemoraxCode(["codex-plugin", "install", "--codex-command", fakeCodex, "--json"], env);
+    assert.equal(install.code, 0, `${install.stdout}\n${install.stderr}`);
+    const { pluginSourcePath, marketplacePath } = JSON.parse(install.stdout);
+    await cp(pluginSourcePath, cacheRoot, { recursive: true });
+    const marketplaceBefore = await readFile(marketplacePath, "utf8");
+    const args = [
+      "uninstall", "--home", memoraxCodeHome,
+      "--codex-home", codexHome, "--codex-command", fakeCodex,
+      "--clients", "codex", "--json",
+    ];
+    for (const failure of ["plugin", "marketplace"]) {
+      const uninstall = await runMemoraxCode(args, { ...env, TEST_CODEX_REMOVE_FAILURE: failure });
+      assert.equal(uninstall.code, 1, `${uninstall.stdout}\n${uninstall.stderr}`);
+      const report = JSON.parse(uninstall.stdout);
+      assert.equal(report.ok, false);
+      assert.equal(report.codexPlugin.ok, false);
+      assert.equal(report.codexPlugin.pluginRemove.ok, false);
+      assert.match(report.codexPlugin.pluginRemove.stderr, /native registry permission denied/);
+      assert.deepEqual(report.codexPlugin.removedPaths, []);
+      assert.equal(report.codexPlugin.marketplaceChanged, false);
+      assert.equal(report.npmPackageRemoval.reason, "plugin_cleanup_failed");
+      assert.equal(await readFile(marketplacePath, "utf8"), marketplaceBefore);
+      await stat(join(pluginSourcePath, ".codex-plugin", "plugin.json"));
+      await stat(join(cacheRoot, ".codex-plugin", "plugin.json"));
+      await assert.rejects(readFile(npmLog, "utf8"), /ENOENT/);
+    }
+    const retry = await runMemoraxCode(args, env);
+    assert.equal(retry.code, 0, `${retry.stdout}\n${retry.stderr}`);
+    assert.equal(JSON.parse(retry.stdout).codexPlugin.ok, true);
+    await assert.rejects(stat(join(pluginSourcePath, ".codex-plugin", "plugin.json")), /ENOENT/);
+    await assert.rejects(stat(cacheRoot), /ENOENT/);
+    assert.deepEqual(JSON.parse(await readFile(npmLog, "utf8")), ["uninstall", "-g", "@memorax/memorax-code"]);
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/packages/ts/memorax-code-backend/test/clients/trae/trae-memory-hook.test.mjs
+++ b/packages/ts/memorax-code-backend/test/clients/trae/trae-memory-hook.test.mjs
@@ -170,6 +170,76 @@ test("Trae runtime preserves interruption authority after coordinator metadata e
   }
 });
 
+test("Trae runtime preserves a replacement Turn when an older Stop finishes", async () => {
+  const fixture = await createFixture("overlapping-stop");
+  const writes = [];
+  const baseRepositoryMemorySession = createRepositoryMemorySessionRuntime();
+  let now = 1_700_000_000_000;
+  const ttlMs = 5 * 60 * 1000;
+  let resolveCalls = 0;
+  let markStopStarted;
+  let releaseStop;
+  const stopStarted = new Promise((resolve) => { markStopStarted = resolve; });
+  const stopGate = new Promise((resolve) => { releaseStop = resolve; });
+  const repositoryMemorySession = {
+    async resolve(input) {
+      resolveCalls += 1;
+      if (resolveCalls === 2) {
+        markStopStarted();
+        await stopGate;
+      }
+      return await baseRepositoryMemorySession.resolve(input);
+    },
+    close() {
+      baseRepositoryMemorySession.close();
+    },
+  };
+  const runtime = createTraeMemoryHookRuntime({
+    env: configuredEnv(fixture.home, { MEMORAX_CODE_TRAE_TRACE_ENABLED: "true" }),
+    automaticWriteback: (request) => { writes.push(request); return { accepted: true }; },
+    repositoryMemorySession,
+    now: () => now,
+    ttlMs,
+  });
+  const first = turnStart("trae-overlapping-stop", "Finish the first Turn.", fixture.workspace, now);
+  const second = turnStart(first.sessionId, "Start a long replacement Turn.", fixture.workspace, now + 1);
+  let pendingStop;
+  try {
+    await runtime.recordTurnStart(first);
+    pendingStop = runtime.writeback({ ...first, lastAssistantMessage: "The first Turn completed." });
+    await stopStarted;
+    now += 1;
+    await runtime.recordTurnStart(second);
+    releaseStop();
+    await pendingStop;
+
+    // Expire coordinator metadata so only the retained active snapshot can
+    // preserve the second Turn's interruption authority when it is replaced.
+    now += ttlMs + 1;
+    assert.equal(runtime.size(), 0);
+    const third = turnStart(first.sessionId, "Replace the long Turn.", fixture.workspace, now);
+    await runtime.recordTurnStart(third);
+    assert.deepEqual(await runtime.writeback({
+      ...third,
+      lastAssistantMessage: "The newest Turn completed.",
+    }), { ok: true, scheduled: true });
+    const events = (await readFile(traeTracePaths(fixture.home).eventsJsonl(first.sessionId), "utf8"))
+      .trim().split(/\r?\n/).map((line) => JSON.parse(line));
+    assert.deepEqual(
+      events.filter((event) => event.type === "turn_end" && event.trace.turn_id === second.turnId)
+        .map((event) => event.outcome),
+      ["interrupted"],
+    );
+    assert.deepEqual(writes.map(({ userText }) => userText), [first.prompt, third.prompt]);
+  } finally {
+    releaseStop();
+    if (pendingStop) await Promise.allSettled([pendingStop]);
+    runtime.close();
+    repositoryMemorySession.close();
+    await fixture.cleanup();
+  }
+});
+
 test("Trae accepts the replacement Turn Stop while its start retrieval is pending", async () => {
   const fixture = await createFixture("pending-retrieval-stop");
   const writes = [];

--- a/packages/ts/memorax-code-backend/test/repository/repository-memory-scope.test.mjs
+++ b/packages/ts/memorax-code-backend/test/repository/repository-memory-scope.test.mjs
@@ -313,6 +313,34 @@ test("repository naming uses origin, then a sole remote, then the canonical comm
   assert.equal(fallback.scope.identitySource, "git-common-dir");
 });
 
+test("repository naming distinguishes SCP remotes from explicit URLs and local paths", async (t) => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-code-workspace-remote-formats-"));
+  t.after(() => fsPromises.rm(root, { recursive: true, force: true }));
+  const workspace = join(root, "Local-Folder");
+  const cases = [
+    ["fixture-host:owner/Project.git", "Project"],
+    ["git@fixture-host:owner/Project.git", "Project"],
+    ["ssh://git@fixture-host/owner/Project.git", "Project"],
+    ["ftp://fixture-host/owner/Project.git", "Local-Folder"],
+    ["https://[broken]/owner/Project.git", "Local-Folder"],
+    ["file:///owner/Project.git", "Local-Folder"],
+    ["file:/owner/Project.git", "Local-Folder"],
+    ["hg::https://fixture-host/owner/Project.git", "Local-Folder"],
+    ["./owner:Project.git", "Local-Folder"],
+    ["C:\\owner\\Project.git", "Local-Folder"],
+    ["C:Project.git", "Local-Folder"],
+  ];
+  for (const [url, repositorySlug] of cases) {
+    await createGitRepository(workspace, [["origin", url]]);
+    const result = await resolveRepositoryMemoryScope({ workspaceRoot: workspace, baseUserId: "alice" });
+
+    assert.equal(result.ok, true, url);
+    assert.equal(result.scope.scopeKind, "git-repository", url);
+    assert.equal(result.scope.effectiveUserId, `alice@${repositorySlug}`, url);
+    assert.equal(result.scope.identitySource, repositorySlug === "Project" ? "origin-remote" : "git-common-dir", url);
+  }
+});
+
 test("Git containment rechecks the readable repository name after a remote rename", async () => {
   const root = await mkdtemp(join(tmpdir(), "memorax-code-workspace-remote-rename-"));
   const workspace = join(root, "workspace");

--- a/packages/ts/memorax-code-claude-adapter/runtime-hooks/memory-cli-session.mjs
+++ b/packages/ts/memorax-code-claude-adapter/runtime-hooks/memory-cli-session.mjs
@@ -10,6 +10,8 @@ try {
   const sessionId = stringValue(input.session_id) ?? stringValue(input.sessionId);
   const envFile = stringValue(process.env.CLAUDE_ENV_FILE);
   if (sessionId && envFile) {
+    // This Hook's environment cannot reach later shell commands; Claude's env
+    // file carries their explicit trace-session binding across that boundary.
     await appendFile(envFile, [
       "export MEMORAX_CODE_MEMORY_CLI_TRACE_CLIENT='claude'",
       `export MEMORAX_CODE_MEMORY_CLI_TRACE_SESSION_ID=${shellSingleQuote(sessionId)}`,

--- a/packages/ts/memorax-code-claude-adapter/runtime-hooks/memory-skill-reminder.mjs
+++ b/packages/ts/memorax-code-claude-adapter/runtime-hooks/memory-skill-reminder.mjs
@@ -39,6 +39,8 @@ async function recordReminder(reminder) {
   const promptId = reminder.turnId;
   if (!promptId || !reminder.transcriptPath) return;
   const connection = resolveBackendConnection();
+  // Optional trace recording must not hold up the reminder for the full memory
+  // request timeout; the shared runner still emits context when recording fails.
   const timeoutMs = Math.min(
     parsePositiveInt(
       process.env.MEMORAX_CODE_CLAUDE_MEMORY_HOOK_TIMEOUT_MS,

--- a/packages/ts/memorax-code-codebuddy-adapter/hooks/repo-memory-job.mjs
+++ b/packages/ts/memorax-code-codebuddy-adapter/hooks/repo-memory-job.mjs
@@ -24,6 +24,8 @@ try {
       });
       return [
         codeBuddy,
+        // Load this installation's Skill explicitly; the headless worker cannot
+        // rely on the GUI's plugin environment or its path format.
         "--plugin-dir",
         pluginRoot,
         "--print",

--- a/packages/ts/memorax-code-codebuddy-adapter/hooks/runtime-hook.mjs
+++ b/packages/ts/memorax-code-codebuddy-adapter/hooks/runtime-hook.mjs
@@ -146,6 +146,8 @@ if (event === "SessionStart") {
   const record = (await readPending(pendingPath))[sessionId];
   if (!record || record.transcriptPath !== transcriptPath) process.exit(0);
   const response = await post("/memory/writeback", { version: 1, client: "codebuddy", sessionId, turnId: record.turnId, transcriptPath, cwd: record.cwd ?? stringValue(input.cwd), workspaceKind: record.workspaceKind ?? stringValue(input.workspaceKind) });
+  // Retain pending state until Backend enqueue acceptance. A new turn may have
+  // replaced it during the request, so cleanup must still match the submitted turn.
   if (response?.ok === true && response?.scheduled === true) {
     await updatePending(pendingPath, (state) => {
       if (state[sessionId]?.turnId === record.turnId) delete state[sessionId];

--- a/packages/ts/memorax-code-codebuddy-adapter/src/config.mjs
+++ b/packages/ts/memorax-code-codebuddy-adapter/src/config.mjs
@@ -49,6 +49,8 @@ export async function enableCodeBuddyAdapter(options = {}) {
   const memoraxCodeHome = options.memoraxCodeHome ?? defaultMemoraxCodeHome();
   const installPath = options.installPath ?? codeBuddyInstallPath(home);
   const localPluginPath = marketplacePluginPath(home);
+  // Installation alone cannot prove native Hook execution; require a fresh
+  // runtime observation instead of carrying one over from the previous install.
   await rm(codeBuddyRuntimeObservationPath(memoraxCodeHome), { force: true });
   await mkdir(dirname(installPath), { recursive: true });
   await rm(installPath, { recursive: true, force: true });

--- a/packages/ts/memorax-code-codebuddy-adapter/src/hook-manifest.mjs
+++ b/packages/ts/memorax-code-codebuddy-adapter/src/hook-manifest.mjs
@@ -6,6 +6,8 @@ const PORTABLE_COMMAND = 'node "${CODEBUDDY_PLUGIN_ROOT}/hooks/runtime-hook.mjs"
 
 export function codeBuddyHookCommand(pluginRoot, platform = process.platform) {
   if (platform !== "win32") return PORTABLE_COMMAND;
+  // WorkBuddy may expose a POSIX-style CODEBUDDY_PLUGIN_ROOT to a native Windows
+  // shell. Use the installed native path instead of relying on that variable.
   return `node "${win32.join(pluginRoot, "hooks", "runtime-hook.mjs").replaceAll("\\", "/")}" turn`;
 }
 

--- a/packages/ts/memorax-code-dsh-adapter/src/plugin.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/src/plugin.mjs
@@ -99,6 +99,8 @@ export function registerMemoraxCodePlugin(ctx, dependencies) {
         event.data,
       );
       if (pendingContext) {
+        // Returning middleware context does not guarantee DSH accepted it; commit
+        // injection state only when the matching native message is published.
         pendingContext.personalContext.commit();
         if (pendingContext.personalContext.triggers.length > 0) {
           trackPending(pendingReminderTraces, recordSkillReminder({

--- a/packages/ts/memorax-code-dsh-adapter/src/profile-lifecycle.mjs
+++ b/packages/ts/memorax-code-dsh-adapter/src/profile-lifecycle.mjs
@@ -567,6 +567,8 @@ function ensureDshPluginInstalledUnlocked(paths, options) {
     updatedAt: new Date().toISOString(),
   };
   atomicWriteJson(paths.statePath, nextState);
+  // A failed reconciliation may reinstall the prior bundle during rollback,
+  // so retire old generations only after every target Profile succeeds.
   if (failedProfiles.length === 0 && managedProfiles.length > 0) {
     cleanupRuntimeGenerations(paths.runtimeRoot, runtimeBundleRoot);
   }
@@ -656,6 +658,8 @@ function rollbackDshPluginReconciliation(paths, options, state, mutatedProfiles,
         updatedAt: new Date().toISOString(),
       }
     : state;
+  // Keep runtime authority disabled until installed Profiles have been
+  // verified against the prior bundle, even if native rollback commands succeeded.
   const verificationState = rollbackState.enabled
     ? { ...rollbackState, enabled: false }
     : rollbackState;

--- a/packages/ts/memorax-code-opencode-adapter/src/plugin.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/src/plugin.mjs
@@ -62,6 +62,8 @@ export function createMemoraxOpenCodePlugin(options = {}) {
           .then(() => {
             backendEnsureSettled = true;
           });
+        // All prompts share this instance's wait budget; expiry must not cancel
+        // recovery that accepted-turn writeback can still await.
         backendPromptGatePromise = Promise.race([
           backendEnsurePromise.then(() => true),
           delay(backendPromptWaitTimeoutMs, false, { ref: false }),
@@ -138,6 +140,8 @@ export function createMemoraxOpenCodePlugin(options = {}) {
     }
 
     function queueSessionFlush(sessionId, target) {
+      // Idle and error notifications can overlap without awaiting plugin work.
+      // Queue SDK reads so later tasks see which Turns still need submission.
       const previous = sessionFlushes.get(sessionId) ?? Promise.resolve();
       const queued = previous
         .catch(() => undefined)

--- a/packages/ts/memorax-code-opencode-adapter/src/repo-memory-server-runner.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/src/repo-memory-server-runner.mjs
@@ -47,6 +47,8 @@ export async function runOpenCodeRepoMemory(input, options = {}) {
         prompt,
       });
     } catch (error) {
+      // Only a session-creation transport failure can select another server;
+      // replaying a failed prompt could repeat file edits already performed.
       if (!isSessionCreationTransportError(error)) throw error;
       inheritedError = error;
     }
@@ -130,7 +132,13 @@ async function runOpenCodeRepoMemorySession(input) {
       },
       "blocking prompt",
     );
-    const finalText = messageText(message);
+    const payload = message?.data ?? message;
+    const assistantError = payload?.info?.error;
+    // HTTP success can still carry a failed assistant with partial output.
+    if (assistantError !== undefined && assistantError !== null) {
+      throw new Error("OpenCode blocking prompt returned an assistant error");
+    }
+    const finalText = messageText(payload);
     if (!finalText) throw new Error("OpenCode repo memory runner received no final text");
     return finalText;
   } finally {
@@ -396,8 +404,7 @@ async function bestEffortDelete(fetchImpl, url, authorization) {
   }
 }
 
-function messageText(message) {
-  const payload = message?.data ?? message;
+function messageText(payload) {
   if (!Array.isArray(payload?.parts)) return undefined;
   return payload.parts
     .flatMap((part) => part?.type === "text" && stringValue(part.text) ? [part.text.trim()] : [])

--- a/packages/ts/memorax-code-opencode-adapter/test/repo-memory-server-runner.test.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/test/repo-memory-server-runner.test.mjs
@@ -119,6 +119,40 @@ test("OpenCode repo memory runner preserves prompt failures and still deletes th
   }
 });
 
+test("OpenCode repo memory runner rejects native errors despite partial text", async () => {
+  for (const [name, wrapped] of [["MessageAbortedError", false], ["UnknownError", true]]) {
+    const requests = [];
+    const message = {
+      info: {
+        role: "assistant",
+        error: { name, data: { message: "Private provider detail" } },
+      },
+      parts: [{ type: "text", text: "Partial maintenance progress." }],
+    };
+    await assert.rejects(runOpenCodeRepoMemory({
+      serverUrl: "http://127.0.0.1:4096",
+      repo: join(tmpdir(), "opencode-native-error"),
+      prompt: "Build Repo Memory.",
+    }, {
+      env: { MEMORAX_CODE_OPENCODE_COMMAND: "/opt/opencode" },
+      fetchImpl: async (url, init) => {
+        requests.push(`${init.method} ${url.pathname}`);
+        if (init.method === "DELETE") throw new Error("cleanup failed");
+        const body = url.pathname === "/session"
+          ? { id: "session-native-error" }
+          : wrapped ? { data: message } : message;
+        return new Response(JSON.stringify(body), { status: 200 });
+      },
+      spawnImpl: () => assert.fail("native prompt errors must not start a fallback server"),
+    }), { message: "OpenCode blocking prompt returned an assistant error" });
+    assert.deepEqual(requests, [
+      "POST /session",
+      "POST /session/session-native-error/message",
+      "DELETE /session/session-native-error",
+    ]);
+  }
+});
+
 test("OpenCode repo memory runner owns a temporary server when the inherited server is unreachable", async () => {
   const root = await mkdtemp(join(tmpdir(), "opencode-repo-memory-fallback-"));
   const requests = [];

--- a/packages/ts/memorax-code-trae-adapter/hooks/runtime-hook.mjs
+++ b/packages/ts/memorax-code-trae-adapter/hooks/runtime-hook.mjs
@@ -104,6 +104,7 @@ if (event === "SessionStart") {
     cwd,
     workspaceKind,
   });
+  // Only accepted starts may replace the persisted prompt used to pair Stop.
   if (response?.ok !== true || !commitActiveTurn(activeTurnPlan)) process.exit(0);
   const repoMemoryWorktree = stringValue(response?.repoMemoryWorktree);
   const reminderResult = await evaluateMemorySkillReminder({
@@ -139,6 +140,8 @@ if (event === "SessionStart") {
 } else {
   const lastAssistantMessage = assistantMessage(input);
   if (!lastAssistantMessage) process.exit(0);
+  // Trae has no stable transcript or native Stop Turn ID. The Hook pair is the
+  // content authority, but a late Stop cannot prove which prompt it originally answered.
   const activeTurn = readActiveTurn(sessionId);
   if (!activeTurn) process.exit(0);
   const response = await post("/memory/writeback", {
@@ -184,6 +187,8 @@ function commitActiveTurn({ record, expectedTurnId }) {
     const state = activeTurnState();
     pruneActiveTurns(state);
     const current = validActiveTurn(state.sessions?.[record.sessionId], record.sessionId);
+    // The HTTP request runs outside this lock; another Hook may have advanced
+    // the session since preparation. Do not overwrite its accepted pairing.
     if (current?.turnId !== expectedTurnId && current?.turnId !== record.turnId) return false;
     state.sessions[record.sessionId] = record;
     const now = Date.now();
@@ -206,6 +211,7 @@ function readActiveTurn(sessionId) {
 function removeActiveTurn(sessionId, turnId) {
   withJsonFileLock(activeTurnsPath, () => {
     const state = activeTurnState();
+    // A delayed writeback response must not clear a replacement turn.
     if (state.sessions?.[sessionId]?.turnId === turnId) delete state.sessions[sessionId];
     state.updatedAt = new Date().toISOString();
     atomicWriteJson(activeTurnsPath, state);

--- a/packages/ts/memorax-code-trae-adapter/src/config.mjs
+++ b/packages/ts/memorax-code-trae-adapter/src/config.mjs
@@ -63,7 +63,24 @@ async function enableTraeAdapterUnlocked(paths, options) {
     return failure("hooks_invalid", paths, error);
   }
 
-  const runtimeDigest = runtimeSourceDigest(paths);
+  const memoraxCodeCommand = stringOption(options.memoraxCodeCommand) ?? defaultMemoraxCodeCommand();
+  const previousMetadata = previousState?.runtimePath
+    ? readJsonFile(join(dirname(dirname(previousState.runtimePath)), ".memorax-code-package.json"))?.value
+    : undefined;
+  // Hook recovery forwards npm through MEMORAX_CODE_NPM_EXEC_PATH. A direct
+  // lifecycle command may have neither variable, so retain a still-valid entrypoint.
+  const npmExecPath = absoluteRegularFile(options.npmExecPath
+    ?? process.env.MEMORAX_CODE_NPM_EXEC_PATH
+    ?? process.env.npm_execpath
+    ?? previousMetadata?.npmExecPath);
+  const runtimeMetadata = {
+    version: 1,
+    ...(memoraxCodeCommand ? { memoraxCodeCommand } : {}),
+    ...(npmExecPath ? { npmExecPath } : {}),
+    memoraxCodeHome: paths.memoraxCodeHome,
+    traeHome: paths.traeHome,
+  };
+  const runtimeDigest = runtimeSourceDigest(paths, runtimeMetadata);
   const generationPath = join(paths.runtimeRoot, runtimeDigest);
   const runtimePath = join(generationPath, "hooks", "runtime-hook.mjs");
   const hookCommand = traeHookCommand(
@@ -72,7 +89,6 @@ async function enableTraeAdapterUnlocked(paths, options) {
     absoluteRegularFile(options.nodePath) ?? process.execPath,
     options.powershellPath ?? defaultWindowsPowerShellPath(),
   );
-  const memoraxCodeCommand = stringOption(options.memoraxCodeCommand) ?? defaultMemoraxCodeCommand();
   const skillDigest = skillDirectoryDigest(paths.skillSourcePath);
   const skillCurrent = directoryDigestIfPresent(paths.skillPath, SKILL_PACKAGE_METADATA) === skillDigest
     && skillPackageMetadataCurrent(paths.skillPath, memoraxCodeCommand);
@@ -101,8 +117,10 @@ async function enableTraeAdapterUnlocked(paths, options) {
   };
 
   try {
+    // Claim partial artifacts before publishing them so an interrupted install
+    // can resume without treating its own Skill as user-owned content.
     atomicWriteJson(paths.statePath, { ...state, enabled: false, installPending: true });
-    materializeRuntimeGeneration(paths, generationPath, runtimeDigest, options);
+    materializeRuntimeGeneration(paths, generationPath, runtimeDigest, runtimeMetadata);
     if (!skillCurrent) {
       materializeDirectory(paths.skillSourcePath, paths.skillPath, memoraxCodeCommand);
     }
@@ -292,6 +310,8 @@ export function traeHookCommand(
   if (platform !== "win32") {
     return `${posixShellLiteral(nodePath)} ${posixShellLiteral(runtimePath)} ${HOOK_MARKER}`;
   }
+  // Encoding keeps quoted paths out of Trae's outer command-line wrapper.
+  // Forward the Hook payload through stdin without embedding it in the command.
   const script = [
     "$ErrorActionPreference='Stop'",
     "$utf8=[Text.UTF8Encoding]::new($false)",
@@ -353,6 +373,7 @@ function resolvePaths(options) {
   return {
     memoraxCodeHome,
     traeHome,
+    // Uninstall removes the adapter directory; its lifecycle lock must survive.
     lifecycleLockTarget: resolve(
       options.lifecycleLockTarget ?? join(memoraxCodeHome, "adapters", "trae-lifecycle"),
     ),
@@ -411,7 +432,7 @@ function validateSources(paths) {
   return undefined;
 }
 
-function materializeRuntimeGeneration(paths, generationPath, runtimeDigest, options) {
+function materializeRuntimeGeneration(paths, generationPath, runtimeDigest, runtimeMetadata) {
   if (existsSync(generationPath)) {
     const record = readJsonFile(join(generationPath, "generation.json"));
     if (record?.unreadable || record?.value?.runtimeDigest !== runtimeDigest
@@ -429,14 +450,8 @@ function materializeRuntimeGeneration(paths, generationPath, runtimeDigest, opti
     cpSync(paths.runtimeObservationSourcePath, join(temporaryPath, "src", "runtime-observation.mjs"));
     cpSync(paths.commonSourcePath, join(temporaryPath, "memorax-code-adapter-common", "src"), { recursive: true });
     atomicWriteJson(join(temporaryPath, "generation.json"), { version: 1, runtimeDigest });
-    const memoraxCodeCommand = stringOption(options.memoraxCodeCommand) ?? defaultMemoraxCodeCommand();
-    const npmExecPath = absoluteRegularFile(options.npmExecPath ?? process.env.npm_execpath);
     atomicWriteJson(join(temporaryPath, ".memorax-code-package.json"), {
-      version: 1,
-      ...(memoraxCodeCommand ? { memoraxCodeCommand } : {}),
-      ...(npmExecPath ? { npmExecPath } : {}),
-      memoraxCodeHome: paths.memoraxCodeHome,
-      traeHome: paths.traeHome,
+      ...runtimeMetadata,
       runtimeDigest,
     });
     renameSync(temporaryPath, generationPath);
@@ -539,11 +554,16 @@ function materializeDirectory(source, destination, memoraxCodeCommand) {
   }
 }
 
-function runtimeSourceDigest(paths) {
+function runtimeSourceDigest(paths, runtimeMetadata) {
   const hash = createHash("sha256");
   hashFile(hash, paths.runtimeHookSourcePath, "hooks/runtime-hook.mjs");
   hashFile(hash, paths.runtimeObservationSourcePath, "src/runtime-observation.mjs");
   hashDirectory(hash, paths.commonSourcePath, "memorax-code-adapter-common/src");
+  // Recovery paths can change without source changes. Include the metadata
+  // in the identity so existing runtime generations remain immutable.
+  hash.update(".memorax-code-package.json\0");
+  hash.update(JSON.stringify(runtimeMetadata));
+  hash.update("\0");
   return hash.digest("hex");
 }
 

--- a/packages/ts/memorax-code-trae-adapter/test/config.test.mjs
+++ b/packages/ts/memorax-code-trae-adapter/test/config.test.mjs
@@ -166,6 +166,89 @@ test("Trae install merges managed Hooks and Skill without changing user Hooks", 
   }
 });
 
+test("Trae runtime generations track recovery metadata without mutating previous generations", async () => {
+  const fixture = await createFixture("recovery-metadata");
+  const npmEnvironment = {
+    MEMORAX_CODE_NPM_EXEC_PATH: process.env.MEMORAX_CODE_NPM_EXEC_PATH,
+    npm_execpath: process.env.npm_execpath,
+  };
+  try {
+    for (const key of Object.keys(npmEnvironment)) delete process.env[key];
+    const movedCommand = join(fixture.root, "moved-memorax-code.mjs");
+    const npmPath = join(fixture.root, "npm-cli.js");
+    const movedNpmPath = join(fixture.root, "moved-npm-cli.js");
+    await Promise.all([movedCommand, npmPath, movedNpmPath]
+      .map((path) => writeFile(path, "// Package path fixture; never executed.\n")));
+    const generations = [];
+    for (const [memoraxCodeCommand, npmExecPath] of [
+      [fixture.options.memoraxCodeCommand, npmPath],
+      [movedCommand, npmPath],
+      [movedCommand, movedNpmPath],
+    ]) {
+      const options = { ...fixture.options, platform: "linux", memoraxCodeCommand, npmExecPath };
+      const installed = await enableTraeAdapter(options);
+      assert.equal(installed.ok, true);
+      assert.equal(installed.changed, true);
+      const state = JSON.parse(await readFile(installed.statePath, "utf8"));
+      for (const previous of generations) {
+        assert.notEqual(state.runtimeDigest, previous.digest, "changed recovery paths require a new generation");
+      }
+      const metadataPath = join(state.runtimeRoot, state.runtimeDigest, ".memorax-code-package.json");
+      const metadata = await readFile(metadataPath, "utf8");
+      assert.deepEqual(JSON.parse(metadata), {
+        version: 1,
+        memoraxCodeCommand,
+        npmExecPath,
+        memoraxCodeHome: fixture.memoraxCodeHome,
+        traeHome: fixture.traeHome,
+        runtimeDigest: state.runtimeDigest,
+      });
+      const hooks = JSON.parse(await readFile(join(fixture.traeHome, "hooks.json"), "utf8"));
+      assert.ok(state.hookCommand.includes(state.runtimePath));
+      for (const event of ["SessionStart", "UserPromptSubmit", "Stop"]) {
+        const commands = hooks.hooks[event]
+          .flatMap((group) => group.hooks ?? [])
+          .map((hook) => hook.command)
+          .filter((command) => command?.includes("--memorax-code-trae-hook-v1"));
+        assert.deepEqual(commands, [state.hookCommand]);
+      }
+
+      const unchanged = await enableTraeAdapter(options);
+      assert.equal(unchanged.ok, true);
+      assert.equal(unchanged.changed, false);
+      const unchangedState = JSON.parse(await readFile(unchanged.statePath, "utf8"));
+      assert.equal(unchangedState.runtimeDigest, state.runtimeDigest);
+      assert.equal(unchangedState.runtimePath, state.runtimePath);
+      generations.push({ digest: state.runtimeDigest, metadataPath, metadata });
+    }
+
+    const recoveryOptions = { ...fixture.options, platform: "linux", memoraxCodeCommand: movedCommand };
+    const retained = await enableTraeAdapter(recoveryOptions);
+    assert.equal(retained.ok, true);
+    assert.equal(retained.changed, false);
+    const retainedState = JSON.parse(await readFile(retained.statePath, "utf8"));
+    assert.equal(retainedState.runtimeDigest, generations[2].digest);
+
+    process.env.MEMORAX_CODE_NPM_EXEC_PATH = npmPath;
+    process.env.npm_execpath = movedNpmPath;
+    const recovered = await enableTraeAdapter(recoveryOptions);
+    assert.equal(recovered.ok, true);
+    assert.equal(recovered.changed, true);
+    const recoveredState = JSON.parse(await readFile(recovered.statePath, "utf8"));
+    assert.equal(recoveredState.runtimeDigest, generations[1].digest);
+
+    for (const generation of generations) {
+      assert.equal(await readFile(generation.metadataPath, "utf8"), generation.metadata);
+    }
+  } finally {
+    for (const [key, value] of Object.entries(npmEnvironment)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    await rm(fixture.root, { recursive: true, force: true });
+  }
+});
+
 test("Trae install resumes from a persisted ownership intent", async () => {
   const fixture = await createFixture("install-recovery");
   try {


### PR DESCRIPTION
## Change Summary

Fix six scoped defects in repository identification, Turn completion, plugin removal, and background memory work. Add focused regressions and short comments explaining content authority, concurrency, and lifecycle constraints across the shared runtime and client adapters.

## Implementation Highlights

- Recognize SCP-style remotes without a username, such as `host:owner/repo.git`, while continuing to exclude local paths and Git remote-helper syntax.
- Preserve a newer Trae active-turn snapshot when an older Stop finishes asynchronously.
- Remove CodeBuddy/WorkBuddy's fixed 100-record parent-chain traversal limit while retaining cycle detection for completed and interrupted transcript extraction.
- Propagate failed native Codex plugin removal and preserve managed artifacts so cleanup can be retried without leaving registrations pointing at deleted files.
- Reject OpenCode Repo Memory worker responses containing an assistant error, even when the HTTP request succeeds and includes partial text.
- Include Trae recovery metadata in runtime generation identity. Re-enabling after a CLI/npm path change switches Hooks to the corresponding generation without overwriting older generations; direct lifecycle invocations retain an existing valid npm entrypoint.
- Explain the relevant scope, writeback, lock, Hook, installation, and recovery boundaries in source comments.

The diff spans 41 files: 6 source files with behavior changes, 6 regression-test files, and 29 files with comments only. It does not add public commands, configuration fields, or dependencies.

## Validation

The following checks cover the final branch contents:

| Profile | Checks | Result |
| --- | --- | --- |
| Backend | `npm run typecheck --prefix packages/ts/memorax-code-backend`; `npm test --prefix packages/ts/memorax-code-backend` | Typecheck passed; 551 passed, 2 skipped |
| Adapter-common | `make test-adapter-common` | 98 passed |
| Shared Skill | `make test-shared-skill` | 90 passed |
| Codex | `make test-codex-adapter` | 67 passed |
| Claude Code | `make test-claude-adapter` | 62 passed |
| DSH | `make test-dsh-adapter` | 31 passed |
| OpenCode | `make test-opencode-adapter` | 37 passed |
| CodeBuddy/WorkBuddy | `make test-codebuddy-adapter` | 27 passed |
| Trae | `npm test --prefix packages/ts/memorax-code-trae-adapter` | 18 passed |
| npm and local trace | Package test suite and local-only trace gate | 278 passed, 2 skipped; gate passed |
| Install/artifacts | Package-check build, pack allowlist, and installed lifecycle smoke assertions | Passed with the existing synthetic Claude CLI fixture injected at the Claude smoke stage |

The stock package smoke script expects a discoverable Claude CLI. Its assertions were run unchanged from a temporary copy with the repository's synthetic CLI supplied for that stage; no real client was invoked. The four skipped tests cover platform-specific filesystem aliases and opt-in operating-system credential stores. Branch diff whitespace checks passed.

## Full End-to-End Validation Results

- Environment: macOS with Node.js 24, isolated user/client homes, MemoraX state, command fixtures, and temporary artifacts.
- Scenario or matrix: synthetic native events, transcript and message records, failed removals, long/cyclic parent chains, replacement Turns, recovery-path migration, and installed-package lifecycle checks.
- Command or workflow: the package profiles listed above, plus the package-check assertions with synthetic Claude CLI injection.
- Result: 1,259 tests passed and 4 skipped across the main suites; synthetic installation smoke checks passed.
- Evidence or artifacts: regression cases are committed with their owning modules; temporary fixtures and processes were cleaned up.
- Reason not run / remaining risk: real-client, MemoraX-backed, and native Windows E2E checks require explicit opt-in and were not run. Trae still cannot independently validate a native Stop Turn ID; the delayed-response cleanup fix does not remove that existing correlation limitation.
