### PR TITLE
fix:(install) recover from transient Windows directory failures

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -117,8 +117,10 @@ failure. For older installations with a complete configuration, the
 no-argument command can perform a one-time migration; see
 [setup-completion behavior](configuration.md#setup-automatic-update-and-package-transition-state).
 
-On Windows, Trae and OpenCode directory installation briefly retries transient
-filesystem errors. If an operation still fails, setup identifies the client,
+On Windows, shared Hook runtime publication and Trae/OpenCode directory
+installation briefly retry transient filesystem errors. If shared runtime
+publication still fails, setup stops before changing the active runtime or
+client integrations. If an adapter operation still fails, setup identifies the client,
 installation step, and error. When the Backend has already recovered, setup
 leaves it running instead of adding another stop/start cycle; client setup
 remains incomplete. Check access to the reported directory, close applications

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -117,6 +117,14 @@ failure. For older installations with a complete configuration, the
 no-argument command can perform a one-time migration; see
 [setup-completion behavior](configuration.md#setup-automatic-update-and-package-transition-state).
 
+On Windows, Trae and OpenCode directory installation briefly retries transient
+filesystem errors. If an operation still fails, setup identifies the client,
+installation step, and error. When the Backend has already recovered, setup
+leaves it running instead of adding another stop/start cycle; client setup
+remains incomplete. Check access to the reported directory, close applications
+that may be using it, then rerun `memorax-code setup`. A running Backend alone
+does not confirm that every selected client integration is ready.
+
 If secure credential setup fails, confirm that the operating-system credential
 backend is available to the same logged-in user and that the MemoraX service is
 reachable. On Linux, confirm that `/usr/bin/secret-tool` is installed and the

--- a/packages/npm/memorax-code/bin/memorax-code-setup.mjs
+++ b/packages/npm/memorax-code/bin/memorax-code-setup.mjs
@@ -26,7 +26,11 @@ import {
   defaultTraeHome,
   traeInstallationDetected,
 } from "../lib/memorax-code-trae-adapter/src/adapter-paths.mjs";
-import { reconcileSetup } from "../lib/setup-reconcile.mjs";
+import {
+  failedLifecycleAdapters,
+  reconcileSetup,
+  startLifecycleReport,
+} from "../lib/setup-reconcile.mjs";
 import { detectSetupMemoryPreferences } from "../lib/setup-memory-preferences.mjs";
 import { ensureTrialSetupCredential } from "../lib/trial-setup.mjs";
 import { commandOnPath } from "../lib/vscode-extension-command.mjs";
@@ -1184,15 +1188,19 @@ async function startBackendAndCheck({
   traeSkipReason,
 } = {}) {
   const adapterFlags = clientLifecycleFlags({ clientMode });
-  const startArgs = ["start", ...adapterFlags];
+  const startArgs = ["start", ...adapterFlags, "--json"];
   const statusArgs = ["status", ...adapterFlags];
   const optionalDshEnv = { [DSH_OPTIONAL_ENV]: "1" };
   let statusResult;
   const result = await reconcileSetup({
-    start: () => runMemoraxCodeCommand(startArgs, {
-      ...pendingClientHookRuntimeEnv(),
-      ...optionalDshEnv,
-    }),
+    start: () => {
+      const started = runMemoraxCodeCommand(startArgs, {
+        ...pendingClientHookRuntimeEnv(),
+        ...optionalDshEnv,
+      }, { print: false });
+      printSetupStartResult(started);
+      return started;
+    },
     stop: () => runMemoraxCodeCommand(["stop", ...adapterFlags]),
     status: () => {
       statusResult = runMemoraxCodeCommand(statusArgs, optionalDshEnv);
@@ -1209,7 +1217,9 @@ async function startBackendAndCheck({
       if (event.type === "start" && event.attempt === 1) {
         logGreen("Starting backend with `memorax-code start`...");
       } else if (event.type === "start-failed" && event.attempt === 1) {
-        logRed("Backend start failed during setup.");
+        logRed(event.reason === "adapter-setup-failed"
+          ? "Client integration setup failed; the Backend is running."
+          : "MemoraX Code start failed during setup.");
       } else if (event.type === "stop") {
         logRed("Attempting automatic recovery: `memorax-code stop` then `memorax-code start`...");
       } else if (event.type === "diagnostic-status") {
@@ -1268,7 +1278,10 @@ function printReconcileFailure(result, {
   skipTraeAdapter,
   traeSkipReason,
 }) {
-  if (result.reason === "hook-runtime-activation-failed") {
+  if (result.reason === "adapter-setup-failed") {
+    logRed("Automatic stop/start recovery was skipped because the Backend is running; setup remains incomplete.");
+    log("Fix the reported client installation error, then retry `memorax-code setup`.");
+  } else if (result.reason === "hook-runtime-activation-failed") {
     logRed("Client Hook runtime activation failed; automatic lifecycle recovery was skipped.");
     logRed("The previously active runtime remains authoritative.");
   } else if (result.reason === "lifecycle-lock-timeout") {
@@ -1371,6 +1384,7 @@ function clientSelectionMessage(clients, { dshSelected = false } = {}) {
 function clientLabel(client) {
   if (client === "codex") return "Codex";
   if (client === "claude") return "Claude Code";
+  if (client === "dsh") return "DeepSeek Harness";
   if (client === "opencode") return "OpenCode";
   if (client === "codebuddy") return "CodeBuddy/WorkBuddy";
   return "Trae";
@@ -1402,8 +1416,41 @@ function stringOption(value) {
   return trimmed ? trimmed : undefined;
 }
 
-function runMemoraxCodeCommand(args, extraEnv = {}) {
+function printSetupStartResult(result) {
+  const report = startLifecycleReport(result);
+  if (!report) {
+    printCommandOutput(result.stdout, BACKEND_PREFIX);
+  } else {
+    if (typeof report.message === "string") logRed(report.message);
+    if (report.backend?.ok === false) {
+      const code = report.backend.errorCode ? ` code=${report.backend.errorCode}` : "";
+      logRed(`Backend: not ok${code} ${report.backend.error ?? report.backend.reason ?? "start failed"}`);
+    }
+    const warnings = report.backend?.warnings;
+    for (const warning of Array.isArray(warnings) ? warnings : []) {
+      if (typeof warning?.message === "string") {
+        log(`Warning: ${warning.message}${warning.errorCode ? ` code=${warning.errorCode}` : ""}`);
+      }
+    }
+    for (const adapter of failedLifecycleAdapters(report)) {
+      const details = [
+        `action=${adapter.action ?? "enable"}`,
+        adapter.stage ? `stage=${adapter.stage}` : undefined,
+        adapter.errorCode ? `code=${adapter.errorCode}` : undefined,
+      ].filter(Boolean).join(" ");
+      const optionalDsh = adapter.client === "dsh" && adapter.optional === true;
+      const message = `${clientLabel(adapter.client)} adapter: ${optionalDsh ? "unavailable" : "not ok"} ${details} ${adapter.error ?? adapter.message ?? adapter.reason ?? "installation failed"}`;
+      if (optionalDsh) log(message);
+      else logRed(message);
+    }
+  }
+  printCommandOutput(result.stderr, BACKEND_PREFIX);
+  if (result.error) logRed(`Failed to run \`memorax-code start\`: ${result.error.message}`);
+}
+
+function runMemoraxCodeCommand(args, extraEnv = {}, { print = true } = {}) {
   return runNodeMemoraxCodeCommand(args, {
+    print,
     env: { ...process.env, ...extraEnv, MEMORAX_CODE_BACKEND_SUPPRESS_GUIDANCE: "1" },
     outputPrefix: BACKEND_PREFIX,
   });

--- a/packages/npm/memorax-code/lib/setup-reconcile.mjs
+++ b/packages/npm/memorax-code/lib/setup-reconcile.mjs
@@ -10,8 +10,8 @@ export async function reconcileSetup({
   let recovered = false;
 
   if (!commandSucceeded(started)) {
-    await onEvent({ type: "start-failed", attempt: 1 });
-    const deterministicFailure = classifyDeterministicStartFailure(started);
+    const deterministicFailure = classifyStartFailure(started);
+    await onEvent({ type: "start-failed", attempt: 1, reason: deterministicFailure?.reason });
     if (deterministicFailure) {
       return await complete(onEvent, deterministicFailure);
     }
@@ -21,7 +21,9 @@ export async function reconcileSetup({
     await onEvent({ type: "start", attempt: 2 });
     started = await start();
     if (!commandSucceeded(started)) {
-      await onEvent({ type: "start-failed", attempt: 2 });
+      const deterministicFailure = classifyStartFailure(started);
+      await onEvent({ type: "start-failed", attempt: 2, reason: deterministicFailure?.reason });
+      if (deterministicFailure) return await complete(onEvent, deterministicFailure);
       await onEvent({ type: "diagnostic-status" });
       await status();
       return await complete(onEvent, compactResult({
@@ -77,7 +79,24 @@ export function clientHookRuntimeActivationFailed(result) {
   return /client Hook runtime activation failed:/i.test(output);
 }
 
-function classifyDeterministicStartFailure(result) {
+export function startLifecycleReport(result) {
+  try {
+    const report = JSON.parse(result.stdout ?? "");
+    if (report?.action !== "start" || typeof report.ok !== "boolean") return undefined;
+    if (report.backend !== undefined && typeof report.backend?.ok !== "boolean") return undefined;
+    return report;
+  } catch {}
+  return undefined;
+}
+
+export function failedLifecycleAdapters(report) {
+  return ["codex", "claude", "dsh", "opencode", "codebuddy", "trae"].flatMap((client) => {
+    const adapter = report?.[`${client}Adapter`];
+    return adapter?.ok === false ? [{ ...adapter, client }] : [];
+  });
+}
+
+function classifyStartFailure(result) {
   if (clientHookRuntimeActivationFailed(result)) {
     return {
       status: "not-verified",
@@ -103,6 +122,15 @@ function classifyDeterministicStartFailure(result) {
     };
   }
 
+  const report = startLifecycleReport(result);
+  // A failed integration can follow a successful Backend recovery. Do not
+  // restart all selected clients again, or treat incomplete setup as ready.
+  if (report?.ok === false && report.backend?.ok === true && report.backend.skipped !== true) {
+    const adapters = failedLifecycleAdapters(report);
+    if (adapters.length > 0) {
+      return { status: "not-verified", reason: "adapter-setup-failed" };
+    }
+  }
   return undefined;
 }
 

--- a/packages/npm/memorax-code/test/setup-reconcile.test.mjs
+++ b/packages/npm/memorax-code/test/setup-reconcile.test.mjs
@@ -73,6 +73,53 @@ test("reconcile performs one stop-start recovery for an ordinary start failure",
   assert.deepEqual(calls, ["start", "stop", "start", "status", "isReady"]);
 });
 
+test("reconcile leaves recovered Backend running when client setup failed", async () => {
+  const calls = [];
+  const events = [];
+  const result = await reconcileSetup({
+    start: async () => {
+      calls.push("start");
+      return {
+        status: 1,
+        stdout: JSON.stringify({
+          ok: false,
+          action: "start",
+          backend: { ok: true, reason: "trae_adapter_enable_failed_backend_recovered" },
+          traeAdapter: { ok: false, action: "enable", error: "EPERM: rename" },
+        }),
+      };
+    },
+    stop: async () => { calls.push("stop"); return succeeded; },
+    status: async () => { calls.push("status"); return succeeded; },
+    isReady: async () => { calls.push("ready"); return true; },
+    onEvent: (event) => events.push(event),
+  });
+
+  assert.deepEqual(result, { status: "not-verified", reason: "adapter-setup-failed" });
+  assert.deepEqual(calls, ["start"]);
+  assert.equal(events.find((event) => event.type === "start-failed").reason, "adapter-setup-failed");
+});
+
+test("reconcile retains recovery when a failure report cannot establish healthy Backend and client failure", async () => {
+  for (const report of [
+    "not JSON",
+    { ok: false, action: "start", backend: { ok: false }, traeAdapter: { ok: false } },
+    { ok: false, action: "start", backend: { ok: true, skipped: true }, traeAdapter: { ok: false } },
+    { ok: false, action: "start", backend: { ok: true }, unknownAdapter: { ok: false } },
+  ]) {
+    const calls = [];
+    const starts = [{ status: 1, stdout: typeof report === "string" ? report : JSON.stringify(report) }, succeeded];
+    const result = await reconcileSetup({
+      start: async () => { calls.push("start"); return starts.shift(); },
+      stop: async () => { calls.push("stop"); return succeeded; },
+      status: async () => { calls.push("status"); return succeeded; },
+      isReady: async () => true,
+    });
+    assert.deepEqual(calls, ["start", "stop", "start", "status"], JSON.stringify(report));
+    assert.equal(result.recovered, true);
+  }
+});
+
 test("reconcile reports a failed recovery without a second stop", async () => {
   const calls = [];
 

--- a/packages/npm/memorax-code/test/setup.test.mjs
+++ b/packages/npm/memorax-code/test/setup.test.mjs
@@ -131,7 +131,7 @@ async function startMockMemorax({ status = 200, body = { success: true, data: { 
   };
 }
 
-async function runSetup({ existingCache = false, explicitCache = false, codexRegistered, hookRuntimeFailure, failStartOnce = false, connectionAuthorityFailure = false, runtimeAuthorityFailureCode, officialMode = false, codexConfig, memoraxCodeConfig, memoraxCodeConfigMode, emptyClaudeSettings = false, claudeAvailable = true, claudeVersionFails = false, claudeSettingsText, codexAvailable = true, codexAppOnly = false, vscodeOnly = false, dshProfiles = [], opencodeAvailable = false, opencodeXdgAvailable = false, opencodeCliAvailable = false, codebuddyAvailable = false, traeAvailable = false, skipCodexPluginInstall = false, skipClaudeAdapterInstall = false, skipOpenCodeAdapterInstall = false, skipCodeBuddyAdapterInstall = false, skipTraeAdapterInstall = false, unavailableStatus = false, prefixedStatus = false, input = "", interactive = true, npmCommand = "install", updateMode = false, setupMode = "automatic", memoraxVerify, memoraxEnv = {}, memoryStatusFixture, trialProvisionFailure = false, hookSnapshot = [], hookUpdatePlan = [], hookFullReview = false, hookFullReviewMissing = false, hookSnapshotFails = false, hookCheckFails = false, hookTrustFails = false, detectedUserId = "memory-user", detectedLanguage = "zh", ttyOverride } = {}) {
+async function runSetup({ existingCache = false, explicitCache = false, codexRegistered, hookRuntimeFailure, failStartOnce = false, adapterStartFailure = false, connectionAuthorityFailure = false, runtimeAuthorityFailureCode, officialMode = false, codexConfig, memoraxCodeConfig, memoraxCodeConfigMode, emptyClaudeSettings = false, claudeAvailable = true, claudeVersionFails = false, claudeSettingsText, codexAvailable = true, codexAppOnly = false, vscodeOnly = false, dshProfiles = [], opencodeAvailable = false, opencodeXdgAvailable = false, opencodeCliAvailable = false, codebuddyAvailable = false, traeAvailable = false, skipCodexPluginInstall = false, skipClaudeAdapterInstall = false, skipOpenCodeAdapterInstall = false, skipCodeBuddyAdapterInstall = false, skipTraeAdapterInstall = false, unavailableStatus = false, prefixedStatus = false, input = "", interactive = true, npmCommand = "install", updateMode = false, setupMode = "automatic", memoraxVerify, memoraxEnv = {}, memoryStatusFixture, trialProvisionFailure = false, hookSnapshot = [], hookUpdatePlan = [], hookFullReview = false, hookFullReviewMissing = false, hookSnapshotFails = false, hookCheckFails = false, hookTrustFails = false, detectedUserId = "memory-user", detectedLanguage = "zh", ttyOverride } = {}) {
   const root = await mkdtemp(join(tmpdir(), "memorax-code-setup-"));
   const binDir = join(root, "bin");
   const codexHome = join(root, "codex-home");
@@ -337,6 +337,14 @@ async function runSetup({ existingCache = false, explicitCache = false, codexReg
     "  console.error('fake memorax-code start failure');",
     "  process.exit(7);",
     "}",
+    "if (process.argv[2] === 'start' && process.env.MEMORAX_CODE_TEST_ADAPTER_START_FAILURE === '1') {",
+    "  console.log(JSON.stringify({",
+    "    ok: false, action: 'start',",
+    "    backend: { ok: true, reason: 'trae_adapter_enable_failed_backend_recovered', warnings: [{ message: 'Backend persistence warning', errorCode: 'EIO' }] },",
+    "    traeAdapter: { ok: false, action: 'enable', stage: 'skill-publish', errorCode: 'EPERM', error: 'rename denied' },",
+    "  }));",
+    "  process.exit(7);",
+    "}",
     "if (process.argv[2] === 'start') {",
     "  const preservedGeneration = process.env.MEMORAX_CODE_TEST_PRESERVED_HOOK_GENERATION;",
     "  if (preservedGeneration) {",
@@ -363,6 +371,8 @@ async function runSetup({ existingCache = false, explicitCache = false, codexReg
     "      process.exit(7);",
     "    }",
     "  }",
+    "  const optionalDshUnavailable = process.env.MEMORAX_CODE_TEST_DSH_ENABLED !== '1' && process.argv[process.argv.indexOf('--clients') + 1]?.split(',').includes('dsh');",
+    "  console.log(JSON.stringify({ ok: true, action: 'start', backend: { ok: true }, ...(optionalDshUnavailable ? { dshAdapter: { ok: false, action: 'enable', optional: true, reason: 'runtime_not_detected' } } : {}) }));",
     "  console.error('fake memorax-code start output');",
     "  if (process.env.MEMORAX_CODE_BACKEND_SUPPRESS_GUIDANCE === '1') console.error('suppressed guidance env seen');",
     "}",
@@ -596,6 +606,7 @@ async function runSetup({ existingCache = false, explicitCache = false, codexReg
     MEMORAX_CODE_SKIP_TRAE_ADAPTER_INSTALL: skipTraeAdapterInstall ? "1" : "0",
     MEMORAX_CODE_TEST_TRAE_AVAILABLE: traeAvailable ? "1" : "0",
     MEMORAX_CODE_TEST_FAIL_START_ONCE: failStartOnce ? "1" : "0",
+    MEMORAX_CODE_TEST_ADAPTER_START_FAILURE: adapterStartFailure ? "1" : "0",
     MEMORAX_CODE_TEST_RUNTIME_AUTHORITY_FAILURE: runtimeAuthorityFailureCode
       ?? (connectionAuthorityFailure ? "BACKEND_CONNECTION_AUTHORITY_INVALID" : ""),
     MEMORAX_CODE_TEST_UNAVAILABLE_STATUS: unavailableStatus ? "1" : "0",
@@ -813,8 +824,10 @@ test("setup fresh install auto-detects Codex and skips an unavailable Claude run
     assert.doesNotMatch(run.result.stderr, /Configure MemoraX Code for which clients/);
     assert.match(run.log, /^codex --version$/m);
     assert.match(run.result.stderr, /Claude Code runtime was not detected; skipping its adapter setup/);
+    assert.match(run.result.stderr, /DeepSeek Harness adapter: unavailable/);
+    assert.doesNotMatch(run.result.stderr, /DeepSeek Harness adapter: not ok/);
     assert.match(run.log, /^memorax-code codex-plugin install --json$/m);
-    assert.match(run.log, /^memorax-code start --clients codex,dsh$/m);
+    assert.match(run.log, /^memorax-code start --clients codex,dsh --json$/m);
     assert.match(run.log, /^memorax-code status --clients codex,dsh$/m);
     assert.match(run.log, /^dsh-adapter-optional start$/m);
     assert.match(run.log, /^dsh-adapter-optional status$/m);
@@ -839,7 +852,7 @@ test("setup fresh install auto-detects CodeBuddy and starts the WorkBuddy adapte
     assert.match(run.result.stderr, /CodeBuddy CLI: codebuddy 9\.9\.9-test/);
     assert.match(run.result.stderr, /WorkBuddy data directory: found/);
     assert.match(run.result.stderr, /Keeping CodeBuddy provider config unchanged and enabling the shared memory Hook integration/);
-    assert.match(run.log, /^memorax-code start --clients dsh,codebuddy$/m);
+    assert.match(run.log, /^memorax-code start --clients dsh,codebuddy --json$/m);
     assert.match(run.log, /^memorax-code status --clients dsh,codebuddy$/m);
     assert.match(run.result.stderr, /CodeBuddy\/WorkBuddy/);
     const config = await readFile(join(run.memoraxCodeHome, "config.toml"), "utf8");
@@ -862,7 +875,7 @@ test("setup fresh install auto-detects Trae and requests one-time Global Hooks a
     assert.match(run.result.stderr, /Trae data directory: found/);
     assert.match(run.result.stderr, /Trae application: detected/);
     assert.match(run.result.stderr, /Keeping Trae provider settings unchanged and installing the shared memory Global Hooks and Skill/);
-    assert.match(run.log, /^memorax-code start --clients dsh,trae$/m);
+    assert.match(run.log, /^memorax-code start --clients dsh,trae --json$/m);
     assert.match(run.log, /^memorax-code status --clients dsh,trae$/m);
     assert.match(run.result.stderr, /Open Trae Settings and enable Global Hooks once/);
     const config = await readFile(join(run.memoraxCodeHome, "config.toml"), "utf8");
@@ -963,7 +976,7 @@ test("setup detects memory preferences before writing MemoraX config", async () 
     assert.match(run.result.stderr, /first workspace-scoped memory request from a trusted workspace/);
     assert.match(run.result.stderr, /MemoraX memory: .*Configured/);
     assert.match(run.result.stderr, /Automatic writeback: .*Enabled/);
-    assert.match(run.log, /^memorax-code start --clients codex,claude,dsh$/m);
+    assert.match(run.log, /^memorax-code start --clients codex,claude,dsh --json$/m);
     assert.match(run.log, /^memorax-cli status --json --config-only$/m);
     assert.match(run.log, /^trial-provision$/m);
     assert.ok(run.log.indexOf("trial-provision") < run.log.indexOf("memorax-code start --clients codex,claude,dsh"));
@@ -1232,11 +1245,11 @@ test("setup recovers from a failed backend start and prints red diagnostics", as
   const run = await runSetup({ failStartOnce: true });
   try {
     assert.equal(run.result.code, 0, run.result.stderr);
-    assert.match(run.log, /^memorax-code start --clients codex,claude,dsh$/m);
+    assert.match(run.log, /^memorax-code start --clients codex,claude,dsh --json$/m);
     assert.match(run.log, /^memorax-code stop --clients codex,claude,dsh$/m);
-    assert.match(run.log, /^memorax-code start --clients codex,claude,dsh$/m);
+    assert.match(run.log, /^memorax-code start --clients codex,claude,dsh --json$/m);
     assert.match(run.log, /^memorax-code status --clients codex,claude,dsh$/m);
-    assert.match(run.result.stderr, /Backend start failed during setup/);
+    assert.match(run.result.stderr, /MemoraX Code start failed during setup/);
     assert.match(run.result.stderr, /\[MemoraX Code Backend\]: fake memorax-code start failure/);
     assert.match(run.result.stderr, /Attempting automatic recovery: `memorax-code stop` then `memorax-code start`/);
     assert.match(run.result.stderr, /\[MemoraX Code Backend\]: fake memorax-code stop output/);
@@ -1248,11 +1261,29 @@ test("setup recovers from a failed backend start and prints red diagnostics", as
   }
 });
 
+test("setup identifies failed client installation without restarting a recovered Backend", async () => {
+  const run = await runSetup({ traeAvailable: true, adapterStartFailure: true });
+  try {
+    assert.equal(run.result.code, 1, run.result.stderr);
+    assert.equal((run.log.match(/^memorax-code start .* --json$/gm) ?? []).length, 1);
+    assert.doesNotMatch(run.log, /^memorax-code stop(?: |$)/m);
+    assert.doesNotMatch(run.log, /^memorax-code status(?: |$)/m);
+    assert.match(run.result.stderr, /Trae adapter: not ok action=enable stage=skill-publish code=EPERM rename denied/);
+    assert.match(run.result.stderr, /Warning: Backend persistence warning code=EIO/);
+    assert.match(run.result.stderr, /Client integration setup failed; the Backend is running/);
+    assert.match(run.result.stderr, /setup remains incomplete/);
+    assert.doesNotMatch(run.result.stderr, /Backend start failed|Automatic recovery did not start the backend|Attempting automatic recovery/);
+    await assertSetupIncomplete(run);
+  } finally {
+    await rm(run.root, { recursive: true, force: true });
+  }
+});
+
 test("setup does not stop adapters after a deterministic connection authority failure", async () => {
   const run = await runSetup({ connectionAuthorityFailure: true });
   try {
     assert.equal(run.result.code, 1, run.result.stderr);
-    assert.equal((run.log.match(/^memorax-code start --clients codex,claude,dsh$/gm) ?? []).length, 1);
+    assert.equal((run.log.match(/^memorax-code start --clients codex,claude,dsh --json$/gm) ?? []).length, 1);
     assert.doesNotMatch(run.log, /^memorax-code stop(?: |$)/m);
     assert.doesNotMatch(run.log, /^memorax-code status(?: |$)/m);
     assert.match(run.result.stderr, /BACKEND_CONNECTION_AUTHORITY_INVALID/);
@@ -1330,7 +1361,7 @@ test("automatic update setup is non-interactive and preserves disabled clients",
     assert.doesNotMatch(run.result.stderr, /Enable it now\?/);
     assert.doesNotMatch(run.result.stderr, /Trust these new or changed Codex Hooks\?/);
     assert.match(run.result.stderr, /Trusted 1 new or changed MemoraX Code Codex Hook/);
-    assert.match(run.log, /^memorax-code start --clients codex$/m);
+    assert.match(run.log, /^memorax-code start --clients codex --json$/m);
     assert.match(run.log, /^memorax-code codex-plugin trust-hooks --yes .*--json$/m);
     const config = await readFile(join(run.memoraxCodeHome, "config.toml"), "utf8");
     assert.match(config, /codex = true/);
@@ -1366,7 +1397,7 @@ test("automatic update setup enables a detected client missing from legacy confi
   try {
     assert.equal(run.result.code, 0, run.result.stderr);
     assert.doesNotMatch(run.result.stderr, /Enable it now\?/);
-    assert.match(run.log, /^memorax-code start --clients codex,codebuddy,trae$/m);
+    assert.match(run.log, /^memorax-code start --clients codex,codebuddy,trae --json$/m);
     const config = await readFile(join(run.memoraxCodeHome, "config.toml"), "utf8");
     assert.match(config, /codex = true/);
     assert.match(config, /claude = false/);
@@ -1397,7 +1428,7 @@ test("automatic update setup leaves an unavailable unconfigured client undecided
   });
   try {
     assert.equal(run.result.code, 0, run.result.stderr);
-    assert.match(run.log, /^memorax-code start --clients codex$/m);
+    assert.match(run.log, /^memorax-code start --clients codex --json$/m);
     const config = await readFile(join(run.memoraxCodeHome, "config.toml"), "utf8");
     assert.equal(tomlSectionText(config, "clients"), tomlSectionText(existingConfig, "clients"));
     assert.doesNotMatch(tomlSectionText(config, "clients"), /codebuddy\s*=/);
@@ -1432,7 +1463,7 @@ test("automatic update setup preserves configured and legacy DSH client intent",
     assert.match(run.result.stderr, /Claude Code runtime was not detected; skipping its adapter setup/);
     assert.match(run.result.stderr, /OpenCode runtime or configuration was not detected; skipping its adapter setup/);
     assert.match(run.result.stderr, /CodeBuddy\/WorkBuddy runtime was not detected; skipping its adapter setup/);
-    assert.match(run.log, /^memorax-code start --clients codex,claude,dsh,opencode,codebuddy$/m);
+    assert.match(run.log, /^memorax-code start --clients codex,claude,dsh,opencode,codebuddy --json$/m);
     assert.match(run.log, /^memorax-code status --clients codex,claude,dsh,opencode,codebuddy$/m);
     await assertSetupComplete(run);
   } finally {

--- a/packages/npm/memorax-code/test/setup.test.mjs
+++ b/packages/npm/memorax-code/test/setup.test.mjs
@@ -180,6 +180,7 @@ async function runSetup({ existingCache = false, explicitCache = false, codexReg
     "backend-connection.mjs",
     "hooks/capture-cwd-hook.mjs",
     "hooks/client-hook-launcher.mjs",
+    "windows-directory-retry.mjs",
     "clients/codex-plugin-artifact.mjs",
     "automatic-update-state.mjs",
     "config-utils.mjs",

--- a/packages/ts/memorax-code-adapter-common/src/hooks/hook-runtime-generation.mjs
+++ b/packages/ts/memorax-code-adapter-common/src/hooks/hook-runtime-generation.mjs
@@ -15,6 +15,7 @@ import {
 } from "node:fs";
 import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { withJsonFileLock } from "../config-utils.mjs";
+import { withWindowsDirectoryRetry } from "../windows-directory-retry.mjs";
 import {
   ensurePrivateDirectory,
   readJsonRuntimeRecord,
@@ -121,11 +122,15 @@ export function stageClientHookRuntimeGeneration({
         durableBoundary: paths.home,
       });
       syncRegularTree(temporaryPath, { syncFile, syncDirectory: syncDir });
-      renameSync(temporaryPath, generationPath);
+      withWindowsDirectoryRetry(() => renameSync(temporaryPath, generationPath));
       syncDir(paths.generationsRoot);
       return { ...record, generationPath, reused: false };
     } catch (error) {
-      rmSync(temporaryPath, { recursive: true, force: true });
+      try {
+        withWindowsDirectoryRetry(() => rmSync(temporaryPath, { recursive: true, force: true }));
+      } catch {
+        // Preserve the publication failure if Windows also blocks stage cleanup.
+      }
       if (existsSync(generationPath)) {
         const existing = readGenerationRecord(generationPath);
         assertSameGeneration(existing, record);

--- a/packages/ts/memorax-code-adapter-common/src/windows-directory-retry.mjs
+++ b/packages/ts/memorax-code-adapter-common/src/windows-directory-retry.mjs
@@ -1,0 +1,19 @@
+const RETRYABLE_ERRORS = new Set(["EPERM", "EACCES", "EBUSY", "ENOTEMPTY"]);
+const RETRY_DELAYS_MS = [100, 200, 300, 400];
+const SLEEP_BUFFER = new Int32Array(new SharedArrayBuffer(4));
+
+// Windows readers may briefly deny a directory removal or rename. Retry only
+// that operation; rerunning an installation would repeat unrelated mutations.
+export function withWindowsDirectoryRetry(operation) {
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      return operation();
+    } catch (error) {
+      if (process.platform !== "win32" || !RETRYABLE_ERRORS.has(error?.code)
+        || attempt >= RETRY_DELAYS_MS.length) {
+        throw error;
+      }
+      Atomics.wait(SLEEP_BUFFER, 0, 0, RETRY_DELAYS_MS[attempt]);
+    }
+  }
+}

--- a/packages/ts/memorax-code-adapter-common/test/hook-runtime-generation.test.mjs
+++ b/packages/ts/memorax-code-adapter-common/test/hook-runtime-generation.test.mjs
@@ -1,8 +1,10 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
+import fs from "node:fs";
 import { chmod, mkdir, mkdtemp, readFile, rename, rm, symlink, writeFile } from "node:fs/promises";
+import { syncBuiltinESMExports } from "node:module";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { test } from "node:test";
 import { pathToFileURL } from "node:url";
 import {
@@ -48,6 +50,77 @@ test("client Hook generations stage immutably and activate atomically", async ()
       "utf8",
     )).includes("generation-a"), true);
   } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("generation publication retries Windows contention without changing current authority", async () => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-code-hook-generation-contention-"));
+  const platform = Object.getOwnPropertyDescriptor(process, "platform");
+  const originalRename = fs.renameSync;
+  const originalRemove = fs.rmSync;
+  try {
+    const packageRoot = join(root, "package");
+    const memoraxCodeHome = join(root, "home");
+    await writeRuntimePackage(packageRoot, "1.0.0", "current");
+    const current = stageClientHookRuntimeGeneration({ packageRoot, memoraxCodeHome });
+    activateClientHookRuntimeGeneration({ memoraxCodeHome, generation: current });
+    const paths = clientHookRuntimePaths(memoraxCodeHome);
+    const currentRecord = await readFile(paths.currentPath, "utf8");
+    await writeRuntimePackage(packageRoot, "1.0.1", "next");
+
+    const publishError = Object.assign(new Error("generation publication denied"), { code: "EPERM" });
+    let persistent = false;
+    let renames = 0;
+    let removals = 0;
+    fs.renameSync = (source, destination) => {
+      if (basename(source).startsWith(".staging-") && (++renames === 1 || persistent)) {
+        throw publishError;
+      }
+      return originalRename(source, destination);
+    };
+    fs.rmSync = (target, ...args) => {
+      if (persistent && basename(target).startsWith(".staging-") && ++removals === 1) {
+        throw Object.assign(new Error("stage cleanup busy"), { code: "EBUSY" });
+      }
+      return originalRemove(target, ...args);
+    };
+    Object.defineProperty(process, "platform", { ...platform, value: "win32" });
+    syncBuiltinESMExports();
+
+    const next = stageClientHookRuntimeGeneration({ packageRoot, memoraxCodeHome });
+    assert.equal(next.reused, false);
+    assert.equal(renames, 2);
+    assert.equal(stageClientHookRuntimeGeneration({ packageRoot, memoraxCodeHome }).reused, true);
+    assert.equal(renames, 2, "an existing generation must be verified and reused");
+    assert.equal(await readFile(paths.currentPath, "utf8"), currentRecord);
+
+    await writeRuntimePackage(packageRoot, "1.0.2", "blocked");
+    persistent = true;
+    assert.throws(() => stageClientHookRuntimeGeneration({ packageRoot, memoraxCodeHome }),
+      (error) => error === publishError);
+    assert.equal(renames, 7, "persistent contention must stop after five publication attempts");
+    assert.equal(removals, 2, "a temporary cleanup failure must also be retried");
+    assert.deepEqual(fs.readdirSync(paths.generationsRoot).sort(),
+      [current.generationId, next.generationId].sort());
+    assert.equal(await readFile(paths.currentPath, "utf8"), currentRecord);
+    assert.equal(readCurrentClientHookRuntime(memoraxCodeHome).status, "valid");
+
+    publishError.code = "EIO";
+    fs.rmSync = (target, ...args) => {
+      if (basename(target).startsWith(".staging-")) throw new Error("stage cleanup failed");
+      return originalRemove(target, ...args);
+    };
+    syncBuiltinESMExports();
+    assert.throws(() => stageClientHookRuntimeGeneration({ packageRoot, memoraxCodeHome }),
+      (error) => error === publishError);
+    assert.equal(renames, 8, "non-retryable errors must fail immediately");
+    assert.equal(await readFile(paths.currentPath, "utf8"), currentRecord);
+  } finally {
+    Object.defineProperty(process, "platform", platform);
+    fs.renameSync = originalRename;
+    fs.rmSync = originalRemove;
+    syncBuiltinESMExports();
     await rm(root, { recursive: true, force: true });
   }
 });

--- a/packages/ts/memorax-code-backend/src/clients/opencode/lifecycle.ts
+++ b/packages/ts/memorax-code-backend/src/clients/opencode/lifecycle.ts
@@ -20,7 +20,15 @@ export const openCodeAdapterLifecycle = {
         openCodeAdapterOptions(argv, serviceOptions.home, backendUrl),
       );
     } catch (error) {
-      return { ok: false, action: "enable", error: error instanceof Error ? error.message : String(error) };
+      return {
+        ok: false,
+        action: "enable",
+        error: error instanceof Error ? error.message : String(error),
+        ...(error instanceof Error && "stage" in error && typeof error.stage === "string"
+          ? { stage: error.stage } : {}),
+        ...(error instanceof Error && "code" in error && typeof error.code === "string"
+          ? { errorCode: error.code } : {}),
+      };
     }
   },
   async disable({ argv, serviceOptions }) {

--- a/packages/ts/memorax-code-backend/src/lifecycle/participant.ts
+++ b/packages/ts/memorax-code-backend/src/lifecycle/participant.ts
@@ -29,6 +29,8 @@ export type AdapterReport = {
   reason?: string;
   message?: string;
   error?: string;
+  errorCode?: string;
+  stage?: string;
   memoraxCodeHome?: string;
   codexHome?: string;
   openCodeConfigDir?: string;

--- a/packages/ts/memorax-code-opencode-adapter/src/plugin-install.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/src/plugin-install.mjs
@@ -18,6 +18,7 @@ import {
   readAdapterState,
   stringOption,
 } from "../../memorax-code-adapter-common/src/config-utils.mjs";
+import { withWindowsDirectoryRetry } from "../../memorax-code-adapter-common/src/windows-directory-retry.mjs";
 import { DEFAULT_BACKEND_URL as BACKEND_DEFAULT } from "../../memorax-code-adapter-common/src/backend-connection.mjs";
 import {
   adapterStatePath,
@@ -543,16 +544,25 @@ function createManagedRepoMemoryHelperLoader(paths, sourceSha256) {
 function materializeSkill(sourcePath, targetPath, memoraxCodeCommand) {
   mkdirSync(dirname(targetPath), { recursive: true });
   const stagePath = `${targetPath}.tmp-${process.pid}-${randomUUID()}`;
+  let stage = "skill-stage";
   try {
     cpSync(sourcePath, stagePath, { recursive: true });
     atomicWriteJson(
       join(stagePath, SKILL_PACKAGE_METADATA),
       skillPackageMetadata(memoraxCodeCommand),
     );
-    rmSync(targetPath, { recursive: true, force: true });
-    renameSync(stagePath, targetPath);
-  } finally {
-    rmSync(stagePath, { recursive: true, force: true });
+    stage = "skill-remove";
+    withWindowsDirectoryRetry(() => rmSync(targetPath, { recursive: true, force: true }));
+    stage = "skill-publish";
+    withWindowsDirectoryRetry(() => renameSync(stagePath, targetPath));
+  } catch (error) {
+    try {
+      withWindowsDirectoryRetry(() => rmSync(stagePath, { recursive: true, force: true }));
+    } catch {
+      // Preserve the installation failure if Windows also blocks stage cleanup.
+    }
+    error.stage = stage;
+    throw error;
   }
 }
 

--- a/packages/ts/memorax-code-opencode-adapter/test/plugin-install.test.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/test/plugin-install.test.mjs
@@ -18,15 +18,18 @@ import {
 } from "../src/plugin-install.mjs";
 
 test("OpenCode config discovery honors its explicit and XDG homes", () => {
+  const home = join(tmpdir(), "opencode-discovery-home");
+  const customHome = join(home, "custom-opencode");
+  const xdgHome = join(home, "xdg-config");
   assert.equal(
-    defaultOpenCodeConfigDir({ OPENCODE_CONFIG_DIR: "/custom/opencode", XDG_CONFIG_HOME: "/ignored" }, "/home/user"),
-    "/custom/opencode",
+    defaultOpenCodeConfigDir({ OPENCODE_CONFIG_DIR: customHome, XDG_CONFIG_HOME: xdgHome }, home),
+    customHome,
   );
   assert.equal(
-    defaultOpenCodeConfigDir({ XDG_CONFIG_HOME: "/xdg/config" }, "/home/user"),
-    "/xdg/config/opencode",
+    defaultOpenCodeConfigDir({ XDG_CONFIG_HOME: xdgHome }, home),
+    join(xdgHome, "opencode"),
   );
-  assert.equal(defaultOpenCodeConfigDir({}, "/home/user"), "/home/user/.config/opencode");
+  assert.equal(defaultOpenCodeConfigDir({}, home), join(home, ".config", "opencode"));
 });
 
 test("OpenCode CLI path discovery recognizes the staged npm package layout", async () => {
@@ -62,7 +65,7 @@ test("OpenCode plugin install materializes a managed loader, canonical skill, an
     assert.match(loader, new RegExp(escapeRegex(`"openCodeConfigDir":${JSON.stringify(fixture.openCodeConfigDir)}`)));
     assert.match(loader, new RegExp(escapeRegex(`"memoraxCodeCommand":${JSON.stringify(fixture.memoraxCodeCommand)}`)));
     assert.match(loader, new RegExp(escapeRegex(`"nodePath":${JSON.stringify(process.execPath)}`)));
-    assert.match(loader, /"cliBinDir":"\/managed\/bin"/);
+    assert.match(loader, new RegExp(escapeRegex(`"cliBinDir":${JSON.stringify(fixture.options.cliBinDir)}`)));
     const repoMemoryHelperLoader = await readFile(installed.repoMemoryHelperPath, "utf8");
     assert.match(repoMemoryHelperLoader, /^\/\/ Managed by MemoraX Code/);
     assert.match(
@@ -397,7 +400,7 @@ async function createFixture(name) {
       repoMemoryHelperSourcePath,
       skillSourcePath,
       memoraxCodeCommand,
-      cliBinDir: "/managed/bin",
+      cliBinDir: join(root, "managed-bin"),
     },
   };
 }

--- a/packages/ts/memorax-code-opencode-adapter/test/plugin-install.test.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/test/plugin-install.test.mjs
@@ -1,6 +1,8 @@
 import { strict as assert } from "node:assert";
 import { spawnSync } from "node:child_process";
+import fs from "node:fs";
 import { copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { syncBuiltinESMExports } from "node:module";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -185,6 +187,61 @@ test("OpenCode plugin install refuses to overwrite a recorded loader without its
     assert.equal(result.reason, "plugin_conflict");
     assert.equal(await readFile(installed.pluginPath, "utf8"), customLoader);
   } finally {
+    await rm(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("OpenCode directory publication retries Windows contention and preserves exhausted failures", async () => {
+  const fixture = await createFixture("directory-contention");
+  const skillPath = join(fixture.openCodeConfigDir, "skills", "memorax-code");
+  const platform = Object.getOwnPropertyDescriptor(process, "platform");
+  const originalRename = fs.renameSync;
+  const originalRemove = fs.rmSync;
+  const publishError = Object.assign(new Error("directory publication denied"), { code: "EPERM" });
+  let persistent = false;
+  let skillRenames = 0;
+  let skillRemovals = 0;
+  fs.renameSync = (source, destination) => {
+    if (destination === skillPath && (++skillRenames === 1 || persistent)) throw publishError;
+    return originalRename(source, destination);
+  };
+  fs.rmSync = (target, ...args) => {
+    if (target === skillPath && ++skillRemovals === 1) {
+      throw Object.assign(new Error("directory removal busy"), { code: "EBUSY" });
+    }
+    if (persistent && target.startsWith(`${skillPath}.tmp-`) && fs.existsSync(target)) {
+      throw Object.assign(new Error("stage cleanup failed"), { code: "EIO" });
+    }
+    return originalRemove(target, ...args);
+  };
+  Object.defineProperty(process, "platform", { ...platform, value: "win32" });
+  syncBuiltinESMExports();
+  try {
+    const installed = ensureOpenCodePluginInstalled(fixture.options);
+    assert.equal(installed.ok, true);
+    assert.equal(await readFile(join(skillPath, "SKILL.md"), "utf8"), "# MemoraX Code\n");
+    assert.deepEqual([skillRenames, skillRemovals], [2, 2]);
+    assert.equal(ensureOpenCodePluginInstalled(fixture.options).changed, false);
+    assert.deepEqual([skillRenames, skillRemovals], [2, 2]);
+
+    const previousState = await readFile(installed.statePath, "utf8");
+    await writeFile(join(fixture.options.skillSourcePath, "SKILL.md"), "# Updated Skill\n");
+    persistent = true;
+    assert.throws(() => ensureOpenCodePluginInstalled(fixture.options), (error) => (
+      error === publishError && error.stage === "skill-publish" && error.code === "EPERM"
+    ));
+    assert.equal(skillRenames, 7, "persistent contention must stop after the bounded retries");
+    assert.equal(await readFile(installed.statePath, "utf8"), previousState);
+    assert.equal(readOpenCodePluginStatus(fixture.options).enabled, false);
+
+    persistent = false;
+    assert.equal(ensureOpenCodePluginInstalled(fixture.options).ok, true);
+    assert.equal(await readFile(join(skillPath, "SKILL.md"), "utf8"), "# Updated Skill\n");
+  } finally {
+    Object.defineProperty(process, "platform", platform);
+    fs.renameSync = originalRename;
+    fs.rmSync = originalRemove;
+    syncBuiltinESMExports();
     await rm(fixture.root, { recursive: true, force: true });
   }
 });

--- a/packages/ts/memorax-code-trae-adapter/src/config.mjs
+++ b/packages/ts/memorax-code-trae-adapter/src/config.mjs
@@ -21,6 +21,7 @@ import {
   withJsonFileLock,
   withJsonFileLockAsync,
 } from "../../memorax-code-adapter-common/src/config-utils.mjs";
+import { withWindowsDirectoryRetry } from "../../memorax-code-adapter-common/src/windows-directory-retry.mjs";
 import {
   defaultMemoraxCodeHome,
   defaultTraeHome,
@@ -127,7 +128,7 @@ async function enableTraeAdapterUnlocked(paths, options) {
     updateManagedHooks(paths.hooksPath, hookCommand, true);
     atomicWriteJson(paths.statePath, state);
   } catch (error) {
-    return failure("install_failed", paths, error);
+    return failure("install_failed", paths, error, "enable");
   }
 
   return await readTraeAdapterStatusUnlocked(paths, { ...options, changed: !current });
@@ -443,6 +444,7 @@ function materializeRuntimeGeneration(paths, generationPath, runtimeDigest, runt
   }
   mkdirSync(paths.runtimeRoot, { recursive: true, mode: 0o700 });
   const temporaryPath = join(paths.runtimeRoot, `.staging-${process.pid}-${randomUUID()}`);
+  let stage = "runtime-stage";
   try {
     mkdirSync(join(temporaryPath, "hooks"), { recursive: true, mode: 0o700 });
     mkdirSync(join(temporaryPath, "src"), { recursive: true, mode: 0o700 });
@@ -454,10 +456,18 @@ function materializeRuntimeGeneration(paths, generationPath, runtimeDigest, runt
       ...runtimeMetadata,
       runtimeDigest,
     });
-    renameSync(temporaryPath, generationPath);
+    stage = "runtime-publish";
+    withWindowsDirectoryRetry(() => renameSync(temporaryPath, generationPath));
   } catch (error) {
-    rmSync(temporaryPath, { recursive: true, force: true });
-    if (!existsSync(generationPath)) throw error;
+    try {
+      withWindowsDirectoryRetry(() => rmSync(temporaryPath, { recursive: true, force: true }));
+    } catch {
+      // Preserve the publication failure if Windows also blocks stage cleanup.
+    }
+    if (!existsSync(generationPath)) {
+      error.stage = stage;
+      throw error;
+    }
   }
 }
 
@@ -539,17 +549,25 @@ function windowsExecutableToken(path) {
 function materializeDirectory(source, destination, memoraxCodeCommand) {
   mkdirSync(dirname(destination), { recursive: true });
   const temporaryPath = `${destination}.tmp-${process.pid}-${randomUUID()}`;
-  rmSync(temporaryPath, { recursive: true, force: true });
+  let stage = "skill-stage";
   try {
+    withWindowsDirectoryRetry(() => rmSync(temporaryPath, { recursive: true, force: true }));
     cpSync(source, temporaryPath, { recursive: true });
     atomicWriteJson(
       join(temporaryPath, SKILL_PACKAGE_METADATA),
       skillPackageMetadata(memoraxCodeCommand),
     );
-    rmSync(destination, { recursive: true, force: true });
-    renameSync(temporaryPath, destination);
+    stage = "skill-remove";
+    withWindowsDirectoryRetry(() => rmSync(destination, { recursive: true, force: true }));
+    stage = "skill-publish";
+    withWindowsDirectoryRetry(() => renameSync(temporaryPath, destination));
   } catch (error) {
-    rmSync(temporaryPath, { recursive: true, force: true });
+    try {
+      withWindowsDirectoryRetry(() => rmSync(temporaryPath, { recursive: true, force: true }));
+    } catch {
+      // Preserve the installation failure; a later attempt can repair the Skill.
+    }
+    error.stage = stage;
     throw error;
   }
 }
@@ -642,6 +660,8 @@ function failure(reason, paths, error, action = "status") {
     managed: existsSync(paths.statePath),
     reason,
     error: error instanceof Error ? error.message : String(error),
+    ...(typeof error?.code === "string" ? { errorCode: error.code } : {}),
+    ...(typeof error?.stage === "string" ? { stage: error.stage } : {}),
     traeHome: paths.traeHome,
     statePath: paths.statePath,
   };

--- a/packages/ts/memorax-code-trae-adapter/test/config.test.mjs
+++ b/packages/ts/memorax-code-trae-adapter/test/config.test.mjs
@@ -22,8 +22,10 @@ import {
 import { writeTraeRuntimeObservation } from "../src/runtime-observation.mjs";
 
 test("Trae home and application discovery honor explicit and platform locations", () => {
-  assert.equal(defaultTraeHome({ TRAE_CN_HOME: "/custom/trae" }, "/home/user"), "/custom/trae");
-  assert.equal(defaultTraeHome({}, "/home/user"), "/home/user/.trae-cn");
+  const home = join(tmpdir(), "trae-discovery-home");
+  const customHome = join(home, "custom-trae");
+  assert.equal(defaultTraeHome({ TRAE_CN_HOME: customHome }, home), customHome);
+  assert.equal(defaultTraeHome({}, home), join(home, ".trae-cn"));
   assert.equal(traeInstallationDetected({
     env: {},
     home: "/home/user",
@@ -146,7 +148,7 @@ test("Trae install merges managed Hooks and Skill without changing user Hooks", 
     for (const event of ["SessionStart", "UserPromptSubmit", "Stop"]) {
       const managed = hooks.hooks[event]
         .flatMap((group) => group.hooks ?? [])
-        .filter((hook) => hook.command?.includes("--memorax-code-trae-hook-v1"));
+        .filter((hook) => hookScript(hook.command).includes("--memorax-code-trae-hook-v1"));
       assert.equal(managed.length, 1);
     }
 
@@ -369,6 +371,7 @@ test("Trae install leaves shared artifacts unchanged when ownership intent canno
 
 test("Trae lifecycle mutations wait for the shared cross-process lock", async () => {
   const fixture = await createFixture("lifecycle-lock");
+  const originalHooks = await readFile(join(fixture.traeHome, "hooks.json"), "utf8");
   let releaseLock;
   let holder;
   let pendingInstall;
@@ -385,7 +388,7 @@ test("Trae lifecycle mutations wait for the shared cross-process lock", async ()
     pendingInstall = enableTraeAdapter(fixture.options);
     await delay(50);
     const blockedHooks = await readFile(join(fixture.traeHome, "hooks.json"), "utf8");
-    assert.equal(blockedHooks.includes("--memorax-code-trae-hook-v1"), false);
+    assert.equal(blockedHooks, originalHooks);
 
     releaseLock();
     releaseLock = undefined;
@@ -413,7 +416,9 @@ test("Trae disable and removal delete only MemoraX-managed content", async () =>
     assert.equal(disabled.ok, true);
     assert.equal(disabled.enabled, false);
     const disabledHooks = JSON.parse(await readFile(join(fixture.traeHome, "hooks.json"), "utf8"));
-    assert.equal(JSON.stringify(disabledHooks).includes("--memorax-code-trae-hook-v1"), false);
+    assert.equal(Object.values(disabledHooks.hooks).flatMap((groups) => groups)
+      .flatMap((group) => group.hooks ?? [])
+      .some((hook) => hookScript(hook.command).includes("--memorax-code-trae-hook-v1")), false);
     assert.equal(disabledHooks.hooks.UserPromptSubmit[0].hooks[0].command, "user-command");
     assert.equal(await readFile(join(installed.skillPath, "SKILL.md"), "utf8"), "# MemoraX Code\n");
 
@@ -518,4 +523,8 @@ function decodePowerShellCommand(command) {
   const encoded = / -EncodedCommand ([A-Za-z0-9+/=]+)$/.exec(command)?.[1];
   assert.ok(encoded, command);
   return Buffer.from(encoded, "base64").toString("utf16le");
+}
+
+function hookScript(command = "") {
+  return command.includes("-EncodedCommand") ? decodePowerShellCommand(command) : command;
 }

--- a/packages/ts/memorax-code-trae-adapter/test/config.test.mjs
+++ b/packages/ts/memorax-code-trae-adapter/test/config.test.mjs
@@ -1,7 +1,9 @@
 import { strict as assert } from "node:assert";
+import fs from "node:fs";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { syncBuiltinESMExports } from "node:module";
 import { tmpdir } from "node:os";
-import { join, win32 } from "node:path";
+import { basename, join, win32 } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { test } from "node:test";
 import { withJsonFileLockAsync } from "../../memorax-code-adapter-common/src/config-utils.mjs";
@@ -245,6 +247,69 @@ test("Trae runtime generations track recovery metadata without mutating previous
       if (value === undefined) delete process.env[key];
       else process.env[key] = value;
     }
+    await rm(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("Trae directory publication retries Windows contention and reports exhausted failures", async () => {
+  const fixture = await createFixture("directory-contention");
+  const options = { ...fixture.options, platform: process.platform };
+  const skillPath = join(fixture.traeHome, "skills", "memorax-code");
+  const platform = Object.getOwnPropertyDescriptor(process, "platform");
+  const originalRename = fs.renameSync;
+  const originalRemove = fs.rmSync;
+  const publishError = Object.assign(new Error("directory publication denied"), { code: "EPERM" });
+  let persistent = false;
+  let runtimeRenames = 0;
+  let skillRenames = 0;
+  let skillRemovals = 0;
+  fs.renameSync = (source, destination) => {
+    if (basename(source).startsWith(".staging-") && ++runtimeRenames === 1) throw publishError;
+    if (destination === skillPath && (++skillRenames === 1 || persistent)) throw publishError;
+    return originalRename(source, destination);
+  };
+  fs.rmSync = (target, ...args) => {
+    if (target === skillPath && ++skillRemovals === 1) {
+      throw Object.assign(new Error("directory removal busy"), { code: "EBUSY" });
+    }
+    if (persistent && target.startsWith(`${skillPath}.tmp-`) && fs.existsSync(target)) {
+      throw Object.assign(new Error("stage cleanup failed"), { code: "EIO" });
+    }
+    return originalRemove(target, ...args);
+  };
+  Object.defineProperty(process, "platform", { ...platform, value: "win32" });
+  syncBuiltinESMExports();
+  try {
+    const installed = await enableTraeAdapter(options);
+    assert.equal(installed.ok, true, installed.error);
+    assert.equal(await readFile(join(skillPath, "SKILL.md"), "utf8"), "# MemoraX Code\n");
+    assert.deepEqual([runtimeRenames, skillRenames, skillRemovals], [2, 2, 2]);
+    assert.equal((await enableTraeAdapter(options)).changed, false);
+    assert.deepEqual([runtimeRenames, skillRenames, skillRemovals], [2, 2, 2]);
+
+    await writeFile(join(options.skillSourcePath, "SKILL.md"), "# Updated Skill\n");
+    persistent = true;
+    const failed = await enableTraeAdapter(options);
+    assert.equal(failed.ok, false);
+    assert.equal(failed.action, "enable");
+    assert.equal(failed.reason, "install_failed");
+    assert.equal(failed.stage, "skill-publish");
+    assert.equal(failed.errorCode, "EPERM");
+    assert.equal(failed.error, publishError.message);
+    assert.equal(skillRenames, 7, "persistent contention must stop after the bounded retries");
+    assert.equal((await readTraeAdapterStatus(options)).reason, "install_incomplete");
+    const state = JSON.parse(await readFile(installed.statePath, "utf8"));
+    assert.equal(state.enabled, false);
+    assert.equal(state.installPending, true);
+
+    persistent = false;
+    assert.equal((await enableTraeAdapter(options)).ok, true);
+    assert.equal(await readFile(join(skillPath, "SKILL.md"), "utf8"), "# Updated Skill\n");
+  } finally {
+    Object.defineProperty(process, "platform", platform);
+    fs.renameSync = originalRename;
+    fs.rmSync = originalRemove;
+    syncBuiltinESMExports();
     await rm(fixture.root, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
## Change Summary

On Windows, a transient directory lock could abort Trae/OpenCode installation or shared Hook runtime publication. Setup could then report a Backend failure and run another global stop/start cycle even after the Backend had recovered; this change retries the affected directory operations and reports incomplete client installation without that extra recovery cycle.

## Implementation Highlights

- Retry Windows `EPERM`, `EACCES`, `EBUSY`, and `ENOTEMPTY` for up to five attempts per directory operation. Other platforms and non-retryable errors retain immediate failure behavior.
- Apply the bounded retry to Trae/OpenCode Skill replacement, Trae runtime publication, and shared Hook generation publication/cleanup. Preserve the original error when cleanup also fails, and retain the previous shared runtime authority after failed publication.
- Read structured lifecycle results during setup. Report the failed client, installation stage, and filesystem error; keep setup incomplete when the Backend recovered but an integration did not. Ordinary Backend failures still receive the existing recovery attempt.
- Cover transient and persistent failures, cleanup failure, and recovery classification. Make the affected Trae/OpenCode assertions portable to Windows and document the recovery behavior.

This is the installation-focused split. CodeBuddy CLI/WorkBuddy separation and concurrent Hook recovery remain separate follow-ups.

## Validation

Ran on this standalone PR source in an isolated Linux ARM64 Docker environment with clean client homes and synthetic fixtures:

- Focused setup reconciliation, shared generation, Trae, and OpenCode tests: **48 passed**.
- `make test`: **1,299 passed, 2 existing skips, 0 failures**; includes Backend typecheck and all adapter/common/npm suites.
- `make docs-check`: passed, including 10 documentation tests.
- `make npm-package-check`: passed; 433-file package allowlist and build/install/update/reinstall/lifecycle checks completed.
- `git diff --check`: passed; independent source review found no actionable material issue.

## Full End-to-End Validation Results

- Environment: prior native Windows AMD64/NTFS validation of the combined candidate `b1f98c05`, using isolated homes, real filesystem handles, and local simulated services.
- Scenario or matrix: Trae/OpenCode normal and repeated installation; temporary and persistent directory occupancy; shared Hook generation publication with previous authority; recovered Backend with a failing Trae installation.
- Command or workflow: installed-package setup/start and adapter installation APIs, with Windows handles that deny delete sharing.
- Result: temporary occupancy retried successfully; persistent occupancy failed within the retry bound and succeeded after release. Shared publication retained the previous `current.json`. Setup reported the failing adapter without adding another global recovery cycle. This does not guarantee an unchanged Backend PID during the underlying start operation.
- Evidence or artifacts: the Windows retest report verified all 433 installed package files and recorded actual rename failures. The retry implementations were unchanged when extracted into this PR; private reports and paths are not published here.
- Reason not run / remaining risk: this standalone split was revalidated in Linux, not rerun on native Windows. The combined Windows source suite also exposed pre-existing symlink-fixture permission failures and Claude missing-entrypoint classification behavior; those are outside this PR. Real remote model/MemoraX services and desktop UI were not tested in this verification run.
