### PR TITLE
fix: make shared JSON lock acquisition and release reliable

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -923,12 +923,19 @@ Repo Memory. State shared across processes requires a bounded lock, atomic
 replacement, or version validation appropriate to its record. An in-memory
 mutex is not cross-process authority.
 
-Shared JSON file locks publish a complete owner record through an exclusive
-same-directory hard link. An unfinished owner record is never visible at the
-public lock path. Private publication and stale-reaper claims share the
-versioned, process-qualified claim namespace so abandoned claims remain
-recoverable. Lock storage must support hard links; unsupported storage fails
-closed rather than falling back to an incomplete or unlocked publication.
+Shared JSON file locks acquire ownership by exclusively creating the lock file,
+then writing its process-qualified owner record. Before entering the critical
+section, the held descriptor and lock path must identify the same file with one
+link; an earlier stale-reaper claim keeps acquisition waiting or retrying. A
+cancelled or timed-out pending publication clears its owner record through the
+held descriptor, leaving it recoverable without deleting a reaper's current path.
+Normal acquisition does not create a hard-link claim. An incomplete owner record
+remains subject to the stale threshold. Stale-owner recovery still
+uses versioned, process-qualified hard-link claims to coordinate competing
+reapers; that recovery requires same-directory hard-link support and actual
+unlink semantics for claim cleanup. Release checks the owner before deleting
+and reports read or deletion failures, retaining any preceding operation error.
+Missing locks or records that cannot prove ownership are left untouched.
 CodeBuddy Hook pending state uses this shared lock and private atomic record
 publication. Its legacy directory lock retains the same path and blocks new
 acquisition until released; an unprovable abandoned directory is not removed

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -218,11 +218,12 @@ the product creates or tightens the home to mode `0700` and newly seeded
 configuration to mode `0600`; Windows relies on the current user's filesystem
 ACLs.
 
-Shared state locks publish complete, process-qualified owner records atomically
-before entering a critical section. This prevents stale-lock recovery from
-mistaking an owner still being written for an abandoned lock. State and managed
-configuration storage must support same-directory hard links; a failed atomic
-publication does not grant ownership or permit an unlocked update.
+Shared state locks exclusively create a private lock file and write its
+process-qualified owner record before entering a critical section. A failed
+owner-record write does not permit the protected operation. Incomplete records
+are eligible for recovery only after the stale threshold; an interrupted
+acquisition can leave such a record. Stale-lock recovery still requires
+same-directory hard links and actual unlink semantics for claim cleanup.
 
 Codex, Claude Code, CodeBuddy/WorkBuddy, DSH, OpenCode, and Trae local trace capture is enabled by default.
 Depending on the enabled client capabilities, traces may include prompts,

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -117,6 +117,13 @@ failure. For older installations with a complete configuration, the
 no-argument command can perform a one-time migration; see
 [setup-completion behavior](configuration.md#setup-automatic-update-and-package-transition-state).
 
+If lock release is blocked by filesystem permissions or a client's deletion
+protection, the command reports `failed to release JSON state lock` with the
+lock path and underlying error. Any preceding operation error is also retained;
+successful configuration alone does not mean lock cleanup succeeded. Resolve
+the reported permission or client protection prompt before retrying. Do not
+delete a lock while its owning process may still be running.
+
 On Windows, shared Hook runtime publication and Trae/OpenCode directory
 installation briefly retry transient filesystem errors. If shared runtime
 publication still fails, setup stops before changing the active runtime or

--- a/packages/npm/memorax-code/test/memorax-code-entrypoint.test.mjs
+++ b/packages/npm/memorax-code/test/memorax-code-entrypoint.test.mjs
@@ -118,6 +118,41 @@ test("setup propagates an explicit home to the setup process", async () => {
   }
 });
 
