### PR TITLE
fix: allow five seconds for guest device identity lookup

### DIFF
--- a/packages/npm/memorax-code/lib/trial-plugin-mark.mjs
+++ b/packages/npm/memorax-code/lib/trial-plugin-mark.mjs
@@ -7,7 +7,7 @@ import {
 } from "node:os";
 import { spawnSync } from "node:child_process";
 
-const COMMAND_TIMEOUT_MS = 1_000;
+const COMMAND_TIMEOUT_MS = 5_000;
 export const TRIAL_MARK_VERSION = 1;
 export const TRIAL_APP_SALT = "memorax-plugin-v1";
 

--- a/packages/npm/memorax-code/test/trial-plugin-mark.test.mjs
+++ b/packages/npm/memorax-code/test/trial-plugin-mark.test.mjs
@@ -1,8 +1,12 @@
 import assert from "node:assert/strict";
+import childProcess from "node:child_process";
+import { syncBuiltinESMExports } from "node:module";
+import os from "node:os";
 import test from "node:test";
 import {
   createTrialMacHash,
   deriveTrialPluginIdentity,
+  generateTrialPluginIdentity,
   TRIAL_APP_SALT,
   TRIAL_MARK_VERSION,
 } from "../lib/trial-plugin-mark.mjs";
@@ -17,6 +21,26 @@ const DEVICE = Object.freeze({
   macHash: "b".repeat(64),
 });
 const GOLDEN_MARK_ID = "mk_e07c335dfbdd06d4752cf8a17e7d4f82555bf4828d82a8efa7cc5b527d4c858e";
+
+test("trial identity tolerates a slow Windows machine ID query", (t) => {
+  t.mock.method(os, "platform", () => "win32");
+  t.mock.method(os, "hostname", () => DEVICE.hostname);
+  t.mock.method(os, "networkInterfaces", () => ({}));
+  t.mock.method(childProcess, "spawnSync", (command, args, options) => {
+    assert.equal(command, "reg.exe");
+    assert.deepEqual(args, ["query", "HKLM\\SOFTWARE\\Microsoft\\Cryptography", "/v", "MachineGuid"]);
+    // Simulate a valid query finishing after the old one-second deadline.
+    if (options.timeout < 1_500) return { status: null, error: { code: "ETIMEDOUT" } };
+    return { status: 0, stdout: `    MachineGuid    REG_SZ    ${DEVICE.machineId}\r\n` };
+  });
+  syncBuiltinESMExports();
+  try {
+    assert.equal(generateTrialPluginIdentity().machineId, DEVICE.machineId);
+  } finally {
+    t.mock.restoreAll();
+    syncBuiltinESMExports();
+  }
+});
 
 test("trial identity matches the backend v1 golden vector", () => {
   assert.deepEqual(deriveTrialPluginIdentity(DEVICE), {


### PR DESCRIPTION
## Change Summary

Windows guest setup can fail with `identity_generation_failed` when a valid `reg.exe` machine-ID query exceeds the one-second deadline. Increase the local device-identity command timeout to five seconds; successful queries still return immediately.

## Implementation Highlights

- Change the shared identity-command budget from `1_000` to `5_000` ms. The same helper also governs the macOS identity lookup.
- Add one focused Windows regression using mocked OS/process calls: a query modeled as completing after 1.5 seconds must produce the expected machine ID. Restore the built-in mocks after the test.

## Validation

- Targeted identity, provisioning-flow, and credential-record suites: **11 passed, 0 failed**:

  ```sh
  node --test packages/npm/memorax-code/test/trial-plugin-mark.test.mjs packages/npm/memorax-code/test/trial-provision-flow.test.mjs packages/npm/memorax-code/test/trial-credential-record.test.mjs
  ```

- The new regression failed before the timeout change and passed afterward. Its latency is simulated; it is not a native Windows process timing test.
- npm staging build completed, and the staged identity module contains the five-second timeout.
- **`make npm-package-check` did not pass**: 262 passed, 19 failed, 2 skipped. The isolated macOS host run encountered `spawn ENOEXEC` in generated CLI fixtures and failed client-detection/setup assertions; package/install smoke was not reached. Full artifact verification remains outstanding.
- `git diff --cached --check`: passed. The commit contains exactly the production constant change and its regression test.

## Full End-to-End Validation Results

- Environment: user-reported native Windows, Node 24.12.0, x64; automated regression checks ran on macOS with isolated test state.
- Scenario/workflow: run the same Node `spawnSync` registry query used by identity collection, reporting only status, elapsed time, and identifier validity.
- Result: the one-second diagnostic returned `ETIMEDOUT`; the user confirmed a two-second limit returned a valid machine ID.
- Evidence: redacted diagnostic results and the user's retest. No machine identifiers or credentials are included.
- Remaining risk: complete guest setup using the changed five-second package has not been rerun on native Windows. The registry diagnostic and mocked regression do not replace that E2E check.
