### PR TITLE
fix:(hooks) serialize concurrent backend recovery

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -299,7 +299,10 @@ lifecycle decisions use versioned durable records and bounded locks, not only
 in-memory serialization.
 
 Concurrent shared Hook recovery is serialized per Backend home and rechecks
-connection authority and health before starting another Backend.
+connection authority and health before starting another Backend. Recovery
+preserves the current managed client set, falling back to configured selection
+when no valid active marker is available; the triggering client does not narrow the
+shared integration set.
 
 Control-plane implementations are grouped by ownership:
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -298,6 +298,9 @@ readiness must not replace the authoritative generation. Cross-process
 lifecycle decisions use versioned durable records and bounded locks, not only
 in-memory serialization.
 
+Concurrent shared Hook recovery is serialized per Backend home and rechecks
+connection authority and health before starting another Backend.
+
 Control-plane implementations are grouped by ownership:
 
 - [npm package](packages/npm/memorax-code) `bin` and `lib` own installed

--- a/packages/ts/memorax-code-adapter-common/src/hooks/ensure-backend-runner.mjs
+++ b/packages/ts/memorax-code-adapter-common/src/hooks/ensure-backend-runner.mjs
@@ -5,6 +5,7 @@ import {
   localBackendRecoveryArguments,
   resolveBackendConnection,
 } from "../backend-connection.mjs";
+import { withJsonFileLockAsync } from "../config-utils.mjs";
 import { isRepoMemoryJobWorker } from "../repo-memory/repo-memory-job-context.mjs";
 
 export const DEFAULT_ENSURE_BACKEND_START_TIMEOUT_MS = 90000;
@@ -41,22 +42,51 @@ export async function ensureBackendAvailable(options, input = {}) {
     return;
   }
 
-  const recoveryArguments = localBackendRecoveryArguments(connection);
-  if (recoveryArguments === undefined) return;
+  if (localBackendRecoveryArguments(connection) === undefined) return;
   if (!command.value || command.removed === true || !memoraxCodeCommandAvailable(command.value)) return;
