### PR TITLE
chore:(release) prepare 0.1.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,39 @@ behavior.
 
 ## Unreleased
 
+## [0.1.16] - 2026-09-10
+
+### Added
+
+- Added independent support for CodeBuddy CLI and WorkBuddy, including
+  discovery, plugin installation, Hooks, and lifecycle operations. Either can
+  be used alone, or both can be enabled with separate configuration roots.
+  Stopping or uninstalling one preserves the other.
+
+### Fixed
+
+- Recognized the official Windows CodeBuddy npm `.cmd` launcher during setup
+  and reported unusable selected runtimes instead of silently skipping them.
+- Migrated identifiable legacy WorkBuddy installations to the separate
+  WorkBuddy client while preserving explicit selections and owned custom
+  roots. Hooks with missing or invalid client identity no longer default to
+  CodeBuddy, and Windows-equivalent root paths are cleaned up consistently.
+- Retried transient Windows directory failures during Trae/OpenCode
+  installation and shared Hook runtime publication, with bounded retries and
+  explicit failure when access remains unavailable.
+- Reported the failing client and installation step accurately during setup,
+  without adding another global stop/start cycle after the Backend has
+  recovered while a client integration remains incomplete.
+- Coordinated concurrent Hook recovery and preserved the managed client set,
+  including explicit client stops, when restoring an unavailable Backend.
+
+### Upgrade note
+
+Finish the current reply before updating, then start a new CodeBuddy CLI
+session or restart WorkBuddy to load the new Hooks. Legacy installations whose
+client ownership is ambiguous require an explicit WorkBuddy home; see the
+[configuration guide](docs/configuration.md#codebuddy-and-workbuddy-integration-paths).
+
 ## [0.1.15] - 2026-09-09
 
 ### Added

--- a/packages/npm/memorax-code/package.json
+++ b/packages/npm/memorax-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax/memorax-code",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "Persistent coding memory for Codex, Claude Code, CodeBuddy/WorkBuddy, DeepSeek Harness, OpenCode, and Trae.",
   "license": "MIT",
   "type": "module",

--- a/packages/ts/memorax-code-backend/package-lock.json
+++ b/packages/ts/memorax-code-backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@memorax-code/backend",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@memorax-code/backend",
-      "version": "0.1.15",
+      "version": "0.1.16",
       "dependencies": {
         "smol-toml": "^1.7.0"
       },

--- a/packages/ts/memorax-code-backend/package.json
+++ b/packages/ts/memorax-code-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/backend",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "private": true,
   "type": "module",
   "description": "Local memory integration, lifecycle, trace, and diagnostics for MemoraX Code.",

--- a/packages/ts/memorax-code-claude-adapter/.claude-plugin/plugin.json
+++ b/packages/ts/memorax-code-claude-adapter/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorax-code-claude-adapter",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "Memory skill and local hooks for MemoraX Code in Claude Code.",
   "author": {
     "name": "MemoraX Code Maintainers"

--- a/packages/ts/memorax-code-claude-adapter/hooks/runtime-shell.json
+++ b/packages/ts/memorax-code-claude-adapter/hooks/runtime-shell.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
-  "shellVersion": "0.1.15",
+  "shellVersion": "0.1.16",
   "runtimeAbi": 1
 }

--- a/packages/ts/memorax-code-claude-adapter/package.json
+++ b/packages/ts/memorax-code-claude-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/claude-adapter",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "private": true,
   "type": "module",
   "description": "Claude Code Hook adapter for MemoraX Code memory services.",

--- a/packages/ts/memorax-code-codebuddy-adapter/.codebuddy-plugin/plugin.json
+++ b/packages/ts/memorax-code-codebuddy-adapter/.codebuddy-plugin/plugin.json
@@ -1,7 +1,9 @@
 {
   "name": "memorax-code-codebuddy-adapter",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "MemoraX Code memory integration for CodeBuddy and WorkBuddy.",
   "hooks": "./hooks/hooks.json",
-  "skills": ["./skills/memorax-code"]
+  "skills": [
+    "./skills/memorax-code"
+  ]
 }

--- a/packages/ts/memorax-code-codebuddy-adapter/package.json
+++ b/packages/ts/memorax-code-codebuddy-adapter/package.json
@@ -1,9 +1,13 @@
 {
   "name": "@memorax-code/codebuddy-adapter",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "private": true,
   "type": "module",
   "description": "CodeBuddy and WorkBuddy Hook adapter for MemoraX Code memory services.",
-  "bin": { "memorax-code-codebuddy": "src/cli.mjs" },
-  "scripts": { "test": "node --test test/*.test.mjs" }
+  "bin": {
+    "memorax-code-codebuddy": "src/cli.mjs"
+  },
+  "scripts": {
+    "test": "node --test test/*.test.mjs"
+  }
 }

--- a/packages/ts/memorax-code-codex-adapter/.codex-plugin/plugin.json
+++ b/packages/ts/memorax-code-codex-adapter/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorax-code-codex-adapter",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "Codex adapter, memory skill, and local hooks for MemoraX Code.",
   "author": {
     "name": "MemoraX AI"

--- a/packages/ts/memorax-code-codex-adapter/hooks/runtime-shell.json
+++ b/packages/ts/memorax-code-codex-adapter/hooks/runtime-shell.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
-  "shellVersion": "0.1.15",
+  "shellVersion": "0.1.16",
   "runtimeAbi": 1
 }

--- a/packages/ts/memorax-code-codex-adapter/package.json
+++ b/packages/ts/memorax-code-codex-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/codex-adapter",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "private": true,
   "type": "module",
   "description": "Codex Hook and memory integration for MemoraX Code.",

--- a/packages/ts/memorax-code-dsh-adapter/package.json
+++ b/packages/ts/memorax-code-dsh-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/dsh-memorax-code",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "private": true,
   "type": "module",
   "description": "DeepSeek Harness native memory adapter for MemoraX Code.",

--- a/packages/ts/memorax-code-opencode-adapter/package.json
+++ b/packages/ts/memorax-code-opencode-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/opencode-adapter",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "private": true,
   "type": "module",
   "description": "OpenCode plugin adapter for MemoraX Code memory services.",

--- a/packages/ts/memorax-code-trae-adapter/package.json
+++ b/packages/ts/memorax-code-trae-adapter/package.json
@@ -1,9 +1,13 @@
 {
   "name": "@memorax-code/trae-adapter",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "private": true,
   "type": "module",
   "description": "Trae Hook adapter for MemoraX Code memory services.",
-  "bin": { "memorax-code-trae": "src/cli.mjs" },
-  "scripts": { "test": "node --test test/*.test.mjs" }
+  "bin": {
+    "memorax-code-trae": "src/cli.mjs"
+  },
+  "scripts": {
+    "test": "node --test test/*.test.mjs"
+  }
 }


### PR DESCRIPTION
Prepare stable 0.1.16 by synchronizing the npm, adapter, plugin, and Hook versions and adding the user-facing changelog for #160, #161, and #162. No runtime behavior or dependencies change; minor JSON formatting is produced by the existing version-sync script.

Validation on the release worktree:

- `node scripts/sync-release-version.mjs --check`: passed.
- `make test`: 1,323 passed, 2 existing skips, 0 failures, including Backend typecheck.
- `make docs-check`: passed, including 10 documentation tests and README synchronization.
- `make npm-package-check`: passed; 433-file allowlist and installed lifecycle/update/reinstall checks.
- `make npm-publish-dry-run`: passed for stable version 0.1.16 and the latest tag.
- Semantic comparison confirms that the 14 JSON files change only version values; independent review and whitespace checks passed.

The same runtime source was previously validated for published npm 0.1.15 → a distinct-version candidate: macOS native CLI scenarios, Linux ARM64 CLI scenarios including a global-prefix upgrade, and the supplied Windows report covering WorkBuddy bundled and npm .cmd entrypoints plus standalone CodeBuddy CLI. Model and MemoraX services were local simulations. This release-only change does not claim additional desktop UI, live-service, or in-progress-Turn migration coverage.

After merge, rebuild and verify the package from a clean worktree at the final main commit before publishing npm and the matching GitHub Release artifacts.