### PR TITLE
feat: support existing-account setup without an interactive terminal

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -240,7 +240,7 @@ sequenceDiagram
     Setup->>Transition: consume only after successful status
   end
 
-  User->>Setup: interactive setup
+  User->>Setup: interactive setup or explicit existing-account stdin setup
   Setup->>Generation: stage immutable Hook runtime
   Setup->>Setup: resolve client selection and connection
   opt Codex selected and detected
@@ -290,8 +290,11 @@ future timestamps, and consume state only after successful start and status.
 
 Public `memorax-code setup` owns disclosure, preferences, credential
 provisioning or entry, client discovery, initial Hook activation, and Backend
-reconciliation. It requires an interactive terminal and commits the versioned
-completion record only after final verification. Invalid or unsupported
+reconciliation. It accepts either interactive input or an explicit
+`--existing-account --non-interactive` request with a raw key on stdin. The latter
+uses detected preferences, preserves explicit client choices, and verifies the
+saved key locally without returning it. Both commit the versioned completion
+record only after final verification. Invalid or unsupported
 completion and transition records fail closed. No-argument routing and legacy
 migration follow the [setup state rules](docs/configuration.md#setup-automatic-update-and-package-transition-state).
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ For DeepSeek Harness (DSH), current releases require Node.js
 Profile, and ensure `pnpm` is on `PATH` before running setup. MemoraX Code
 does not install or update DSH.
 
-On Linux, setup-managed credentials require `/usr/bin/secret-tool` from
+On Linux, guest credentials require `/usr/bin/secret-tool` from
 libsecret and an available Secret Service in the current user session. For
 Remote SSH, WSL, or Dev Containers, install MemoraX Code in the same environment
 as the coding agent. MemoraX search and writeback require network access.
@@ -87,6 +87,26 @@ memorax-code setup --existing-account
 ```
 
 Follow the setup prompts to enter your MemoraX username and API key locally.
+
+For a coding agent without an interactive terminal, pass the API key through
+stdin. The examples assume `MEMORAX_SETUP_API_KEY` is already provided by the
+caller. Do not put the key in command arguments or project files.
+
+```bash
+printf '%s\n' "$MEMORAX_SETUP_API_KEY" | memorax-code setup --existing-account --non-interactive
+```
+
+In Windows PowerShell:
+
+```powershell
+$env:MEMORAX_SETUP_API_KEY | memorax-code.cmd setup --existing-account --non-interactive
+```
+
+This explicit command replaces the saved key and uses the detected local
+username and system language. It reports `API Key match: true` after local
+configuration and readiness checks; this does not verify cloud credentials.
+See [non-interactive setup](docs/configuration.md#existing-account-setup-without-a-terminal)
+for input and reuse behavior.
 
 > [!TIP]
 > Using MemoraX Code across devices? Find the username and API key in the
@@ -161,8 +181,8 @@ For client-specific diagnostic commands, see
 ### Installation Troubleshooting
 
 Package installation does not launch setup automatically; run one of the setup
-commands above in an interactive terminal. For incomplete setup or unavailable
-memory, start with the status commands and follow
+commands above, using stdin mode when an agent has no interactive terminal.
+For incomplete setup or unavailable memory, start with the status commands and follow
 [Troubleshooting](docs/troubleshooting.md).
 
 #### Windows: `memorax-code` or `memorax-cli` Is Not Found

--- a/README.zh.md
+++ b/README.zh.md
@@ -55,7 +55,7 @@ CodeBuddy CLI、WorkBuddy、DeepSeek Harness、OpenCode 或 Trae 中的至少一
 请先安装或初始化 DSH，创建至少一个 Profile，并确保 `pnpm` 在 `PATH` 中可用。
 MemoraX Code 不会安装或更新 DSH。
 
-Linux 下，setup 管理凭据需要 libsecret 提供的 `/usr/bin/secret-tool`，以及当前用户会话中可用的
+Linux 下，游客凭据管理需要 libsecret 提供的 `/usr/bin/secret-tool`，以及当前用户会话中可用的
 Secret Service。使用 Remote SSH、WSL 或 Dev Container 时，请将 MemoraX Code 安装在
 Coding Agent 所在的同一环境中。MemoraX 搜索和写回需要网络访问。
 
@@ -79,6 +79,23 @@ memorax-code setup --existing-account
 ```
 
 按照安装引导，在本机终端中输入 MemoraX 用户名和 API Key。
+
+如果 Coding Agent 无法提供交互式终端，可以通过 stdin 传入 API Key。以下示例假定调用方
+已提供 `MEMORAX_SETUP_API_KEY` 变量；请勿将 Key 填入命令参数或项目文件。
+
+```bash
+printf '%s\n' "$MEMORAX_SETUP_API_KEY" | memorax-code setup --existing-account --non-interactive
+```
+
+Windows PowerShell 使用：
+
+```powershell
+$env:MEMORAX_SETUP_API_KEY | memorax-code.cmd setup --existing-account --non-interactive
+```
+
+该显式命令会替换已保存的 Key，使用检测到的本机用户名和系统语言。
+本地配置与就绪检查通过后会输出 `API Key match: true`，不代表云端凭据已验证。
+输入要求及配置复用行为见[非交互安装说明](docs/configuration.md#existing-account-setup-without-a-terminal)。
 
 > [!TIP]
 > 跨设备使用时，可在一台已配置设备的配置文件（默认位于 `~/.memorax-code/config.toml`）中
@@ -139,7 +156,7 @@ Windows PowerShell 请使用 `memorax-cli.cmd status`。客户端真正执行 Ho
 
 ### 安装故障排查
 
-npm 包安装完成后不会自动启动 setup，请在交互式终端中运行上面适合您的安装引导命令。
+npm 包安装完成后不会自动启动 setup，请运行上面适合您的安装引导命令；Agent 没有交互式终端时可使用 stdin 模式。
 如果 setup 未完成或记忆不可用，请先运行状态检查命令，再按[故障排查](docs/troubleshooting.md)处理。
 
 #### Windows：找不到 `memorax-code` 或 `memorax-cli`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -144,6 +144,14 @@ metadata remain only in secure credential storage. Device-mark metadata is not
 written to the user configuration file; it is read only for explicit account
 inspection and matching anonymous quota reminders.
 
+Explicit existing-account setup can accept a raw API key through stdin with
+`--non-interactive`, without an interactive terminal. It writes the key to private
+configuration and verifies the saved value without placing it in its command
+arguments or output. The invoking shell or coding agent remains responsible
+for how it obtains and retains that input; stdin does not prevent upstream
+command-history or conversation logging. A local key match and setup completion
+do not establish remote authentication.
+
 Quota-reminder deduplication is stored separately in a private local runtime
 record containing a one-way connection fingerprint and reminder levels, never
 a raw API key or Mark ID. An anonymous quota reminder reads the ready secure

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -96,14 +96,47 @@ default of yes; declining records `false`. An absent client that is not
 detected remains absent, while a selected client that is temporarily
 unavailable remains selected. Direct npm installation does not detect clients
 or modify `[clients]`.
-Automatic update reconciliation preserves explicit choices and silently
-enables a detected client whose field is absent. This lets configurations
-written before an adapter was supported adopt it when its runtime is already
+Non-interactive existing-account setup and automatic update reconciliation
+preserve explicit choices and silently enable a detected client whose field is
+absent. This lets configurations written before an adapter was supported
+adopt it when its runtime is already
 installed, without overriding an explicit `false`.
 
 Client selection controls managed client-integration lifecycle only. It does
 not change any coding agent's provider settings.
 `--clients none` runs the Backend without managing a client integration.
+
+## Existing-account setup without a terminal
+
+`memorax-code setup --existing-account --non-interactive` is the public
+non-interactive account setup entrypoint. It reads one raw API key from stdin
+until EOF, with a 16 KiB input limit; surrounding whitespace is trimmed.
+The value must be non-empty and contain no embedded line breaks or NUL bytes.
+The key comes from stdin, not a command-line argument or environment fallback.
+A conflicting `MEMORAX_CODE_MEMORAX_API_KEY` override is rejected. The caller
+must close stdin; do not send JSON or the interactive setup answers. The flag
+is valid only with `--existing-account`, not guest setup or update reconciliation.
+
+The command replaces the saved connection key and uses the detected
+operating-system username and system language defaults (`zh` or `en`). If a
+safe username cannot be detected, it fails and directs the user to interactive
+setup. To reuse an already complete connection, the caller should retain it
+instead of invoking this explicit replacement command. Existing explicit
+client choices, including `false`, are preserved; newly detected clients with
+no recorded choice are enabled.
+
+The command uses the same private configuration writes, Hook activation,
+Backend reconciliation, and setup-completion authority as interactive setup.
+Before recording completion, it checks that the saved key matches stdin and
+that local configuration and selected integrations are ready. A successful
+run prints `API Key match: true` without printing the key. This is a local
+persistence check; only a real MemoraX operation verifies remote authentication.
+
+For shell examples, see the package README.
+On Windows PowerShell, use `memorax-code.cmd` without changing execution policy.
+The caller owns secure input handling: MemoraX Code does not put the stdin key
+in its command-line arguments or output, but cannot prevent a shell or coding
+agent from retaining the command or conversation that supplied it.
 
 ## Setup, automatic update, and package-transition state
 
@@ -122,6 +155,9 @@ restores an account-free credential and writes its API key to `config.toml`.
 `memorax-code setup --existing-account` bypasses automatic reuse and accepts
 an existing connection's username and API key. `--reconfigure` bypasses reuse
 and follows the account-free path again.
+
+The explicit `--existing-account --non-interactive` mode also works without a
+terminal; see [its input and configuration rules](#existing-account-setup-without-a-terminal).
 
 Successful setup writes a private versioned record at:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -53,9 +53,22 @@ default setup reuses it automatically. Use `memorax-code setup --reconfigure`
 to replace it, or `memorax-code setup --existing-account` to enter an
 existing MemoraX connection.
 
-Setup requires terminal input and terminal-visible stderr. A pipe, background
-process, or redirected stdin/stderr cannot complete setup; rerun it in a normal
-interactive terminal.
+Interactive setup requires terminal input and terminal-visible stderr. If a
+coding agent reports `an interactive terminal is required`, use the explicit
+non-interactive existing-account mode instead of emulating a terminal with winpty or
+Python. For example, in Windows PowerShell, with a key already supplied in
+`MEMORAX_SETUP_API_KEY`:
+
+```powershell
+$env:MEMORAX_SETUP_API_KEY | memorax-code.cmd setup --existing-account --non-interactive
+```
+
+Close stdin after one raw key; do not pipe a sequence of interactive answers.
+This mode uses the detected username and language and replaces the saved key.
+If username detection fails, complete setup in a normal interactive terminal.
+See [non-interactive setup rules](configuration.md#existing-account-setup-without-a-terminal).
+Guest setup still requires an interactive terminal. Do not change PowerShell
+execution policy to run the `.ps1` shim; use `.cmd`.
 
 ## Windows: `memorax-code` or `memorax-cli` is not found
 
@@ -65,7 +78,7 @@ coding agent was started before installation, commands may be unavailable even
 though the package is installed. The same package installs both `memorax-code`
 and `memorax-cli`; do not install a separate CLI package.
 
-Interactive setup verifies npm's global command directory and adds it to the
+Setup verifies npm's global command directory and adds it to the
 current setup process and the Windows user `PATH` when needed. If the current
 shell cannot find `memorax-code`, use npm's actual global prefix to bootstrap
 setup and verify the CLI in PowerShell:
@@ -111,9 +124,12 @@ not required.
 Setup writes
 `$MEMORAX_CODE_HOME/runtime/setup/setup-completion.json` only after
 configuration, client and Hook reconciliation, Backend start, and final
-readiness checks succeed. If setup has not completed, rerun
-`memorax-code setup` in an interactive terminal and resolve the reported
-failure. For older installations with a complete configuration, the
+readiness checks succeed. A default `config.toml` alone is not proof of
+completion. Existing-account stdin mode also requires the saved API key to
+match its input. If setup has not completed, rerun the appropriate setup mode
+and resolve the reported failure; do not print the configuration to check a
+key. `API Key match: true` is a local check, not remote authentication. For
+older installations with a complete configuration, the
 no-argument command can perform a one-time migration; see
 [setup-completion behavior](configuration.md#setup-automatic-update-and-package-transition-state).
 

--- a/packages/npm/memorax-code/README.md
+++ b/packages/npm/memorax-code/README.md
@@ -24,6 +24,20 @@ one, then run:
 memorax-code setup --existing-account
 ```
 
+For an agent without an interactive terminal, supply the key through stdin.
+This example assumes the caller already provided `MEMORAX_SETUP_API_KEY`:
+
+```bash
+printf '%s\n' "$MEMORAX_SETUP_API_KEY" | memorax-code setup --existing-account --non-interactive
+```
+
+In Windows PowerShell, use
+`$env:MEMORAX_SETUP_API_KEY | memorax-code.cmd setup --existing-account --non-interactive`.
+This command replaces the saved key, detects the local username and language,
+and checks the saved key without printing it. `API Key match: true` reports a
+local match, not cloud authentication. Input requirements and reuse behavior
+are described in `docs/configuration.md`.
+
 > Using MemoraX Code across devices? Find the MemoraX username and API key
 > needed by setup in the MemoraX Code configuration file on a configured device
 > (normally `~/.memorax-code/config.toml`), then enter them locally during setup
@@ -49,11 +63,11 @@ After obtaining the Mark ID, create your MemoraX account. The platform does
 not currently support attaching a Mark ID to an account that has already been
 registered.
 
-Both setup paths automatically detect supported coding agents. Later setup
-runs reuse a complete saved configuration; use
+Both account and guest setup automatically detect supported coding agents.
+Default setup reuses a complete saved configuration; use
 `memorax-code setup --reconfigure` to replace it.
 
-On Windows, interactive setup also verifies npm's global command directory and
+On Windows, setup also verifies npm's global command directory and
 adds it to the current setup process and the Windows user `PATH` when needed.
 If the current shell cannot find `memorax-code`, bootstrap setup with:
 

--- a/packages/npm/memorax-code/bin/memorax-code-setup.mjs
+++ b/packages/npm/memorax-code/bin/memorax-code-setup.mjs
@@ -38,6 +38,7 @@ import {
   startLifecycleReport,
 } from "../lib/setup-reconcile.mjs";
 import { detectSetupMemoryPreferences } from "../lib/setup-memory-preferences.mjs";
+import { readSetupApiKey } from "../lib/setup-api-key-input.mjs";
 import { ensureTrialSetupCredential } from "../lib/trial-setup.mjs";
 import { commandOnPath } from "../lib/vscode-extension-command.mjs";
 import { resolveWindowsCliInvocation } from "../lib/windows-cli-invocation.mjs";
@@ -66,6 +67,7 @@ const skipTraeAdapterInstall = truthyEnv(process.env.MEMORAX_CODE_SKIP_TRAE_ADAP
 const updateMode = truthyEnv(process.env.MEMORAX_CODE_SETUP_UPDATE);
 const automaticUpdateMode = truthyEnv(process.env.MEMORAX_CODE_SETUP_AUTOMATIC_UPDATE);
 const setupMode = setupModeFromEnvironment(process.env.MEMORAX_CODE_SETUP_MODE);
+const nonInteractive = process.argv.includes("--non-interactive");
 if (!setupMode) {
   logRed("Setup mode is invalid.");
   process.exit(1);
@@ -73,6 +75,19 @@ if (!setupMode) {
 if (automaticUpdateMode && !updateMode) {
   logRed("Automatic update setup requires update mode.");
   process.exit(1);
+}
+let stdinApiKey;
+if (nonInteractive) {
+  if (setupMode !== "existing-account" || updateMode) {
+    logRed("--non-interactive requires existing-account setup, not update reconciliation.");
+    process.exit(1);
+  }
+  try {
+    stdinApiKey = await readSetupApiKey();
+  } catch (error) {
+    logRed(error.message);
+    process.exit(1);
+  }
 }
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
@@ -107,12 +122,12 @@ if (automaticUpdateMode && !existingSetup) {
   logRed("Automatic update setup requires an existing [clients] selection.");
   process.exit(1);
 }
-if (!automaticUpdateMode && !canPromptOnStderr()) {
+if (!automaticUpdateMode && !nonInteractive && !canPromptOnStderr()) {
   logRed("Setup requires an interactive terminal.");
   log("Run `memorax-code setup` from a terminal, or use `memorax-code status` to inspect an existing setup.");
   process.exit(1);
 }
-const scriptedAnswers = !automaticUpdateMode && process.stdin.isTTY !== true
+const scriptedAnswers = !automaticUpdateMode && !nonInteractive && process.stdin.isTTY !== true
   ? parseScriptedAnswers(readFileSync(0, "utf8"))
   : undefined;
 if (seedMissingMemoraxCodeConfig() === "failed") {
@@ -187,13 +202,14 @@ const detectedClients = requestedClients.filter((client) => {
 const newlyDetectedClients = existingSetup
   ? detectedClients.filter((client) => !explicitClientChoices.includes(client))
   : [];
-const selectedClients = automaticUpdateMode
-  ? requestedClients.filter((client) => (
-      previousClients.includes(client) || newlyDetectedClients.includes(client)
-    ))
-  : existingSetup
-    ? await chooseUpdateClients(previousClients, newlyDetectedClients, scriptedAnswers)
-    : detectedClients;
+// Non-interactive setup accepts the same default choices as interactive setup.
+const selectedClients = !existingSetup
+  ? detectedClients
+  : automaticUpdateMode || nonInteractive
+    ? requestedClients.filter((client) => (
+        previousClients.includes(client) || newlyDetectedClients.includes(client)
+      ))
+    : await chooseUpdateClients(previousClients, newlyDetectedClients, scriptedAnswers);
 const clientsWithPersistedIntent = existingSetup
   ? requestedClients.filter((client) => (
       explicitClientChoices.includes(client) || newlyDetectedClients.includes(client)
@@ -248,6 +264,7 @@ if (!updateMode) {
   } else {
     memoraxConfigResult = await maybeConfigureMemoraxMemory(scriptedAnswers, {
       existingAccount: setupMode === "existing-account",
+      apiKey: stdinApiKey,
     });
   }
 }
@@ -394,6 +411,17 @@ if (!updateMode && readMemoraxInstallStatus()?.configured !== true) {
   logRed("Setup could not verify a ready MemoraX connection after Backend reconciliation.");
   process.exit(1);
 }
+if (nonInteractive) {
+  // Verify the persisted value before publishing completion, without exposing it.
+  let matches = false;
+  try {
+    matches = parse(readFileSync(memoraxCodeConfigPath(), "utf8"))?.memorax?.api_key === stdinApiKey;
+  } catch {
+    // Missing or malformed configuration must not become a successful setup.
+  }
+  log(`API Key match: ${matches}`);
+  if (!matches) process.exit(1);
+}
 try {
   const completion = writeSetupCompletionRecord({
     memoraxCodeHome: memoraxCodeHome(),
@@ -413,9 +441,24 @@ process.exit(0);
 async function maybeConfigureMemoraxMemory(scriptedAnswers, {
   existingAccount = false,
   showDisclosure = true,
+  apiKey,
 } = {}) {
   if (showDisclosure) printMemoraxDisclosure();
   const detectedPreferences = detectSetupMemoryPreferences();
+  if (apiKey !== undefined) {
+    if (!detectedPreferences.userId) {
+      logRed("Username could not be detected; run interactive setup to provide it.");
+      return "failed";
+    }
+    printDetectedMemoryPreferences(detectedPreferences);
+    return await writeMemoraxConfigFromInput({
+      userId: detectedPreferences.userId,
+      endpoint: memoraxInstallEndpoint(),
+      outputLanguage: detectedPreferences.outputLanguage ?? MEMORAX_DEFAULT_MEMORY_OUTPUT_LANGUAGE,
+      existingAccount: true,
+      apiKey,
+    });
+  }
   if (scriptedAnswers) {
     return await configureMemoraxMemoryFromAnswers(scriptedAnswers, detectedPreferences, {
       existingAccount,

--- a/packages/npm/memorax-code/bin/memorax-code.mjs
+++ b/packages/npm/memorax-code/bin/memorax-code.mjs
@@ -9,6 +9,7 @@ import { stagePackagedClientHookRuntime } from "../lib/client-hook-runtime.mjs";
 import { unsupportedNodeVersionMessage } from "../lib/node-version.mjs";
 import { runNpmCommand } from "../lib/npm-invocation.mjs";
 import { ensureNpmPackageRuntimeEnv, runBackendEntrypoint } from "../lib/run-entrypoint.mjs";
+import { readSetupApiKey } from "../lib/setup-api-key-input.mjs";
 import { ensureWindowsNpmGlobalPath } from "../lib/windows-user-path.mjs";
 
 const nodeVersionError = unsupportedNodeVersionMessage();
@@ -45,7 +46,7 @@ function printMainHelp() {
   console.log(`Usage: memorax-code [command] [options]
 
 Commands:
-  setup       Run or repair the interactive setup
+  setup       Run or repair setup
   account     Manage local MemoraX account information
   start       Reconcile selected integrations and start the Backend
   status      Show Backend and integration status
@@ -74,13 +75,14 @@ Options:
 }
 
 function printSetupHelp() {
-  console.log(`Usage: memorax-code setup [--existing-account | --reconfigure] [--home DIR]
+  console.log(`Usage: memorax-code setup [--existing-account | --reconfigure] [--non-interactive] [--home DIR]
 
-Run interactive setup to configure or repair MemoraX Code. A complete existing
-configuration is reused automatically.
+Configure or repair MemoraX Code interactively, or use --existing-account
+--non-interactive with an API Key on stdin. Plain setup reuses a complete configuration.
 
 Options:
   --existing-account  Configure an existing account instead of anonymous access
+  --non-interactive   With --existing-account, read the API Key from stdin and use defaults without prompting
   --reconfigure       Re-detect memory preferences instead of reusing configuration
   --home DIR           Configure the specified MemoraX Code home
   -h, --help           Show this help message`);
@@ -279,15 +281,17 @@ async function runSetupCommand(args, { updateMode = false } = {}) {
   }
   let memoraxCodeHome;
   let setupMode;
+  let apiKey;
   try {
     memoraxCodeHome = requestedMemoraxCodeHome(args);
     setupMode = parseSetupMode(args);
+    if (args.includes("--non-interactive")) apiKey = await readSetupApiKey();
   } catch (error) {
     console.error(`memorax-code setup: ${error instanceof Error ? error.message : String(error)}`);
     printSetupHelp();
     return 2;
   }
-  if (!setupCanPrompt()) {
+  if (apiKey === undefined && !setupCanPrompt()) {
     console.error("memorax-code setup: an interactive terminal is required");
     return 1;
   }
@@ -309,6 +313,7 @@ async function runSetupCommand(args, { updateMode = false } = {}) {
       return await spawnSetupProcess(memoraxCodeHome, {
         updateMode,
         setupMode,
+        apiKey,
       });
     });
   } catch (error) {
@@ -388,6 +393,7 @@ function assertAccountArgs(args) {
 
 function parseSetupMode(args) {
   let setupMode = "automatic";
+  let nonInteractive = false;
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
     if (arg === "--existing-account" || arg === "--reconfigure") {
@@ -396,14 +402,19 @@ function parseSetupMode(args) {
         throw new Error("--existing-account and --reconfigure cannot be used together");
       }
       setupMode = requestedMode;
+    } else if (arg === "--non-interactive") {
+      nonInteractive = true;
     } else if (arg === "--home") {
       const value = args[++index];
       if (!value || value.startsWith("--")) throw new Error("--home requires a directory");
     } else if (arg.startsWith("--home=")) {
       if (!arg.slice("--home=".length).trim()) throw new Error("--home requires a directory");
     } else {
-      throw new Error(`unknown option ${arg}`);
+      throw new Error("unknown setup option; see --help for supported input methods");
     }
+  }
+  if (nonInteractive && setupMode !== "existing-account") {
+    throw new Error("--non-interactive requires --existing-account");
   }
   return setupMode;
 }
@@ -444,7 +455,7 @@ function hasReadyMemoraxConfiguration(memoraxCodeHome) {
   return !result.error && !result.signal && result.status === 0;
 }
 
-async function spawnSetupProcess(memoraxCodeHome, { updateMode = false, setupMode = "automatic" } = {}) {
+async function spawnSetupProcess(memoraxCodeHome, { updateMode = false, setupMode = "automatic", apiKey } = {}) {
   ensureNpmPackageRuntimeEnv();
   const env = {
     ...process.env,
@@ -454,10 +465,18 @@ async function spawnSetupProcess(memoraxCodeHome, { updateMode = false, setupMod
   delete env.MEMORAX_CODE_SETUP_MODE;
   if (updateMode) env.MEMORAX_CODE_SETUP_UPDATE = "1";
   if (setupMode !== "automatic") env.MEMORAX_CODE_SETUP_MODE = setupMode;
-  const child = spawn(process.execPath, [join(packageRoot(), "bin", "memorax-code-setup.mjs")], {
-    stdio: "inherit",
+  const child = spawn(process.execPath, [
+    join(packageRoot(), "bin", "memorax-code-setup.mjs"),
+    ...(apiKey === undefined ? [] : ["--non-interactive"]),
+  ], {
+    stdio: apiKey === undefined ? "inherit" : ["pipe", "inherit", "inherit"],
     env,
   });
+  if (apiKey !== undefined) {
+    // The secret travels only through stdin, never child arguments or environment.
+    child.stdin.on("error", () => {}); // Early child failure is reported by its exit status.
+    child.stdin.end(apiKey);
+  }
   return await new Promise((resolve) => {
     child.on("error", (error) => {
       console.error(`memorax-code setup: failed to start setup: ${error.message}`);

--- a/packages/npm/memorax-code/lib/setup-api-key-input.mjs
+++ b/packages/npm/memorax-code/lib/setup-api-key-input.mjs
@@ -1,0 +1,31 @@
+const MAX_API_KEY_BYTES = 16 * 1024;
+
+// Both setup processes read the same bounded, single-value stdin contract.
+// Never include input or underlying read errors in diagnostics.
+export async function readSetupApiKey() {
+  if (process.stdin.isTTY === true) {
+    throw new Error("--non-interactive requires an API Key piped to stdin followed by EOF");
+  }
+  const chunks = [];
+  let size = 0;
+  try {
+    // A pipe may deliver the key in delayed chunks; wait for EOF, not a TTY.
+    for await (const chunk of process.stdin) {
+      size += chunk.length;
+      if (size > MAX_API_KEY_BYTES) break;
+      chunks.push(chunk);
+    }
+  } catch {
+    throw new Error("unable to read API Key from stdin");
+  }
+  if (size > MAX_API_KEY_BYTES) throw new Error("API Key input exceeds 16 KiB");
+  const apiKey = Buffer.concat(chunks).toString("utf8").trim();
+  if (!apiKey || /[\0\r\n]/.test(apiKey)) {
+    throw new Error("stdin must contain one non-empty API Key");
+  }
+  const override = process.env.MEMORAX_CODE_MEMORAX_API_KEY?.trim();
+  if (override && override !== apiKey) {
+    throw new Error("MEMORAX_CODE_MEMORAX_API_KEY conflicts with the supplied API Key");
+  }
+  return apiKey;
+}

--- a/packages/npm/memorax-code/test/automatic-update-entrypoint.test.mjs
+++ b/packages/npm/memorax-code/test/automatic-update-entrypoint.test.mjs
@@ -62,6 +62,7 @@ async function createFixture(t) {
     "lib/resolve-codex-command.mjs",
     "lib/resolve-codebuddy-command.mjs",
     "lib/run-entrypoint.mjs",
+    "lib/setup-api-key-input.mjs",
     "lib/vscode-extension-command.mjs",
     "lib/windows-cli-invocation.mjs",
     "lib/windows-user-path.mjs",

--- a/packages/npm/memorax-code/test/memorax-code-entrypoint.test.mjs
+++ b/packages/npm/memorax-code/test/memorax-code-entrypoint.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { chmod, cp, mkdir, mkdtemp, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, delimiter, dirname, join } from "node:path";
@@ -250,7 +251,7 @@ test("root help documents setup and update", async () => {
     assert.equal(result.status, 0, result.stderr);
     assert.equal(result.error, undefined);
     assert.match(result.stdout, /^Usage: memorax-code \[command\] \[options\]/);
-    assert.match(result.stdout, /^  setup\s+Run or repair the interactive setup$/m);
+    assert.match(result.stdout, /^  setup\s+Run or repair setup$/m);
     assert.match(result.stdout, /^  account\s+Manage local MemoraX account information$/m);
     assert.match(result.stdout, /^  update\s+Update the globally installed npm package$/m);
     assert.doesNotMatch(result.stdout, /repo-memory|user-profile/);
@@ -309,16 +310,17 @@ test("account command reveals only the requested local trial Mark ID", async () 
   }
 });
 
-test("setup help describes automatic, existing-account, and reconfigure modes", async () => {
+test("setup help describes interactive and non-interactive existing-account modes", async () => {
   const fixture = await createPackageFixture();
   try {
     const result = runCli(fixture, ["setup", "--help"]);
 
     assert.equal(result.status, 0, result.stderr);
     assert.equal(result.error, undefined);
-    assert.match(result.stdout, /^Usage: memorax-code setup \[--existing-account \| --reconfigure\] \[--home DIR\]/);
-    assert.match(result.stdout, /A complete existing\nconfiguration is reused automatically/);
+    assert.match(result.stdout, /^Usage: memorax-code setup \[--existing-account \| --reconfigure\] \[--non-interactive\] \[--home DIR\]/);
+    assert.match(result.stdout, /Plain setup reuses a complete configuration/);
     assert.match(result.stdout, /^  --existing-account\s+Configure an existing account instead of anonymous access$/m);
+    assert.match(result.stdout, /^  --non-interactive\s+With --existing-account, read the API Key from stdin and use defaults without prompting$/m);
     assert.match(result.stdout, /^  --reconfigure\s+Re-detect memory preferences instead of reusing configuration$/m);
     assert.equal(await pathExists(fixture.setupLogPath), false);
     assert.equal(await pathExists(fixture.backendLogPath), false);
@@ -365,6 +367,68 @@ test("setup rejects conflicting setup modes before starting setup", async () => 
   }
 });
 
+test("setup forwards an existing-account API key through private stdin without a TTY", async () => {
+  const fixture = await createPackageFixture();
+  const apiKey = `sk_${"P".repeat(43)}`;
+  try {
+    const result = await runCli(fixture, ["setup", "--existing-account", "--non-interactive"], {
+      inputChunks: [apiKey.slice(0, 9), apiKey.slice(9), "\r\n"],
+      timeout: 10_000,
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.error, undefined);
+    assert.deepEqual(await readJsonLines(fixture.setupLogPath), [{
+      args: ["--non-interactive"],
+      home: fixture.memoraxCodeHome,
+      setupMode: "existing-account",
+      stdinKeyHash: createHash("sha256").update(apiKey).digest("hex"),
+      keyInEnvironment: false,
+      stdinIsTTY: false,
+    }]);
+    assert.equal(`${result.stdout}\n${result.stderr}`.includes(apiKey), false);
+    assert.equal((await readFile(fixture.setupLogPath, "utf8")).includes(apiKey), false);
+    assert.equal(await pathExists(fixture.backendLogPath), false);
+  } finally {
+    await fixture.cleanup();
+  }
+});
+
+test("setup rejects invalid API key stdin before starting setup without exposing input", async (t) => {
+  const apiKey = `sk_${"I".repeat(43)}`;
+  for (const scenario of [
+    { name: "missing existing-account mode", args: ["--non-interactive"], input: apiKey },
+    { name: "reconfigure mode", args: ["--reconfigure", "--non-interactive"], input: apiKey },
+    { name: "key accidentally passed as an argument", args: ["--existing-account", "--non-interactive", apiKey], input: apiKey },
+    { name: "empty input", input: "" },
+    { name: "multiple lines", input: `${apiKey}\nsecond-line` },
+    { name: "NUL", input: `${apiKey}\0` },
+    { name: "oversized input", input: `${apiKey}${"x".repeat(16 * 1024)}` },
+    { name: "TTY input", input: apiKey, stdinIsTTY: true },
+  ]) {
+    await t.test(scenario.name, async () => {
+      const fixture = await createPackageFixture();
+      try {
+        const result = runCli(fixture, ["setup", ...(scenario.args ?? ["--existing-account", "--non-interactive"])], {
+          input: scenario.input,
+          stdinIsTTY: scenario.stdinIsTTY,
+        });
+
+        assert.equal(result.error, undefined);
+        assert.notEqual(result.status, 0);
+        assert.match(result.stderr, /API key|non-interactive|setup option/i);
+        assert.equal(`${result.stdout}\n${result.stderr}`.includes(apiKey), false);
+        assert.equal(await pathExists(fixture.setupLogPath), false);
+        assert.equal(await pathExists(fixture.backendLogPath), false);
+        assert.equal(await pathExists(join(fixture.memoraxCodeHome, "config.toml")), false);
+        assert.equal(await pathExists(join(fixture.memoraxCodeHome, setupCompletionRelativePath)), false);
+      } finally {
+        await fixture.cleanup();
+      }
+    });
+  }
+});
+
 test("unknown commands are still delegated to the Backend entrypoint", async () => {
   const fixture = await createPackageFixture();
   try {
@@ -395,6 +459,7 @@ async function createPackageFixture() {
     "lib/resolve-codex-command.mjs",
     "lib/resolve-codebuddy-command.mjs",
     "lib/run-entrypoint.mjs",
+    "lib/setup-api-key-input.mjs",
     "lib/vscode-extension-command.mjs",
     "lib/windows-cli-invocation.mjs",
     "lib/windows-user-path.mjs",
@@ -457,12 +522,19 @@ async function createPackageFixture() {
     "",
   ].join("\n"));
   await writeFile(join(root, "bin", "memorax-code-setup.mjs"), [
-    "import { appendFileSync } from 'node:fs';",
+    "import { appendFileSync, readFileSync } from 'node:fs';",
+    "import { createHash } from 'node:crypto';",
+    "const stdinKey = process.argv.includes('--non-interactive') ? readFileSync(0, 'utf8').replace(/\\r?\\n$/, '') : undefined;",
     "appendFileSync(process.env.MEMORAX_CODE_TEST_SETUP_LOG, JSON.stringify({",
     "  args: process.argv.slice(2),",
     "  home: process.env.MEMORAX_CODE_HOME,",
     "  setupMode: process.env.MEMORAX_CODE_SETUP_MODE ?? 'automatic',",
     "  ...(process.env.MEMORAX_CODE_SETUP_UPDATE === undefined ? {} : { updateMode: process.env.MEMORAX_CODE_SETUP_UPDATE }),",
+    "  ...(stdinKey === undefined ? {} : {",
+    "    stdinKeyHash: createHash('sha256').update(stdinKey).digest('hex'),",
+    "    keyInEnvironment: Object.values(process.env).some((value) => value.includes(stdinKey)),",
+    "    stdinIsTTY: process.stdin.isTTY === true,",
+    "  }),",
     "}) + '\\n');",
     "process.exit(Number(process.env.MEMORAX_CODE_TEST_SETUP_EXIT_CODE ?? 0));",
     "",
@@ -498,6 +570,8 @@ function runCli(fixture, args = [], {
   backendExitCode = 0,
   extraEnv = {},
   setupExitCode = 0,
+  input,
+  inputChunks,
   stdinIsTTY = false,
   timeout = 5_000,
 } = {}) {
@@ -522,16 +596,38 @@ function runCli(fixture, args = [], {
   Object.assign(env, extraEnv);
   if (assumeInteractive) env.MEMORAX_CODE_SETUP_ASSUME_INTERACTIVE = "1";
   else delete env.MEMORAX_CODE_SETUP_ASSUME_INTERACTIVE;
-  return spawnSync(
-    process.execPath,
-    [stdinIsTTY ? join(fixture.root, "entrypoint-tty.mjs") : join(fixture.root, "bin", "memorax-code.mjs"), ...args],
-    {
-      encoding: "utf8",
-      env,
-      stdio: ["ignore", "pipe", "pipe"],
-      timeout,
-    },
-  );
+  const cliArgs = [stdinIsTTY ? join(fixture.root, "entrypoint-tty.mjs") : join(fixture.root, "bin", "memorax-code.mjs"), ...args];
+  const options = {
+    env,
+    stdio: [input === undefined && !inputChunks ? "ignore" : "pipe", "pipe", "pipe"],
+    timeout,
+  };
+  if (inputChunks) {
+    return new Promise((resolve) => {
+      const child = spawn(process.execPath, cliArgs, options);
+      let stdout = "";
+      let stderr = "";
+      let error;
+      let timer;
+      child.stdout.on("data", (chunk) => { stdout += String(chunk); });
+      child.stderr.on("data", (chunk) => { stderr += String(chunk); });
+      child.on("error", (value) => { error = value; });
+      child.stdin.on("error", () => {});
+      child.on("close", (status) => {
+        clearTimeout(timer);
+        resolve({ status, error, stdout, stderr });
+      });
+      const writeChunk = (index) => {
+        if (index === inputChunks.length) child.stdin.end();
+        else {
+          child.stdin.write(inputChunks[index]);
+          timer = setTimeout(() => writeChunk(index + 1), 40);
+        }
+      };
+      timer = setTimeout(() => writeChunk(0), 300);
+    });
+  }
+  return spawnSync(process.execPath, cliArgs, { ...options, encoding: "utf8", input });
 }
 
 function validSetupRecord() {

--- a/packages/npm/memorax-code/test/memorax-code-update.test.mjs
+++ b/packages/npm/memorax-code/test/memorax-code-update.test.mjs
@@ -31,6 +31,7 @@ async function createPackageFixture(version) {
     await cp(join(commonRoot, name), target);
   }
   await cp(join(packageRoot, "lib", "run-entrypoint.mjs"), join(root, "lib", "run-entrypoint.mjs"));
+  await cp(join(packageRoot, "lib", "setup-api-key-input.mjs"), join(root, "lib", "setup-api-key-input.mjs"));
   await cp(join(packageRoot, "lib", "resolve-claude-command.mjs"), join(root, "lib", "resolve-claude-command.mjs"));
   await cp(join(packageRoot, "lib", "resolve-codex-command.mjs"), join(root, "lib", "resolve-codex-command.mjs"));
   await cp(join(packageRoot, "lib", "resolve-codebuddy-command.mjs"), join(root, "lib", "resolve-codebuddy-command.mjs"));

--- a/packages/npm/memorax-code/test/npm-package-layout.test.mjs
+++ b/packages/npm/memorax-code/test/npm-package-layout.test.mjs
@@ -82,6 +82,8 @@ test("runtime package accepts the User Profile launcher and rejects Python artif
 });
 
 test("credential runtime allowlist accepts only reviewed main and marketplace files", () => {
+  assert.equal(isReviewedCredentialRuntimePath("lib/setup-api-key-input.mjs"), true);
+  assert.equal(isAllowedNpmPackFilePath("lib/setup-api-key-input.mjs"), true);
   const names = [
     "linux-secret-service.mjs",
     "macos-keychain.mjs",
@@ -104,6 +106,7 @@ test("credential runtime allowlist accepts only reviewed main and marketplace fi
     }
   }
   for (const path of [
+    "lib/setup-api-key-input.mjs.bak",
     "lib/memorax-code-adapter-common/src/credentials/evil-secret.mjs",
     "lib/memorax-code-claude-marketplace/plugins/memorax-code-claude-adapter/memorax-code-adapter-common/src/credentials/evil-secret.mjs",
     "lib/memorax-code-adapter-common/src/credentials/macos-keychain.mjs.bak",

--- a/packages/npm/memorax-code/test/package-transition.test.mjs
+++ b/packages/npm/memorax-code/test/package-transition.test.mjs
@@ -365,7 +365,7 @@ async function createFixture({
     // Exercise the shipped update CLI and transition module against a fake lifecycle CLI.
     await cp(join(packageRoot, "bin", "memorax-code.mjs"), join(root, "bin", "update-cli.mjs"));
     for (const name of [
-      "automatic-update", "client-hook-runtime", "npm-invocation", "run-entrypoint",
+      "automatic-update", "client-hook-runtime", "npm-invocation", "run-entrypoint", "setup-api-key-input",
       "resolve-claude-command", "resolve-codex-command", "resolve-codebuddy-command",
       "windows-cli-invocation", "windows-user-path", "vscode-extension-command",
     ]) {

--- a/packages/npm/memorax-code/test/setup.test.mjs
+++ b/packages/npm/memorax-code/test/setup.test.mjs
@@ -19,6 +19,7 @@ const codexAdapterSourceRoot = fileURLToPath(new URL(
 ));
 const clientHookRuntimePath = fileURLToPath(new URL("../lib/client-hook-runtime.mjs", import.meta.url));
 const setupReconcilePath = fileURLToPath(new URL("../lib/setup-reconcile.mjs", import.meta.url));
+const setupApiKeyInputPath = fileURLToPath(new URL("../lib/setup-api-key-input.mjs", import.meta.url));
 const codexRuntimeShellPath = fileURLToPath(new URL(
   "../../../ts/memorax-code-codex-adapter/hooks/runtime-shell.json",
   import.meta.url,
@@ -140,7 +141,7 @@ async function startMockMemorax({ status = 200, body = { success: true, data: { 
   };
 }
 
-async function runSetup({ existingCache = false, explicitCache = false, codexRegistered, hookRuntimeFailure, failStartOnce = false, adapterStartFailure = false, connectionAuthorityFailure = false, runtimeAuthorityFailureCode, officialMode = false, codexConfig, memoraxCodeConfig, memoraxCodeConfigMode, emptyClaudeSettings = false, claudeAvailable = true, claudeVersionFails = false, claudeSettingsText, codexAvailable = true, codexAppOnly = false, vscodeOnly = false, dshProfiles = [], opencodeAvailable = false, opencodeXdgAvailable = false, opencodeCliAvailable = false, codebuddyAvailable = false, codebuddyNativeConfig = false, workbuddyAvailable = false, legacyWorkBuddyInstallation = false, failingBuddyVersion, missingBuddyStatus, traeAvailable = false, skipCodexPluginInstall = false, skipClaudeAdapterInstall = false, skipOpenCodeAdapterInstall = false, skipCodeBuddyAdapterInstall = false, skipWorkBuddyAdapterInstall = false, skipTraeAdapterInstall = false, unavailableStatus = false, prefixedStatus = false, input = "", interactive = true, npmCommand = "install", updateMode = false, setupMode = "automatic", memoraxVerify, memoraxEnv = {}, memoryStatusFixture, trialProvisionFailure = false, hookSnapshot = [], hookUpdatePlan = [], hookFullReview = false, hookFullReviewMissing = false, hookSnapshotFails = false, hookCheckFails = false, hookTrustFails = false, detectedUserId = "memory-user", detectedLanguage = "zh", ttyOverride } = {}) {
+async function runSetup({ existingCache = false, explicitCache = false, codexRegistered, hookRuntimeFailure, failStartOnce = false, adapterStartFailure = false, connectionAuthorityFailure = false, runtimeAuthorityFailureCode, officialMode = false, codexConfig, memoraxCodeConfig, memoraxCodeConfigMode, emptyClaudeSettings = false, claudeAvailable = true, claudeVersionFails = false, claudeSettingsText, codexAvailable = true, codexAppOnly = false, vscodeOnly = false, dshProfiles = [], opencodeAvailable = false, opencodeXdgAvailable = false, opencodeCliAvailable = false, codebuddyAvailable = false, codebuddyNativeConfig = false, workbuddyAvailable = false, legacyWorkBuddyInstallation = false, failingBuddyVersion, missingBuddyStatus, traeAvailable = false, skipCodexPluginInstall = false, skipClaudeAdapterInstall = false, skipOpenCodeAdapterInstall = false, skipCodeBuddyAdapterInstall = false, skipWorkBuddyAdapterInstall = false, skipTraeAdapterInstall = false, unavailableStatus = false, prefixedStatus = false, input = "", nativeSetupArgs = [], interactive = true, npmCommand = "install", updateMode = false, setupMode = "automatic", memoraxVerify, memoraxEnv = {}, memoryStatusFixture, tamperApiKeyAfterStart = false, trialProvisionFailure = false, hookSnapshot = [], hookUpdatePlan = [], hookFullReview = false, hookFullReviewMissing = false, hookSnapshotFails = false, hookCheckFails = false, hookTrustFails = false, detectedUserId = "memory-user", detectedLanguage = "zh", ttyOverride } = {}) {
   const root = await mkdtemp(join(tmpdir(), "memorax-code-setup-"));
   const binDir = join(root, "bin");
   const codexHome = join(root, "codex-home");
@@ -221,6 +222,7 @@ async function runSetup({ existingCache = false, explicitCache = false, codexReg
   }
   await copyFile(clientHookRuntimePath, join(libDir, "client-hook-runtime.mjs"));
   await copyFile(setupReconcilePath, join(libDir, "setup-reconcile.mjs"));
+  await copyFile(setupApiKeyInputPath, join(libDir, "setup-api-key-input.mjs"));
   await writeFile(join(libDir, "setup-memory-preferences.mjs"), [
     "export function detectSetupMemoryPreferences() {",
     `  return Object.freeze(${JSON.stringify({
@@ -322,9 +324,13 @@ async function runSetup({ existingCache = false, explicitCache = false, codexReg
   await symlink(smolTomlPath, join(nodeModulesDir, "smol-toml"), "dir");
   await writeFile(join(binDir, "memorax-code.mjs"), [
     "#!/usr/bin/env node",
-    "import { appendFileSync, existsSync, readdirSync, rmSync, writeFileSync } from 'node:fs';",
+    "import { appendFileSync, existsSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';",
     "import { join } from 'node:path';",
     `appendFileSync(${JSON.stringify(logPath)}, 'memorax-code ' + process.argv.slice(2).join(' ') + '\\n');`,
+    `if (${JSON.stringify(tamperApiKeyAfterStart)} && process.argv[2] === 'start') {`,
+    "  const path = join(process.env.MEMORAX_CODE_HOME, 'config.toml');",
+    "  writeFileSync(path, readFileSync(path, 'utf8').replace(/^api_key =.*$/m, 'api_key = \"replaced-fixture-key\"'));",
+    "}",
     `if (process.env.MEMORAX_CODE_DSH_ADAPTER_OPTIONAL === '1') appendFileSync(${JSON.stringify(logPath)}, 'dsh-adapter-optional ' + process.argv[2] + '\\n');`,
     `if (process.argv[2] === 'codex-plugin') appendFileSync(${JSON.stringify(logPath)}, 'codex-runtime ' + (process.env.CODEX_CLI_PATH ?? '') + '\\n');`,
     "if (process.argv[2] === '--version') { console.log('memorax-code 0.1.1-test'); process.exit(0); }",
@@ -709,7 +715,7 @@ async function runSetup({ existingCache = false, explicitCache = false, codexReg
     childEnv.MEMORAX_CODE_CODEX_COMMAND = join(root, "missing-codex");
   }
   const result = await new Promise((resolve) => {
-    const child = spawn(process.execPath, [setupEntrypoint], {
+    const child = spawn(process.execPath, [setupEntrypoint, ...nativeSetupArgs], {
       env: childEnv,
       stdio: ["pipe", "pipe", "pipe"],
     });
@@ -1232,6 +1238,73 @@ test("setup configures an existing MemoraX account without trial provisioning", 
     await assertSetupComplete(run);
   } finally {
     await rm(run.root, { recursive: true, force: true });
+  }
+});
+
+test("setup accepts API key stdin without a TTY and preserves independent client choices", async () => {
+  const apiKey = `sk_${"W".repeat(43)}`;
+  const run = await runSetup({
+    interactive: false,
+    nativeSetupArgs: ["--non-interactive"],
+    setupMode: "existing-account",
+    input: `${apiKey}\r\n`,
+    codexAvailable: false,
+    claudeAvailable: false,
+    codebuddyAvailable: true,
+    workbuddyAvailable: true,
+    detectedUserId: "workbuddy-user",
+    detectedLanguage: null,
+    trialProvisionFailure: true,
+    memoraxCodeConfig: "[clients]\ncodex = false\nclaude = false\ncodebuddy = false\n\n[memory.writeback]\nenabled = false\n",
+  });
+  try {
+    assert.equal(run.result.code, 0, run.result.stderr);
+    const output = `${run.result.stdout}\n${run.result.stderr}`;
+    assert.match(output, /API Key match: true/);
+    assert.equal(output.includes(apiKey), false);
+    assert.equal(run.log.includes(apiKey), false);
+    assert.doesNotMatch(run.log, /^trial-provision$/m);
+    assert.match(run.log, /^memorax-code start --clients dsh,workbuddy --json$/m);
+    const config = await readFile(join(run.memoraxCodeHome, "config.toml"), "utf8");
+    assert.ok(config.includes(`api_key = "${apiKey}"`));
+    assert.match(config, /user_id = "workbuddy-user"/);
+    assert.match(config, /output_language = "zh"/);
+    assert.match(tomlSectionText(config, "clients"), /^codebuddy = false$/m);
+    assert.match(tomlSectionText(config, "clients"), /^workbuddy = true$/m);
+    assert.match(tomlSectionText(config, "memory.writeback"), /^enabled = false$/m);
+    await assertSetupComplete(run);
+  } finally {
+    await rm(run.root, { recursive: true, force: true });
+  }
+});
+
+test("API key stdin setup cannot complete with a missing username or a replaced saved key", async (t) => {
+  const apiKey = `sk_${"F".repeat(43)}`;
+  for (const scenario of [
+    { name: "missing default username", options: { detectedUserId: null }, started: false },
+    { name: "saved key changed after start", options: { tamperApiKeyAfterStart: true }, started: true },
+  ]) {
+    await t.test(scenario.name, async () => {
+      const run = await runSetup({
+        interactive: false,
+        nativeSetupArgs: ["--non-interactive"],
+        setupMode: "existing-account",
+        input: apiKey,
+        ...scenario.options,
+      });
+      try {
+        assert.equal(run.result.code, 1, run.result.stderr);
+        const output = `${run.result.stdout}\n${run.result.stderr}`;
+        assert.doesNotMatch(output, /Setup completed successfully|API Key match: true/);
+        assert.equal(output.includes(apiKey), false);
+        assert.equal(run.log.includes(apiKey), false);
+        assert.doesNotMatch(run.log, /^trial-provision$/m);
+        assert.equal(/^memorax-code start /m.test(run.log), scenario.started);
+        await assertSetupIncomplete(run);
+      } finally {
+        await rm(run.root, { recursive: true, force: true });
+      }
+    });
   }
 });
 

--- a/scripts/npm-package-layout.mjs
+++ b/scripts/npm-package-layout.mjs
@@ -52,6 +52,7 @@ const rootLibFiles = new Set([
   "lib/resolve-codebuddy-command.mjs",
   "lib/run-entrypoint.mjs",
   "lib/setup-memory-preferences.mjs",
+  "lib/setup-api-key-input.mjs",
   "lib/setup-reconcile.mjs",
   "lib/trial-plugin-mark.mjs",
   "lib/trial-provision-client.mjs",
@@ -152,6 +153,7 @@ export function isAllowedNpmPackPath(rawPath) {
 
 export function isReviewedCredentialRuntimePath(rawPath) {
   const path = String(rawPath).replaceAll("\\", "/");
+  if (path === "lib/setup-api-key-input.mjs") return true;
   const prefix = credentialRuntimePrefixes.find((candidate) => path.startsWith(candidate));
   return prefix !== undefined && reviewedCredentialFiles.has(path.slice(prefix.length));
 }


### PR DESCRIPTION
## Change Summary

Coding agents without an interactive terminal cannot complete existing-account setup. Add `memorax-code setup --existing-account --non-interactive` so a raw API key supplied through stdin can drive the existing configuration, client installation, and Backend readiness flow.

## Implementation Highlights

- Validate one non-empty stdin value through EOF, with a 16 KiB limit. Reject TTY input, embedded line breaks/NUL bytes, incompatible flags, and conflicting API-key overrides without echoing the supplied value. Forward the key to the setup child through stdin.
- Use the detected local username and language, replace the saved connection key, and preserve explicit client choices and existing writeback preferences. Verify the persisted key and local readiness before recording setup completion. `API Key match: true` confirms local persistence; it does not authenticate against MemoraX.
- Package the shared input reader and update CLI help, both READMEs, the npm README, configuration, troubleshooting, and security documentation. The public flag is `--non-interactive`; the intermediate development spelling is not shipped.

## Validation

- Focused setup and entrypoint suites: **67 passed**. The new scenarios expose four failures against the pre-feature implementation and pass with this change.
- Install/artifacts — `make npm-package-check`: **308 passed, 2 existing skips**; all **438 packaged files** passed the allowlist. Build, package installation, update/uninstall smoke checks, and the local-only trace gate passed.
- Documentation — `make docs-check`: **10 passed**, with documentation links and committed README language synchronization passing.
- `git diff --check`: passed. The previously merged lock and client-artifact implementations remain unchanged.

## Full End-to-End Validation Results

- Environment: disposable Linux ARM64 Docker container, Node.js 24.20.0, nonroot user, isolated npm prefix and all client/state homes. Synthetic keys only; no native coding clients or MemoraX service calls.
- Workflow: install the built `.tgz`; run the public non-interactive setup command with piped stdin; run it again with a different key; reject empty input and a conflicting environment override; uninstall and remove the isolated state.
- Result: both setup runs exited 0, printed `Setup completed successfully.` and `API Key match: true`, and persisted the expected defaults and completion record. Home/config permissions were private, no lock files remained, and output contained no supplied key. Invalid input exited 2 without creating or changing configuration. Uninstall removed the package and command, and state cleanup completed.
- Remaining validation: native macOS/Windows and real-agent installation were not repeated for this PR split. The Docker check verifies the packaged CLI and local lifecycle; it does not establish native terminal/permission behavior or remote authentication.