-  const result = await runMemoraxCode(
-    command.value,
-    options.buildStartArgs(homes, recoveryArguments),
-    parsePositiveInt(options.startTimeoutValue, DEFAULT_ENSURE_BACKEND_START_TIMEOUT_MS),
-    options.nodePath,
-    recoveryEnvironment(options.recoveryEnv, metadata),
-  );
-  if (result.code !== 0) {
-    options.debug?.(
-      `MemoraX Code backend start failed with code ${result.code}${result.stderr ? `: ${result.stderr}` : ""}`,
-    );
-    return;
+  const startTimeoutMs = parsePositiveInt(options.startTimeoutValue, DEFAULT_ENSURE_BACKEND_START_TIMEOUT_MS);
+  const deadline = Date.now() + startTimeoutMs;
+  try {
+    // Hooks from different clients and processes share one recovery attempt.
+    // This lock is separate from the lifecycle lock acquired by the child CLI.
+    await withJsonFileLockAsync(join(homes.memoraxCodeHome, "runtime", "backend", "hook-recovery.json"), async () => {
+      connection = refreshedBackendConnection(options.backendConnection, homes.memoraxCodeHome);
+      const remainingHealthMs = Math.min(healthTimeoutMs, deadline - Date.now());
+      if (remainingHealthMs <= 0) return;
+      if (await backendHealthy(connection, remainingHealthMs)) {
+        await options.onHealthy?.({ homes, backendUrl: connection.url });
+        return;
+      }
+      const recoveryArguments = localBackendRecoveryArguments(connection);
+      const remainingStartMs = deadline - Date.now();
+      if (recoveryArguments === undefined || remainingStartMs <= 0 || !memoraxCodeCommandAvailable(command.value)) return;
+      const result = await runMemoraxCode(
+        command.value,
+        options.buildStartArgs(homes, recoveryArguments),
+        remainingStartMs,
+        options.nodePath,
+        recoveryEnvironment(options.recoveryEnv, metadata),
+      );
+      if (result.code !== 0) {
+        options.debug?.(
+          `MemoraX Code backend start failed with code ${result.code}${result.stderr ? `: ${result.stderr}` : ""}`,
+        );
+      }
+    }, { timeoutMs: startTimeoutMs });
+  } catch (error) {
+    options.debug?.(error instanceof Error ? error.message : String(error));
   }
+
+}
+
+function refreshedBackendConnection(supplied, memoraxCodeHome) {
+  if (!supplied) return resolveBackendConnection({ memoraxCodeHome });
+  return resolveBackendConnection({
+    memoraxCodeHome,
+    env: {},
+    backendUrl: supplied.source === "authority" || supplied.source === "default" ? undefined : supplied.url,
+    backendToken: supplied.tokenSource === "authority-file" ? undefined : supplied.token,
+  });
 }
 
 export function stringValue(value) {

--- a/packages/ts/memorax-code-adapter-common/src/hooks/ensure-backend-runner.mjs
+++ b/packages/ts/memorax-code-adapter-common/src/hooks/ensure-backend-runner.mjs
@@ -62,7 +62,7 @@ export async function ensureBackendAvailable(options, input = {}) {
       if (recoveryArguments === undefined || remainingStartMs <= 0 || !memoraxCodeCommandAvailable(command.value)) return;
       const result = await runMemoraxCode(
         command.value,
-        options.buildStartArgs(homes, recoveryArguments),
+        [...options.buildStartArgs(homes, recoveryArguments), "--preserve-clients"],
         remainingStartMs,
         options.nodePath,
         recoveryEnvironment(options.recoveryEnv, metadata),

--- a/packages/ts/memorax-code-adapter-common/test/ensure-backend-runner.test.mjs
+++ b/packages/ts/memorax-code-adapter-common/test/ensure-backend-runner.test.mjs
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { createServer } from "node:http";
+import { backendTokenPath, writeBackendConnectionAuthority, writeBackendTokenRecord } from "../src/backend-connection.mjs";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -49,4 +52,95 @@ test("shared Backend recovery passes caller-supplied internal environment", asyn
     marker: "1",
     revision: "revision-1",
   });
+});
+
+test("concurrent client Hooks share one recovery and refresh its rotated connection token", async (t) => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-code-concurrent-recovery-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const memoraxCodeHome = join(root, "memorax-code-home");
+  let starts = 0;
+  let healthy = false;
+  const initialHealthResponses = [];
+  const turns = new Set();
+  const server = createServer(async (request, response) => {
+    let text = "";
+    for await (const chunk of request) text += chunk;
+    if (request.url === "/health") {
+      if (!healthy && initialHealthResponses.length < 2) {
+        initialHealthResponses.push(response);
+        if (initialHealthResponses.length === 2) {
+          for (const pending of initialHealthResponses) pending.writeHead(503).end();
+        }
+        return;
+      }
+      const authorized = healthy && request.headers["x-memorax-code-backend-token"] === "rotated-token";
+      response.writeHead(authorized ? 200 : 503, { "content-type": "application/json" });
+      response.end(JSON.stringify({ ok: authorized, service: "memorax-code-backend" }));
+      return;
+    }
+    if (request.url === "/start") {
+      starts += 1;
+      turns.clear();
+      writeBackendTokenRecord({ memoraxCodeHome, token: "rotated-token", createdAt: new Date().toISOString() });
+      healthy = true;
+      response.end("started");
+      return;
+    }
+    if (request.url === "/memory/turn-start") {
+      const authorized = healthy && request.headers["x-memorax-code-backend-token"] === "rotated-token";
+      if (authorized) turns.add(JSON.parse(text).client);
+      response.writeHead(authorized ? 200 : 401).end();
+      return;
+    }
+    response.writeHead(404).end();
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  t.after(() => new Promise((resolve) => server.close(resolve)));
+  const url = `http://127.0.0.1:${server.address().port}`;
+  writeBackendTokenRecord({ memoraxCodeHome, token: "initial-token", createdAt: new Date().toISOString() });
+  writeBackendConnectionAuthority({ memoraxCodeHome, url, tokenPath: backendTokenPath(memoraxCodeHome) });
+  const command = join(root, "recover.mjs");
+  await writeFile(command, `await fetch(${JSON.stringify(`${url}/start`)}, { method: "POST" });\n`);
+  const hook = join(root, "hook.mjs");
+  await writeFile(hook, `
+import { ensureBackendAvailable } from ${JSON.stringify(new URL("../src/hooks/ensure-backend-runner.mjs", import.meta.url).href)};
+import { resolveBackendConnection } from ${JSON.stringify(new URL("../src/backend-connection.mjs", import.meta.url).href)};
+const client = process.argv[2];
+const memoraxCodeHome = ${JSON.stringify(memoraxCodeHome)};
+const connection = resolveBackendConnection({ memoraxCodeHome });
+if (client === "claude") connection.source = "option";
+await ensureBackendAvailable({
+  backendConnection: connection,
+  healthTimeoutValue: "3000",
+  startTimeoutValue: "10000",
+  memoraxCodeCommand: ${JSON.stringify(command)},
+  resolveHomes: () => ({ memoraxCodeHome }),
+  buildStartArgs: () => ["start"],
+});
+const current = resolveBackendConnection({ memoraxCodeHome });
+const response = await fetch(new URL("/memory/turn-start", current.url), {
+  method: "POST",
+  headers: { "x-memorax-code-backend-token": current.token, "content-type": "application/json" },
+  body: JSON.stringify({ client }),
+});
+if (!response.ok) throw new Error("turn start was rejected");
+`);
+  const env = {
+    ...process.env,
+    MEMORAX_CODE_HOME: memoraxCodeHome,
+    MEMORAX_CODE_BACKEND_URL: "",
+    MEMORAX_CODE_BACKEND_HOST: "",
+    MEMORAX_CODE_BACKEND_PORT: "",
+    MEMORAX_CODE_BACKEND_TOKEN: "",
+  };
+  const children = ["codex", "claude"].map((client) => new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [hook, client], { env, stdio: ["ignore", "ignore", "pipe"] });
+    let stderr = "";
+    child.stderr.on("data", (chunk) => { stderr += chunk; });
+    child.on("error", reject);
+    child.on("close", (code) => resolve({ code, stderr }));
+  }));
+  for (const result of await Promise.all(children)) assert.equal(result.code, 0, result.stderr);
+  assert.equal(starts, 1);
+  assert.deepEqual([...turns].sort(), ["claude", "codex"]);
 });

