### PR TITLE
fix: preserve QA timestamps and writeback content

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -169,7 +169,13 @@ lives in the Claude adapter. The DSH adapter owns Profile discovery and
 mutation plus per-user runtime generation materialization. The OpenCode adapter
 installs an auto-discovered thin loader and shared skill without editing
 OpenCode provider configuration. The CodeBuddy adapter owns its marketplace
-plugin, while the Trae adapter merges only marker-owned Global Hooks and
+plugin and managed global `UserPromptSubmit` Hook. Native global Hooks load
+before plugin initialization, allowing the first prompt to use the same
+transcript-boundary and prompt-digest correlation as later turns. The plugin
+retains `SessionStart` and `Stop`; its old prompt dispatch is ignored to avoid
+duplicate handling during updates. The global entry honors native plugin
+disablement before Backend recovery, and lifecycle disable/remove cleans up
+only its owned Hook. The Trae adapter merges only marker-owned Global Hooks and
 materializes the shared Skill without changing provider settings. These
 implementations are loaded by their Backend lifecycle participants. Preserve
 the participant contract and each client's actual authority instead of forcing
@@ -532,6 +538,12 @@ content stops locally; accepted duplicates need not issue another Add request.
   flush; turn or size limits can trigger that flush during enqueue.
 - Buffering and chunking belong to the memory capability; rollout, transcript,
   DSH event-interval, and SDK message parsing remains client-specific.
+- Native materializers pass the selected QA timestamps through the shared
+  completion contract. The coordinator supplies explicitly labelled observations
+  when native times are absent; automatic enqueue freezes any remaining fallback
+  before buffering. Message timestamps and source labels survive redaction,
+  chunking, and retries. Provider Add metadata carries only the aligned time-source
+  labels, not local trace context. See [timestamp semantics](docs/configuration.md#automatic-writeback-timestamps).
 - DSH accepts only a contiguous native interval bounded by the matching
   `turn/start` and completed `turn/end`. The Backend materializes direct user
   text and visible model-assistant text; plugin recall, tools, reasoning, and
@@ -558,6 +570,8 @@ content stops locally; accepted duplicates need not issue another Add request.
   the paired `Stop` assistant text. The Backend rejects commands naming a
   replaced Turn while its active/interruption state remains available. A
   complete validated Hook command can restore writeback after Backend restart.
+  The validated Turn ID retains the prompt observation time; optional
+  `assistantObservedAt` preserves the Stop Hook observation across HTTP delivery.
   The adapter pairs native `Stop` with its persisted active record; it does not
   independently validate a native Stop Turn ID. An old Stop arriving after
   that record is replaced therefore is not guaranteed to be rejected. Missing

--- a/README.md
+++ b/README.md
@@ -266,6 +266,9 @@ memory-impact disclosure, then extracts and stores reusable memory. It
 does not upload the complete retained client trace artifact or local trace
 path.
 
+QA writeback preserves available native timestamps and labels observation-time
+fallbacks; see [message timestamps](docs/configuration.md#automatic-writeback-timestamps).
+
 Sign in to [MemoraX Console](https://platform.memorax.net/) at any time to view,
 edit, or delete saved memories. MemoraX Cloud does not receive model-provider
 credentials or local Backend tokens.

--- a/README.zh.md
+++ b/README.zh.md
@@ -222,6 +222,8 @@ MemoraX Code 会先比较含义：语义相同的请求不重复写入；长期�
 选择的用户指令和对应的 Agent 最终回复，并先移除最终回复中的记忆作用说明，再用于提取和保存记忆；它不会上传完整的本地客户端 trace
 文件或本地 trace 路径。
 
+QA 写回会保留可用的原生时间戳，并标明使用观测时间的回退情况，详见[消息时间戳](docs/configuration.md#automatic-writeback-timestamps)。
+
 登录 [MemoraX Console](https://platform.memorax.net/) 后，可以随时查看、修改或删除已经保存的记忆。
 MemoraX 云端不会接收模型服务商凭据或本地 Backend Token。
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -171,6 +171,11 @@ OpenCode SDK session-message Turn, or Trae's validated Hook pair. It does not
 send the retained trace file, raw transcript path, raw DSH interval, SDK
 message records, or trace-only provenance as part of that payload.
 
+Automatic QA writeback also sends the selected native message/event timestamps
+or explicitly labelled local observation times. An aligned source-label array
+in Add metadata distinguishes them; it contains no transcript paths or trace
+identifiers. See [timestamp semantics](docs/configuration.md#automatic-writeback-timestamps).
+
 Automatic writeback bounds each selected message to its configured Add limit,
 then applies a local best-effort detector before hashing, buffering, chunking,
 observability, or network dispatch. Recognized private keys, authorization

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -276,13 +276,21 @@ for legacy CodeBuddy installations. When both homes exist, setup removes only th
 legacy MemoraX-managed plugin state from `.codebuddy`; other platforms use
 `~/.workbuddy`. The Skill is
 materialized from the canonical MemoraX Code Skill and is owned by the managed
-marketplace plugin; user files outside that plugin are not modified.
+marketplace plugin.
+
+Setup also merges a managed `UserPromptSubmit` Hook into
+`<CODEBUDDY_HOME>/settings.json`. It captures the first prompt even when the
+native plugin is still loading; `SessionStart` and `Stop` remain in the plugin.
+Other user Hooks and model settings are preserved. Stopping or removing the
+integration removes its global Hook, and manually disabling the native plugin
+also prevents that Hook from starting the Backend or collecting prompts.
 
 On Windows, setup writes destination-specific native Hook paths so PowerShell
 does not receive a `/c/Users/...` plugin path. `memorax-code-codebuddy status
 --json` reports `codebuddyHooks.status` as `unverified` until a real WorkBuddy
 Hook executes, `observed` afterward, and `invalid` when the installed Hook
-manifest or runtime is incomplete. Restart or refresh WorkBuddy after setup.
+manifest, managed prompt Hook, or runtime is incomplete. Restart or refresh
+WorkBuddy after setup.
 
 ## Trae integration paths
 
@@ -453,6 +461,39 @@ new CLI processes must inherit the override too. The controls apply to new
 write decisions. They do not cancel requests already sent or guarantee that
 previously buffered turns are discarded: graceful Backend shutdown can flush
 those turns. They also do not delete memories already stored in MemoraX.
+
+### Automatic writeback timestamps
+
+Automatic QA messages use epoch-millisecond timestamps from the matching
+native content records when available. The selected sources are:
+
+| Client | User time | Assistant time |
+| --- | --- | --- |
+| Codex | Selected rollout user record | Matching `task_complete` event, otherwise the selected final message record |
+| Claude Code | Selected transcript user record | Selected terminal assistant record |
+| DeepSeek Harness | First included native user-message event | Completed `turn/end` event, otherwise the last included assistant-message event |
+| OpenCode | Original SDK user `time.created` | Final SDK assistant `time.completed` |
+| CodeBuddy/WorkBuddy | Selected transcript user record, when supplied | Selected completed assistant record, when supplied |
+| Trae | Persisted prompt Hook observation | Stop Hook observation |
+
+A native record timestamp is not necessarily the exact UI submit or last-token
+time. Missing or invalid native timestamps use a known Turn-start observation
+for the user and a completion-processing observation for the assistant; when
+the start observation is unavailable, the user also uses completion processing.
+These fallback times are fixed before buffering and provider retries.
+
+Each automatic Add includes `metadata.memorax_code_timestamp_sources`, aligned
+with its `messages` array: `native` means a selected native record/event time,
+and `observed` means a local observation. Trae always uses `observed`. Explicit
+Add callers that do not supply source information leave this metadata absent;
+an unlabelled message in a mixed-source request is `unspecified`.
+
+Buffering, chunking, and retries preserve message times and their sources.
+Fragments of the same original message retain the same time; equal or
+out-of-order supplied timestamps are not rewritten to impose artificial order.
+An Add may contain multiple Turns, and one Turn may span multiple Adds. This
+does not add Session/Turn fields to Search or reconstruct timestamps missing
+from previously uploaded data.
 
 ### Automatic writeback redaction
 

--- a/packages/ts/memorax-code-backend/src/clients/claude/memory-hook-runtime.ts
+++ b/packages/ts/memorax-code-backend/src/clients/claude/memory-hook-runtime.ts
@@ -174,6 +174,8 @@ export function createClaudeMemoryHookRuntime(
         }),
         userText: transcript.turn.userPrompt,
         assistantText: transcript.turn.assistantReply,
+        userTimestamp: transcript.turn.userTimestamp,
+        assistantTimestamp: transcript.turn.assistantTimestamp,
         traceContext,
       });
       if (!writeback.scheduled) {

--- a/packages/ts/memorax-code-backend/src/clients/claude/transcript-turn.ts
+++ b/packages/ts/memorax-code-backend/src/clients/claude/transcript-turn.ts
@@ -1,4 +1,5 @@
 import { readFile } from "node:fs/promises";
+import { parseNativeMessageTimestamp } from "../../shared/message-time.js";
 
 type JsonRecord = Record<string, unknown>;
 
@@ -28,6 +29,8 @@ export type ClaudeTranscriptTurn = {
   sessionTurnIndex: number;
   userPrompt: string;
   assistantReply: string;
+  userTimestamp?: number;
+  assistantTimestamp?: number;
   activities: ClaudeTurnActivity[];
   usage?: ClaudeTurnTokenUsage;
 };
@@ -115,6 +118,7 @@ export function claudeTranscriptTurnFromJsonLines(
     branch: ClaudePromptBranch;
     userPrompt: string;
     assistantReply?: string;
+    assistantTimestamp?: number;
     activities: ClaudeTurnActivity[];
     usage?: ClaudeTurnTokenUsage;
   }> = [];
@@ -133,6 +137,9 @@ export function claudeTranscriptTurnFromJsonLines(
         branch,
         userPrompt: branch.userPrompt,
         ...(assistantReply ? { assistantReply } : {}),
+        // This dates the selected terminal transcript record; Claude does not
+        // expose an independent last-token completion time in this authority.
+        assistantTimestamp: parseNativeMessageTimestamp(record.timestamp),
         activities: claudeMemoryActivities(branch.assistantMessages),
         ...(usage ? { usage } : {}),
       });
@@ -153,6 +160,8 @@ export function claudeTranscriptTurnFromJsonLines(
         sessionTurnIndex,
         userPrompt: candidate.userPrompt,
         assistantReply: candidate.assistantReply,
+        ...(candidate.branch.userTimestamp === undefined ? {} : { userTimestamp: candidate.branch.userTimestamp }),
+        ...(candidate.assistantTimestamp === undefined ? {} : { assistantTimestamp: candidate.assistantTimestamp }),
         activities: candidate.activities,
         ...(candidate.usage ? { usage: candidate.usage } : {}),
       },
@@ -304,6 +313,7 @@ function transcriptRecords(transcript: string):
 type ClaudePromptBranch = Readonly<{
   promptId?: string;
   userPrompt?: string;
+  userTimestamp?: number;
   assistantMessages: JsonRecord[];
   records: JsonRecord[];
   ambiguous: boolean;
@@ -364,6 +374,7 @@ function promptBranch(
       return {
         promptId: promptIdFromRecord(current),
         userPrompt: prompt,
+        userTimestamp: parseNativeMessageTimestamp(current.timestamp),
         assistantMessages,
         records: branchRecords,
         ambiguous: false,

--- a/packages/ts/memorax-code-backend/src/clients/codebuddy/jsonl-history.ts
+++ b/packages/ts/memorax-code-backend/src/clients/codebuddy/jsonl-history.ts
@@ -1,4 +1,5 @@
 import { readFile } from "node:fs/promises";
+import { parseNativeMessageTimestamp } from "../../shared/message-time.js";
 import { codeBuddyPromptDigest, parseCodeBuddyTurnId } from "./turn-id.js";
 
 export type CodeBuddyHistoryRecord = Readonly<Record<string, unknown>>;
@@ -8,6 +9,8 @@ export type CodeBuddyTurn = Readonly<{
   sessionTurnIndex?: number;
   userPrompt: string;
   assistantReply: string;
+  userTimestamp?: number;
+  assistantTimestamp?: number;
   activities: readonly CodeBuddyActivity[];
 }>;
 export type CodeBuddyActivity = Readonly<{ kind: "tool"; name: string; input?: string; output?: string }>;
@@ -56,6 +59,9 @@ export function codeBuddyTranscriptTurnFromJsonLines(
   const assistant = branch[0];
   const reply = assistantText(assistant);
   if (!reply) return { ok: false, reason: "assistant_message_missing" };
+  // A timestamp is optional in supported transcripts; only the selected
+  // native record supplies it, never its tools or a different completed branch.
+  const assistantTimestamp = parseNativeMessageTimestamp(assistant.timestamp);
   return {
     ok: true,
     turn: {
@@ -63,6 +69,8 @@ export function codeBuddyTranscriptTurnFromJsonLines(
       turnId: input.turnId,
       userPrompt: selected.userPrompt,
       assistantReply: reply,
+      ...(selected.userTimestamp !== undefined ? { userTimestamp: selected.userTimestamp } : {}),
+      ...(assistantTimestamp !== undefined ? { assistantTimestamp } : {}),
       activities: turnActivities(selected.records),
       sessionTurnIndex: selected.sessionTurnIndex,
     },
@@ -100,6 +108,7 @@ export function codeBuddyInterruptedTranscriptTurnFromJsonLines(
 type SelectedCodeBuddyTurnBranch = Readonly<{
   records: ParsedHistoryRecord[];
   userPrompt: string;
+  userTimestamp?: number;
   sessionTurnIndex: number;
 }>;
 
@@ -136,6 +145,7 @@ function selectCodeBuddyTurnBranch(
     ok: true,
     records: recordsInBranch(records, userId),
     userPrompt,
+    userTimestamp: parseNativeMessageTimestamp(user.timestamp),
     sessionTurnIndex: users.indexOf(user) + 1,
   };
 }
@@ -160,7 +170,8 @@ function parseJsonLines(text: string): ParsedHistoryRecord[] | undefined {
         return undefined;
       }
     }
-    const newlineBytes = newline >= 0 ? (rawLine.endsWith("\r") ? 2 : 1) : 0;
+    // rawLine already includes CR when the delimiter is CRLF; only LF is missing.
+    const newlineBytes = newline >= 0 ? 1 : 0;
     byteOffset += Buffer.byteLength(rawLine, "utf8") + newlineBytes;
     cursor = newline >= 0 ? newline + 1 : text.length;
   }

--- a/packages/ts/memorax-code-backend/src/clients/codebuddy/memory-hook-runtime.ts
+++ b/packages/ts/memorax-code-backend/src/clients/codebuddy/memory-hook-runtime.ts
@@ -81,6 +81,8 @@ export function createCodeBuddyMemoryHookRuntime(options: Options = {}): CodeBud
         resolveRepositoryMemory: async () => repositoryMemory,
         userText: transcript.turn.userPrompt,
         assistantText: transcript.turn.assistantReply,
+        userTimestamp: transcript.turn.userTimestamp,
+        assistantTimestamp: transcript.turn.assistantTimestamp,
         traceContext: traceContextFromCodeBuddyHookBody(command),
       });
       await recordCodeBuddyTurnMaterialization(options, traceContext, transcript.turn);

--- a/packages/ts/memorax-code-backend/src/clients/codex/memory-hook-runtime.ts
+++ b/packages/ts/memorax-code-backend/src/clients/codex/memory-hook-runtime.ts
@@ -210,6 +210,8 @@ export function createCodexMemoryHookRuntime(options: CodexMemoryHookRuntimeOpti
         ),
         userText: rollout.turn.userPrompt,
         assistantText: rollout.turn.assistantReply,
+        userTimestamp: rollout.turn.userTimestamp,
+        assistantTimestamp: rollout.turn.assistantTimestamp,
         traceContext,
       });
       if (!writeback.scheduled) {

--- a/packages/ts/memorax-code-backend/src/clients/codex/rollout-turn.ts
+++ b/packages/ts/memorax-code-backend/src/clients/codex/rollout-turn.ts
@@ -1,4 +1,5 @@
 import { readFile } from "node:fs/promises";
+import { parseNativeMessageTimestamp } from "../../shared/message-time.js";
 
 type JsonRecord = Record<string, unknown>;
 
@@ -32,6 +33,8 @@ export type CodexRolloutTurn = {
   turnId: string;
   userPrompt: string;
   assistantReply: string;
+  userTimestamp?: number;
+  assistantTimestamp?: number;
   activities: CodexTurnActivity[];
   usage?: CodexTurnTokenUsage;
 };
@@ -112,7 +115,11 @@ export function codexRolloutTurnFromJsonLines(
   if (!scan.assistantReply) return { ok: false, reason: "assistant_message_missing" };
   return {
     ok: true,
-    turn: rolloutTurnFromScan(scan, input, scan.userPrompt, scan.assistantReply),
+    turn: {
+      ...rolloutTurnFromScan(scan, input, scan.userPrompt, scan.assistantReply),
+      ...(scan.userTimestamp === undefined ? {} : { userTimestamp: scan.userTimestamp }),
+      ...(scan.assistantTimestamp === undefined ? {} : { assistantTimestamp: scan.assistantTimestamp }),
+    },
   };
 }
 
@@ -149,6 +156,8 @@ type CodexRolloutTurnScan = {
   turnMetadataMismatch: boolean;
   userPrompt?: string;
   assistantReply?: string;
+  userTimestamp?: number;
+  assistantTimestamp?: number;
   visibleAssistantMessages: string[];
   interrupted: boolean;
   interruptedAt?: string;
@@ -172,9 +181,14 @@ function scanCodexRolloutTurn(transcript: string, targetTurnId: string): CodexRo
   let turnMetadataMismatch = false;
   let userPrompt: string | undefined;
   let assistantReply: string | undefined;
+  let userTimestamp: number | undefined;
+  let assistantTimestamp: number | undefined;
+  let completedTimestamp: number | undefined;
   const visibleAssistantMessages: string[] = [];
   let responseItemUserPrompt: string | undefined;
   let responseItemAssistantReply: string | undefined;
+  let responseItemUserTimestamp: number | undefined;
+  let responseItemAssistantTimestamp: number | undefined;
   let interrupted = false;
   let interruptedAt: string | undefined;
   let rolledBack = false;
@@ -255,8 +269,10 @@ function scanCodexRolloutTurn(transcript: string, targetTurnId: string): CodexRo
             if (role === "user") {
               userMessageTurnIds.add(activeTurnId);
               responseItemUserPrompt = message;
+              responseItemUserTimestamp = parseNativeMessageTimestamp(record.timestamp);
             } else {
               responseItemAssistantReply = message;
+              responseItemAssistantTimestamp = parseNativeMessageTimestamp(record.timestamp);
             }
           }
         }
@@ -283,6 +299,7 @@ function scanCodexRolloutTurn(transcript: string, targetTurnId: string): CodexRo
       if (completedTurnId === targetTurnId) {
         targetSeen = true;
         assistantReply ??= nonBlankString(payload.last_agent_message) ?? nonBlankString(payload.lastAgentMessage);
+        completedTimestamp = parseNativeMessageTimestamp(record.timestamp);
       }
       if (completedTurnId && completedTurnId === activeTurnId) activeTurnId = undefined;
       continue;
@@ -320,7 +337,11 @@ function scanCodexRolloutTurn(transcript: string, targetTurnId: string): CodexRo
     if (eventType === "user_message") {
       if (activeTurnId) userMessageTurnIds.add(activeTurnId);
       if (activeTurnId !== targetTurnId) continue;
-      userPrompt = nonBlankString(payload.message) ?? userPrompt;
+      const message = nonBlankString(payload.message);
+      if (message) {
+        userPrompt = message;
+        userTimestamp = parseNativeMessageTimestamp(record.timestamp);
+      }
       continue;
     }
     if (activeTurnId !== targetTurnId) continue;
@@ -330,7 +351,10 @@ function scanCodexRolloutTurn(transcript: string, targetTurnId: string): CodexRo
       if (payload.phase === "commentary" || payload.phase === "final_answer") {
         visibleAssistantMessages.push(message);
       }
-      if (payload.phase === "final_answer") assistantReply = message;
+      if (payload.phase === "final_answer") {
+        assistantReply = message;
+        assistantTimestamp = parseNativeMessageTimestamp(record.timestamp);
+      }
     }
   }
 
@@ -345,6 +369,12 @@ function scanCodexRolloutTurn(transcript: string, targetTurnId: string): CodexRo
     // missing response-item text may use the matching Turn's legacy text.
     userPrompt: responseItemUserPrompt ?? userPrompt,
     assistantReply: responseItemAssistantReply ?? assistantReply,
+    // Text and time share the same record authority, even when that record has
+    // no usable time. An exact task_complete can date completion separately.
+    userTimestamp: responseItemUserPrompt === undefined ? userTimestamp : responseItemUserTimestamp,
+    assistantTimestamp: completedTimestamp ?? (responseItemAssistantReply === undefined
+      ? assistantTimestamp
+      : responseItemAssistantTimestamp),
     visibleAssistantMessages,
     interrupted,
     interruptedAt,

--- a/packages/ts/memorax-code-backend/src/clients/dsh/memory-hook-runtime.ts
+++ b/packages/ts/memorax-code-backend/src/clients/dsh/memory-hook-runtime.ts
@@ -154,6 +154,8 @@ export function createDshMemoryHookRuntime(
         }),
         userText: materialized.turn.userPrompt,
         assistantText: materialized.turn.assistantReply,
