### PR TITLE
chore: prepare 0.1.14 release

### DIFF
--- a/packages/npm/memorax-code/package.json
+++ b/packages/npm/memorax-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax/memorax-code",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Persistent coding memory for Codex, Claude Code, CodeBuddy/WorkBuddy, DeepSeek Harness, OpenCode, and Trae.",
   "license": "MIT",
   "type": "module",

--- a/packages/ts/memorax-code-backend/package-lock.json
+++ b/packages/ts/memorax-code-backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@memorax-code/backend",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@memorax-code/backend",
-      "version": "0.1.13",
+      "version": "0.1.14",
       "dependencies": {
         "smol-toml": "^1.7.0"
       },

--- a/packages/ts/memorax-code-backend/package.json
+++ b/packages/ts/memorax-code-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/backend",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "private": true,
   "type": "module",
   "description": "Local memory integration, lifecycle, trace, and diagnostics for MemoraX Code.",

--- a/packages/ts/memorax-code-claude-adapter/.claude-plugin/plugin.json
+++ b/packages/ts/memorax-code-claude-adapter/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorax-code-claude-adapter",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Memory skill and local hooks for MemoraX Code in Claude Code.",
   "author": {
     "name": "MemoraX Code Maintainers"

--- a/packages/ts/memorax-code-claude-adapter/hooks/runtime-shell.json
+++ b/packages/ts/memorax-code-claude-adapter/hooks/runtime-shell.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
-  "shellVersion": "0.1.13",
+  "shellVersion": "0.1.14",
   "runtimeAbi": 1
 }

--- a/packages/ts/memorax-code-claude-adapter/package.json
+++ b/packages/ts/memorax-code-claude-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/claude-adapter",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "private": true,
   "type": "module",
   "description": "Claude Code Hook adapter for MemoraX Code memory services.",

--- a/packages/ts/memorax-code-codebuddy-adapter/.codebuddy-plugin/plugin.json
+++ b/packages/ts/memorax-code-codebuddy-adapter/.codebuddy-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorax-code-codebuddy-adapter",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "MemoraX Code memory integration for CodeBuddy and WorkBuddy.",
   "hooks": "./hooks/hooks.json",
   "skills": ["./skills/memorax-code"]

--- a/packages/ts/memorax-code-codebuddy-adapter/package.json
+++ b/packages/ts/memorax-code-codebuddy-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/codebuddy-adapter",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "private": true,
   "type": "module",
   "description": "CodeBuddy and WorkBuddy Hook adapter for MemoraX Code memory services.",

--- a/packages/ts/memorax-code-codex-adapter/.codex-plugin/plugin.json
+++ b/packages/ts/memorax-code-codex-adapter/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorax-code-codex-adapter",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Codex adapter, memory skill, and local hooks for MemoraX Code.",
   "author": {
     "name": "MemoraX AI"

--- a/packages/ts/memorax-code-codex-adapter/hooks/runtime-shell.json
+++ b/packages/ts/memorax-code-codex-adapter/hooks/runtime-shell.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
-  "shellVersion": "0.1.13",
+  "shellVersion": "0.1.14",
   "runtimeAbi": 1
 }

--- a/packages/ts/memorax-code-codex-adapter/package.json
+++ b/packages/ts/memorax-code-codex-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/codex-adapter",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "private": true,
   "type": "module",
   "description": "Codex Hook and memory integration for MemoraX Code.",

--- a/packages/ts/memorax-code-dsh-adapter/package.json
+++ b/packages/ts/memorax-code-dsh-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/dsh-memorax-code",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "private": true,
   "type": "module",
   "description": "DeepSeek Harness native memory adapter for MemoraX Code.",

--- a/packages/ts/memorax-code-opencode-adapter/package.json
+++ b/packages/ts/memorax-code-opencode-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/opencode-adapter",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "private": true,
   "type": "module",
   "description": "OpenCode plugin adapter for MemoraX Code memory services.",

--- a/packages/ts/memorax-code-trae-adapter/package.json
+++ b/packages/ts/memorax-code-trae-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/trae-adapter",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "private": true,
   "type": "module",
   "description": "Trae Hook adapter for MemoraX Code memory services.",


### PR DESCRIPTION
## Change Summary
Prepare `@memorax/memorax-code@0.1.14` from the current `main`. This PR only updates release versions; it includes no runtime behavior changes.

## Implementation Highlights
- Synchronize the shared release version across the npm package, Backend, all six adapters, native plugin manifests, runtime-shell manifests, and Backend lockfile (14 files, 15 version values).
- The release includes the shared harness/runtime work and fixes already merged since `v0.1.13` in #145–#154, including native QA timestamps, lossless writeback chunking, and WorkBuddy cold-start capture.
- Rebuild the publication package from a clean worktree at the final merged `main` commit before publishing with the `latest` tag.

## Validation
- `node scripts/sync-release-version.mjs --check` and `git diff --check`: passed. Independent review confirmed only 15 version values changed across 14 files.
- Executed in sequence on Linux ARM64 (Node 24.20.0, npm 11.19.0, unprivileged user):
  1. `make test`: 1,283 passed, 2 existing skips, 0 failed; includes the local-only trace contract.
  2. `make npm-package-check`: passed, including the 427-file allowlist, isolated install/update/lifecycle smoke and the stock Claude CLI fixture.
  3. `make npm-publish-dry-run`: passed for public `latest`.
- macOS ARM64 `make npm-publish-dry-run` also passed. The macOS and Linux tarballs are byte-for-byte identical: 427 files, 444,150 bytes, SHA-256 `2518126a5c556e93ba18b1b71d31de05d18245f04bcbb65457423bdb5b7e1ca8`.
- Container preparation supplied a random container-only machine ID, regular checkout mtimes, and a non-root account. All 481 tracked paths retained their exact contents, modes, and symlink targets; no test assertions were changed.

## Full End-to-End Validation Results
- Environment: isolated Linux ARM64 container and macOS ARM64 package build; no host client state or credentials mounted into the container.
- Scenario or matrix: full automated suites plus packaged installation, update, lifecycle, file-boundary and publish dry-run checks.
- Command or workflow: the three release gates listed above, followed by cross-platform tarball comparison.
- Result: all release gates passed; npm publication will use a fresh build from the merged main commit.
- Evidence or artifacts: reproducible tarball fingerprint above; full validation logs retained locally outside Git. Prior native-client validation and Windows follow-up results are documented in #154.
- Reason not run / remaining risk: real-client and real-MemoraX checks were not repeated for version-only changes. Carry forward the known native DSH Windows limitation with plugin/runtime paths containing spaces described in #154.