--- a/packages/ts/memorax-code-backend/src/lifecycle/orchestrator.ts
+++ b/packages/ts/memorax-code-backend/src/lifecycle/orchestrator.ts
@@ -205,10 +205,11 @@ async function startMemoraxCodeServiceLocked(
     return { ok: false, action: "start", backend: serviceStateFailure };
   }
   const packageReplacement = isPackageReplacement();
+  const preserveClients = packageReplacement || argv.includes("--preserve-clients");
   // Active client intent must not bypass strict lifecycle config validation.
-  if (packageReplacement) loadManagedClientsConfig(memoraxCodeHome);
+  if (preserveClients) loadManagedClientsConfig(memoraxCodeHome);
   const requestedClients = managedClientsFor(argv, serviceOptions, {
-    preferActive: packageReplacement,
+    preferActive: preserveClients,
   });
   const clients = isDshAdapterRecovery()
     ? { ...requestedClients, dsh: true }

--- a/packages/ts/memorax-code-backend/test/lifecycle/management-cli.test.mjs
+++ b/packages/ts/memorax-code-backend/test/lifecycle/management-cli.test.mjs
@@ -495,6 +495,95 @@ test("unqualified Backend recovery preserves both configured client integrations
   }
 });
 
+test("client Hook recovery preserves managed integrations and respects explicit stops", { timeout: 60_000 }, async (t) => {
+  for (const client of ["codebuddy", "trae"]) {
+    await t.test(client, { timeout: 30_000 }, async () => {
+      const root = await mkdtemp(join(tmpdir(), `memorax-code-${client}-shared-recovery-`));
+      const home = join(root, "memorax-code-home");
+      const clientHome = join(root, `${client}-home`);
+      const claudeHome = join(root, "claude-home");
+      const cliPath = fileURLToPath(new URL("../../dist/memorax-code.js", import.meta.url));
+      const port = await freePort();
+      await mkdir(clientHome, { recursive: true });
+      await mkdir(claudeHome, { recursive: true });
+      const claudeCli = await prepareClaudePluginCli(home);
+      await writeFile(join(claudeHome, "settings.json"), "{}\n");
+      const configPath = join(home, "config.toml");
+      const config = [
+        "[clients]", "codex = false", "claude = false", "dsh = false", "opencode = false",
+        `${client} = true`, "",
+      ].join("\n");
+      await writeFile(configPath, config);
+      const env = {
+        MEMORAX_CODE_HOME: home,
+        MEMORAX_CODE_BACKEND_URL: `http://127.0.0.1:${port}`,
+        MEMORAX_CODE_COMMAND: cliPath,
+        CODEBUDDY_HOME: clientHome,
+        TRAE_HOME: clientHome,
+        TRAE_CN_HOME: clientHome,
+        CLAUDE_CONFIG_DIR: claudeHome,
+        FAKE_CLAUDE_PLUGIN_CALLS: claudeCli.callsPath,
+        MEMORAX_CODE_CLAUDE_COMMAND: claudeCli.claudeCommand,
+      };
+      const commonArgs = [
+        "--home", home, "--port", String(port),
+        `--${client}-home`, clientHome, "--claude-home", claudeHome,
+      ];
+      const activeClientsPath = join(home, "runtime", "backend", "managed-clients.json");
+      try {
+        const started = await runCli(cliPath, [
+          "start", "--json", ...commonArgs, "--clients", `${client},claude`,
+        ], { env });
+        assert.equal(started.code, 0, `${started.stdout}\n${started.stderr}`);
+        const startReport = JSON.parse(started.stdout);
+        assert.equal(startReport.claudeAdapter.enabled, true);
+        const adapter = startReport[`${client}Adapter`];
+        assert.equal(adapter.enabled, true);
+        const hookPath = client === "codebuddy"
+          ? join(adapter.marketplacePath, "hooks", "runtime-hook.mjs")
+          : join(adapter.installPath, "runtime-hook.mjs");
+        for (const phase of ["active", "stopped", "configured"]) {
+          if (phase === "stopped") {
+            await writeFile(configPath, config.replace("claude = false", "claude = true"));
+            const stopped = await runCli(cliPath, [
+              "stop", "--json", ...commonArgs, "--clients", "claude",
+            ], { env });
+            assert.equal(stopped.code, 0, `${stopped.stdout}\n${stopped.stderr}`);
+          }
+          const backendOnlyStop = await runCli(cliPath, [
+            "stop", "--json", ...commonArgs, "--clients", "none",
+          ], { env });
+          assert.equal(backendOnlyStop.code, 0, `${backendOnlyStop.stdout}\n${backendOnlyStop.stderr}`);
+          if (phase === "configured") await rm(activeClientsPath);
+          const recovered = await runCli(hookPath, [], {
+            env,
+            input: JSON.stringify({
+              hook_event_name: "SessionStart", session_id: `${client}-${phase}`,
+              transcript_path: join(root, "session.jsonl"), source: "startup", cwd: root,
+            }),
+          });
+          assert.equal(recovered.code, 0, `${recovered.stdout}\n${recovered.stderr}`);
+          const status = await runCli(cliPath, [
+            "status", "--json", ...commonArgs, "--clients", `${client},claude`,
+          ], { env });
+          const report = JSON.parse(status.stdout);
+          assert.equal(report.backend.ok, true, `${phase}: ${status.stdout}\n${status.stderr}`);
+          assert.equal(report[`${client}Adapter`].enabled, true, phase);
+          assert.equal(report.claudeAdapter.enabled, phase !== "stopped", phase);
+          assert.deepEqual(JSON.parse(await readFile(activeClientsPath, "utf8")), {
+            codex: false, claude: phase !== "stopped", dsh: false, opencode: false, [client]: true,
+          }, phase);
+        }
+      } finally {
+        await runCli(cliPath, [
+          "stop", "--json", ...commonArgs, "--clients", `${client},claude`,
+        ], { env });
+        await rm(root, { recursive: true, force: true });
+      }
+    });
+  }
+});
+
 test("partial client stop preserves Backend until an explicit Backend-only stop", async () => {
   const home = await mkdtemp(join(tmpdir(), "memorax-code-clients-partial-home-"));
   const codexHome = await mkdtemp(join(tmpdir(), "memorax-code-clients-partial-codex-"));
@@ -632,13 +721,18 @@ test("memorax-code lifecycle rejects invalid config before mutating clients or B
     const activeClients = { codex: false, claude: true, dsh: false, opencode: false };
     await mkdir(join(home, "runtime", "backend"), { recursive: true });
     await writeFile(activeClientsPath, `${JSON.stringify(activeClients)}\n`);
-    const replacement = await runCli(cliPath, ["start", "--json", ...commonArgs], {
-      env: { ...env, MEMORAX_CODE_PACKAGE_REPLACEMENT: "1" },
-    });
-    assert.equal(replacement.code, 1, `${replacement.stdout}\n${replacement.stderr}`);
-    assert.match(replacement.stderr, /failed to parse MemoraX Code lifecycle config/);
-    assert.deepEqual(JSON.parse(await readFile(activeClientsPath, "utf8")), activeClients);
-    assert.equal(await pathExists(join(home, "runtime", "backend", "backend.pid.json")), false);
+    for (const recovery of [
+      { args: [], env: { ...env, MEMORAX_CODE_PACKAGE_REPLACEMENT: "1" } },
+      { args: ["--preserve-clients"], env },
+    ]) {
+      const result = await runCli(cliPath, ["start", "--json", ...commonArgs, ...recovery.args], {
+        env: recovery.env,
+      });
+      assert.equal(result.code, 1, `${result.stdout}\n${result.stderr}`);
+      assert.match(result.stderr, /failed to parse MemoraX Code lifecycle config/);
+      assert.deepEqual(JSON.parse(await readFile(activeClientsPath, "utf8")), activeClients);
+      assert.equal(await pathExists(join(home, "runtime", "backend", "backend.pid.json")), false);
+    }
   } finally {
     await runCli(cliPath, ["stop", "--json", ...commonArgs, "--clients", "none"], { env });
     await rm(home, { recursive: true, force: true });

--- a/packages/ts/memorax-code-claude-adapter/test/ensure-backend-hook.test.mjs
+++ b/packages/ts/memorax-code-claude-adapter/test/ensure-backend-hook.test.mjs
@@ -55,6 +55,7 @@ test("unhealthy backend restores the persisted shared client selection", async (
       "127.0.0.1",
       "--port",
       "9",
+      "--preserve-clients",
     ]]);
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -111,6 +112,7 @@ test("unhealthy Backend recovery preserves the persisted host and port", async (
       "--claude-home", claudeHome,
       "--host", "127.0.0.1",
       "--port", "9",
+      "--preserve-clients",
     ]]);
   } finally {
     await rm(root, { recursive: true, force: true });

--- a/packages/ts/memorax-code-codebuddy-adapter/hooks/runtime-hook.mjs
+++ b/packages/ts/memorax-code-codebuddy-adapter/hooks/runtime-hook.mjs
@@ -93,7 +93,6 @@ await ensureBackendAvailable({
   buildStartArgs: (homes, recoveryArguments) => [
     "start",
     "--home", homes.memoraxCodeHome,
-    "--clients", "codebuddy",
     "--codebuddy-home", homes.codeBuddyHome,
     ...recoveryArguments,
   ],

--- a/packages/ts/memorax-code-codex-adapter/test/ensure-backend-hook.test.mjs
+++ b/packages/ts/memorax-code-codex-adapter/test/ensure-backend-hook.test.mjs
@@ -171,6 +171,7 @@ test("unhealthy Backend starts memorax-code for Codex", async () => {
     "--codex-home", f.codexHome,
     "--host", "127.0.0.1",
     "--port", "9",
+    "--preserve-clients",
   ]);
 });
 
@@ -223,6 +224,7 @@ test("unhealthy Backend recovery preserves the persisted host and port", async (
     "--codex-home", f.codexHome,
     "--host", "127.0.0.1",
     "--port", "9",
+    "--preserve-clients",
   ]);
 });
 