+        userTimestamp: materialized.turn.userTimestamp,
+        assistantTimestamp: materialized.turn.assistantTimestamp,
         traceContext,
       });
       if (!writeback.scheduled) {

--- a/packages/ts/memorax-code-backend/src/clients/dsh/session-turn.ts
+++ b/packages/ts/memorax-code-backend/src/clients/dsh/session-turn.ts
@@ -1,4 +1,5 @@
 import { isRecord } from "../../shared/record.js";
+import { parseNativeMessageTimestamp } from "../../shared/message-time.js";
 
 export type DshSessionTurn = Readonly<{
   sessionId: string;
@@ -7,6 +8,8 @@ export type DshSessionTurn = Readonly<{
   endSeq: number;
   userPrompt: string;
   assistantReply: string;
+  userTimestamp?: number;
+  assistantTimestamp?: number;
   outcome: string;
 }>;
 
@@ -120,6 +123,9 @@ export function dshSessionEventTurn(input: DshSessionTurnInput): DshSessionTurnR
 
   const userParts: string[] = [];
   const assistantParts: string[] = [];
+  let userTimestamp: number | undefined;
+  let assistantTimestamp: number | undefined;
+  let completedTimestamp: number | undefined;
   let outcome: string | undefined;
 
   for (const [index, value] of input.events.entries()) {
@@ -164,6 +170,7 @@ export function dshSessionEventTurn(input: DshSessionTurnInput): DshSessionTurnR
         const reason = data && isRecord(data.reason) ? stringField(data.reason, "kind") : undefined;
         if (!reason) return { ok: false, reason: "event_invalid" };
         outcome = reason;
+        completedTimestamp = parseNativeMessageTimestamp(value.time);
         break;
       }
       case "user/message": {
@@ -180,7 +187,10 @@ export function dshSessionEventTurn(input: DshSessionTurnInput): DshSessionTurnR
           }
           const text = textContent(message.content);
           if (text === undefined) return { ok: false, reason: "event_invalid" };
-          if (text) userParts.push(text);
+          if (text) {
+            if (userParts.length === 0) userTimestamp = parseNativeMessageTimestamp(value.time);
+            userParts.push(text);
+          }
         }
         break;
       }
@@ -197,7 +207,10 @@ export function dshSessionEventTurn(input: DshSessionTurnInput): DshSessionTurnR
         ) return { ok: false, reason: "event_invalid" };
         const text = textContent(message.content);
         if (text === undefined) return { ok: false, reason: "event_invalid" };
-        if (text) assistantParts.push(text);
+        if (text) {
+          assistantParts.push(text);
+          assistantTimestamp = parseNativeMessageTimestamp(value.time);
+        }
         break;
       }
     }
@@ -213,6 +226,9 @@ export function dshSessionEventTurn(input: DshSessionTurnInput): DshSessionTurnR
   if (!userPrompt) return { ok: false, reason: "user_prompt_missing" };
   const assistantReply = assistantParts.join("\n\n").trim();
   if (!assistantReply) return { ok: false, reason: "assistant_message_missing" };
+  // Native turn/end marks completion of the merged reply. Older intervals
+  // without its time can only provide the last included assistant message time.
+  assistantTimestamp = completedTimestamp ?? assistantTimestamp;
   return {
     ok: true,
     turn: {
@@ -222,6 +238,8 @@ export function dshSessionEventTurn(input: DshSessionTurnInput): DshSessionTurnR
       endSeq: input.endSeq,
       userPrompt,
       assistantReply,
+      ...(userTimestamp !== undefined ? { userTimestamp } : {}),
+      ...(assistantTimestamp !== undefined ? { assistantTimestamp } : {}),
       outcome,
     },
   };

--- a/packages/ts/memorax-code-backend/src/clients/opencode/memory-hook-runtime.ts
+++ b/packages/ts/memorax-code-backend/src/clients/opencode/memory-hook-runtime.ts
@@ -175,6 +175,8 @@ export function createOpenCodeMemoryHookRuntime(
         }),
         userText: materialized.turn.userPrompt,
         assistantText: materialized.turn.assistantReply,