+test("setup reports a blocked lock release even after the setup process succeeds", async () => {
+  const fixture = await createPackageFixture();
+  const entrypoint = join(fixture.root, "entrypoint-tty.mjs");
+  const lockPath = `${join(fixture.memoraxCodeHome, setupCompletionRelativePath)}.lock`;
+  try {
+    await writeFile(entrypoint, [
+      "import fs from 'node:fs';",
+      "import { syncBuiltinESMExports } from 'node:module';",
+      `const lockPath = ${JSON.stringify(lockPath)};`,
+      "const originalUnlink = fs.unlinkSync;",
+      "fs.unlinkSync = (path) => {",
+      "  if (path === lockPath) throw new Error('[safe-delete][SAFE_DELETE_BULK_CONFIRM_REQUIRED] confirmation required');",
+      "  return originalUnlink(path);",
+      "};",
+      "syncBuiltinESMExports();",
+      await readFile(entrypoint, "utf8"),
+    ].join("\n"));
+
+    const result = runCli(fixture, ["setup", "--existing-account"], {
+      assumeInteractive: true,
+      stdinIsTTY: true,
+    });
+
+    assert.equal(result.error, undefined);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /memorax-code setup: failed to release JSON state lock:/);
+    assert.ok(result.stderr.includes(lockPath));
+    assert.match(result.stderr, /SAFE_DELETE_BULK_CONFIRM_REQUIRED/);
+    assert.equal((await readJsonLines(fixture.setupLogPath)).length, 1);
+    assert.equal(await pathExists(lockPath), true);
+  } finally {
+    await fixture.cleanup();
+  }
+});
+
 test("setup propagates the setup process exit code", async () => {
   const fixture = await createPackageFixture();
   try {
@@ -432,6 +467,11 @@ async function createPackageFixture() {
     "process.exit(Number(process.env.MEMORAX_CODE_TEST_SETUP_EXIT_CODE ?? 0));",
     "",
   ].join("\n"));
+  await writeFile(join(root, "entrypoint-tty.mjs"), [
+    "Object.defineProperty(process.stdin, 'isTTY', { value: true });",
+    "await import('./bin/memorax-code.mjs');",
+    "",
+  ].join("\n"));
   const backendEntrypoint = join(root, "lib", "memorax-code-backend", "dist", "memorax-code.js");
   await mkdir(dirname(backendEntrypoint), { recursive: true });
   await writeFile(backendEntrypoint, [
@@ -458,6 +498,7 @@ function runCli(fixture, args = [], {
   backendExitCode = 0,
   extraEnv = {},
   setupExitCode = 0,
+  stdinIsTTY = false,
   timeout = 5_000,
 } = {}) {
   const env = {
@@ -483,7 +524,7 @@ function runCli(fixture, args = [], {
   else delete env.MEMORAX_CODE_SETUP_ASSUME_INTERACTIVE;
   return spawnSync(
     process.execPath,
-    [join(fixture.root, "bin", "memorax-code.mjs"), ...args],
+    [stdinIsTTY ? join(fixture.root, "entrypoint-tty.mjs") : join(fixture.root, "bin", "memorax-code.mjs"), ...args],
     {
       encoding: "utf8",
       env,

--- a/packages/ts/memorax-code-adapter-common/src/config-utils.mjs
+++ b/packages/ts/memorax-code-adapter-common/src/config-utils.mjs
@@ -3,6 +3,8 @@ import { spawnSync } from "node:child_process";
 import {
   closeSync,
   existsSync,
+  fstatSync,
+  ftruncateSync,
   linkSync,
   mkdirSync,
   openSync,
@@ -114,27 +116,36 @@ export function withJsonFileLock(path, operation, options = {}) {
     ensurePrivateDirectory(directory, { durableBoundary: directory });
   }
 
-  while (!tryAcquireJsonFileLock(lockPath, ownerId)) {
-    if (removeStaleJsonFileLock(lockPath, staleMs, observedProcessStarts)) continue;
-    const remainingMs = deadline - Date.now();
-    if (remainingMs <= 0) {
-      const error = new Error(`timed out waiting for JSON state lock: ${lockPath}`);
-      error.code = "JSON_FILE_LOCK_TIMEOUT";
-      error.path = path;
-      error.lockPath = lockPath;
-      throw error;
+  const acquisition = {};
+  try {
+    while (!tryAcquireJsonFileLock(lockPath, ownerId, acquisition)) {
+      if (removeStaleJsonFileLock(lockPath, staleMs, observedProcessStarts)) continue;
+      const remainingMs = deadline - Date.now();
+      if (remainingMs <= 0) {
+        const error = new Error(`timed out waiting for JSON state lock: ${lockPath}`);
+        error.code = "JSON_FILE_LOCK_TIMEOUT";
+        error.path = path;
+        error.lockPath = lockPath;
+        throw error;
+      }
+      sleepSync(Math.min(retryMs, remainingMs));
     }
-    sleepSync(Math.min(retryMs, remainingMs));
+  } finally {
+    closeJsonFileLockAcquisition(acquisition, true);
   }
 
+  let operationFailure;
   try {
     const result = operation();
     if (result && typeof result.then === "function") {
       throw new TypeError("withJsonFileLock operation must be synchronous");
     }
     return result;
+  } catch (error) {
+    operationFailure = { error };
+    throw error;
   } finally {
-    releaseJsonFileLock(lockPath, ownerId);
+    releaseJsonFileLock(lockPath, ownerId, operationFailure);
   }
 }
 
@@ -155,71 +166,101 @@ export async function withJsonFileLockAsync(path, operation, options = {}) {
     ensurePrivateDirectory(directory, { durableBoundary: directory });
   }
 
-  while (!tryAcquireJsonFileLock(lockPath, ownerId)) {
-    throwIfJsonFileLockAborted(signal, path, lockPath);
-    if (removeStaleJsonFileLock(lockPath, staleMs, observedProcessStarts)) continue;
-    const remainingMs = deadline - Date.now();
-    if (remainingMs <= 0) {
-      const error = new Error(`timed out waiting for JSON state lock: ${lockPath}`);
-      error.code = "JSON_FILE_LOCK_TIMEOUT";
-      error.path = path;
-      error.lockPath = lockPath;
-      throw error;
+  const acquisition = {};
+  try {
+    while (!tryAcquireJsonFileLock(lockPath, ownerId, acquisition)) {
+      throwIfJsonFileLockAborted(signal, path, lockPath);
+      if (removeStaleJsonFileLock(lockPath, staleMs, observedProcessStarts)) continue;
+      const remainingMs = deadline - Date.now();
+      if (remainingMs <= 0) {
+        const error = new Error(`timed out waiting for JSON state lock: ${lockPath}`);
+        error.code = "JSON_FILE_LOCK_TIMEOUT";
+        error.path = path;
+        error.lockPath = lockPath;
+        throw error;
+      }
+      await sleep(Math.min(retryMs, remainingMs), signal, path, lockPath);
     }
-    await sleep(Math.min(retryMs, remainingMs), signal, path, lockPath);
+  } finally {
+    closeJsonFileLockAcquisition(acquisition, true);
   }
 
+  let operationFailure;
   try {
     throwIfJsonFileLockAborted(signal, path, lockPath);
     return await operation();
+  } catch (error) {
+    operationFailure = { error };
+    throw error;
   } finally {
-    releaseJsonFileLock(lockPath, ownerId);
+    releaseJsonFileLock(lockPath, ownerId, operationFailure);
   }
 }
 
-function tryAcquireJsonFileLock(lockPath, ownerId) {
-  if (existsSync(lockPath)) return false;
-  const claimPath = jsonFileLockClaimPath(lockPath);
-  let descriptor;
-  let claimCreated = false;
+function tryAcquireJsonFileLock(lockPath, ownerId, acquisition) {
+  if (acquisition.descriptor === undefined) {
+    let descriptor;
+    try {
+      // Normal acquisition needs no disposable claim that a host may recycle.
+      descriptor = openSync(lockPath, "wx", 0o600);
+      writeFileSync(descriptor, `${JSON.stringify({
+        version: 1,
+        ownerId,
+        pid: process.pid,
+        processStartedAt: new Date(performance.timeOrigin).toISOString(),
+        createdAt: new Date().toISOString(),
+      })}\n`);
+      acquisition.descriptor = descriptor;
+    } catch (error) {
+      if (descriptor !== undefined) {
+        try {
+          closeSync(descriptor);
+        } catch {
+          // Best-effort cleanup after an incomplete lock acquisition.
+        }
+        // Preserve a replacement or incomplete owner record for stale recovery.
+        releaseJsonFileLock(lockPath, ownerId, { error });
+      }
+      if (error?.code === "EEXIST") return false;
+      throw error;
+    }
+  }
+
+  // A reaper may have observed the empty file before the owner record was written.
+  // Keep the descriptor while waiting: an open, unlinked file is not ownership.
+  const owned = fstatSync(acquisition.descriptor);
+  let current;
   try {
-    descriptor = openSync(claimPath, "wx", 0o600);
-    claimCreated = true;
-    writeFileSync(descriptor, `${JSON.stringify({
-      version: 1,
-      ownerId,
-      pid: process.pid,
-      processStartedAt: new Date(performance.timeOrigin).toISOString(),
-      createdAt: new Date().toISOString(),
-    })}\n`);
-    closeSync(descriptor);
-    descriptor = undefined;
-    // Reapers must never observe a public lock before its owner record is complete.
-    linkSync(claimPath, lockPath);
-    return true;
+    current = statSync(lockPath);
   } catch (error) {
-    if (error?.code === "EEXIST") return false;
-    throw error;
+    if (error?.code !== "ENOENT") throw error;
+  }
+  if (!current || current.dev !== owned.dev || current.ino !== owned.ino) {
+    closeJsonFileLockAcquisition(acquisition);
+    return false;
+  }
+  // An earlier reaper can still unlink this file until it drops its claim.
+  if (owned.nlink !== 1 || current.nlink !== 1) return false;
+  closeJsonFileLockAcquisition(acquisition);
+  return true;
+}
+
+function closeJsonFileLockAcquisition(acquisition, abandoned = false) {
+  const descriptor = acquisition.descriptor;
+  if (descriptor === undefined) return;
+  acquisition.descriptor = undefined;
+  try {
+    // A timed-out or aborted publication never entered the critical section.
+    // Clear its owner through the held descriptor so stale recovery can reclaim
+    // it even if this process stays alive; never unlink an in-flight reaper's path.
+    if (abandoned) ftruncateSync(descriptor, 0);
   } finally {
-    if (descriptor !== undefined) {
-      try {
-        closeSync(descriptor);
-      } catch {
-        // Best-effort cleanup after an incomplete lock acquisition.
-      }
-    }
-    if (claimCreated) {
-      try {
-        rmSync(claimPath, { force: true });
-      } catch {
-        // An orphaned private claim remains recoverable after this process exits.
-      }
-    }
+    closeSync(descriptor);
   }
 }
 
 function jsonFileLockClaimPath(lockPath) {
-  // Publication candidates and reaper links share process-qualified recovery.
+  // Stale-reaper claims retain process-qualified ownership for recovery.
   const claimId = randomUUID().replaceAll("-", "").slice(0, 24);
   return `${lockPath}.reap-v1-${process.pid}-${Math.trunc(performance.timeOrigin)}-${claimId}`;
 }
@@ -263,11 +304,12 @@ function removeStaleJsonFileLock(lockPath, staleMs, observedProcessStarts) {
     return false;
   }
   try {
-    const current = statSync(lockPath);
-    const claim = statSync(claimPath);
-    if (current.dev !== claim.dev || current.ino !== claim.ino) return false;
-    if (current.nlink !== 2 || claim.nlink !== 2) return false;
     if (readFileSync(claimPath, "utf8") !== snapshot.raw) return false;
+    const claim = statSync(claimPath);
+    if (claim.dev !== snapshot.dev || claim.ino !== snapshot.ino || claim.nlink !== 2) return false;
+    // Check the path last: two detached claims must not count as lock + claim.
+    const current = statSync(lockPath);
+    if (current.dev !== claim.dev || current.ino !== claim.ino || current.nlink !== 2) return false;
     unlinkSync(lockPath);
     return true;
   } catch {
@@ -313,12 +355,37 @@ function reapClaimOwnerIsAlive(pid, expectedProcessStartedAtMs, observedProcessS
   return sameProcessStart(expectedProcessStartedAtMs, actualProcessStartedAtMs);
 }
 
-function releaseJsonFileLock(lockPath, ownerId) {
+function releaseJsonFileLock(lockPath, ownerId, operationFailure) {
   try {
-    const lock = JSON.parse(readFileSync(lockPath, "utf8"));
+    const raw = readFileSync(lockPath, "utf8");
+    let lock;
+    try {
+      lock = JSON.parse(raw);
+    } catch {
+      // An incomplete owner record cannot prove ownership; leave it for stale recovery.
+      return;
+    }
     if (lock?.ownerId === ownerId) unlinkSync(lockPath);
-  } catch {
-    // A missing, changed, or unreadable lock is not ours to remove.
+  } catch (cause) {
+    if (cause?.code === "ENOENT") return;
+    const releaseError = new Error(
+      `failed to release JSON state lock: ${lockPath}: ${cause?.message ?? String(cause)}`,
+      { cause },
+    );
+    releaseError.code = "JSON_FILE_LOCK_RELEASE_FAILED";
+    releaseError.lockPath = lockPath;
+    if (operationFailure) {
+      // CLI callers often print only message; retain both failures there and as causes.
+      const error = new AggregateError(
+        [operationFailure.error, releaseError],
+        `${operationFailure.error?.message ?? String(operationFailure.error)}; ${releaseError.message}`,
+        { cause: operationFailure.error },
+      );
+      error.code = releaseError.code;
+      error.lockPath = lockPath;
+      throw error;
+    }
+    throw releaseError;
   }
 }
 

--- a/packages/ts/memorax-code-adapter-common/test/config-utils-lock.test.mjs
+++ b/packages/ts/memorax-code-adapter-common/test/config-utils-lock.test.mjs
@@ -68,39 +68,46 @@ test("JSON state lock wait is bounded and releases the owning lock", async () =>
   }
 });
 
-test("JSON state locks publish complete owner records before becoming visible", async () => {
-  const root = await mkdtemp(join(tmpdir(), "memorax-code-json-lock-publication-"));
+test("JSON state locks acquire repeatedly without creating recycled reap claims", async () => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-code-json-lock-acquisition-"));
   const path = join(root, "state.json");
   const lockPath = `${path}.lock`;
-  const originalWrite = fs.writeFileSync;
-  let ownerWrites = 0;
-  fs.writeFileSync = (target, content, ...options) => {
-    if (typeof content === "string" && content.includes('"ownerId"')) {
-      ownerWrites += 1;
-      assert.equal(fs.existsSync(lockPath), false, "an incomplete owner record must not be visible to stale-lock reapers");
+  const recycledPath = join(root, "recycled");
+  await mkdir(recycledPath);
+  const originalRemove = fs.rmSync;
+  let recycledClaims = 0;
+  fs.rmSync = (target, ...options) => {
+    if (typeof target === "string" && target.startsWith(`${lockPath}.reap-`)) {
+      // Recycling preserves the inode's link count even after the claim leaves this directory.
+      fs.renameSync(target, join(recycledPath, String(recycledClaims++)));
+      return;
     }
-    return originalWrite(target, content, ...options);
+    return originalRemove(target, ...options);
   };
   syncBuiltinESMExports();
   try {
-    for (const acquire of [withJsonFileLock, withJsonFileLockAsync]) {
+    for (const acquire of [withJsonFileLock, withJsonFileLockAsync, withJsonFileLock, withJsonFileLockAsync]) {
       await acquire(path, () => {
+        // The callback requires complete owner data, not atomic visibility during the preceding write.
         const owner = JSON.parse(fs.readFileSync(lockPath, "utf8"));
         assert.equal(owner.pid, process.pid);
         assert.equal(owner.version, 1);
         assert.match(owner.ownerId, new RegExp(`^${process.pid}:`));
+        assert.equal(fs.statSync(lockPath).nlink, 1, "normal acquisition must not leave a recycled hard-link alias");
       });
       await assert.rejects(access(lockPath), /ENOENT/);
+      assert.deepEqual(fs.readdirSync(root), ["recycled"]);
+      assert.deepEqual(fs.readdirSync(recycledPath), []);
     }
-    assert.equal(ownerWrites, 2);
+    assert.equal(recycledClaims, 0);
   } finally {
-    fs.writeFileSync = originalWrite;
+    fs.rmSync = originalRemove;
     syncBuiltinESMExports();
     await rm(root, { recursive: true, force: true });
   }
 });
 
-test("JSON state lock owner-write failure cleans its private claim without removing a concurrent owner", async () => {
+test("JSON state lock owner-write failure preserves a replacement owner", async () => {
   const root = await mkdtemp(join(tmpdir(), "memorax-code-json-lock-write-failure-"));
   const path = join(root, "state.json");
   const lockPath = `${path}.lock`;
@@ -120,6 +127,171 @@ test("JSON state lock owner-write failure cleans its private claim without remov
     assert.deepEqual(fs.readdirSync(root), ["state.json.lock"]);
   } finally {
     fs.writeFileSync = originalWrite;
+    syncBuiltinESMExports();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("JSON state lock owner-write failure retains an incomplete record for stale recovery", async () => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-code-json-lock-incomplete-"));
+  const path = join(root, "state.json");
+  const lockPath = `${path}.lock`;
+  const originalWrite = fs.writeFileSync;
+  const writeFailure = Object.assign(new Error("owner record write failed"), { code: "EIO" });
+  let operationCalled = false;
+  fs.writeFileSync = (target) => {
+    originalWrite(target, '{"version":');
+    throw writeFailure;
+  };
+  syncBuiltinESMExports();
+  try {
+    assert.throws(() => withJsonFileLock(path, () => { operationCalled = true; }), error => error === writeFailure);
+    assert.equal(operationCalled, false);
+    assert.equal(fs.readFileSync(lockPath, "utf8"), '{"version":');
+    assert.deepEqual(fs.readdirSync(root), ["state.json.lock"]);
+
+    fs.writeFileSync = originalWrite;
+    syncBuiltinESMExports();
+    const staleTime = new Date(Date.now() - 1000);
+    await utimes(lockPath, staleTime, staleTime);
+    assert.equal(withJsonFileLock(path, () => "recovered", {
+      timeoutMs: 100,
+      retryMs: 5,
+      staleMs: 20,
+    }), "recovered");
+    await assert.rejects(access(lockPath), /ENOENT/);
+  } finally {
+    fs.writeFileSync = originalWrite;
+    syncBuiltinESMExports();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("JSON state lock release reports blocked cleanup and preserves the operation error", async (t) => {
+  for (const acquire of [withJsonFileLock, withJsonFileLockAsync]) {
+    for (const failedOperation of [false, true]) {
+      await t.test(`${acquire.name}: operation ${failedOperation ? "failed" : "succeeded"}`, async () => {
+        const root = await mkdtemp(join(tmpdir(), "memorax-code-json-lock-release-"));
+        const path = join(root, "state.json");
+        const lockPath = `${path}.lock`;
+        const originalUnlink = fs.unlinkSync;
+        const deleteFailure = new Error("[safe-delete][SAFE_DELETE_BULK_CONFIRM_REQUIRED] confirmation required");
+        const operationFailure = Object.assign(new Error("client setup failed"), { code: "CLIENT_SETUP_FAILED" });
+        let operationCalled = false;
+        let deleteAttempts = 0;
+        fs.unlinkSync = (target) => {
+          if (target !== lockPath) return originalUnlink(target);
+          deleteAttempts += 1;
+          throw deleteFailure;
+        };
+        syncBuiltinESMExports();
+        try {
+          await assert.rejects(async () => acquire(path, () => {
+            operationCalled = true;
+            if (failedOperation) throw operationFailure;
+            return "complete";
+          }), (error) => {
+            assert.equal(error.code, "JSON_FILE_LOCK_RELEASE_FAILED");
+            assert.equal(error.lockPath, lockPath);
+            assert.ok(error.message.includes(lockPath));
+            assert.match(error.message, /SAFE_DELETE_BULK_CONFIRM_REQUIRED/);
+            if (failedOperation) {
+              assert.ok(error instanceof AggregateError);
+              assert.equal(error.cause, operationFailure);
+              assert.equal(error.errors[0], operationFailure);
+              assert.equal(error.errors[1].cause, deleteFailure);
+              assert.match(error.message, /client setup failed/);
+            } else {
+              assert.equal(error.cause, deleteFailure);
+            }
+            return true;
+          });
+          assert.equal(operationCalled, true);
+          assert.equal(deleteAttempts, 1);
+          await access(lockPath);
+        } finally {
+          fs.unlinkSync = originalUnlink;
+          syncBuiltinESMExports();
+          await rm(root, { recursive: true, force: true });
+        }
+      });
+    }
+  }
+});
+
+test("JSON state lock release preserves unknown ownership but reports unreadable locks", async () => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-code-json-lock-release-owner-"));
+  const path = join(root, "state.json");
+  const lockPath = `${path}.lock`;
+  const originalRead = fs.readFileSync;
+  const readFailure = Object.assign(new Error("lock read denied"), { code: "EACCES" });
+  try {
+    for (const acquire of [withJsonFileLock, withJsonFileLockAsync]) {
+      assert.equal(await acquire(path, () => {
+        fs.unlinkSync(lockPath);
+        return "missing";
+      }), "missing");
+      await assert.rejects(access(lockPath), /ENOENT/);
+
+      const replacement = JSON.stringify({ ownerId: "replacement-owner" });
+      assert.equal(await acquire(path, () => {
+        fs.writeFileSync(lockPath, replacement);
+        return "replaced";
+      }), "replaced");
+      assert.equal(await readFile(lockPath, "utf8"), replacement);
+      await rm(lockPath);
+
+      await assert.rejects(async () => acquire(path, () => {
+        fs.readFileSync = (target, ...options) => {
+          if (target === lockPath) throw readFailure;
+          return originalRead(target, ...options);
+        };
+        syncBuiltinESMExports();
+      }), (error) => error.code === "JSON_FILE_LOCK_RELEASE_FAILED" && error.cause === readFailure);
+      fs.readFileSync = originalRead;
+      syncBuiltinESMExports();
+      await access(lockPath);
+      await rm(lockPath);
+    }
+  } finally {
+    fs.readFileSync = originalRead;
+    syncBuiltinESMExports();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("JSON state lock owner-write failure also reports blocked release", async () => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-code-json-lock-write-release-"));
+  const path = join(root, "state.json");
+  const lockPath = `${path}.lock`;
+  const originalWrite = fs.writeFileSync;
+  const originalUnlink = fs.unlinkSync;
+  const writeFailure = Object.assign(new Error("owner record write failed"), { code: "EIO" });
+  const deleteFailure = Object.assign(new Error("lock delete denied"), { code: "EPERM" });
+  fs.writeFileSync = (...args) => {
+    originalWrite(...args);
+    throw writeFailure;
+  };
+  fs.unlinkSync = (target) => {
+    if (target === lockPath) throw deleteFailure;
+    return originalUnlink(target);
+  };
+  syncBuiltinESMExports();
+  try {
+    assert.throws(() => withJsonFileLock(path, () => assert.fail("must not enter the critical section")), (error) => {
+      assert.equal(error.code, "JSON_FILE_LOCK_RELEASE_FAILED");
+      assert.ok(error instanceof AggregateError);
+      assert.equal(error.cause, writeFailure);
+      assert.equal(error.errors[0], writeFailure);
+      assert.equal(error.errors[1].cause, deleteFailure);
+      assert.match(error.message, /owner record write failed/);
+      assert.match(error.message, /lock delete denied/);
+      return true;
+    });
+    await access(lockPath);
+  } finally {
+    fs.writeFileSync = originalWrite;
+    fs.unlinkSync = originalUnlink;
     syncBuiltinESMExports();
     await rm(root, { recursive: true, force: true });
   }
@@ -303,6 +475,106 @@ test("JSON state lock bypasses an orphaned current reap claim", async () => {
     await assert.rejects(access(lockPath), /ENOENT/);
   } finally {
     await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("JSON state lock retries when its unpublished owner is reaped", async () => {
+  const root = await mkdtemp(join(tmpdir(), "memorax-code-json-lock-unpublished-"));
+  const path = join(root, "state.json");
+  const releaseReplacement = deferred();
+  const originalWrite = fs.writeFileSync;
+  const order = [];
+  let replaceBeforeWrite = true;
+  let first;
+  let replacement;
+  fs.writeFileSync = (descriptor, ...args) => {
+    if (replaceBeforeWrite && typeof descriptor === "number") {
+      replaceBeforeWrite = false;
+      const staleTime = new Date(Date.now() - 1000);
+      fs.futimesSync(descriptor, staleTime, staleTime);
+      replacement = withJsonFileLockAsync(path, async () => {
+        order.push("replacement:start");
+        await releaseReplacement.promise;
+        order.push("replacement:end");
+      }, { timeoutMs: 500, retryMs: 2, staleMs: 20 });
+    }
+    return originalWrite(descriptor, ...args);
+  };
+  syncBuiltinESMExports();
+  try {
+    first = withJsonFileLockAsync(path, () => { order.push("first"); }, {
+      timeoutMs: 500, retryMs: 2, staleMs: 20,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    assert.deepEqual(order, ["replacement:start"]);
+    releaseReplacement.resolve();
+    await Promise.all([first, replacement]);
+    assert.deepEqual(order, ["replacement:start", "replacement:end", "first"]);
+    await assert.rejects(access(`${path}.lock`), /ENOENT/);
+  } finally {
+    fs.writeFileSync = originalWrite;
+    syncBuiltinESMExports();
+    releaseReplacement.resolve();
+    await Promise.allSettled([first, replacement]);
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("JSON state lock waits for an in-flight stale-reaper claim before entering", async (t) => {
+  for (const outcome of ["reaped", "timeout", "aborted"]) {
+    await t.test(outcome, async () => {
+      const root = await mkdtemp(join(tmpdir(), "memorax-code-json-lock-publication-"));
+      const path = join(root, "state.json");
+      const lockPath = `${path}.lock`;
+      const claimPath = `${lockPath}.reap-paused-fixture`;
+      const originalWrite = fs.writeFileSync;
+      let pauseReaper = true;
+      let entered = false;
+      let acquisition;
+      fs.writeFileSync = (descriptor, ...args) => {
+        if (pauseReaper && typeof descriptor === "number") {
+          pauseReaper = false;
+          // A reaper checked the empty lock and paused just before unlinking it.
+          fs.linkSync(lockPath, claimPath);
+        }
+        return originalWrite(descriptor, ...args);
+      };
+      syncBuiltinESMExports();
+      try {
+        const controller = new AbortController();
+        const options = { timeoutMs: outcome === "timeout" ? 20 : 500, retryMs: 2, signal: controller.signal };
+        const operation = () => { entered = true; };
+        if (outcome === "timeout") {
+          assert.throws(() => withJsonFileLock(path, operation, options), { code: "JSON_FILE_LOCK_TIMEOUT" });
+        } else {
+          acquisition = withJsonFileLockAsync(path, operation, options);
+        }
+        assert.equal(entered, false);
+        if (outcome === "reaped") {
+          fs.unlinkSync(lockPath);
+          fs.unlinkSync(claimPath);
+          await acquisition;
+          assert.equal(entered, true);
+        } else {
+          if (outcome === "aborted") {
+            controller.abort();
+            await assert.rejects(acquisition, { code: "JSON_FILE_LOCK_ABORTED" });
+          }
+          assert.equal(await readFile(lockPath, "utf8"), "");
+          fs.unlinkSync(claimPath);
+          const staleTime = new Date(Date.now() - 1000);
+          await utimes(lockPath, staleTime, staleTime);
+          assert.equal(withJsonFileLock(path, () => "recovered", { staleMs: 20 }), "recovered");
+        }
+        await assert.rejects(access(lockPath), /ENOENT/);
+      } finally {
+        fs.writeFileSync = originalWrite;
+        syncBuiltinESMExports();
+        await rm(claimPath, { force: true });
+        await acquisition?.catch(() => undefined);
+        await rm(root, { recursive: true, force: true });
+      }
+    });
   }
 });
 

--- a/packages/ts/memorax-code-codebuddy-adapter/test/pending-state.test.mjs
+++ b/packages/ts/memorax-code-codebuddy-adapter/test/pending-state.test.mjs
@@ -162,14 +162,18 @@ function startWriter(path, releasePath, sessionId) {
     import { syncBuiltinESMExports } from "node:module";
     const [path, releasePath, sessionId] = process.argv.slice(1);
     const exists = fs.existsSync;
+    const open = fs.openSync;
     let reported = false;
-    fs.existsSync = (target) => {
-      const present = exists(target);
-      if (target === path + ".lock" && present && !reported) {
-        reported = true;
-        process.send("contending");
+    fs.openSync = (target, flags, ...options) => {
+      try {
+        return open(target, flags, ...options);
+      } catch (error) {
+        if (target === path + ".lock" && flags === "wx" && error?.code === "EEXIST" && !reported) {
+          reported = true;
+          process.send("contending");
+        }
+        throw error;
       }
-      return present;
     };
     syncBuiltinESMExports();
     const { updatePending } = await import(${JSON.stringify(pendingModuleUrl)});


### PR DESCRIPTION
## Change Summary

Hosts that recycle deleted lock claim files can retain extra hard links from ordinary acquisitions, causing later stale-lock recovery to time out. Acquire shared JSON locks directly and report release failures so callers do not silently leave an owned lock behind.

## Implementation Highlights

- Replace normal acquisition claims with exclusive private-file creation. Verify that the held descriptor and lock path identify the same inode, with no outstanding reaper link, before entering the critical section.
- Preserve stale-reaper coordination, validate the original snapshot, and check the current lock path last. Clear abandoned pending ownership through its descriptor on timeout or cancellation.
- Report lock read/deletion failures as `JSON_FILE_LOCK_RELEASE_FAILED`; preserve an earlier operation error alongside cleanup failure. Keep ownership checks before removal.
- Update lock documentation and regression coverage for recycled claims, interrupted publication, concurrent reapers, pending-state writers, and setup cleanup.

## Validation

- Focused lock, setup-entrypoint, and pending-state tests: 53 passed.
- `make test-ts`: 1,044 passed, including Backend typecheck, shared modules, shared Skill, and all six adapter suites.
- `make npm-package-check`: passed; 293 npm tests passed, 2 existing skips, 433 packaged files validated, and the local-only trace gate passed.
- `make docs-check`: passed, including 10 documentation tests and README synchronization.
- `git diff --check`: passed.

## Full End-to-End Validation Results

- Environment: disposable Docker container with an init process, Debian 12, Linux ARM64, Node.js 24.20.0, running tests as a regular user. A temporary container machine ID supplies the existing trial-identity test prerequisite.
- Scenario or matrix: this PR's standalone state on main; isolated package build, installation, update, and uninstall.
- Command or workflow: the unmodified `make npm-package-check` gate with temporary state and synthetic client fixtures.
- Result: all package lifecycle checks completed successfully.
- Evidence or artifacts: executable regression tests and package-check assertions; no credentials or private traces are included.
- Reason not run / remaining risk: native macOS/Windows client installation was not repeated for this split. Stale-lock recovery still requires hard links and actual unlink semantics; host deletion protection can still block cleanup and is now reported.