@@ -338,6 +340,7 @@ test("durable ensure-backend runtime keeps the plugin metadata command for Backe
       "--codex-home", f.codexHome,
       "--host", "127.0.0.1",
       "--port", "9",
+      "--preserve-clients",
     ]]);
     assert.equal(await readFile(npmRecordPath, "utf8"), npmExecPath);
   } finally {

--- a/packages/ts/memorax-code-opencode-adapter/test/plugin.test.mjs
+++ b/packages/ts/memorax-code-opencode-adapter/test/plugin.test.mjs
@@ -270,6 +270,7 @@ test("managed plugin starts the Backend once and bounds prompt waiting", async (
       "--opencode-config-dir", openCodeConfigDir,
       "--host", "127.0.0.1",
       "--port", "9",
+      "--preserve-clients",
     ]]);
     const prompt = async (id) => {
       const output = promptOutput(id, id);

--- a/packages/ts/memorax-code-trae-adapter/hooks/runtime-hook.mjs
+++ b/packages/ts/memorax-code-trae-adapter/hooks/runtime-hook.mjs
@@ -81,7 +81,6 @@ await ensureBackendAvailable({
   buildStartArgs: (homes, recoveryArguments) => [
     "start",
     "--home", homes.memoraxCodeHome,
-    "--clients", "trae",
     "--trae-home", homes.traeHome,
     ...recoveryArguments,
   ],


### PR DESCRIPTION
## Change Summary

Concurrent client Hooks could each observe an unavailable Backend and launch recovery, causing another start and token rotation after a Hook had resumed. Serialize shared recovery per Backend home, refresh connection authority after waiting, and restore the existing managed client set so the winning Hook cannot disable another integration.

## Implementation Highlights

- Reuse the private cross-process JSON lock around shared Hook recovery, separate from the lifecycle lock acquired by the recovery CLI. Recheck health and persisted connection authority after acquiring it, retaining explicit URL/token overrides.
- Share the recovery budget across lock acquisition, the second health check, and the recovery command.
- Pass an internal `--preserve-clients` flag from the shared runner and remove CodeBuddy/Trae's single-client recovery selection. Restore the active managed set as-is; use configured selection when no valid active marker is available. Do not union configured or triggering clients back into an explicitly stopped set.
- Preserve lifecycle configuration validation, explicit user `--clients` precedence, and DSH revision authorization.
- Document the recovery boundary and add a lifecycle regression through installed CodeBuddy/Trae Hooks, alongside the existing two-process/token-rotation regression.

This is the second split after #160. The client-preservation dependency omitted from the initial split is now included. CodeBuddy CLI/WorkBuddy independent support remains a separate PR.

## Validation

Validated this standalone revision based on main `bd6d20d`, with isolated homes and synthetic fixtures in Linux ARM64 Docker:

- Red/green: both CodeBuddy and Trae recovery disabled the secondary Claude integration on the original PR revision; both preserve it after this fix.
- The same regression verifies that explicit Claude stop remains respected despite configuration selecting it, and that absent active state falls back to configured selection. Invalid lifecycle configuration still rejects recovery before mutation.
- `make test`: **1,303 passed, 2 existing skips, 0 failures**, including Backend typecheck and all six adapter/common/npm suites.
- `make docs-check`: passed, including 10 documentation tests and README synchronization.
- `make npm-package-check`: passed; **433-file** package allowlist and build/install/update/reinstall/lifecycle checks completed.
- Source whitespace check passed. All 484 regular source files matched the tested container snapshot and the published tree; unrelated combined work was preserved.

## Full End-to-End Validation Results

- Environment: isolated Linux ARM64 Docker with an init process, real Backend lifecycle processes, installed CodeBuddy/Trae Hook artifacts, and a synthetic Claude native-plugin CLI.
- Scenario: enable the triggering client plus Claude, stop only the Backend, then execute the installed SessionStart Hook. Repeat after explicit Claude stop and after removing active selection state.
- Result: Backend recovery retains the correct client set, keeps the triggering integration enabled, and preserves or disables Claude according to the retained lifecycle selection. Both client cases passed all three phases.
- Limits: this is lifecycle integration validation, not a native client/model/MemoraX end-to-end run. This revision was not rerun on native Windows or desktop clients. Earlier combined-candidate Windows results do not establish correctness of this standalone revision.

## Deferred Review Item

The timeout handler still sends SIGTERM and returns before confirming the recovery child's exit. This was acknowledged and deferred at the maintainer's request. A reproduction confirmed overlapping command lifetimes, while the separate lifecycle lock serialized actual lifecycle work while its original owner remained alive. No timeout/process-termination changes are included here; follow-up work must avoid indiscriminately killing the intentionally detached managed Backend.