+        userTimestamp: materialized.turn.userTimestamp,
+        assistantTimestamp: materialized.turn.assistantTimestamp,
         traceContext,
       });
       if (!writeback.scheduled) {

--- a/packages/ts/memorax-code-backend/src/clients/opencode/message-turn.ts
+++ b/packages/ts/memorax-code-backend/src/clients/opencode/message-turn.ts
@@ -1,4 +1,5 @@
 import { isRecord } from "../../shared/record.js";
+import { parseNativeMessageTimestamp } from "../../shared/message-time.js";
 
 export type OpenCodeMessageTurn = Readonly<{
   sessionId: string;
@@ -6,6 +7,8 @@ export type OpenCodeMessageTurn = Readonly<{
   assistantMessageId: string;
   userPrompt: string;
   assistantReply: string;
+  userTimestamp?: number;
+  assistantTimestamp?: number;
   outcome: "completed" | "interrupted";
 }>;
 
@@ -66,6 +69,10 @@ export function openCodeMessageTurn(
   if (!userPrompt) return { ok: false, reason: "user_prompt_missing" };
   const assistantReply = messageText(assistant, input.sessionId, input.assistantMessageId);
   if (!assistantReply && !interrupted) return { ok: false, reason: "assistant_message_missing" };
+  // Compaction may change the final reply's parent, but the original user's
+  // creation time still belongs to the prompt selected above.
+  const userTimestamp = parseNativeMessageTimestamp(isRecord(user.info.time) ? user.info.time.created : undefined);
+  const assistantTimestamp = parseNativeMessageTimestamp(assistantTime?.completed);
   return {
     ok: true,
     turn: {
@@ -74,6 +81,8 @@ export function openCodeMessageTurn(
       assistantMessageId: input.assistantMessageId,
       userPrompt,
       assistantReply,
+      ...(userTimestamp !== undefined ? { userTimestamp } : {}),
+      ...(assistantTimestamp !== undefined ? { assistantTimestamp } : {}),
       outcome: interrupted ? "interrupted" : "completed",
     },
   };

--- a/packages/ts/memorax-code-backend/src/clients/trae/memory-hook-runtime.ts
+++ b/packages/ts/memorax-code-backend/src/clients/trae/memory-hook-runtime.ts
@@ -15,6 +15,8 @@ import type {
   MemoryTurnWritebackSkipReason,
 } from "../../memory/turn-coordinator.js";
 import type { RepositoryMemoryScopeFailureReason } from "../../repository/scope.js";
+import { parseNativeMessageTimestamp } from "../../shared/message-time.js";
+import { parseTraeTurnId, traePromptDigest } from "./turn-id.js";
 import { traceContextFromTraeHookBody, type TraceContext } from "../../trace/context.js";
 import {
   markCurrentTraceTurnOutcome,
@@ -107,6 +109,7 @@ export function createTraeMemoryHookRuntime(
     },
 
     async writeback(command) {
+      const assistantObservedAt = command.assistantObservedAt ?? now();
       turnCoordinator.pruneExpired();
       const commandKey = traeRuntimeTurnKey(command.sessionId, command.turnId);
       const activeTurn = activeTurns.get(command.sessionId);
@@ -119,6 +122,11 @@ export function createTraeMemoryHookRuntime(
       }
       const key = traeTurnKey(command.sessionId, command.turnId);
       const entry = turnCoordinator.getTurn(key) ?? activeTurn;
+      // Old Hooks already encode prompt observation in their validated Turn ID.
+      // Trae has no native message clock; these remain observation timestamps.
+      const identity = parseTraeTurnId(command);
+      const userObservedAt = identity?.promptDigest === traePromptDigest(command.prompt)
+        ? parseNativeMessageTimestamp(identity.createdAt) : undefined;
       const traceContext = entry?.traceContext ?? traceContextFromTraeHookBody(command);
       const repositoryMemory = await memory.resolveRepositoryMemory(command);
       await recordCompletedTurn(traceContext, command, options, now);
@@ -129,6 +137,10 @@ export function createTraeMemoryHookRuntime(
         resolveRepositoryMemory: async () => repositoryMemory,
         userText: command.prompt,
         assistantText: command.lastAssistantMessage,
+        userTimestamp: userObservedAt,
+        userTimestampSource: "observed",
+        assistantTimestamp: assistantObservedAt,
+        assistantTimestampSource: "observed",
         traceContext,
       });
       await recordMaterializedTurn(traceContext, command, options);

--- a/packages/ts/memorax-code-backend/src/memory/automatic-writeback.ts
+++ b/packages/ts/memorax-code-backend/src/memory/automatic-writeback.ts
@@ -38,10 +38,18 @@ import {
   type MemoryPayloadRedactionKind,
 } from "./payload-redaction.js";
 import type { MemoraxQuotaSnapshot } from "../provider/memorax/quota.js";
+import { parseNativeMessageTimestamp } from "../shared/message-time.js";
 
 export type AutomaticMemoryWritebackClient = "codex" | "claude-code" | "opencode" | "dsh" | "codebuddy" | "trae";
 
-export type AutomaticMemoryWritebackOptions = {
+export type AutomaticMemoryWritebackTiming = {
+  userTimestamp?: number;
+  assistantTimestamp?: number;
+  userTimestampSource?: "native" | "observed";
+  assistantTimestampSource?: "native" | "observed";
+};
+
+export type AutomaticMemoryWritebackOptions = AutomaticMemoryWritebackTiming & {
   client: AutomaticMemoryWritebackClient;
   sessionKey?: string;
   userText?: string;
@@ -295,14 +303,27 @@ function automaticMemoryWritebackDecision(
 
   const idempotencyKey = `automatic:${options.client}:${hashText(options.repositoryScope.effectiveUserId)}:${sessionKey}:${hashText(userText)}:${hashText(assistantText)}`;
   if (hasPendingWriteback(state, idempotencyKey)) return { write: false, skipReason: "duplicate_pending" };
+  // Freeze missing-time observations before buffering or retries. Upload time
+  // must never replace a native message time or pretend to be one.
+  const observedAt = Date.now();
+  const userTimestamp = parseNativeMessageTimestamp(options.userTimestamp);
+  const assistantTimestamp = parseNativeMessageTimestamp(options.assistantTimestamp);
   return {
     write: true,
     client: options.client,
     sessionKey,
     idempotencyKey,
     messages: [
-      { role: "user", content: userText },
-      { role: "assistant", content: assistantText },
+      {
+        role: "user", content: userText,
+        timestamp: userTimestamp ?? observedAt,
+        timestampSource: userTimestamp === undefined ? "observed" : options.userTimestampSource ?? "native",
+      },
+      {
+        role: "assistant", content: assistantText,
+        timestamp: assistantTimestamp ?? observedAt,
+        timestampSource: assistantTimestamp === undefined ? "observed" : options.assistantTimestampSource ?? "native",
+      },
     ],
   };
 }

--- a/packages/ts/memorax-code-backend/src/memory/harness-runtime.ts
+++ b/packages/ts/memorax-code-backend/src/memory/harness-runtime.ts
@@ -3,6 +3,7 @@ import {
   createAutomaticMemoryWritebackRuntime,
   type AutomaticMemoryWritebackEnqueue,
   type AutomaticMemoryWritebackRuntime,
+  type AutomaticMemoryWritebackTiming,
 } from "./automatic-writeback.js";
 import type { MemoryHookTurnStartResult } from "./hook-command.js";
 import type {
@@ -80,7 +81,7 @@ export type HarnessTurnStart = Omit<MemoryTurnStart, "client" | "clientTurnId" |
 
 // Only client-specific materializers may supply completion content. A terminal
 // Hook signal or a trace record alone does not establish this input.
-export type HarnessTurnCompletion = Readonly<{
+export type HarnessTurnCompletion = Readonly<AutomaticMemoryWritebackTiming & {
   sessionId: string;
   clientTurnId: string;
   metadata?: MemoryTurnState;
@@ -228,6 +229,10 @@ export function createHarnessMemoryRuntime(
         resolveRepositoryMemory: input.resolveRepositoryMemory,
         userText: input.userText,
         assistantText: input.assistantText,
+        userTimestamp: input.userTimestamp,
+        assistantTimestamp: input.assistantTimestamp,
+        userTimestampSource: input.userTimestampSource,
+        assistantTimestampSource: input.assistantTimestampSource,
         writeback: {
           client: definition.client,
           sessionKey: input.sessionId,

--- a/packages/ts/memorax-code-backend/src/memory/hook-command.ts
+++ b/packages/ts/memorax-code-backend/src/memory/hook-command.ts
@@ -1,4 +1,5 @@
 import { isRecord } from "../shared/record.js";
+import { parseNativeMessageTimestamp } from "../shared/message-time.js";
 import { codeBuddyPromptDigest, parseCodeBuddyTurnId } from "../clients/codebuddy/turn-id.js";
 import { parseTraeTurnId, traePromptDigest } from "../clients/trae/turn-id.js";
 
@@ -48,7 +49,7 @@ const WRITEBACK_KEYS: Readonly<Record<MemoryHookClient, ReadonlySet<string>>> = 
     "events",
   ]),
   codebuddy: new Set([...BASE_COMMAND_KEYS, "turnId", "transcriptPath"]),
-  trae: new Set([...BASE_COMMAND_KEYS, "turnId", "prompt", "lastAssistantMessage"]),
+  trae: new Set([...BASE_COMMAND_KEYS, "turnId", "prompt", "lastAssistantMessage", "assistantObservedAt"]),
 };
 const SKILL_REMINDER_KEYS: Readonly<Record<MemoryHookClient, ReadonlySet<string>>> = {
   codex: new Set([...BASE_COMMAND_KEYS, "turnId", "transcriptPath", "content", "triggers"]),
@@ -153,6 +154,7 @@ export type TraeWritebackCommand = MemoryHookCommandBase<"trae"> & Readonly<{
   turnId: string;
   prompt: string;
   lastAssistantMessage: string;
+  assistantObservedAt?: number;
 }>;
 
 export type WritebackCommand =
@@ -360,7 +362,15 @@ export function parseWritebackCommand(
     if (!turnId || !prompt || !lastAssistantMessage || !validTraeTurnId(turnId, base.sessionId, prompt)) {
       return invalidCommand();
     }
-    return { ok: true, command: { ...base, client: "trae", turnId, prompt, lastAssistantMessage } };
+    const assistantObservedAt = typeof value.assistantObservedAt === "number"
+      ? parseNativeMessageTimestamp(value.assistantObservedAt) : undefined;
+    if (value.assistantObservedAt !== undefined && assistantObservedAt === undefined) {
+      return invalidCommand();
+    }
+    return { ok: true, command: {
+      ...base, client: "trae", turnId, prompt, lastAssistantMessage,
+      ...(assistantObservedAt === undefined ? {} : { assistantObservedAt }),
+    } };
   }
   const lastAssistantMessage = requiredStringField(value, "lastAssistantMessage");
   if (!lastAssistantMessage) return invalidCommand();

--- a/packages/ts/memorax-code-backend/src/memory/turn-coordinator.ts
+++ b/packages/ts/memorax-code-backend/src/memory/turn-coordinator.ts
@@ -3,6 +3,7 @@ import type {
   AutomaticMemoryWritebackEnqueue,
   AutomaticMemoryWritebackOptions,
   AutomaticMemoryWritebackRejectionReason,
+  AutomaticMemoryWritebackTiming,
 } from "./automatic-writeback.js";
 import type { ConfiguredRepositoryMemoryResult } from "./repository-session.js";
 import {
@@ -12,6 +13,7 @@ import {
   type RepositoryMemoryScopeFailureReason,
 } from "../repository/scope.js";
 import type { TraceContext } from "../trace/context.js";
+import { parseNativeMessageTimestamp } from "../shared/message-time.js";
 
 export type MemoryTurnClient = AutomaticMemoryWritebackClient;
 
@@ -54,7 +56,7 @@ export type MemoryTurnWritebackResult =
     metadataDisposition: Exclude<MemoryTurnMetadataDisposition, "consumed">;
   };
 
-export type MemoryTurnCompletion = Readonly<{
+export type MemoryTurnCompletion = Readonly<AutomaticMemoryWritebackTiming & {
   key: MemoryTurnKey;
   metadata?: MemoryTurnState;
   resolveRepositoryMemory: () => Promise<ConfiguredRepositoryMemoryResult>;
@@ -148,6 +150,7 @@ export function createMemoryTurnCoordinator(options: MemoryTurnCoordinatorOption
       }
     },
     async completeMaterializedTurn(input) {
+      const observedAt = now();
       const reject = (
         reason: MemoryTurnWritebackSkipReason,
       ): MemoryTurnWritebackResult => ({
@@ -177,10 +180,21 @@ export function createMemoryTurnCoordinator(options: MemoryTurnCoordinatorOption
         }
         repositoryScope = currentScope;
       }
+      const userTimestamp = parseNativeMessageTimestamp(input.userTimestamp);
+      const assistantTimestamp = parseNativeMessageTimestamp(input.assistantTimestamp);
       const acceptance = options.automaticWriteback({
         ...input.writeback,
         userText: input.userText,
         assistantText: input.assistantText,
+        // Metadata.createdAt is a start observation, not native message time.
+        // Keep that distinction even when a legacy record has no timestamp.
+        userTimestamp: userTimestamp
+          ?? parseNativeMessageTimestamp(input.metadata?.createdAt) ?? observedAt,
+        assistantTimestamp: assistantTimestamp ?? observedAt,
+        userTimestampSource: userTimestamp === undefined
+          ? "observed" : input.userTimestampSource ?? "native",
+        assistantTimestampSource: assistantTimestamp === undefined
+          ? "observed" : input.assistantTimestampSource ?? "native",
         repositoryScope,
       });
       if (!acceptance.accepted) {

--- a/packages/ts/memorax-code-backend/src/memory/writeback-chunk.ts
+++ b/packages/ts/memorax-code-backend/src/memory/writeback-chunk.ts
@@ -9,6 +9,8 @@ const CODE_CHUNK_GROUP_ID_PREFIX = "memory-writeback-chunk:v1:";
 export type WritebackMessage = {
   role: "user" | "assistant";
   content: string;
+  timestamp?: number;
+  timestampSource?: "native" | "observed";
 };
 
 export type MemoryWritebackAddPart = {
@@ -135,8 +137,8 @@ function chunkWritebackMessage(
   config: { maxChars: number; overlapRatio: number },
 ): WritebackMessage[] {
   return splitTextWithOverlap(message.content, config.maxChars, config.overlapRatio)
-    .map((content) => ({ role: message.role, content }))
-    .filter((part) => part.content.trim());
+    .map((content) => ({ ...message, content }))
+    .filter((part) => part.content.length > 0);
 }
 
 function splitTextWithOverlap(text: string, maxChars: number, overlapRatio: number): string[] {

--- a/packages/ts/memorax-code-backend/src/provider/memorax/adapter.ts
+++ b/packages/ts/memorax-code-backend/src/provider/memorax/adapter.ts
@@ -27,6 +27,7 @@ import {
 } from "../../repository/scope.js";
 import type { TraceContext } from "../../trace/context.js";
 import { isRecord } from "../../shared/record.js";
+import { parseNativeMessageTimestamp } from "../../shared/message-time.js";
 
 const SLOT_RESULT_SCHEMA_VERSION = "slot-invocation-result.preview.v1";
 const FORWARDED_WRITEBACK_METADATA_KEYS = [
@@ -105,6 +106,13 @@ type MemoraxAddPayload = {
   metadata: Record<string, unknown>;
   async_mode: true;
   timestamp: number;
+};
+
+type MemoraxWritebackMessage = {
+  role: "user" | "assistant";
+  content: string;
+  timestamp?: number;
+  timestampSource?: "native" | "observed";
 };
 
 type MemoraxRunContext = {
@@ -309,12 +317,12 @@ async function invokeMemoraxWriteback(
 ): Promise<MemoraxInvocationResult> {
   const env = options.env ?? process.env;
   const context = isRecord(request.context) ? request.context : {};
-  const messages = writebackMessagesFromContext(context, request.content);
+  const addOptions = memoraxAddOptionsFromContext(context, env);
+  if (!addOptions.ok) return { ok: false, error: addOptions.error };
+  const messages = writebackMessagesFromContext(context, request.content, addOptions.options);
   if (messages.length === 0) return { ok: false, error: "writeback messages are required" };
   const idempotencyKey = writebackIdempotencyKeyFromContext(context);
   if (!idempotencyKey) return { ok: false, error: "writeback idempotency key is required" };
-  const addOptions = memoraxAddOptionsFromContext(context, env);
-  if (!addOptions.ok) return { ok: false, error: addOptions.error };
   const payload = buildMemoraxAddPayload(config, run, messages, context, idempotencyKey, repositoryScope, addOptions.options);
   try {
     const { body: raw, quota } = await callMemoAdd(config, payload, options.fetchImpl);
@@ -370,7 +378,7 @@ async function invokeMemoraxWriteback(
 function buildMemoraxAddPayload(
   config: MemoraxAdapterConfig,
   run: MemoraxRunContext,
-  messages: Array<{ role: "user" | "assistant"; content: string; timestamp?: number }>,
+  messages: MemoraxWritebackMessage[],
   context: Record<string, unknown>,
   idempotencyKey: string,
   repositoryScope: RepositoryMemoryScope,
@@ -381,14 +389,13 @@ function buildMemoraxAddPayload(
   const chunk = options.contentType === "code" && options.mode === "default"
     ? writebackChunkFromContext(context)
     : undefined;
-  let lastTimestamp = 0;
-  const stamped = messages.map((message, index) => {
-    let timestamp = Number.isFinite(message.timestamp) ? Number(message.timestamp) : now + index;
-    if (timestamp < 10_000_000_000) timestamp = now + index;
-    if (timestamp <= lastTimestamp) timestamp = lastTimestamp + 1;
-    lastTimestamp = timestamp;
-    return { role: message.role, content: message.content, timestamp };
-  });
+  // Preserve caller times exactly, including equal fragment timestamps and
+  // out-of-order arrival. Array order and chunk indexes already express order.
+  const stamped = messages.map((message, index) => ({
+    role: message.role,
+    content: message.content,
+    timestamp: parseNativeMessageTimestamp(message.timestamp) ?? now + index,
+  }));
   const scopeKind = repositoryMemoryScopeKind(repositoryScope);
   return {
     messages: stamped,
@@ -405,6 +412,9 @@ function buildMemoraxAddPayload(
       source: "memorax-code",
       tags: ["memorax-code"],
       ...extraMetadata,
+      ...(messages.some((message) => message.timestampSource) ? {
+        memorax_code_timestamp_sources: messages.map((message) => message.timestampSource ?? "unspecified"),
+      } : {}),
       memorax_code_memory_scope: memoraxScopeVersion(scopeKind),
       memorax_code_base_user_id: repositoryScope.baseUserId,
       memorax_code_workspace: repositoryScope.repositorySlug,
@@ -466,23 +476,36 @@ function repositoryScopeForConfig(
 function writebackMessagesFromContext(
   context: Record<string, unknown>,
   fallbackContent: unknown,
-): Array<{ role: "user" | "assistant"; content: string; timestamp?: number }> {
+  options: MemoraxAddOptions,
+): MemoraxWritebackMessage[] {
+  const preserveWhitespace = options.contentType === "code" && options.mode === "default"
+    && writebackChunkFromContext(context) !== undefined;
   const rawMessages = Array.isArray(context.messages) ? context.messages : [];
   const messages = rawMessages
-    .map((message) => normalizeWritebackMessage(message))
-    .filter((message): message is { role: "user" | "assistant"; content: string; timestamp?: number } => Boolean(message));
+    .map((message) => normalizeWritebackMessage(message, preserveWhitespace))
+    .filter((message): message is MemoraxWritebackMessage => Boolean(message));
   if (messages.length > 0) return messages;
   const content = typeof fallbackContent === "string" ? fallbackContent.trim() : "";
   return content ? [{ role: "assistant", content }] : [];
 }
 
-function normalizeWritebackMessage(value: unknown): { role: "user" | "assistant"; content: string; timestamp?: number } | undefined {
+function normalizeWritebackMessage(value: unknown, preserveWhitespace: boolean): MemoraxWritebackMessage | undefined {
   if (!isRecord(value)) return undefined;
   const role = value.role === "user" || value.role === "assistant" ? value.role : undefined;
-  const content = typeof value.content === "string" ? value.content.trim() : "";
+  const rawContent = typeof value.content === "string" ? value.content : "";
+  // Complete messages were normalized before chunking. A fragment's boundary
+  // whitespace, including a whitespace-only fragment, belongs to that message.
+  const content = preserveWhitespace ? rawContent : rawContent.trim();
   if (!role || !content) return undefined;
-  const timestamp = typeof value.timestamp === "number" && Number.isFinite(value.timestamp) ? value.timestamp : undefined;
-  return { role, content, ...(timestamp === undefined ? {} : { timestamp }) };
+  const timestamp = typeof value.timestamp === "number" ? parseNativeMessageTimestamp(value.timestamp) : undefined;
+  const timestampSource = value.timestampSource === "native" || value.timestampSource === "observed"
+    ? (timestamp === undefined ? "observed" : value.timestampSource)
+    : undefined;
+  return {
+    role, content,
+    ...(timestamp === undefined ? {} : { timestamp }),
+    ...(timestampSource === undefined ? {} : { timestampSource }),
+  };
 }
 
 function renderMemoraxContextBlocks(items: unknown[], config: MemoraxAdapterConfig): MemoraxContextBlock[] {

--- a/packages/ts/memorax-code-backend/src/shared/message-time.ts
+++ b/packages/ts/memorax-code-backend/src/shared/message-time.ts
@@ -1,0 +1,12 @@
+// Native records use epoch milliseconds or ISO timestamps with an explicit
+// timezone. Reject seconds and locale-dependent strings rather than guessing.
+export function parseNativeMessageTimestamp(value: unknown): number | undefined {
+  const timestamp = typeof value === "number"
+    ? value
+    : typeof value === "string" && /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/i.test(value)
+      ? Date.parse(value)
+      : NaN;
+  return Number.isSafeInteger(timestamp) && timestamp >= 10_000_000_000 && timestamp <= 8_640_000_000_000_000
+    ? timestamp
+    : undefined;
+}

--- a/packages/ts/memorax-code-backend/test/clients/claude/claude-memory-hook-runtime.test.mjs
+++ b/packages/ts/memorax-code-backend/test/clients/claude/claude-memory-hook-runtime.test.mjs
@@ -47,8 +47,11 @@ test("Claude Hook returns the Backend-authorized Git worktree", async () => {
   }
 });
 
-test("Claude Hook writeback uses exact transcript content", async () => {
-  const fixture = await transcriptFixture("Materialized prompt.", "Materialized answer.");
+test("Claude Hook writeback uses exact transcript content and native times", async () => {
+  const fixture = await transcriptFixture("Materialized prompt.", "Materialized answer.", {
+    userTimestamp: "2026-09-01T08:00:00.000Z",
+    assistantRecords: [{ ...assistantRecord("Materialized answer."), timestamp: "2026-09-01T08:03:00.000Z" }],
+  });
   const writebacks = [];
   const diagnostics = [];
   const runtime = createClaudeMemoryHookRuntime({
@@ -74,6 +77,8 @@ test("Claude Hook writeback uses exact transcript content", async () => {
     assert.equal(writebacks.length, 1);
     assert.equal(writebacks[0].userText, "Materialized prompt.");
     assert.equal(writebacks[0].assistantText, "Materialized answer.");
+    assert.equal(writebacks[0].userTimestamp, Date.parse("2026-09-01T08:00:00.000Z"));
+    assert.equal(writebacks[0].assistantTimestamp, Date.parse("2026-09-01T08:03:00.000Z"));
     assert.equal(writebacks[0].client, "claude-code");
     assert.equal(writebacks[0].memoryObservabilitySource, "claude_hook_writeback");
     assert.equal(writebacks[0].repositoryScope, SCOPE);
@@ -785,12 +790,12 @@ function turnStart(transcriptPath, promptId = PROMPT_ID) {
 async function transcriptFixture(
   userPrompt,
   assistantReply,
-  { promptId = PROMPT_ID, assistantRecords } = {},
+  { promptId = PROMPT_ID, assistantRecords, userTimestamp } = {},
 ) {
   const root = await mkdtemp(join(tmpdir(), "memorax-code-claude-hook-transcript-"));
   const path = join(root, "transcript.jsonl");
   await writeFile(path, [
-    JSON.stringify(userRecord(userPrompt, promptId)),
+    JSON.stringify({ ...userRecord(userPrompt, promptId), timestamp: userTimestamp }),
     ...(assistantRecords ?? [assistantRecord(assistantReply)])
       .map((record) => JSON.stringify(record)),
     "",

--- a/packages/ts/memorax-code-backend/test/clients/claude/claude-transcript-completed-turn.test.mjs
+++ b/packages/ts/memorax-code-backend/test/clients/claude/claude-transcript-completed-turn.test.mjs
@@ -15,17 +15,19 @@ import {
 
 test("Claude transcript resolves one exact completed prompt branch", () => {
   const transcript = jsonLines([
-    userRecord({ uuid: "user-visible", content: "Materialized Claude prompt." }),
+    userRecord({ uuid: "user-visible", content: "Materialized Claude prompt.", timestamp: "2026-09-01T08:00:00.000Z" }),
     assistantRecord({ uuid: "assistant-tool", parentUuid: "user-visible", stopReason: "tool_use", content: [{ type: "tool_use", id: "tool-1", name: "Read", input: {} }] }),
     userRecord({
       uuid: "user-tool-result",
       parentUuid: "assistant-tool",
+      timestamp: "2026-09-01T08:01:00.000Z",
       content: [{ type: "tool_result", tool_use_id: "tool-1", content: "tool output must not become the prompt" }],
     }),
     userRecord({ uuid: "user-meta", parentUuid: "user-tool-result", content: "hidden metadata", isMeta: true }),
     assistantRecord({
       uuid: "assistant-final",
       parentUuid: "user-meta",
+      timestamp: "2026-09-01T08:03:00.000Z",
       stopReason: "end_turn",
       content: [
         { type: "thinking", thinking: "private" },
@@ -35,6 +37,7 @@ test("Claude transcript resolves one exact completed prompt branch", () => {
     assistantRecord({
       uuid: "assistant-sidechain",
       parentUuid: "user-visible",
+      timestamp: "2026-09-01T08:04:00.000Z",
       stopReason: "end_turn",
       content: [{ type: "text", text: "Sidechain answer must be ignored." }],
       isSidechain: true,
@@ -52,6 +55,8 @@ test("Claude transcript resolves one exact completed prompt branch", () => {
       sessionTurnIndex: 1,
       userPrompt: "Materialized Claude prompt.",
       assistantReply: "Materialized Claude answer.",
+      userTimestamp: Date.parse("2026-09-01T08:00:00.000Z"),
+      assistantTimestamp: Date.parse("2026-09-01T08:03:00.000Z"),
       activities: [],
     },
   });
@@ -307,6 +312,7 @@ test("Claude transcript coalesces ancestor and descendant end_turn snapshots", (
     assistantRecord({
       uuid: "assistant-terminal-ancestor",
       parentUuid: "user-lineage-result",
+      timestamp: "2026-07-27T10:00:02.000Z",
       messageId: "message-terminal-snapshot",
       stopReason: "end_turn",
       content: [{ type: "text", text: "Earlier terminal snapshot." }],
@@ -314,6 +320,7 @@ test("Claude transcript coalesces ancestor and descendant end_turn snapshots", (
     assistantRecord({
       uuid: "assistant-terminal-descendant",
       parentUuid: "assistant-terminal-ancestor",
+      timestamp: Date.parse("2026-07-27T10:00:05.000Z"),
       messageId: "message-terminal-snapshot",
       stopReason: "end_turn",
       content: [{ type: "text", text: "Final terminal snapshot." }],
@@ -331,6 +338,7 @@ test("Claude transcript coalesces ancestor and descendant end_turn snapshots", (
       sessionTurnIndex: 1,
       userPrompt: "Recover one terminal lineage.",
       assistantReply: "Final terminal snapshot.",
+      assistantTimestamp: Date.parse("2026-07-27T10:00:05.000Z"),
       activities: [{ index: 1, type: "memory_cli_search" }],
     },
   });

--- a/packages/ts/memorax-code-backend/test/clients/codebuddy/codebuddy-memory-hook-trace.test.mjs
+++ b/packages/ts/memorax-code-backend/test/clients/codebuddy/codebuddy-memory-hook-trace.test.mjs
@@ -195,8 +195,8 @@ test("CodeBuddy runtime writes back the uniquely materialized provisional turn",
   const prompt = "persist this turn";
   const turnId = provisionalTurnId(sessionId, prompt);
   await writeFile(transcriptPath, lines([
-    { id: "u-native", type: "message", role: "user", sessionId, content: [{ type: "input_text", text: prompt }] },
-    { id: "a-native", type: "message", role: "assistant", parentId: "u-native", status: "completed", content: [{ type: "output_text", text: "persisted reply" }] },
+    { id: "u-native", type: "message", role: "user", sessionId, timestamp: 1_700_000_000_000, content: [{ type: "input_text", text: prompt }] },
+    { id: "a-native", type: "message", role: "assistant", parentId: "u-native", status: "completed", timestamp: 1_700_000_060_000, content: [{ type: "output_text", text: "persisted reply" }] },
   ]));
   const writes = [];
   const runtime = createCodeBuddyMemoryHookRuntime({
@@ -215,6 +215,8 @@ test("CodeBuddy runtime writes back the uniquely materialized provisional turn",
     assert.equal(writes.length, 1);
     assert.equal(writes[0].userText, prompt);
     assert.equal(writes[0].assistantText, "persisted reply");
+    assert.equal(writes[0].userTimestamp, 1_700_000_000_000);
+    assert.equal(writes[0].assistantTimestamp, 1_700_000_060_000);
   } finally {
     runtime.close();
   }

--- a/packages/ts/memorax-code-backend/test/clients/codebuddy/codebuddy-transcript.test.mjs
+++ b/packages/ts/memorax-code-backend/test/clients/codebuddy/codebuddy-transcript.test.mjs
@@ -10,13 +10,13 @@ import {
 const sessionId = "session-1";
 test("extracts hidden user query and completed assistant branch", () => {
   const lines = [
-    { id: "u1", type: "message", role: "user", sessionId, content: [
+    { id: "u1", type: "message", role: "user", sessionId, timestamp: "2026-09-07T08:00:00+08:00", content: [
       { type: "output_text", text: "<user_query>ignore this block</user_query>" },
       { type: "input_text", text: "<system-reminder>hidden</system-reminder><user_query>remember this</user_query>" },
     ] },
     { id: "c1", type: "function_call", role: "assistant", parentId: "u1", name: "Bash", arguments: "{}" },
     { id: "r1", type: "function_call_result", parentId: "c1", output: "ok" },
-    { id: "a1", type: "message", role: "assistant", parentId: "r1", status: "completed", content: [
+    { id: "a1", type: "message", role: "assistant", parentId: "r1", status: "completed", timestamp: "2026-09-07T00:05:00.000Z", content: [
       { type: "input_text", text: "ignore this block" },
       { type: "output_text", text: "done" },
     ] },
@@ -25,6 +25,8 @@ test("extracts hidden user query and completed assistant branch", () => {
   assert.equal(result.ok, true);
   assert.equal(result.turn.userPrompt, "remember this");
   assert.equal(result.turn.assistantReply, "done");
+  assert.equal(result.turn.userTimestamp, Date.parse("2026-09-07T00:00:00.000Z"));
+  assert.equal(result.turn.assistantTimestamp, Date.parse("2026-09-07T00:05:00.000Z"));
 });
 
 test("preserves completed and interrupted replies through a long tool chain", () => {
@@ -53,6 +55,8 @@ test("preserves completed and interrupted replies through a long tool chain", ()
   assert.equal(completed.ok, true);
   assert.equal(completed.turn.userPrompt, "long task");
   assert.equal(completed.turn.assistantReply, "done");
+  assert.equal(completed.turn.userTimestamp, undefined);
+  assert.equal(completed.turn.assistantTimestamp, undefined);
   assert.equal(completed.turn.activities.length, callCount * 2);
 
   assistant.status = "incomplete";
@@ -173,12 +177,12 @@ test("fails closed on two completed branches", () => {
 
 test("uses the provisional transcript boundary for repeated prompts", () => {
   const first = [
-    { id: "u1", type: "message", role: "user", sessionId, content: [{ type: "input_text", text: "repeat" }] },
-    { id: "a1", type: "message", role: "assistant", parentId: "u1", status: "completed", content: [{ type: "output_text", text: "first" }] },
+    { id: "u1", type: "message", role: "user", sessionId, timestamp: 1_700_000_000_000, content: [{ type: "input_text", text: "repeat" }] },
+    { id: "a1", type: "message", role: "assistant", parentId: "u1", status: "completed", timestamp: 1_700_000_060_000, content: [{ type: "output_text", text: "first" }] },
   ].map(JSON.stringify).join("\n") + "\n";
   const second = [
-    { id: "u2", type: "message", role: "user", sessionId, content: [{ type: "input_text", text: "repeat" }] },
-    { id: "a2", type: "message", role: "assistant", parentId: "u2", status: "completed", content: [{ type: "output_text", text: "second" }] },
+    { id: "u2", type: "message", role: "user", sessionId, timestamp: 1_700_000_300_000, content: [{ type: "input_text", text: "repeat" }] },
+    { id: "a2", type: "message", role: "assistant", parentId: "u2", status: "completed", timestamp: 1_700_000_420_000, content: [{ type: "output_text", text: "second" }] },
   ].map(JSON.stringify).join("\n") + "\n";
   const result = codeBuddyTranscriptTurnFromJsonLines(first + second, {
     sessionId,
@@ -186,6 +190,8 @@ test("uses the provisional transcript boundary for repeated prompts", () => {
   });
   assert.equal(result.ok, true);
   assert.equal(result.turn.assistantReply, "second");
+  assert.equal(result.turn.userTimestamp, 1_700_000_300_000);
+  assert.equal(result.turn.assistantTimestamp, 1_700_000_420_000);
 });
 
 test("does not accept session-less user records when session markers exist", () => {
@@ -229,20 +235,27 @@ test("fails closed on malformed JSONL instead of using a partial transcript", ()
 });
 
 test("uses UTF-8 byte boundaries when a repeated prompt follows non-ASCII history", () => {
-  const first = [
-    { id: "u1", type: "message", role: "user", sessionId, content: [{ type: "input_text", text: "重复" }] },
-    { id: "a1", type: "message", role: "assistant", parentId: "u1", status: "completed", content: [{ type: "output_text", text: "第一轮" }] },
-  ].map(JSON.stringify).join("\n") + "\n";
-  const second = [
-    { id: "u2", type: "message", role: "user", sessionId, content: [{ type: "input_text", text: "重复" }] },
-    { id: "a2", type: "message", role: "assistant", parentId: "u2", status: "completed", content: [{ type: "output_text", text: "第二轮" }] },
-  ].map(JSON.stringify).join("\n") + "\n";
-  const result = codeBuddyTranscriptTurnFromJsonLines(first + second, {
-    sessionId,
-    turnId: provisionalTurnId("重复", Buffer.byteLength(first, "utf8")),
-  });
-  assert.equal(result.ok, true);
-  assert.equal(result.turn.assistantReply, "第二轮");
+  for (const newline of ["\n", "\r\n"]) {
+    const first = [
+      { id: "u1", type: "message", role: "user", sessionId, content: [{ type: "input_text", text: "重复" }] },
+      { id: "a1", type: "message", role: "assistant", parentId: "u1", status: "completed", content: [{ type: "output_text", text: "第一轮" }] },
+    ].map(JSON.stringify).join(newline) + newline;
+    const second = [
+      { id: "u2", type: "message", role: "user", sessionId, content: [{ type: "input_text", text: "重复" }] },
+      { id: "a2", type: "message", role: "assistant", parentId: "u2", status: "completed", content: [{ type: "output_text", text: "第二轮" }] },
+    ].map(JSON.stringify).join(newline) + newline;
+    const boundary = Buffer.byteLength(first, "utf8");
+    const result = codeBuddyTranscriptTurnFromJsonLines(first + second, {
+      sessionId,
+      turnId: provisionalTurnId("重复", boundary),
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.turn.assistantReply, "第二轮");
+    assert.deepEqual(codeBuddyTranscriptTurnFromJsonLines(first + second, {
+      sessionId,
+      turnId: provisionalTurnId("重复", boundary + 1),
+    }), { ok: false, reason: "user_prompt_missing" }, "records before the exact byte boundary must stay excluded");
+  }
 });
 
 test("rejects a prompt materialized before the provisional boundary", () => {

--- a/packages/ts/memorax-code-backend/test/clients/codex/codex-memory-hook-runtime.test.mjs
+++ b/packages/ts/memorax-code-backend/test/clients/codex/codex-memory-hook-runtime.test.mjs
@@ -186,6 +186,10 @@ test("memory hook writeback accepts repeated authority metadata in the exact Cod
 
     assert.equal(requests[0].body.messages[0].content, "Remember this persisted Codex turn.");
     assert.equal(requests[0].body.messages[1].content, "Stored persisted Codex answer.");
+    assert.deepEqual(requests[0].body.messages.map((message) => message.timestamp), [
+      Date.parse("2026-07-16T00:00:02.000Z"),
+      Date.parse("2026-07-16T00:00:03.000Z"),
+    ]);
     assert.equal(requests[0].body.user_id, "user-1@memorax-code");
     assert.equal(requests[0].body.metadata.memorax_code_base_user_id, "user-1");
     assert.equal(requests[0].body.metadata.memorax_code_workspace, "memorax-code");

--- a/packages/ts/memorax-code-backend/test/clients/codex/codex-rollout-turn.test.mjs
+++ b/packages/ts/memorax-code-backend/test/clients/codex/codex-rollout-turn.test.mjs
@@ -17,9 +17,9 @@ test("Codex rollout reader selects the exact open turn and preserves prompt and 
     taskComplete("turn-before", "Earlier reply."),
     taskStarted("turn-target"),
     turnContext("turn-target"),
-    userMessage("  Target prompt with trailing newline.\n"),
+    { ...userMessage("  Target prompt with trailing newline.\n"), timestamp: "2026-09-01T08:00:00.000Z" },
     agentMessage("Intermediate update.", "commentary"),
-    agentMessage("Target final reply.\n", "final_answer"),
+    { ...agentMessage("Target final reply.\n", "final_answer"), timestamp: "2026-09-01T08:03:00.000Z" },
   ]);
 
   assert.deepEqual(codexRolloutTurnFromJsonLines(transcript, {
@@ -32,6 +32,8 @@ test("Codex rollout reader selects the exact open turn and preserves prompt and 
       turnId: "turn-target",
       userPrompt: "  Target prompt with trailing newline.\n",
       assistantReply: "Target final reply.\n",
+      userTimestamp: Date.parse("2026-09-01T08:00:00.000Z"),
+      assistantTimestamp: Date.parse("2026-09-01T08:03:00.000Z"),
       activities: [],
     },
   });
@@ -42,7 +44,8 @@ test("Codex rollout reader uses task_complete as a completed-turn assistant fall
     sessionMeta("session-1"),
     taskStarted("turn-1"),
     userMessage("Stored prompt."),
-    taskComplete("turn-1", "Stored final reply."),
+    { ...taskComplete("turn-1", "Stored final reply."), timestamp: "2026-09-01T08:03:00.000Z" },
+    { ...taskComplete("other-turn", "Other final reply."), timestamp: "2026-09-01T08:05:00.000Z" },
   ]);
 
   assert.deepEqual(codexRolloutTurnFromJsonLines(transcript, {
@@ -55,6 +58,8 @@ test("Codex rollout reader uses task_complete as a completed-turn assistant fall
       turnId: "turn-1",
       userPrompt: "Stored prompt.",
       assistantReply: "Stored final reply.",
+      userTimestamp: Date.parse("2026-07-16T00:00:03.000Z"),
+      assistantTimestamp: Date.parse("2026-09-01T08:03:00.000Z"),
       activities: [],
     },
   });
@@ -65,9 +70,9 @@ test("Codex rollout reader supports response_item-only user and final assistant 
     sessionMeta("session-1"),
     taskStarted("turn-1"),
     turnContext("turn-1"),
-    responseItemUserMessage("Current-format prompt.", "turn-1"),
-    responseMessage("assistant", "Current-format final reply.", "final_answer", "turn-1"),
-    taskComplete("turn-1"),
+    { ...responseItemUserMessage("Current-format prompt.", "turn-1"), timestamp: "2026-09-01T08:00:00.000Z" },
+    { ...responseMessage("assistant", "Current-format final reply.", "final_answer", "turn-1"), timestamp: "2026-09-01T08:02:58.000Z" },
+    { ...taskComplete("turn-1"), timestamp: "2026-09-01T08:03:00.000Z" },
   ]);
 
   assert.deepEqual(codexRolloutTurnFromJsonLines(transcript, {
@@ -80,6 +85,8 @@ test("Codex rollout reader supports response_item-only user and final assistant 
       turnId: "turn-1",
       userPrompt: "Current-format prompt.",
       assistantReply: "Current-format final reply.",
+      userTimestamp: Date.parse("2026-09-01T08:00:00.000Z"),
+      assistantTimestamp: Date.parse("2026-09-01T08:03:00.000Z"),
       activities: [],
     },
   });
@@ -90,11 +97,11 @@ test("Codex rollout reader prefers response_item messages over legacy event mess
     sessionMeta("session-1"),
     taskStarted("turn-1"),
     turnContext("turn-1"),
-    responseItemUserMessage("Current-format prompt."),
-    userMessage("Legacy prompt."),
-    responseMessage("assistant", "Current-format final reply.", "final_answer"),
-    agentMessage("Legacy final reply.", "final_answer"),
-    taskComplete("turn-1", "Legacy final reply."),
+    { ...responseItemUserMessage("Current-format prompt."), timestamp: "invalid" },
+    { ...userMessage("Legacy prompt."), timestamp: "2026-09-01T08:00:00.000Z" },
+    { ...responseMessage("assistant", "Current-format final reply.", "final_answer"), timestamp: "2026-09-01T08:02:58.000Z" },
+    { ...agentMessage("Legacy final reply.", "final_answer"), timestamp: "2026-09-01T08:02:59.000Z" },
+    { ...taskComplete("turn-1", "Legacy final reply."), timestamp: "invalid" },
   ]);
 
   assert.deepEqual(codexRolloutTurnFromJsonLines(transcript, {
@@ -107,6 +114,7 @@ test("Codex rollout reader prefers response_item messages over legacy event mess
       turnId: "turn-1",
       userPrompt: "Current-format prompt.",
       assistantReply: "Current-format final reply.",
+      assistantTimestamp: Date.parse("2026-09-01T08:02:58.000Z"),
       activities: [],
     },
   });
@@ -214,6 +222,8 @@ test("Codex rollout reader aggregates cumulative token snapshots for the complet
       turnId: "turn-1",
       userPrompt: "Prompt.",
       assistantReply: "Reply.",
+      userTimestamp: Date.parse("2026-07-16T00:00:03.000Z"),
+      assistantTimestamp: Date.parse("2026-07-16T00:00:05.000Z"),
       activities: [],
       usage: {
         input_tokens: 100,
@@ -289,6 +299,8 @@ test("Codex rollout reader uses the file header authority across imported histor
       turnId: "turn-target",
       userPrompt: "Current prompt.",
       assistantReply: "Current reply.",
+      userTimestamp: Date.parse("2026-07-16T00:00:03.000Z"),
+      assistantTimestamp: Date.parse("2026-07-16T00:00:04.000Z"),
       activities: [{ index: 1, type: "repo_memory_operation", operation: "repo-read" }],
     },
   });
@@ -338,6 +350,8 @@ test("Codex rollout reader treats repeated authority session metadata as idempot
       turnId: "turn-1",
       userPrompt: "Prompt from a resumed session.",
       assistantReply: "Reply from a resumed session.",
+      userTimestamp: Date.parse("2026-07-16T00:00:03.000Z"),
+      assistantTimestamp: Date.parse("2026-07-16T00:00:04.000Z"),
       activities: [],
       usage,
     },

--- a/packages/ts/memorax-code-backend/test/clients/dsh/dsh-memory-hook.test.mjs
+++ b/packages/ts/memorax-code-backend/test/clients/dsh/dsh-memory-hook.test.mjs
@@ -309,6 +309,10 @@ test("Backend runs DSH Search, normalized Trace, and Add from one native Turn in
       { role: "user", content: "Implement the DSH adapter." },
       { role: "assistant", content: "I will inspect.\n\nThe adapter is ready." },
     ]);
+    assert.deepEqual(requests[1].body.messages.map(({ timestamp }) => timestamp), [
+      1_700_000_000_001,
+      1_700_000_000_010,
+    ]);
     assert.equal(JSON.stringify(requests[1].body).includes("recalled memory"), false);
     assert.equal(JSON.stringify(requests[1].body).includes("private tool result"), false);
 

--- a/packages/ts/memorax-code-backend/test/clients/dsh/dsh-session-turn.test.mjs
+++ b/packages/ts/memorax-code-backend/test/clients/dsh/dsh-session-turn.test.mjs
@@ -16,11 +16,23 @@ test("DSH turn materialization accepts one exact native interval and excludes pl
       endSeq: 10,
       userPrompt: "Implement the DSH adapter.",
       assistantReply: "I will inspect.\n\nThe adapter is ready.",
+      userTimestamp: 1_700_000_000_001,
+      assistantTimestamp: 1_700_000_000_010,
       outcome: "completed",
     },
   });
   assert.equal(JSON.stringify(result).includes("recalled memory"), false);
   assert.equal(JSON.stringify(result).includes("private tool result"), false);
+
+  const withoutEndTime = dshTurnInterval({ cwd: CWD });
+  delete withoutEndTime.events.at(-1).time;
+  assert.equal(dshSessionEventTurn(withoutEndTime).turn.assistantTimestamp, 1_700_000_000_007);
+  delete withoutEndTime.events[1].time;
+  withoutEndTime.events[7].time = "not-a-time";
+  const withoutMessageTimes = dshSessionEventTurn(withoutEndTime);
+  assert.equal(withoutMessageTimes.ok, true);
+  assert.equal(withoutMessageTimes.turn.userTimestamp, undefined, "plugin recall is not a prompt time source");
+  assert.equal(withoutMessageTimes.turn.assistantTimestamp, undefined, "earlier assistant text cannot date the final reply");
 
   const ordinaryFork = dshTurnInterval({ cwd: CWD });
   ordinaryFork.sessionHeader.parentSession = "ordinary-parent";

--- a/packages/ts/memorax-code-backend/test/clients/opencode/opencode-memory-hook.test.mjs
+++ b/packages/ts/memorax-code-backend/test/clients/opencode/opencode-memory-hook.test.mjs
@@ -25,6 +25,8 @@ test("OpenCode SDK messages materialize only an exact completed normal turn", ()
       assistantMessageId: "assistant-1",
       userPrompt: "OpenCode user prompt.",
       assistantReply: "OpenCode assistant reply.",
+      userTimestamp: 1_700_000_000_000,
+      assistantTimestamp: 1_700_000_060_000,
       outcome: "completed",
     },
   });
@@ -56,6 +58,8 @@ test("OpenCode SDK messages materialize only an exact completed normal turn", ()
       assistantMessageId: "assistant-1",
       userPrompt: "OpenCode user prompt.",
       assistantReply: "",
+      userTimestamp: 1_700_000_000_000,
+      assistantTimestamp: 1_700_000_060_000,
       outcome: "interrupted",
     },
   });
@@ -91,6 +95,8 @@ test("OpenCode SDK messages materialize only an exact completed normal turn", ()
       assistantMessageId: "assistant-1",
       userPrompt: "OpenCode user prompt.",
       assistantReply: "",
+      userTimestamp: 1_700_000_000_000,
+      assistantTimestamp: 1_700_000_060_000,
       outcome: "interrupted",
     },
   });
@@ -110,6 +116,8 @@ test("OpenCode SDK messages materialize a completed compaction continuation as t
       assistantMessageId: "assistant-final",
       userPrompt: "OpenCode user prompt.",
       assistantReply: "OpenCode final reply.",
+      userTimestamp: 1_700_000_000_000,
+      assistantTimestamp: 1_700_000_300_000,
       outcome: "completed",
     },
   });
@@ -149,6 +157,8 @@ test("OpenCode SDK messages materialize a completed compaction continuation as t
       assistantMessageId: "assistant-final",
       userPrompt: "OpenCode user prompt.",
       assistantReply: "",
+      userTimestamp: 1_700_000_000_000,
+      assistantTimestamp: 1_700_000_300_000,
       outcome: "interrupted",
     },
   });
@@ -292,6 +302,10 @@ test("OpenCode runtime routes SDK content and carries write quota to the next pr
       { role: "user", content: "OpenCode user prompt." },
       { role: "assistant", content: "OpenCode assistant reply." },
     ]);
+    assert.deepEqual(requests[1].body.messages.map(({ timestamp }) => timestamp), [
+      1_700_000_000_000,
+      1_700_000_060_000,
+    ]);
 
     assert.deepEqual(await runtime.recordTurnStart({
       version: 1,
@@ -377,6 +391,8 @@ test("OpenCode SDK completion requires a prior scope binding but not unexpired t
     assert.equal(writebacks[0].client, "opencode");
     assert.equal(writebacks[0].userText, "OpenCode user prompt.");
     assert.equal(writebacks[0].assistantText, "OpenCode final reply.");
+    assert.equal(writebacks[0].userTimestamp, 1_700_000_000_000);
+    assert.equal(writebacks[0].assistantTimestamp, 1_700_000_300_000);
     assert.equal(writebacks[0].traceContext.turnId, "user-1");
     assert.equal(writebacks[0].memoryObservabilitySource, "opencode_plugin_writeback");
   } finally {
@@ -393,7 +409,7 @@ function openCodeMessages() {
         id: "user-1",
         sessionID: "session-1",
         role: "user",
-        time: { created: 1 },
+        time: { created: 1_700_000_000_000 },
       },
       parts: [textPart("user-1", "OpenCode user prompt.")],
     },
@@ -403,7 +419,7 @@ function openCodeMessages() {
         sessionID: "session-1",
         role: "assistant",
         parentID: "user-1",
-        time: { created: 2, completed: 3 },
+        time: { created: 1_700_000_001_000, completed: 1_700_000_060_000 },
       },
       parts: [textPart("assistant-1", "OpenCode assistant reply.")],
     },
@@ -419,7 +435,7 @@ function compactedOpenCodeMessages() {
         sessionID: "session-1",
         role: "assistant",
         parentID: "user-1",
-        time: { created: 2, completed: 3 },
+        time: { created: 1_700_000_001_000, completed: 1_700_000_060_000 },
       },
       parts: [],
     },
@@ -428,7 +444,7 @@ function compactedOpenCodeMessages() {
         id: "user-compaction",
         sessionID: "session-1",
         role: "user",
-        time: { created: 4 },
+        time: { created: 1_700_000_120_000 },
       },
       parts: [{
         ...part("compaction", "user-compaction"),
@@ -441,7 +457,7 @@ function compactedOpenCodeMessages() {
         id: "user-continuation",
         sessionID: "session-1",
         role: "user",
-        time: { created: 5 },
+        time: { created: 1_700_000_180_000 },
       },
       parts: [{
         ...textPart("user-continuation", "Continue."),
@@ -455,7 +471,7 @@ function compactedOpenCodeMessages() {
         sessionID: "session-1",
         role: "assistant",
         parentID: "user-continuation",
-        time: { created: 6, completed: 7 },
+        time: { created: 1_700_000_181_000, completed: 1_700_000_300_000 },
       },
       parts: [textPart("assistant-final", "OpenCode final reply.")],
     },

--- a/packages/ts/memorax-code-backend/test/clients/trae/trae-memory-hook.test.mjs
+++ b/packages/ts/memorax-code-backend/test/clients/trae/trae-memory-hook.test.mjs
@@ -5,15 +5,19 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
 import { createTraeMemoryHookRuntime } from "../../../dist/clients/trae/memory-hook-runtime.js";
+import { parseWritebackCommand } from "../../../dist/memory/hook-command.js";
 import { createRepositoryMemorySessionRuntime } from "../../../dist/memory/repository-session.js";
 import { traeTracePaths } from "../../../dist/trace/config.js";
 
 test("Trae runtime writes exact Hook content once for a repeated completed Turn", async () => {
   const fixture = await createFixture("exact-writeback");
   const requests = [];
+  const userObservedAt = 1_700_000_000_000;
+  const assistantObservedAt = userObservedAt + 120_000;
   const runtime = createTraeMemoryHookRuntime({
     env: configuredEnv(fixture.home, { MEMORAX_CODE_TRAE_TRACE_ENABLED: "false" }),
     fetchImpl: memoraxFetch(requests),
+    now: () => assistantObservedAt + 60_000,
   });
   const prompt = "  Preserve this Trae prompt exactly.  ";
   const assistant = "  Preserve this Trae response exactly.  ";
@@ -23,14 +27,20 @@ test("Trae runtime writes exact Hook content once for a repeated completed Turn"
     const writeback = {
       ...command,
       lastAssistantMessage: assistant,
+      assistantObservedAt,
     };
-    assert.deepEqual(await runtime.writeback(writeback), { ok: true, scheduled: true });
+    const parsed = parseWritebackCommand(writeback);
+    assert.equal(parsed.ok, true);
+    assert.deepEqual(parsed.command, writeback);
+    assert.deepEqual(await runtime.writeback(parsed.command), { ok: true, scheduled: true });
     assert.deepEqual(await runtime.writeback(writeback), { ok: true, scheduled: true });
     await waitFor(() => requests.length === 1, "Trae writeback did not settle");
     assert.deepEqual(requests[0].body.messages.map(({ role, content }) => ({ role, content })), [
       { role: "user", content: prompt.trim() },
       { role: "assistant", content: assistant.trim() },
     ]);
+    assert.deepEqual(requests[0].body.messages.map(({ timestamp }) => timestamp), [userObservedAt, assistantObservedAt]);
+    assert.deepEqual(requests[0].body.metadata.memorax_code_timestamp_sources, ["observed", "observed"]);
     assert.match(requests[0].body.metadata.idempotency_key, /^automatic:trae:/);
   } finally {
     runtime.close();
@@ -317,6 +327,7 @@ test("Trae complete Hook payload restores writeback after Backend runtime restar
   const writes = [];
   const afterRestart = createTraeMemoryHookRuntime({
     env,
+    now: () => 1_700_000_180_000,
     automaticWriteback: (request) => {
       writes.push(request);
       return { accepted: true };
@@ -332,6 +343,10 @@ test("Trae complete Hook payload restores writeback after Backend runtime restar
       userText: command.prompt,
       assistantText: "The complete Stop payload restored the turn.",
     }]);
+    assert.equal(writes[0].userTimestamp, 1_700_000_000_000);
+    assert.equal(writes[0].assistantTimestamp, 1_700_000_180_000);
+    assert.equal(writes[0].userTimestampSource, "observed");
+    assert.equal(writes[0].assistantTimestampSource, "observed");
   } finally {
     afterRestart.close();
     await fixture.cleanup();

--- a/packages/ts/memorax-code-backend/test/memory/automatic-memory-writeback.test.mjs
+++ b/packages/ts/memorax-code-backend/test/memory/automatic-memory-writeback.test.mjs
@@ -36,6 +36,7 @@ test("automatic memory writeback accepts and redacts a normalized completed turn
       sessionKey: "session-automatic-normalized",
       userText: `${userPrefix}${crossingToken}${"x".repeat(1_000_001)}`,
       assistantText: `Use the credential store; password=${password}`,
+      userTimestamp: 1788000000000,
       repositoryScope: REPOSITORY_SCOPE,
       env: {
         ...WRITEBACK_ENV,
@@ -56,6 +57,8 @@ test("automatic memory writeback accepts and redacts a normalized completed turn
     assert.equal(JSON.stringify(requests[0]).includes("ghp_C"), false);
     assert.equal(JSON.stringify(requests[0]).includes(password), false);
     assert.equal(requests[0].body.user_id, "user-1@automatic-memory-tests");
+    assert.equal(requests[0].body.messages[0].timestamp, 1788000000000);
+    assert.deepEqual(requests[0].body.metadata.memorax_code_timestamp_sources, ["native", "observed"]);
     assert.match(
       requests[0].body.metadata.idempotency_key,
       /^automatic:codex:[a-f0-9]{16}:session-automatic-normalized:/,
@@ -336,6 +339,8 @@ test("automatic memory writeback retries a retryable provider failure", async (t
         assert.deepEqual(events.map((event) => event.request.attempt), [1, 2]);
         assert.equal(events.every((event) => event.source === "claude_hook_writeback"), true);
         assert.equal(requests[0].body.metadata.idempotency_key, requests[1].body.metadata.idempotency_key);
+        assert.deepEqual(requests[0].body, requests[1].body, "retries must not restamp fallback observations");
+        assert.deepEqual(requests[0].body.metadata.memorax_code_timestamp_sources, ["observed", "observed"]);
       } finally {
         runtime.close();
       }
@@ -423,15 +428,17 @@ test("automatic memory writeback buffers normalized turns until the turn limit",
     MEMORAX_CODE_MEMORY_WRITEBACK_BUFFER_MAX_AGE_MS: "60000",
   };
   try {
-    for (const [userText, assistantText] of [
-      ["First buffered prompt.", "First buffered answer."],
-      ["Second buffered prompt.", "Second buffered answer."],
+    for (const [userText, assistantText, userTimestamp, assistantTimestamp] of [
+      ["First buffered prompt.", "First buffered answer.", 1788000000000, 1788000300000],
+      ["Second buffered prompt.", "Second buffered answer.", 1788000900000, 1788001200000],
     ]) {
       runtime.enqueue({
         client: "codex",
         sessionKey: "session-automatic-buffer",
         userText,
         assistantText,
+        userTimestamp,
+        assistantTimestamp,
         repositoryScope: REPOSITORY_SCOPE,
         env,
         fetchImpl: memoraxFetch(requests),
@@ -445,6 +452,10 @@ test("automatic memory writeback buffers normalized turns until the turn limit",
       "Second buffered prompt.",
       "Second buffered answer.",
     ]);
+    assert.deepEqual(requests[0].body.messages.map((message) => message.timestamp), [
+      1788000000000, 1788000300000, 1788000900000, 1788001200000,
+    ]);
+    assert.deepEqual(requests[0].body.metadata.memorax_code_timestamp_sources, ["native", "native", "native", "native"]);
   } finally {
     runtime.close();
   }
@@ -509,6 +520,8 @@ test("automatic memory writeback validates a normalized long decimal before chun
       sessionKey: "session-automatic-chunk",
       userText: "Summarize",
       assistantText: "123456789.6059746146202087",
+      userTimestamp: 1788000300000,
+      assistantTimestamp: 1788000300000,
       repositoryScope: REPOSITORY_SCOPE,
       env: {
         ...WRITEBACK_ENV,
@@ -528,6 +541,67 @@ test("automatic memory writeback validates a normalized long decimal before chun
       ["9.60597461"],
       ["6146202087"],
     ]);
+    assert.deepEqual(requests.map((request) => request.body.messages.map((message) => message.timestamp)), [
+      [1788000300000, 1788000300000], [1788000300000], [1788000300000],
+    ]);
+    assert.deepEqual(requests.map((request) => request.body.metadata.memorax_code_timestamp_sources), [
+      ["native", "native"], ["native"], ["native"],
+    ]);
+  } finally {
+    runtime.close();
+  }
+});
+
+test("automatic memory writeback preserves fragment whitespace and timing through buffering and retry", async () => {
+  const requests = [];
+  const runtime = createAutomaticMemoryWritebackRuntime();
+  const texts = {
+    user: ["User prefix  \r\n ", " \t \n".repeat(4), "  user suffix."].join(""),
+    assistant: ["Assistant text \n", "\t \r\n".repeat(4), " final answer."].join(""),
+  };
+  const timestamp = 1788000400000;
+  try {
+    assert.deepEqual(runtime.enqueue({
+      client: "codex",
+      sessionKey: "session-fragment-whitespace",
+      userText: ` \t${texts.user}\n `,
+      assistantText: `\n${texts.assistant}\t `,
+      userTimestamp: timestamp,
+      assistantTimestamp: timestamp,
+      assistantTimestampSource: "observed",
+      repositoryScope: REPOSITORY_SCOPE,
+      env: {
+        ...WRITEBACK_ENV,
+        MEMORAX_CODE_MEMORY_WRITEBACK_BUFFER_ENABLED: "true",
+        MEMORAX_CODE_MEMORY_WRITEBACK_BUFFER_MAX_TURNS: "1",
+        MEMORAX_CODE_MEMORY_WRITEBACK_CHUNK_MAX_CHARS: "16",
+        MEMORAX_CODE_MEMORY_WRITEBACK_CHUNK_OVERLAP_RATIO: "0",
+      },
+      fetchImpl: async (url, init) => {
+        requests.push({ url: String(url), body: JSON.parse(init.body) });
+        return requests.length === 1
+          ? new Response("", { status: 503, headers: { "retry-after": "0" } })
+          : memoraxSuccessResponse("fragment-whitespace");
+      },
+    }), { accepted: true });
+    await runtime.drain();
+
+    assert.equal(requests.length, 6, "five logical parts plus one failed attempt must be sent");
+    assert.deepEqual(requests[0].body, requests[1].body);
+    const parts = requests.slice(1).map((request) => request.body);
+    assert.deepEqual(parts.map((part) => part.chunk.index), [0, 1, 2, 3, 4]);
+    assert.equal(parts.every((part) => part.chunk.count === 5), true);
+    for (const role of ["user", "assistant"]) {
+      const messages = parts.flatMap((part) => part.messages).filter((message) => message.role === role);
+      assert.equal(messages.map((message) => message.content).join(""), texts[role]);
+      assert.equal(messages.some((message) => message.content.length > 0 && !message.content.trim()), true);
+    }
+    for (const part of parts) {
+      assert.equal(part.messages.every((message) => message.content.length <= 16 && message.timestamp === timestamp), true);
+      assert.deepEqual(part.metadata.memorax_code_timestamp_sources, part.messages.map((message) => (
+        message.role === "user" ? "native" : "observed"
+      )));
+    }
   } finally {
     runtime.close();
   }

--- a/packages/ts/memorax-code-backend/test/memory/hook-command.test.mjs
+++ b/packages/ts/memorax-code-backend/test/memory/hook-command.test.mjs
@@ -64,6 +64,13 @@ const invalidFields = {
       ["prompt-mismatched turn id", { prompt: "Different prompt." }],
       ["missing assistant authority", { lastAssistantMessage: " " }],
       ["foreign message authority", { messages: [] }],
+      ["non-finite assistant observation", { assistantObservedAt: Number.NaN }],
+      ["infinite assistant observation", { assistantObservedAt: Number.POSITIVE_INFINITY }],
+      ["out-of-range assistant observation", { assistantObservedAt: 8_640_000_000_000_001 }],
+      ["fractional assistant observation", { assistantObservedAt: 1_700_000_000_000.5 }],
+      ["epoch-second assistant observation", { assistantObservedAt: 1_700_000_000 }],
+      ["string assistant observation", { assistantObservedAt: "1700000000000" }],
+      ["null assistant observation", { assistantObservedAt: null }],
     ],
   },
 };

--- a/packages/ts/memorax-code-backend/test/provider/memorax/memorax-adapter.test.mjs
+++ b/packages/ts/memorax-code-backend/test/provider/memorax/memorax-adapter.test.mjs
@@ -432,7 +432,7 @@ test("MemoraX adapter maps writeback to /v1/memories/add and keeps trace provena
           idempotencyKey: "session-1:branch-1:action-1",
           messages: [
             { role: "user", content: "remember this", timestamp: 1777392000000 },
-            { role: "assistant", content: "noted", timestamp: 1777392000001 },
+            { role: "assistant", content: "noted", timestamp: 1777391999000 },
           ],
           transcriptPath: localPathSentinel,
           traceContext,
@@ -486,6 +486,8 @@ test("MemoraX adapter maps writeback to /v1/memories/add and keeps trace provena
       ["user", "remember this"],
       ["assistant", "noted"],
     ]);
+    assert.deepEqual(requests[0].body.messages.map((message) => message.timestamp), [1777392000000, 1777391999000]);
+    assert.equal("memorax_code_timestamp_sources" in requests[0].body.metadata, false);
     assert.equal(requests[0].body.metadata.source, "memorax-code");
     assert.equal(requests[0].body.metadata.memorax_code_memory_scope, "repository-name.v1");
     assert.equal(requests[0].body.metadata.memorax_code_base_user_id, "user-1");
@@ -768,6 +770,36 @@ for (const [phase, operation] of [["headers", "query"], ["body", "writeback"]]) 
     assert.equal(result.httpStatus, undefined);
   });
 }
+
+test("MemoraX adapter rejects blank messages outside valid default code fragments", async () => {
+  for (const context of [
+    {},
+    { contentType: "code", mode: "default", chunk: { group_id: "chunk", index: 2, count: 2 } },
+    { contentType: "code", mode: "raw", chunk: { group_id: "chunk", index: 0, count: 2 } },
+  ]) {
+    const result = await invokeMemoraxMemoryProvider(
+      { sessionId: "blank-writeback", prompt: "" },
+      {
+        operation: "writeback",
+        context: {
+          ...context,
+          idempotencyKey: "blank-writeback",
+          messages: [{ role: "assistant", content: " \r\n\t " }],
+        },
+      },
+      {
+        env: {
+          MEMORAX_CODE_MEMORAX_ENDPOINT: "http://memorax.test",
+          MEMORAX_CODE_MEMORAX_API_KEY: "secret",
+          MEMORAX_CODE_MEMORAX_USER_ID: "user-1",
+        },
+        repositoryScope: testRepositoryScope(),
+        fetchImpl: async () => { throw new Error("blank content must not reach HTTP"); },
+      },
+    );
+    assert.deepEqual(result, { ok: false, error: "writeback messages are required" });
+  }
+});
 
 test("MemoraX adapter preserves prebuilt code evidence packs", async () => {
   const requests = [];

--- a/packages/ts/memorax-code-backend/test/transport/http/memory-hook.test.mjs
+++ b/packages/ts/memorax-code-backend/test/transport/http/memory-hook.test.mjs
@@ -123,6 +123,11 @@ test("Backend memory hook endpoints record and write back a turn", async () => {
     assert.equal(traeWriteback.status, 200);
     assert.deepEqual(await traeWriteback.json(), { ok: true, scheduled: true });
     await waitFor(() => requests.length === 2, "HTTP Hook writebacks did not call MemoraX add");
+    const codexAdd = requests.find((request) => request.body.session_id === "session-http").body;
+    assert.deepEqual(codexAdd.messages.map((message) => message.timestamp), [
+      Date.parse("2026-07-16T00:00:02.000Z"), Date.parse("2026-07-16T00:00:03.000Z"),
+    ]);
+    assert.deepEqual(codexAdd.metadata.memorax_code_timestamp_sources, ["native", "native"]);
   } finally {
     await new Promise((resolve) => server.close(resolve));
     globalThis.fetch = originalFetch;

--- a/packages/ts/memorax-code-codebuddy-adapter/hooks/hooks.json
+++ b/packages/ts/memorax-code-codebuddy-adapter/hooks/hooks.json
@@ -12,17 +12,6 @@
         ]
       }
     ],
-    "UserPromptSubmit": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node \"${CODEBUDDY_PLUGIN_ROOT}/hooks/runtime-hook.mjs\" turn",
-            "timeout": 15
-          }
-        ]
-      }
-    ],
     "Stop": [
       {
         "hooks": [

--- a/packages/ts/memorax-code-codebuddy-adapter/hooks/runtime-hook.mjs
+++ b/packages/ts/memorax-code-codebuddy-adapter/hooks/runtime-hook.mjs
@@ -45,6 +45,17 @@ const codeBuddyHome = commonStringValue(process.env.CODEBUDDY_HOME)
   ?? commonStringValue(input?.codebuddy_home)
   ?? commonStringValue(input?.codeBuddyHome)
   ?? defaultCodeBuddyHome();
+const managedPrompt = process.argv[2] === "managed-user-prompt";
+// Global prompt Hooks load before plugins on cold startup. Honor native plugin
+// disablement before observation or Backend recovery, and ignore old manifest
+// prompt dispatch so an upgrade cannot submit the same event twice.
+if (managedPrompt) {
+  const settings = await readRecord(join(codeBuddyHome, "settings.json"));
+  if (event !== "UserPromptSubmit"
+    || settings.enabledPlugins?.["memorax-code-codebuddy-adapter@memorax-code-local"] !== true) process.exit(0);
+} else if (event === "UserPromptSubmit") {
+  process.exit(0);
+}
 try {
   await writeCodeBuddyRuntimeObservation({ memoraxCodeHome: home, codeBuddyHome, pluginRoot });
 } catch (error) {

--- a/packages/ts/memorax-code-codebuddy-adapter/src/config.mjs
+++ b/packages/ts/memorax-code-codebuddy-adapter/src/config.mjs
@@ -7,7 +7,11 @@ import { resolveHookCodeBuddyCommand } from "../../memorax-code-adapter-common/s
 import { withJsonFileLockAsync } from "../../memorax-code-adapter-common/src/config-utils.mjs";
 import {
   codeBuddyHookManifestConfigured,
+  codeBuddyUserPromptHookCommand,
+  codeBuddyUserPromptHookConfigured,
+  hasManagedCodeBuddyUserPromptHook,
   materializeCodeBuddyHookManifest,
+  updateCodeBuddyUserPromptHook,
 } from "./hook-manifest.mjs";
 import {
   codeBuddyRuntimeObservationPath,
@@ -72,6 +76,7 @@ export async function enableCodeBuddyAdapter(options = {}) {
   await updateSettings(home, (settings) => {
     settings.enabledPlugins = recordValue(settings.enabledPlugins);
     settings.enabledPlugins[PLUGIN_ID] = true;
+    updateCodeBuddyUserPromptHook(settings, codeBuddyUserPromptHookCommand(localPluginPath, platform));
   });
   await updateLegacyRegistry(home, { installPath, enabled: true });
   await removeLegacyManagedInstallation(home, platform);
@@ -111,7 +116,8 @@ export async function readCodeBuddyAdapterStatus(options = {}) {
   const legacyHome = legacyCodeBuddyHome(home, platform);
   const legacyManaged = legacyHome ? await managedCodeBuddyInstallationExists(legacyHome) : false;
   const hookConfigured = installedRoots.length > 0
-    && (await Promise.all(installedRoots.map((root) => codeBuddyHookManifestConfigured(root, platform)))).every(Boolean);
+    && (await Promise.all(installedRoots.map((root) => codeBuddyHookManifestConfigured(root, platform)))).every(Boolean)
+    && codeBuddyUserPromptHookConfigured(settings, codeBuddyUserPromptHookCommand(localPluginPath, platform), enabled);
   const observation = await readCodeBuddyRuntimeObservation(memoraxCodeHome);
   const runtimeObserved = hookConfigured && observationMatches(observation, home, platform);
   return { ok: true, action: "status", runtime: "codebuddy", integration: "hooks", installed, enabled, managed: installed && marketplaceReady, codeBuddyHome: home, installPath, marketplace: MARKETPLACE_NAME, pluginId: PLUGIN_ID, marketplaceReady, legacyCodeBuddyHome: legacyManaged ? legacyHome : undefined, legacyManaged, codebuddyHooks: { ok: hookConfigured, configured: hookConfigured, runtimeObserved, status: hookConfigured ? (runtimeObserved ? "observed" : "unverified") : "invalid", observationPath: codeBuddyRuntimeObservationPath(memoraxCodeHome) }, codebuddySkills: { ok: skillInstalled, status: skillInstalled ? "installed" : "missing", managed: skillInstalled, memoraxCode: skillInstalled, path: skillPath } };
@@ -130,6 +136,7 @@ async function disableManagedCodeBuddyInstallation(home) {
   await updateSettings(home, (settings) => {
     settings.enabledPlugins = recordValue(settings.enabledPlugins);
     settings.enabledPlugins[PLUGIN_ID] = false;
+    updateCodeBuddyUserPromptHook(settings);
   });
   await updateLegacyRegistry(home, { installPath: codeBuddyInstallPath(home), enabled: false });
 }
@@ -144,6 +151,7 @@ async function removeManagedCodeBuddyInstallation(home) {
   await updateJsonRecordIfPresent(codeBuddySettingsPath(home), (settings) => {
     settings.enabledPlugins = recordValue(settings.enabledPlugins);
     delete settings.enabledPlugins[PLUGIN_ID];
+    updateCodeBuddyUserPromptHook(settings);
   });
   await updateJsonRecordIfPresent(knownMarketplacesPath(home), (known) => {
     delete known[MARKETPLACE_NAME];
@@ -167,6 +175,7 @@ async function managedCodeBuddyInstallationExists(home) {
   const known = await readJsonRecord(knownMarketplacesPath(home));
   const registry = await readJsonRecord(installedRegistryPath(home));
   return Object.hasOwn(recordValue(settings.enabledPlugins), PLUGIN_ID)
+    || hasManagedCodeBuddyUserPromptHook(settings)
     || Object.hasOwn(known, MARKETPLACE_NAME)
     || Object.hasOwn(recordValue(registry.plugins), PLUGIN_ID);
 }

--- a/packages/ts/memorax-code-codebuddy-adapter/src/hook-manifest.mjs
+++ b/packages/ts/memorax-code-codebuddy-adapter/src/hook-manifest.mjs
@@ -1,7 +1,7 @@
 import { readFile, stat, writeFile } from "node:fs/promises";
-import { join, win32 } from "node:path";
+import { join, resolve, win32 } from "node:path";
 
-const REQUIRED_EVENTS = ["SessionStart", "UserPromptSubmit", "Stop"];
+const REQUIRED_EVENTS = ["SessionStart", "Stop"];
 const PORTABLE_COMMAND = 'node "${CODEBUDDY_PLUGIN_ROOT}/hooks/runtime-hook.mjs" turn';
 
 export function codeBuddyHookCommand(pluginRoot, platform = process.platform) {
@@ -11,10 +11,54 @@ export function codeBuddyHookCommand(pluginRoot, platform = process.platform) {
   return `node "${win32.join(pluginRoot, "hooks", "runtime-hook.mjs").replaceAll("\\", "/")}" turn`;
 }
 
+export function codeBuddyUserPromptHookCommand(pluginRoot, platform = process.platform) {
+  const path = platform === "win32"
+    ? win32.resolve(pluginRoot, "hooks", "runtime-hook.mjs").replaceAll("\\", "/")
+    : resolve(pluginRoot, "hooks", "runtime-hook.mjs");
+  const quoted = platform === "win32" ? `"${path}"` : `'${path.replaceAll("'", "'\\''")}'`;
+  return `node ${quoted} managed-user-prompt`;
+}
+
+export function hasManagedCodeBuddyUserPromptHook(settings) {
+  return userPromptGroups(settings).some((group) => (
+    Array.isArray(group?.hooks) && group.hooks.some(isManagedUserPromptHook)
+  ));
+}
+
+export function updateCodeBuddyUserPromptHook(settings, command) {
+  const groups = userPromptGroups(settings);
+  if (settings.hooks === undefined && !command) return;
+  settings.hooks ??= {};
+  const filtered = groups.flatMap((group) => {
+    if (!Array.isArray(group?.hooks)) return [group];
+    const hooks = group.hooks.filter((hook) => !isManagedUserPromptHook(hook));
+    if (hooks.length === group.hooks.length) return [group];
+    return hooks.length > 0 ? [{ ...group, hooks }] : [];
+  });
+  if (command) filtered.push({ hooks: [{ type: "command", command, timeout: 15 }] });
+  if (filtered.length > 0) settings.hooks.UserPromptSubmit = filtered;
+  else delete settings.hooks.UserPromptSubmit;
+}
+
+export function codeBuddyUserPromptHookConfigured(settings, command, enabled) {
+  try {
+    const managed = userPromptGroups(settings)
+      .flatMap((group) => Array.isArray(group?.hooks) ? group.hooks : [])
+      .filter(isManagedUserPromptHook);
+    return enabled
+      ? managed.length === 1 && managed[0].command === command
+      : managed.length === 0;
+  } catch {
+    return false;
+  }
+}
+
 export async function materializeCodeBuddyHookManifest(pluginRoot, platform = process.platform) {
-  if (platform !== "win32") return;
   const path = join(pluginRoot, "hooks", "hooks.json");
   const manifest = JSON.parse(await readFile(path, "utf8"));
+  // Global prompt Hooks load before WorkBuddy's asynchronous plugin discovery.
+  // Keep only one prompt path when refreshing an existing plugin cache.
+  delete manifest.hooks.UserPromptSubmit;
   const command = codeBuddyHookCommand(pluginRoot, platform);
   for (const event of REQUIRED_EVENTS) {
     const hooks = commandHooks(manifest, event);
@@ -29,13 +73,31 @@ export async function codeBuddyHookManifestConfigured(pluginRoot, platform = pro
     await stat(join(pluginRoot, "hooks", "runtime-hook.mjs"));
     const manifest = JSON.parse(await readFile(join(pluginRoot, "hooks", "hooks.json"), "utf8"));
     const expected = codeBuddyHookCommand(pluginRoot, platform);
-    return REQUIRED_EVENTS.every((event) => {
+    return manifest.hooks?.UserPromptSubmit === undefined && REQUIRED_EVENTS.every((event) => {
       const hooks = commandHooks(manifest, event);
       return hooks.length > 0 && hooks.every((hook) => hook.command === expected);
     });
   } catch {
     return false;
   }
+}
+
+function userPromptGroups(settings) {
+  if (settings.hooks === undefined) return [];
+  if (!settings.hooks || typeof settings.hooks !== "object" || Array.isArray(settings.hooks)) {
+    throw new Error("invalid CodeBuddy global Hook settings");
+  }
+  const groups = settings.hooks.UserPromptSubmit;
+  if (groups !== undefined && !Array.isArray(groups)) {
+    throw new Error("invalid CodeBuddy UserPromptSubmit Hook settings");
+  }
+  return groups ?? [];
+}
+
+function isManagedUserPromptHook(hook) {
+  return hook?.type === "command" && typeof hook.command === "string"
+    && hook.command.replaceAll("\\", "/").includes("/memorax-code-codebuddy-adapter/hooks/runtime-hook.mjs")
+    && /\smanaged-user-prompt\s*$/.test(hook.command);
 }
 
 function commandHooks(manifest, event) {

--- a/packages/ts/memorax-code-codebuddy-adapter/test/config.test.mjs
+++ b/packages/ts/memorax-code-codebuddy-adapter/test/config.test.mjs
@@ -1,5 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import { cp, mkdir, mkdtemp, readFile, stat, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -15,7 +16,7 @@ import {
   codeBuddySettingsPath,
   codeBuddyInstallPath,
 } from "../src/config.mjs";
-import { codeBuddyHookCommand } from "../src/hook-manifest.mjs";
+import { codeBuddyHookCommand, codeBuddyUserPromptHookCommand } from "../src/hook-manifest.mjs";
 import { writeCodeBuddyRuntimeObservation } from "../src/runtime-observation.mjs";
 import { resolveHookCodeBuddyCommand } from "../../memorax-code-adapter-common/src/clients/codebuddy-command.mjs";
 
@@ -53,6 +54,20 @@ test("builds a native Windows Hook command without the WorkBuddy root placeholde
     codeBuddyHookCommand("C:\\Users\\tester\\.codebuddy\\plugins\\memorax", "win32"),
     'node "C:/Users/tester/.codebuddy/plugins/memorax/hooks/runtime-hook.mjs" turn',
   );
+  assert.equal(
+    codeBuddyUserPromptHookCommand("C:\\Users\\Test User\\.workbuddy\\plugins\\memorax", "win32"),
+    'node "C:/Users/Test User/.workbuddy/plugins/memorax/hooks/runtime-hook.mjs" managed-user-prompt',
+  );
+});
+
+test("quotes the absolute global Hook path for a POSIX shell", { skip: process.platform === "win32" }, async () => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-codebuddy-quoted-"));
+  const pluginRoot = join(root, "user's space $home", "memorax-code-codebuddy-adapter");
+  await mkdir(join(pluginRoot, "hooks"), { recursive: true });
+  await writeFile(join(pluginRoot, "hooks", "runtime-hook.mjs"), "process.stdout.write(process.argv[2]);\n");
+  const result = spawnSync("/bin/sh", ["-c", codeBuddyUserPromptHookCommand(pluginRoot)], { encoding: "utf8" });
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout, "managed-user-prompt");
 });
 
 test("finds WorkBuddy's bare Windows CLI for Repo Memory jobs", () => {
@@ -99,6 +114,15 @@ test("installs and removes an isolated CodeBuddy plugin registry entry", async (
   await mkdir(join(home, "plugins"), { recursive: true });
   await mkdir(join(home, "skills", "user-skill"), { recursive: true });
   await writeFile(join(home, "skills", "user-skill", "SKILL.md"), "user-owned\n");
+  const userPromptGroup = { matcher: "*", hooks: [
+    { type: "command", command: "echo user-prompt" },
+    { type: "command", command: "echo managed-user-prompt" },
+  ] };
+  const userSessionStart = [{ hooks: [{ type: "command", command: "echo user-session" }] }];
+  await writeFile(codeBuddySettingsPath(home), JSON.stringify({ hooks: {
+    SessionStart: userSessionStart,
+    UserPromptSubmit: [userPromptGroup, { hooks: [{ type: "command", command: codeBuddyUserPromptHookCommand("/old/memorax-code-codebuddy-adapter") }] }],
+  } }));
   await writeFile(join(home, "plugins", "installed_plugins.json"), JSON.stringify({ version: 2, plugins: {
     "user-plugin@user-marketplace": [{ scope: "user", installPath: "/user/plugin", enabled: true }],
   }}));
@@ -134,10 +158,12 @@ test("installs and removes an isolated CodeBuddy plugin registry entry", async (
   const pluginRoot = join(marketplaceRoot(home), "plugins", "memorax-code-codebuddy-adapter");
   const hooksManifest = JSON.parse(await readFile(join(pluginRoot, "hooks", "hooks.json"), "utf8"));
   const expectedHookCommand = codeBuddyHookCommand(pluginRoot, "win32");
-  for (const event of ["SessionStart", "UserPromptSubmit", "Stop"]) {
+  for (const event of ["SessionStart", "Stop"]) {
     assert.equal(hooksManifest.hooks[event][0].hooks[0].command, expectedHookCommand);
     assert.doesNotMatch(hooksManifest.hooks[event][0].hooks[0].command, /CODEBUDDY_PLUGIN_ROOT/);
   }
+  assert.equal(hooksManifest.hooks.UserPromptSubmit, undefined);
+  const expectedPromptCommand = codeBuddyUserPromptHookCommand(pluginRoot, "win32");
   await writeCodeBuddyRuntimeObservation({
     memoraxCodeHome,
     codeBuddyHome: home,
@@ -154,13 +180,30 @@ test("installs and removes an isolated CodeBuddy plugin registry entry", async (
   assert.equal(known["memorax-code-local"].type, "directory");
   const settings = JSON.parse(await readFile(codeBuddySettingsPath(home), "utf8"));
   assert.equal(settings.enabledPlugins["memorax-code-codebuddy-adapter@memorax-code-local"], true);
+  assert.deepEqual(settings.hooks, {
+    SessionStart: userSessionStart,
+    UserPromptSubmit: [userPromptGroup, { hooks: [{ type: "command", command: expectedPromptCommand, timeout: 15 }] }],
+  });
+  // Same-version installs replace both old plugin copies and keep one global prompt Hook.
+  for (const installedRoot of [pluginRoot, codeBuddyInstallPath(home)]) {
+    const oldManifest = JSON.parse(await readFile(join(installedRoot, "hooks", "hooks.json"), "utf8"));
+    oldManifest.hooks.UserPromptSubmit = [{ hooks: [{ type: "command", command: codeBuddyHookCommand(installedRoot, "win32") }] }];
+    await writeFile(join(installedRoot, "hooks", "hooks.json"), JSON.stringify(oldManifest));
+  }
+  await enableCodeBuddyAdapter({ codeBuddyHome: home, platform: "win32" });
+  assert.deepEqual(JSON.parse(await readFile(codeBuddySettingsPath(home), "utf8")).hooks, settings.hooks);
+  for (const installedRoot of [pluginRoot, codeBuddyInstallPath(home)]) {
+    assert.equal(JSON.parse(await readFile(join(installedRoot, "hooks", "hooks.json"), "utf8")).hooks.UserPromptSubmit, undefined);
+  }
   await disableCodeBuddyAdapter({ codeBuddyHome: home });
-  const disabledStatus = await readCodeBuddyAdapterStatus({ codeBuddyHome: home });
+  const disabledStatus = await readCodeBuddyAdapterStatus({ codeBuddyHome: home, platform: "win32" });
   assert.equal(disabledStatus.enabled, false);
+  assert.equal(disabledStatus.codebuddyHooks.ok, true);
   assert.equal(disabledStatus.marketplaceReady, true);
   assert.equal(disabledStatus.codebuddySkills.ok, true);
   const disabledSettings = JSON.parse(await readFile(codeBuddySettingsPath(home), "utf8"));
   assert.equal(disabledSettings.enabledPlugins["memorax-code-codebuddy-adapter@memorax-code-local"], false);
+  assert.deepEqual(disabledSettings.hooks, { SessionStart: userSessionStart, UserPromptSubmit: [userPromptGroup] });
   await removeCodeBuddyPluginInstallation({ codeBuddyHome: home });
   const removedStatus = await readCodeBuddyAdapterStatus({ codeBuddyHome: home });
   assert.equal(removedStatus.installed, false);
@@ -170,6 +213,7 @@ test("installs and removes an isolated CodeBuddy plugin registry entry", async (
   assert.equal(removedKnown["memorax-code-local"], undefined);
   const removedSettings = JSON.parse(await readFile(codeBuddySettingsPath(home), "utf8"));
   assert.equal(removedSettings.enabledPlugins["memorax-code-codebuddy-adapter@memorax-code-local"], undefined);
+  assert.deepEqual(removedSettings.hooks, disabledSettings.hooks);
   const removedRegistry = JSON.parse(await readFile(join(home, "plugins", "installed_plugins.json"), "utf8"));
   assert.ok(removedRegistry.plugins["user-plugin@user-marketplace"]);
   assert.equal(await exists(marketplaceRoot(home)), false);
@@ -213,6 +257,7 @@ test("reconciles a managed legacy .codebuddy home when .workbuddy is selected", 
   assert.equal(disabled.legacyCodeBuddyHome, legacyHome);
   const disabledLegacySettings = JSON.parse(await readFile(codeBuddySettingsPath(legacyHome), "utf8"));
   assert.equal(disabledLegacySettings.enabledPlugins["memorax-code-codebuddy-adapter@memorax-code-local"], false);
+  assert.equal(disabledLegacySettings.hooks.UserPromptSubmit, undefined);
 
   await enableCodeBuddyAdapter({
     codeBuddyHome: workBuddyHome,
@@ -225,6 +270,7 @@ test("reconciles a managed legacy .codebuddy home when .workbuddy is selected", 
   const migratedLegacySettings = JSON.parse(await readFile(codeBuddySettingsPath(legacyHome), "utf8"));
   assert.equal(migratedLegacySettings.enabledPlugins["memorax-code-codebuddy-adapter@memorax-code-local"], undefined);
   assert.equal(migratedLegacySettings.enabledPlugins["user-plugin@user-marketplace"], true);
+  assert.equal(migratedLegacySettings.hooks.UserPromptSubmit, undefined);
   const migratedLegacyKnown = JSON.parse(await readFile(knownMarketplacesPath(legacyHome), "utf8"));
   assert.equal(migratedLegacyKnown["memorax-code-local"], undefined);
   assert.ok(migratedLegacyKnown["user-marketplace"]);
@@ -244,6 +290,8 @@ test("reconciles a managed legacy .codebuddy home when .workbuddy is selected", 
   const removedLegacyRegistry = JSON.parse(await readFile(join(legacyHome, "plugins", "installed_plugins.json"), "utf8"));
   assert.equal(removedLegacyRegistry.plugins["memorax-code-codebuddy-adapter@memorax-code-local"], undefined);
   assert.ok(removedLegacyRegistry.plugins["user-plugin@user-marketplace"]);
+  assert.equal(JSON.parse(await readFile(codeBuddySettingsPath(legacyHome), "utf8")).hooks.UserPromptSubmit, undefined);
+  assert.equal(JSON.parse(await readFile(codeBuddySettingsPath(workBuddyHome), "utf8")).hooks.UserPromptSubmit, undefined);
 });
 
 test("installs the complete plugin when the package lives under node_modules", async () => {
@@ -277,7 +325,7 @@ test("installs the complete plugin when the package lives under node_modules", a
   }
 });
 
-test("status rejects a Windows plugin that still uses the portable root placeholder", async () => {
+test("status rejects stale plugin and global prompt Hook configurations", async () => {
   const root = await mkdtemp(join(tmpdir(), "memorax-codebuddy-invalid-hook-"));
   const home = join(root, "codebuddy-home");
   await enableCodeBuddyAdapter({
@@ -291,16 +339,37 @@ test("status rejects a Windows plugin that still uses the portable root placehol
   manifest.hooks.SessionStart[0].hooks[0].command = 'node "${CODEBUDDY_PLUGIN_ROOT}/hooks/runtime-hook.mjs" turn';
   await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
 
-  const status = await readCodeBuddyAdapterStatus({
-    codeBuddyHome: home,
-    memoraxCodeHome: join(root, "memorax-code-home"),
-    platform: "win32",
-  });
-  assert.equal(status.codebuddyHooks.ok, false);
-  assert.equal(status.codebuddyHooks.status, "invalid");
+  await assertInvalid();
+
+  manifest.hooks.SessionStart[0].hooks[0].command = codeBuddyHookCommand(pluginRoot, "win32");
+  manifest.hooks.UserPromptSubmit = [{ hooks: [{ type: "command", command: codeBuddyHookCommand(pluginRoot, "win32") }] }];
+  await writeFile(manifestPath, JSON.stringify(manifest));
+  await assertInvalid();
+
+  delete manifest.hooks.UserPromptSubmit;
+  await writeFile(manifestPath, JSON.stringify(manifest));
+  const settings = JSON.parse(await readFile(codeBuddySettingsPath(home), "utf8"));
+  settings.hooks.UserPromptSubmit = [];
+  await writeFile(codeBuddySettingsPath(home), JSON.stringify(settings));
+  await assertInvalid();
+
+  settings.hooks.UserPromptSubmit = [{ hooks: [{ type: "command", command: codeBuddyUserPromptHookCommand(pluginRoot, "win32") }] }];
+  settings.hooks.UserPromptSubmit.push(settings.hooks.UserPromptSubmit[0]);
+  await writeFile(codeBuddySettingsPath(home), JSON.stringify(settings));
+  await assertInvalid();
+
+  async function assertInvalid() {
+    const status = await readCodeBuddyAdapterStatus({
+      codeBuddyHome: home,
+      memoraxCodeHome: join(root, "memorax-code-home"),
+      platform: "win32",
+    });
+    assert.equal(status.codebuddyHooks.ok, false);
+    assert.equal(status.codebuddyHooks.status, "invalid");
+  }
 });
 
-test("disable and remove are no-ops for an uninstalled CodeBuddy home", async () => {
+test("leaves an uninstalled home untouched and removes an orphaned managed global Hook", async () => {
   const home = await mkdtemp(join(tmpdir(), "memorax-codebuddy-empty-"));
   const disabled = await disableCodeBuddyAdapter({ codeBuddyHome: home });
   assert.equal(disabled.installed, false);
@@ -308,6 +377,13 @@ test("disable and remove are no-ops for an uninstalled CodeBuddy home", async ()
   const removed = await removeCodeBuddyPluginInstallation({ codeBuddyHome: home });
   assert.equal(removed.removed, false);
   assert.equal(await exists(join(home, "plugins", "installed_plugins.json")), false);
+  const userGroup = { hooks: [{ type: "command", command: "echo user-prompt" }] };
+  await writeFile(codeBuddySettingsPath(home), JSON.stringify({ hooks: { UserPromptSubmit: [
+    userGroup,
+    { hooks: [{ type: "command", command: codeBuddyUserPromptHookCommand(join(home, "memorax-code-codebuddy-adapter")) }] },
+  ] } }));
+  assert.equal((await removeCodeBuddyPluginInstallation({ codeBuddyHome: home })).removed, true);
+  assert.deepEqual(JSON.parse(await readFile(codeBuddySettingsPath(home), "utf8")).hooks.UserPromptSubmit, [userGroup]);
 });
 
 test("malformed CodeBuddy registry fails closed", async () => {
@@ -315,6 +391,11 @@ test("malformed CodeBuddy registry fails closed", async () => {
   await mkdir(join(home, "plugins"), { recursive: true });
   await writeFile(join(home, "plugins", "installed_plugins.json"), "not-json\n");
   await assert.rejects(() => enableCodeBuddyAdapter({ codeBuddyHome: home }), /JSON|Unexpected token/);
+  const otherHome = await mkdtemp(join(tmpdir(), "memorax-codebuddy-malformed-hooks-"));
+  const settings = { hooks: { UserPromptSubmit: "malformed" } };
+  await writeFile(codeBuddySettingsPath(otherHome), JSON.stringify(settings));
+  await assert.rejects(() => enableCodeBuddyAdapter({ codeBuddyHome: otherHome }), /invalid CodeBuddy UserPromptSubmit Hook settings/);
+  assert.deepEqual(JSON.parse(await readFile(codeBuddySettingsPath(otherHome), "utf8")), settings);
 });
 
 test("recovers an abandoned legacy registry lock without losing user plugins", async () => {

--- a/packages/ts/memorax-code-codebuddy-adapter/test/runtime-hook.test.mjs
+++ b/packages/ts/memorax-code-codebuddy-adapter/test/runtime-hook.test.mjs
@@ -88,6 +88,32 @@ test("UserPromptSubmit posts turn-start, injects the skill reminder, and traces 
   } finally { await server.close(); }
 });
 
+test("managed prompt entry respects plugin disablement and rejects other events or legacy dispatch", async () => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-codebuddy-hook-"));
+  const requests = [];
+  const server = await startServer(requests, { ok: true });
+  try {
+    for (const fixture of [
+      { name: "disabled", pluginEnabled: false },
+      { name: "missing", pluginEnabled: null },
+      { name: "wrong-event", event: "SessionStart", mode: "managed-user-prompt" },
+      { name: "legacy-prompt", mode: "turn" },
+    ]) {
+      const home = join(root, fixture.name);
+      await mkdir(home, { recursive: true });
+      const result = await runHook({
+        hook_event_name: fixture.event ?? "UserPromptSubmit", session_id: "guarded-session",
+        transcript_path: join(home, "session.jsonl"), prompt: "do not start", cwd: home,
+      }, { root: home, server, ...fixture });
+      assert.equal(result.status, 0, result.stderr);
+      assert.equal(result.stdout, "");
+      assert.deepEqual(requests, [], fixture.name);
+      await assert.rejects(readFile(join(home, "adapters", "codebuddy", "pending.json")), { code: "ENOENT" });
+      await assert.rejects(readFile(join(home, "adapters", "codebuddy", "runtime-observed.json")), { code: "ENOENT" });
+    }
+  } finally { await server.close(); }
+});
+
 test("UserPromptSubmit applies the configured reminder cadence to native turn identities", async () => {
   const root = await mkdtemp(join(tmpdir(), "memorax-codebuddy-hook-"));
   const transcriptPath = join(root, "session.jsonl");
@@ -226,7 +252,7 @@ test("UserPromptSubmit retries reuse one deterministic pending turn and a new pr
   } finally { await server.close(); }
 });
 
-test("Stop posts writeback and clears only an accepted pending turn", async () => {
+test("a global prompt before plugin SessionStart writes back once at Stop", async () => {
   const root = await mkdtemp(join(tmpdir(), "memorax-codebuddy-hook-"));
   const transcriptPath = join(root, "session.jsonl");
   await writeFile(transcriptPath, "");
@@ -240,6 +266,12 @@ test("Stop posts writeback and clears only an accepted pending turn", async () =
     assert.equal(start.status, 0);
     const pending = JSON.parse(await readFile(join(root, "adapters", "codebuddy", "pending.json"), "utf8"));
     const turnId = pending["session-2"].turnId;
+    const sessionStart = await runHook({
+      hook_event_name: "SessionStart", session_id: "session-2", transcript_path: transcriptPath,
+      source: "startup", cwd: root,
+    }, { root, server });
+    assert.equal(sessionStart.status, 0);
+    assert.deepEqual(JSON.parse(await readFile(join(root, "adapters", "codebuddy", "pending.json"), "utf8")), pending);
     await writeFile(transcriptPath, [
       JSON.stringify({ id: "u1", role: "user", sessionId: "session-2", content: "<user_query>hello</user_query>" }),
       JSON.stringify({ id: "a1", role: "assistant", parentId: "u1", status: "completed", content: "done" }), "",
@@ -250,6 +282,8 @@ test("Stop posts writeback and clears only an accepted pending turn", async () =
     assert.equal(stop.status, 0);
     assert.equal(requests.at(-1).path, "/memory/writeback");
     assert.equal(requests.at(-1).body.turnId, turnId);
+    assert.equal(requests.filter((request) => request.path === "/memory/turn-start").length, 1);
+    assert.equal(requests.filter((request) => request.path === "/memory/writeback").length, 1);
     assert.deepEqual(JSON.parse(await readFile(join(root, "adapters", "codebuddy", "pending.json"), "utf8")), {});
   } finally { await server.close(); }
 });
@@ -289,14 +323,22 @@ async function startServer(requests, response) {
   return server;
 }
 
-function runHook(input, { root, server, hookEnv = {} }) {
+async function runHook(input, { root, server, hookEnv = {}, pluginEnabled = true, mode }) {
   const address = server.address();
+  const codeBuddyHome = join(root, "workbuddy");
+  if (pluginEnabled !== null) {
+    await mkdir(codeBuddyHome, { recursive: true });
+    await writeFile(join(codeBuddyHome, "settings.json"), JSON.stringify({
+      enabledPlugins: { "memorax-code-codebuddy-adapter@memorax-code-local": pluginEnabled },
+    }));
+  }
   return new Promise((resolve) => {
-    const child = spawn(process.execPath, [hookPath], {
+    const child = spawn(process.execPath, [hookPath, mode ?? (input.hook_event_name === "UserPromptSubmit" ? "managed-user-prompt" : "turn")], {
       cwd: root,
       env: {
         ...process.env,
         CODEBUDDY_ENV_FILE: "",
+        CODEBUDDY_HOME: codeBuddyHome,
         MEMORAX_CODE_HOME: root,
         MEMORAX_CODE_BACKEND_URL: `http://127.0.0.1:${address.port}`,
         ...hookEnv,

--- a/packages/ts/memorax-code-trae-adapter/hooks/runtime-hook.mjs
+++ b/packages/ts/memorax-code-trae-adapter/hooks/runtime-hook.mjs
@@ -6,6 +6,8 @@ import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { writeTraeRuntimeObservation } from "../src/runtime-observation.mjs";
 
+// Capture Stop arrival before Backend startup or any local/HTTP work can delay it.
+const hookObservedAt = Date.now();
 const runtimeRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const commonRoot = join(runtimeRoot, "memorax-code-adapter-common", "src");
 const { buildRepoProcedureMemoryContext } = await import(pathToFileURL(join(commonRoot, "repo-memory", "repo-procedure-memory-context.mjs")).href);
@@ -151,6 +153,7 @@ if (event === "SessionStart") {
     turnId: activeTurn.turnId,
     prompt: activeTurn.prompt,
     lastAssistantMessage,
+    assistantObservedAt: hookObservedAt,
     cwd: activeTurn.cwd ?? stringValue(input.cwd),
     workspaceKind: activeTurn.workspaceKind,
   });

--- a/packages/ts/memorax-code-trae-adapter/test/runtime-hook.test.mjs
+++ b/packages/ts/memorax-code-trae-adapter/test/runtime-hook.test.mjs
@@ -62,6 +62,7 @@ test("Trae Stop writes the matching Hook pair and clears only an accepted Turn",
       text_content: "validated final answer",
       cwd: fixture.root,
     };
+    const stopStartedAt = Date.now();
 
     for (const reply of [
       { status: 503, body: { ok: false } },
@@ -88,7 +89,13 @@ test("Trae Stop writes the matching Hook pair and clears only an accepted Turn",
       lastAssistantMessage: "validated final answer",
       cwd: fixture.root,
     };
-    assert.deepEqual(writebacks.map(({ body }) => body), Array(3).fill(expectedWriteback));
+    assert.equal(writebacks.length, 3);
+    for (const { body } of writebacks) {
+      const { assistantObservedAt, ...content } = body;
+      assert.deepEqual(content, expectedWriteback);
+      assert.ok(Number.isSafeInteger(assistantObservedAt));
+      assert.ok(assistantObservedAt >= stopStartedAt && assistantObservedAt <= Date.now());
+    }
     const turns = JSON.parse(await readFile(turnsPath, "utf8"));
     assert.deepEqual(turns.sessions, {});
   } finally {


### PR DESCRIPTION
## Change Summary
Automatic QA writeback previously replaced message times with upload-time timestamps and could drop whitespace at chunk boundaries. Preserve matched native timestamps or fixed observed fallbacks throughout writeback, retain complete chunk content, and capture WorkBuddy's first prompt before plugin initialization.

## Implementation Highlights
- Carry user and assistant times from each of the six clients through turn coordination, buffering, chunking, and retries. Expose aligned `memorax_code_timestamp_sources` metadata and preserve supplied equal or non-monotonic timestamps.
- Normalize complete messages before chunking, then preserve boundary whitespace and nonempty whitespace-only fragments for valid `code/default` chunks. Ordinary Add validation remains unchanged.
- Move WorkBuddy `UserPromptSubmit` to an owned global Hook while retaining plugin `SessionStart`/`Stop`. Respect native plugin disablement, clean up through lifecycle operations, and ignore legacy prompt dispatch to avoid duplicates.
- Correct CRLF byte-offset counting in the WorkBuddy transcript reader. Update the owning documentation and focused regression tests. Search correlation and historical backfill are outside this change.

## Validation
- User-provided Linux ARM64 validation screenshot reports: `make test` passed with **1,283 passing / 2 existing skips / 0 failures**; `make npm-package-check` passed. The screenshot also reports identical Linux/Windows candidate tarball SHA-256; full Linux logs were unavailable for independent review.
- Passed on macOS: Backend typecheck, `make docs-check`, local-only trace contract, package allowlist (**427 files**), focused writeback tests (**38**), WorkBuddy transcript tests (**18**), and the complete WorkBuddy adapter suite (**29**).
- Earlier macOS full Backend and npm checks remain non-green: generated test executables reported `ENOEXEC`, with additional follow-on failures not independently cleared. Those attempts are not counted as passing; the Linux full-suite results above are separate evidence.
- Rebuilt after commit `57c182d`; the tarball is byte-identical to the tested candidate: `8bf82f1b0821ffa2f2203c526435cb7e80d092875b028f14dad1aabebe519997`.

## Full End-to-End Validation Results
Native clients were exercised through standard package installation and their own QA/Hook or SDK flow. Test scripts did not replay Hooks or directly POST writeback to substitute for native completion. Windows written reports and redacted JSON summaries were reviewed locally; Linux results are attributed to the supplied screenshot. Credentials, transcripts, trace bundles, and private paths are not included in this PR.

| Environment and scenario | Workflow and result |
| --- | --- |
| macOS WorkBuddy 5.4.7 / CLI 2.132.0 | **3/3** fresh positional cold starts passed with local model and MemoraX stubs. The long reply produced 5 successful chunks over 6 HTTP attempts, retaining CRLF and two whitespace-only fragments; the 503 retry body was byte-identical. Native times were preserved and automatic Search remained 0. |
| Linux ARM64: Codex, Claude Code, OpenCode, CodeBuddy CLI, DSH | Reported native automatic writeback passed with local model and MemoraX stubs, including message times, chunk whitespace, and 503 retries. CodeBuddy cold starts passed **3/3**. Required hard links worked on the tested container overlayfs. |
| Windows: Codex 0.153.4, Claude Code 2.1.260, OpenCode 1.18.27, WorkBuddy CLI 2.132.0 | Native QA with local model/MemoraX stubs passed exact content reconstruction, native times/source alignment, byte-identical 503 retries, and 0 automatic Search. WorkBuddy cold starts passed **3/3**, with native disable/stop/remove checks. Including the two-turn Codex buffer scenario: **8 Turns / 32 successful parts / 37 HTTP attempts**. A separate Codex 0.151.0 control also passed. |
| Windows Trae 3.3.98 | Signed-in Auto model and real MemoraX service: **1 Turn / 7 successful parts / 9 HTTP attempts**. Exact content, fixed `observed` times, and recovery from two real 429 responses passed. Native sandboxing remained enabled; Backend home was inside the test workspace. |
| Windows DSH 0.1.2-rc.1 | Real model gateway and real MemoraX service: **1 Turn / 7 successful parts / 10 HTTP attempts**, using a Backend path without spaces. Exact content and `native` times passed, including assistant completed `turn/end` time; three real 429 responses recovered with identical payloads. |
| Windows WorkBuddy reader boundary (synthetic, not native QA) | CRLF transcript with a non-ASCII prefix and repeated prompts accepted the exact user byte offset and rejected offset + 1. |

Remaining limits:
- Windows DSH's native plugin manager independently failed to forward a local plugin path containing spaces to pnpm. Changing only Backend home to a path without spaces allowed the standard install and native E2E to pass. This upstream installation compatibility issue is not fixed here.
- Real-service tests verify asynchronous Add acceptance, not completed remote extraction or subsequent Search retrieval. Pure-whitespace internal fragments and forced 503 responses were covered by deterministic stub scenarios; the Trae/DSH real-service scenarios exercised boundary whitespace and real 429 responses.
- Linux amd64, Linux Trae desktop, and full account-free trial initialization in the minimal container were not validated. Trae's custom Backend-home sandbox behavior outside the workspace was not addressed.
