### PR TITLE
chore:(release) prepare 0.1.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,38 @@ behavior.
 
 ## Unreleased
 
+## [0.1.17] - 2026-09-12
+
+### Added
+
+- Added `memorax-code setup --existing-account --non-interactive` for coding
+  agents without an interactive terminal. It accepts one API key through stdin,
+  uses the detected username and language, preserves explicit client choices,
+  and checks that the saved key matches before completing setup.
+
+### Fixed
+
+- Removed hard-link claims from normal JSON lock acquisition and used direct
+  file removal for lock release, reducing failures under client deletion
+  protection. Concurrent stale-lock recovery releases losing claims before
+  slower process checks. Lock cleanup failures now retain the underlying error
+  instead of silently reporting success.
+- Reused complete, unchanged Codex and CodeBuddy/WorkBuddy plugin artifacts
+  during setup and activation. Skills already included in a copied plugin are
+  no longer deleted and copied again; changed or incomplete artifacts are
+  still repaired.
+- Kept WorkBuddy's inherited configuration-directory alias from redirecting
+  standalone CodeBuddy CLI installation into the WorkBuddy directory.
+- Allowed Codex uninstall to finish when its marketplace is already absent,
+  and included underlying registration and activation errors in setup output.
+
+### Upgrade note
+
+The explicit non-interactive command replaces the saved API key. A reported
+key match verifies local persistence, not remote authentication. Interactive
+setup remains available, and guest setup still requires a terminal. See
+[non-interactive setup](docs/configuration.md#existing-account-setup-without-a-terminal).
+
 ## [0.1.16] - 2026-09-10
 
 ### Added
@@ -298,6 +330,7 @@ Later upgrades do not require this workaround.
 - Required a non-empty MemoraX user ID and API key during interactive setup,
   with clearer registration guidance.
 
+[0.1.17]: https://www.npmjs.com/package/@memorax/memorax-code/v/0.1.17
 [0.1.15]: https://www.npmjs.com/package/@memorax/memorax-code/v/0.1.15
 [0.1.14]: https://www.npmjs.com/package/@memorax/memorax-code/v/0.1.14
 [0.1.10]: https://www.npmjs.com/package/@memorax/memorax-code/v/0.1.10

--- a/packages/npm/memorax-code/package.json
+++ b/packages/npm/memorax-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax/memorax-code",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "Persistent coding memory for Codex, Claude Code, CodeBuddy/WorkBuddy, DeepSeek Harness, OpenCode, and Trae.",
   "license": "MIT",
   "type": "module",

--- a/packages/ts/memorax-code-backend/package-lock.json
+++ b/packages/ts/memorax-code-backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@memorax-code/backend",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@memorax-code/backend",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "dependencies": {
         "smol-toml": "^1.7.0"
       },

--- a/packages/ts/memorax-code-backend/package.json
+++ b/packages/ts/memorax-code-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/backend",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "private": true,
   "type": "module",
   "description": "Local memory integration, lifecycle, trace, and diagnostics for MemoraX Code.",

--- a/packages/ts/memorax-code-claude-adapter/.claude-plugin/plugin.json
+++ b/packages/ts/memorax-code-claude-adapter/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorax-code-claude-adapter",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "Memory skill and local hooks for MemoraX Code in Claude Code.",
   "author": {
     "name": "MemoraX Code Maintainers"

--- a/packages/ts/memorax-code-claude-adapter/hooks/runtime-shell.json
+++ b/packages/ts/memorax-code-claude-adapter/hooks/runtime-shell.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
-  "shellVersion": "0.1.16",
+  "shellVersion": "0.1.17",
   "runtimeAbi": 1
 }

--- a/packages/ts/memorax-code-claude-adapter/package.json
+++ b/packages/ts/memorax-code-claude-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/claude-adapter",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "private": true,
   "type": "module",
   "description": "Claude Code Hook adapter for MemoraX Code memory services.",

--- a/packages/ts/memorax-code-codebuddy-adapter/.codebuddy-plugin/plugin.json
+++ b/packages/ts/memorax-code-codebuddy-adapter/.codebuddy-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorax-code-codebuddy-adapter",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "MemoraX Code memory integration for CodeBuddy and WorkBuddy.",
   "hooks": "./hooks/hooks.json",
   "skills": [

--- a/packages/ts/memorax-code-codebuddy-adapter/package.json
+++ b/packages/ts/memorax-code-codebuddy-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/codebuddy-adapter",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "private": true,
   "type": "module",
   "description": "CodeBuddy and WorkBuddy Hook adapter for MemoraX Code memory services.",

--- a/packages/ts/memorax-code-codex-adapter/.codex-plugin/plugin.json
+++ b/packages/ts/memorax-code-codex-adapter/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorax-code-codex-adapter",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "Codex adapter, memory skill, and local hooks for MemoraX Code.",
   "author": {
     "name": "MemoraX AI"

--- a/packages/ts/memorax-code-codex-adapter/hooks/runtime-shell.json
+++ b/packages/ts/memorax-code-codex-adapter/hooks/runtime-shell.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
-  "shellVersion": "0.1.16",
+  "shellVersion": "0.1.17",
   "runtimeAbi": 1
 }

--- a/packages/ts/memorax-code-codex-adapter/package.json
+++ b/packages/ts/memorax-code-codex-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/codex-adapter",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "private": true,
   "type": "module",
   "description": "Codex Hook and memory integration for MemoraX Code.",

--- a/packages/ts/memorax-code-dsh-adapter/package.json
+++ b/packages/ts/memorax-code-dsh-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/dsh-memorax-code",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "private": true,
   "type": "module",
   "description": "DeepSeek Harness native memory adapter for MemoraX Code.",

--- a/packages/ts/memorax-code-opencode-adapter/package.json
+++ b/packages/ts/memorax-code-opencode-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/opencode-adapter",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "private": true,
   "type": "module",
   "description": "OpenCode plugin adapter for MemoraX Code memory services.",

--- a/packages/ts/memorax-code-trae-adapter/package.json
+++ b/packages/ts/memorax-code-trae-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorax-code/trae-adapter",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "private": true,
   "type": "module",
   "description": "Trae Hook adapter for MemoraX Code memory services.",


### PR DESCRIPTION
Prepare stable 0.1.17 by synchronizing npm, Backend, adapter, plugin, and Hook versions and adding the user-facing changelog for #165, #166, and #167. The release adds existing-account setup without an interactive terminal and improves lock handling, plugin reuse, client directory isolation, and Codex uninstall diagnostics.

The diff contains 14 JSON version files and `CHANGELOG.md`. A semantic comparison confirms that JSON changes are limited to version values; runtime code and dependencies are unchanged.

Validation in an isolated Linux ARM64 release worktree, using Node.js 24 and an unprivileged user:

- Release-version consistency and whitespace checks passed.
- `make test`: 1,356 passed, 2 existing opt-in credential-store skips, 0 failures, including Backend typecheck.
- `make docs-check`: passed, including 10 documentation tests and README synchronization.
- `make npm-package-check`: passed, including the 438-file allowlist and installed-package lifecycle, update, and reinstall checks.
- `make npm-publish-dry-run`: passed for 0.1.17 with public access and the `latest` tag. Candidate package: 462,680 bytes compressed; 2,947,600 bytes unpacked.

The container uses a generated test-only machine ID for the existing guest-credential fixture; no real credentials or host client configuration were used. Native macOS/Windows clients and live MemoraX services were not rerun for this release-only change.

After merge, rebuild and verify from a clean worktree at the final main commit before publishing npm and the matching Git tag, GitHub Release, package attachment, and SHA256SUMS.
